### PR TITLE
runtime: cold-plug DRA CDI devices from PodResources DynamicResources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ site/
 opt/
 tools/packaging/kernel/configs/**/.config
 root_hash.txt
+containerd-shim-kata-v2.node

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -324,6 +324,10 @@ DEFKUBELETROOTDIR := /var/lib/kubelet
 DEFPODRESOURCEAPISOCK := ""
 DEFPODRESOURCEAPISOCK_NV := "$(DEFKUBELETROOTDIR)/pod-resources/kubelet.sock"
 
+# PodResources sources consulted for device cold plug. Same default for
+# every flavor/hypervisor target (no _NV split).
+DEFPODRESOURCEDEVICESOURCES := [\"device-plugin\"]
+
 SED = sed
 
 CLI_DIR = cmd
@@ -837,6 +841,7 @@ USER_VARS += DEFDISABLEIMAGENVDIMM_NV
 USER_VARS += DEFDISABLEIMAGENVDIMM_CLH
 USER_VARS += DEFPODRESOURCEAPISOCK
 USER_VARS += DEFPODRESOURCEAPISOCK_NV
+USER_VARS += DEFPODRESOURCEDEVICESOURCES
 
 V              = @
 Q              = $(V:1=)

--- a/src/runtime/config/configuration-clh-azure.toml.in
+++ b/src/runtime/config/configuration-clh-azure.toml.in
@@ -539,3 +539,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-clh-azure.toml.in
+++ b/src/runtime/config/configuration-clh-azure.toml.in
@@ -538,3 +538,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -539,3 +539,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -538,3 +538,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -420,3 +420,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -419,3 +419,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -776,3 +776,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -774,3 +774,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -822,3 +822,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -820,3 +820,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -799,3 +799,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -797,3 +797,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -796,3 +796,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -794,3 +794,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -754,3 +754,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -752,3 +752,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -784,3 +784,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -782,3 +782,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -761,3 +761,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -759,3 +759,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -765,3 +765,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -763,3 +763,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -328,3 +328,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -327,3 +327,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -473,3 +473,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -472,3 +472,12 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
@@ -12,8 +12,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
@@ -78,7 +81,14 @@ func kubeletPodResourceSocketAvailable(sock string) bool {
 
 func coldPlugWithAPI(ctx context.Context, s *service, ociSpec *specs.Spec) error {
 	ann := ociSpec.Annotations
-	devices, err := getDeviceSpec(ctx, s.config.PodResourceAPISock, ann)
+	sources := s.config.PodResourceDeviceSources
+	if len(sources) == 0 {
+		// Config loading defaults this to ["device-plugin"]; if it is empty
+		// anyway, fail closed rather than guess a source.
+		return fmt.Errorf("cold plug: pod_resource_device_sources is empty, refusing to guess a device source")
+	}
+
+	devices, err := getDeviceSpec(ctx, s.config.PodResourceAPISock, ann, sources)
 	if err != nil {
 		return err
 	}
@@ -100,7 +110,19 @@ func coldPlugWithAPI(ctx context.Context, s *service, ociSpec *specs.Spec) error
 // kubelet's pod resource api. This is necessary for cold plug because
 // the Kubelet does not pass the device information via CRI during
 // Sandbox creation.
-func getDeviceSpec(ctx context.Context, socket string, ann map[string]string) ([]string, error) {
+//
+// sources selects which PodResources fields are read: "device-plugin"
+// (container.Devices) and/or "dra" (DynamicResources CDI devices). List both
+// only for disjoint device sets: kubelet double-counts a device advertised via
+// both at scheduling; a same-device collision here is caught by the overlap check.
+// Fail closed: an unlisted source carrying CDI-resolvable data is an error,
+// so misconfiguration cannot silently boot the guest without its devices;
+// data that never resolves in the CDI registry is not cold-pluggable and
+// is exempt.
+func getDeviceSpec(ctx context.Context, socket string, ann map[string]string, sources []string) ([]string, error) {
+	wantDevicePlugin := contains(sources, oci.PodResourceDeviceSourceDevicePlugin)
+	wantDRA := contains(sources, oci.PodResourceDeviceSourceDRA)
+
 	podName, podNs := getPodIdentifiers(ann)
 
 	// create dialer for unix socket
@@ -141,17 +163,142 @@ func getDeviceSpec(ctx context.Context, socket string, ann map[string]string) ([
 	}
 
 	// Process results
-	var devices []string
+	var devices, allDevicePluginDevs, allDRADevs []string
 	for _, container := range podRes.Containers {
+		if container == nil {
+			// A nil entry would panic on the field accesses below.
+			continue
+		}
+		var devicePluginDevs []string
 		for _, d := range container.Devices {
 			shimLog.WithField("container", container.Name).Debugf("Pod Resources Device: %s = %v\n",
 				d.ResourceName, d.DeviceIds)
-			cdiDevs := formatCDIDevIDs(d.ResourceName, d.DeviceIds)
-			devices = append(devices, cdiDevs...)
+			devicePluginDevs = append(devicePluginDevs, formatCDIDevIDs(d.ResourceName, d.DeviceIds)...)
+		}
+
+		draDevs := collectPodResourceCDIDevices(container)
+
+		if !wantDevicePlugin && len(devicePluginDevs) > 0 {
+			if resolvable := cdiResolvableDevices(devicePluginDevs); len(resolvable) > 0 {
+				return nil, fmt.Errorf(
+					"cold plug: container %q has cold-pluggable (CDI-resolvable) device-plugin PodResources data (%v) but %q is not in pod_resource_device_sources=%v; "+
+						"add %q to the config option or this data will be silently dropped",
+					container.Name, resolvable, oci.PodResourceDeviceSourceDevicePlugin, sources, oci.PodResourceDeviceSourceDevicePlugin)
+			}
+			shimLog.WithField("container", container.Name).Debug(
+				"cold plug: container has device-plugin PodResources data but none of it is CDI-resolvable; ignoring (delivered via the regular OCI container path)")
+		}
+		if !wantDRA && len(draDevs) > 0 {
+			if resolvable := cdiResolvableDevices(draDevs); len(resolvable) > 0 {
+				return nil, fmt.Errorf(
+					"cold plug: container %q has cold-pluggable (CDI-resolvable) DRA PodResources data (%v) but %q is not in pod_resource_device_sources=%v; "+
+						"add %q to the config option or this data will be silently dropped",
+					container.Name, resolvable, oci.PodResourceDeviceSourceDRA, sources, oci.PodResourceDeviceSourceDRA)
+			}
+			shimLog.WithField("container", container.Name).Debug(
+				"cold plug: container has DRA PodResources data but none of it is CDI-resolvable; ignoring (delivered via the regular OCI container path)")
+		}
+
+		if wantDevicePlugin {
+			deduped := dedupStrings(devicePluginDevs)
+			devices = append(devices, deduped...)
+			allDevicePluginDevs = append(allDevicePluginDevs, deduped...)
+		}
+		if wantDRA {
+			deduped := dedupStrings(draDevs)
+			devices = append(devices, deduped...)
+			allDRADevs = append(allDRADevs, deduped...)
 		}
 	}
 
-	return devices, nil
+	if wantDevicePlugin && wantDRA {
+		if err := checkCrossSourcePhysicalOverlap(dedupStrings(allDevicePluginDevs), dedupStrings(allDRADevs)); err != nil {
+			return nil, err
+		}
+	}
+
+	return dedupStrings(devices), nil
+}
+
+// collectPodResourceCDIDevices returns the CDI device names in a container's
+// DynamicResources (KEP-3695): DRA allocations are reported only there, never
+// in the device-plugin Devices field.
+func collectPodResourceCDIDevices(container *podresourcesv1.ContainerResources) []string {
+	var devices []string
+	for _, dr := range container.GetDynamicResources() {
+		for _, cr := range dr.GetClaimResources() {
+			for _, cdiDev := range cr.GetCDIDevices() {
+				name := cdiDev.GetName()
+				if name == "" {
+					continue
+				}
+				shimLog.WithFields(logrus.Fields{
+					"container":      container.Name,
+					"claim":          dr.GetClaimName(),
+					"claimNamespace": dr.GetClaimNamespace(),
+				}).Debugf("Pod Resources DRA CDI Device: %s\n", name)
+				devices = append(devices, name)
+			}
+		}
+	}
+	return devices
+}
+
+// dedupStrings deduplicates preserving order: a ResourceClaim shared by
+// several containers reports the same CDI device once per container, and
+// plugging it twice would duplicate its OCI edits.
+func dedupStrings(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// cdiResolvableDevices returns the names that resolve to at least one device
+// node in the CDI registry; only node-bearing devices are cold-plugged
+// (InjectCDIDevices acts on device nodes), so only those matter to the
+// fail-closed unlisted-source check. A CDI device with only env/mount edits
+// injects nothing here and must not trip the guard. A stale registry view can
+// only soften the check into a debug log: InjectCDIDevices re-checks after an
+// explicit Refresh.
+func cdiResolvableDevices(devs []string) []string {
+	if len(devs) == 0 {
+		return nil
+	}
+
+	var resolvable []string
+	registry := cdi.GetRegistry()
+	for _, name := range devs {
+		dev := registry.DeviceDB().GetDevice(name)
+		if dev == nil || dev.Device == nil {
+			continue
+		}
+		for _, node := range dev.ContainerEdits.DeviceNodes {
+			if node != nil && node.Path != "" {
+				resolvable = append(resolvable, name)
+				break
+			}
+		}
+	}
+	return resolvable
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // formatCDIDevIDs formats the way CDI package expects

--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug_overlap.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug_overlap.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 NAVER Cloud Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package containerdshim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
+)
+
+// sysRoot and devRoot are variables so tests can point device-node
+// resolution at a temp-dir fixture.
+var (
+	sysRoot = "/sys"
+	devRoot = "/dev"
+)
+
+// checkCrossSourcePhysicalOverlap errors when a device-plugin CDI device and
+// a DRA CDI device resolve to the same underlying physical device. The same
+// device can be reachable via a legacy iommu-group cdev on one side and a
+// per-device vfio cdev on the other, so string-comparing CDI names misses a
+// double plug; compare physical coordinates (PCI BDF or mdev UUID) instead.
+func checkCrossSourcePhysicalOverlap(devicePluginDevs, draDevs []string) error {
+	if len(devicePluginDevs) == 0 || len(draDevs) == 0 {
+		return nil
+	}
+
+	dpCoords, err := resolvePhysicalCoords(devicePluginDevs)
+	if err != nil {
+		return err
+	}
+	draCoords, err := resolvePhysicalCoords(draDevs)
+	if err != nil {
+		return err
+	}
+
+	for coord, dpName := range dpCoords {
+		if draName, ok := draCoords[coord]; ok {
+			return fmt.Errorf(
+				"cold plug: physical device %q is reachable via both pod_resource_device_sources: "+
+					"%q (device-plugin CDI device %q) and %q (dra CDI device %q); "+
+					"this would double cold-plug the same underlying device",
+				coord, oci.PodResourceDeviceSourceDevicePlugin, dpName, oci.PodResourceDeviceSourceDRA, draName)
+		}
+	}
+
+	return nil
+}
+
+// resolvePhysicalCoords maps CDI devices to physical coordinates (BDF or
+// mdev UUID). Unresolvable names are skipped (InjectCDIDevices already
+// rejects them); a path that cannot be normalized is an error: the guard
+// cannot prove it does not overlap.
+func resolvePhysicalCoords(cdiDevs []string) (map[string]string, error) {
+	coords := make(map[string]string)
+
+	registry := cdi.GetRegistry()
+	for _, name := range cdiDevs {
+		dev := registry.DeviceDB().GetDevice(name)
+		if dev == nil || dev.Device == nil {
+			// A nil embedded spec would nil-panic on ContainerEdits below.
+			continue
+		}
+
+		for _, node := range dev.ContainerEdits.DeviceNodes {
+			if node == nil || node.Path == "" {
+				continue
+			}
+			coord, err := normalizeDeviceNodePath(node.Path)
+			if err != nil {
+				return nil, fmt.Errorf("cold plug: failed to normalize device node path for overlap check (device %q): %w", name, err)
+			}
+			for _, c := range coord {
+				if _, exists := coords[c]; !exists {
+					coords[c] = name
+				}
+			}
+		}
+	}
+
+	return coords, nil
+}
+
+// normalizeDeviceNodePath maps a device node path to physical coordinate
+// keys. A legacy /dev/vfio/N group cdev expands to every BDF in the group,
+// since any member could alias a per-device cdev from the other source;
+// non-vfio paths are their own key.
+func normalizeDeviceNodePath(path string) ([]string, error) {
+	vfioDevicesDir := filepath.Join(devRoot, "vfio", "devices")
+	vfioGroupDir := filepath.Join(devRoot, "vfio")
+
+	if filepath.Dir(path) == vfioDevicesDir {
+		return normalizeVFIODeviceCdev(path)
+	}
+
+	if filepath.Dir(path) == vfioGroupDir {
+		base := filepath.Base(path)
+		if isIOMMUGroup(base) {
+			return normalizeIOMMUGroupCdev(base)
+		}
+	}
+
+	return []string{path}, nil
+}
+
+// normalizeVFIODeviceCdev resolves /dev/vfio/devices/vfioN via its sysfs
+// device symlink; the target basename is the device's own identity (PCI BDF,
+// or mdev instance UUID -- never the parent), so distinct mdev slices of one
+// parent never collide. Mdevs are assumed cdev-only: group-node vs cdev
+// aliasing of an mdev is out of scope.
+func normalizeVFIODeviceCdev(path string) ([]string, error) {
+	vfioName := filepath.Base(path)
+
+	link := filepath.Join(sysRoot, "class", "vfio-dev", vfioName, "device")
+	target, err := os.Readlink(link)
+	if err != nil {
+		return nil, fmt.Errorf("failed to readlink %s: %w", link, err)
+	}
+
+	return []string{filepath.Base(target)}, nil
+}
+
+// normalizeIOMMUGroupCdev returns the BDFs of every device in the IOMMU group.
+func normalizeIOMMUGroupCdev(group string) ([]string, error) {
+	devicesDir := filepath.Join(sysRoot, "kernel", "iommu_groups", group, "devices")
+	entries, err := os.ReadDir(devicesDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", devicesDir, err)
+	}
+
+	var bdfs []string
+	for _, e := range entries {
+		bdfs = append(bdfs, e.Name())
+	}
+
+	return bdfs, nil
+}
+
+func isIOMMUGroup(base string) bool {
+	return base != "" && strings.TrimLeft(base, "0123456789") == ""
+}

--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug_overlap_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug_overlap_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 NAVER Cloud Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package containerdshim
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+)
+
+// setCDISpecDir disables the registry's auto-refresh: racing the fsnotify watch against the explicit Refresh() makes lookups flaky.
+func setCDISpecDir(t *testing.T, dir string) {
+	t.Helper()
+	cdi.GetRegistry(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false))
+}
+
+func writeCDISpec(t *testing.T, dir, name, kind string, devices map[string]string) {
+	t.Helper()
+
+	content := "cdiVersion: \"0.5.0\"\nkind: \"" + kind + "\"\ndevices:\n"
+	for devName, path := range devices {
+		content += "  - name: \"" + devName + "\"\n" +
+			"    containerEdits:\n" +
+			"      deviceNodes:\n" +
+			"      - path: \"" + path + "\"\n"
+	}
+
+	err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(content), 0o644)
+	require.NoError(t, err)
+}
+
+// writeCDISpecEnvOnly writes a CDI device that resolves but declares no device
+// nodes (only an env edit), to exercise the node-less exemption.
+func writeCDISpecEnvOnly(t *testing.T, dir, name, kind, devName string) {
+	t.Helper()
+
+	content := "cdiVersion: \"0.5.0\"\nkind: \"" + kind + "\"\ndevices:\n" +
+		"  - name: \"" + devName + "\"\n" +
+		"    containerEdits:\n" +
+		"      env:\n" +
+		"      - \"FOO=bar\"\n"
+
+	err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(content), 0o644)
+	require.NoError(t, err)
+}
+
+func withSysDevRoots(t *testing.T, sys, dev string) {
+	t.Helper()
+	origSys, origDev := sysRoot, devRoot
+	sysRoot, devRoot = sys, dev
+	t.Cleanup(func() {
+		sysRoot, devRoot = origSys, origDev
+	})
+}
+
+func buildVFIODeviceCdevFixture(t *testing.T, sysDir, vfioName, bdf string) {
+	t.Helper()
+
+	linkDir := filepath.Join(sysDir, "class", "vfio-dev", vfioName)
+	require.NoError(t, os.MkdirAll(linkDir, 0o755))
+
+	targetDir := filepath.Join(sysDir, "devices", "pci0000:00", bdf)
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	rel, err := filepath.Rel(linkDir, targetDir)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(rel, filepath.Join(linkDir, "device")))
+}
+
+// buildVFIOMdevCdevFixture nests the mdev UUID under the parent BDF, mirroring real sysfs; the UUID basename is the device identity.
+func buildVFIOMdevCdevFixture(t *testing.T, sysDir, vfioName, parentBDF, mdevUUID string) {
+	t.Helper()
+
+	linkDir := filepath.Join(sysDir, "class", "vfio-dev", vfioName)
+	require.NoError(t, os.MkdirAll(linkDir, 0o755))
+
+	targetDir := filepath.Join(sysDir, "devices", "pci0000:00", parentBDF, mdevUUID)
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	rel, err := filepath.Rel(linkDir, targetDir)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(rel, filepath.Join(linkDir, "device")))
+}
+
+func buildIOMMUGroupFixture(t *testing.T, sysDir, group string, bdfs ...string) {
+	t.Helper()
+
+	devicesDir := filepath.Join(sysDir, "kernel", "iommu_groups", group, "devices")
+	require.NoError(t, os.MkdirAll(devicesDir, 0o755))
+
+	for _, bdf := range bdfs {
+		require.NoError(t, os.WriteFile(filepath.Join(devicesDir, bdf), []byte{}, 0o644))
+	}
+}
+
+func TestNormalizeDeviceNodePath(t *testing.T) {
+	assert := assert.New(t)
+	sysDir := t.TempDir()
+	devDir := t.TempDir()
+	withSysDevRoots(t, sysDir, devDir)
+
+	t.Run("vfio device cdev resolves to BDF", func(t *testing.T) {
+		buildVFIODeviceCdevFixture(t, sysDir, "vfio0", "0000:65:00.0")
+
+		coords, err := normalizeDeviceNodePath(filepath.Join(devDir, "vfio", "devices", "vfio0"))
+		assert.NoError(err)
+		assert.Equal([]string{"0000:65:00.0"}, coords)
+	})
+
+	t.Run("legacy iommu group cdev resolves to member BDFs", func(t *testing.T) {
+		buildIOMMUGroupFixture(t, sysDir, "42", "0000:65:00.0", "0000:65:00.1")
+
+		coords, err := normalizeDeviceNodePath(filepath.Join(devDir, "vfio", "42"))
+		assert.NoError(err)
+		assert.ElementsMatch([]string{"0000:65:00.0", "0000:65:00.1"}, coords)
+	})
+
+	t.Run("unrelated path falls back to the path itself", func(t *testing.T) {
+		coords, err := normalizeDeviceNodePath("/dev/nvidia0")
+		assert.NoError(err)
+		assert.Equal([]string{"/dev/nvidia0"}, coords)
+	})
+
+	t.Run("vfio device cdev backing an mdev resolves to the mdev instance UUID, not the parent BDF", func(t *testing.T) {
+		const parentBDF = "0000:65:00.0"
+		const mdevUUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		buildVFIOMdevCdevFixture(t, sysDir, "vfio-mdev0", parentBDF, mdevUUID)
+
+		coords, err := normalizeDeviceNodePath(filepath.Join(devDir, "vfio", "devices", "vfio-mdev0"))
+		assert.NoError(err)
+		assert.Equal([]string{mdevUUID}, coords)
+	})
+
+	t.Run("vfio device cdev with unresolvable symlink errors", func(t *testing.T) {
+		_, err := normalizeDeviceNodePath(filepath.Join(devDir, "vfio", "devices", "vfio-missing"))
+		assert.Error(err)
+	})
+}
+
+func TestCheckCrossSourcePhysicalOverlap(t *testing.T) {
+	sysDir := t.TempDir()
+	devDir := t.TempDir()
+	specDir := t.TempDir()
+	withSysDevRoots(t, sysDir, devDir)
+	setCDISpecDir(t, specDir)
+
+	t.Run("no overlap when sets are disjoint", func(t *testing.T) {
+		assert := assert.New(t)
+		buildVFIODeviceCdevFixture(t, sysDir, "vfio0", "0000:65:00.0")
+		buildVFIODeviceCdevFixture(t, sysDir, "vfio1", "0000:66:00.0")
+
+		writeCDISpec(t, specDir, "dp", "vendor.com/gpu", map[string]string{
+			"gpu0": filepath.Join(devDir, "vfio", "devices", "vfio0"),
+		})
+		writeCDISpec(t, specDir, "dra", "vendor.com/dra", map[string]string{
+			"gpu1": filepath.Join(devDir, "vfio", "devices", "vfio1"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=gpu0"},
+			[]string{"vendor.com/dra=gpu1"},
+		)
+		assert.NoError(err)
+	})
+
+	t.Run("direct overlap: same BDF via vfio device cdev on both sides", func(t *testing.T) {
+		assert := assert.New(t)
+		buildVFIODeviceCdevFixture(t, sysDir, "vfio2", "0000:70:00.0")
+
+		writeCDISpec(t, specDir, "dp2", "vendor.com/gpu", map[string]string{
+			"gpu2": filepath.Join(devDir, "vfio", "devices", "vfio2"),
+		})
+		writeCDISpec(t, specDir, "dra2", "vendor.com/dra", map[string]string{
+			"gpu2": filepath.Join(devDir, "vfio", "devices", "vfio2"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=gpu2"},
+			[]string{"vendor.com/dra=gpu2"},
+		)
+		assert.Error(err)
+		assert.Contains(err.Error(), "0000:70:00.0")
+	})
+
+	// Key regression: the same BDF via a legacy iommu-group cdev on one side
+	// and a per-device vfio cdev on the other; a path-string comparison misses it.
+	t.Run("aliased overlap: legacy group cdev vs vfio device cdev for the same BDF", func(t *testing.T) {
+		assert := assert.New(t)
+
+		const bdf = "0000:99:00.0"
+		buildVFIODeviceCdevFixture(t, sysDir, "vfio9", bdf)
+		buildIOMMUGroupFixture(t, sysDir, "9", bdf)
+
+		writeCDISpec(t, specDir, "dp3", "vendor.com/gpu", map[string]string{
+			"gpu9": filepath.Join(devDir, "vfio", "9"),
+		})
+		writeCDISpec(t, specDir, "dra3", "vendor.com/dra", map[string]string{
+			"gpu9": filepath.Join(devDir, "vfio", "devices", "vfio9"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=gpu9"},
+			[]string{"vendor.com/dra=gpu9"},
+		)
+		assert.Error(err)
+		assert.Contains(err.Error(), bdf)
+	})
+
+	t.Run("distinct mdev slices of the same parent GPU never collide", func(t *testing.T) {
+		assert := assert.New(t)
+		const parentBDF = "0000:88:00.0"
+		const uuid1 = "11111111-1111-1111-1111-111111111111"
+		const uuid2 = "22222222-2222-2222-2222-222222222222"
+		buildVFIOMdevCdevFixture(t, sysDir, "vfio-mdev1", parentBDF, uuid1)
+		buildVFIOMdevCdevFixture(t, sysDir, "vfio-mdev2", parentBDF, uuid2)
+
+		writeCDISpec(t, specDir, "dp-mdev", "vendor.com/gpu", map[string]string{
+			"slice1": filepath.Join(devDir, "vfio", "devices", "vfio-mdev1"),
+		})
+		writeCDISpec(t, specDir, "dra-mdev", "vendor.com/dra", map[string]string{
+			"slice2": filepath.Join(devDir, "vfio", "devices", "vfio-mdev2"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=slice1"},
+			[]string{"vendor.com/dra=slice2"},
+		)
+		assert.NoError(err)
+	})
+
+	t.Run("same mdev instance UUID on both sides collides", func(t *testing.T) {
+		assert := assert.New(t)
+		const parentBDF = "0000:89:00.0"
+		const uuid = "33333333-3333-3333-3333-333333333333"
+		buildVFIOMdevCdevFixture(t, sysDir, "vfio-mdev3", parentBDF, uuid)
+
+		writeCDISpec(t, specDir, "dp-mdev-same", "vendor.com/gpu", map[string]string{
+			"slice3": filepath.Join(devDir, "vfio", "devices", "vfio-mdev3"),
+		})
+		writeCDISpec(t, specDir, "dra-mdev-same", "vendor.com/dra", map[string]string{
+			"slice3": filepath.Join(devDir, "vfio", "devices", "vfio-mdev3"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=slice3"},
+			[]string{"vendor.com/dra=slice3"},
+		)
+		assert.Error(err)
+		assert.Contains(err.Error(), uuid)
+	})
+
+	t.Run("device node normalization failure fails closed instead of being skipped", func(t *testing.T) {
+		assert := assert.New(t)
+		// CDI-resolvable devices whose vfio-dev sysfs symlink is missing:
+		// the normalization failure must propagate, not be skipped.
+		writeCDISpec(t, specDir, "dp-broken", "vendor.com/gpu", map[string]string{
+			"gpu-broken": filepath.Join(devDir, "vfio", "devices", "vfio-broken-missing"),
+		})
+		writeCDISpec(t, specDir, "dra-broken", "vendor.com/dra", map[string]string{
+			"gpu-broken-2": filepath.Join(devDir, "vfio", "devices", "vfio-broken-missing-2"),
+		})
+		cdi.GetRegistry().Refresh()
+
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=gpu-broken"},
+			[]string{"vendor.com/dra=gpu-broken-2"},
+		)
+		assert.Error(err)
+	})
+
+	t.Run("empty inputs never error", func(t *testing.T) {
+		assert := assert.New(t)
+		assert.NoError(checkCrossSourcePhysicalOverlap(nil, nil))
+		assert.NoError(checkCrossSourcePhysicalOverlap([]string{"vendor.com/gpu=gpu0"}, nil))
+		assert.NoError(checkCrossSourcePhysicalOverlap(nil, []string{"vendor.com/dra=gpu0"}))
+	})
+
+	t.Run("unresolvable CDI device names are skipped silently", func(t *testing.T) {
+		assert := assert.New(t)
+		err := checkCrossSourcePhysicalOverlap(
+			[]string{"vendor.com/gpu=does-not-exist"},
+			[]string{"vendor.com/dra=also-does-not-exist"},
+		)
+		assert.NoError(err)
+	})
+}
+
+func TestGetDeviceSpecCrossSourceOverlapGuard(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	sysDir := t.TempDir()
+	devDir := t.TempDir()
+	specDir := t.TempDir()
+	withSysDevRoots(t, sysDir, devDir)
+	setCDISpecDir(t, specDir)
+
+	const bdf = "0000:AA:00.0"
+	buildVFIODeviceCdevFixture(t, sysDir, "vfioAA", bdf)
+
+	writeCDISpec(t, specDir, "dp", "vendor.com/gpu", map[string]string{
+		"gpuAA": filepath.Join(devDir, "vfio", "devices", "vfioAA"),
+	})
+	writeCDISpec(t, specDir, "dra", "vendor.com/dra", map[string]string{
+		"gpuAA": filepath.Join(devDir, "vfio", "devices", "vfioAA"),
+	})
+	cdi.GetRegistry().Refresh()
+
+	podRes := &podresourcesv1.PodResources{
+		Name:      "pod-a",
+		Namespace: "ns-a",
+		Containers: []*podresourcesv1.ContainerResources{
+			{
+				Name: "ctr-a",
+				Devices: []*podresourcesv1.ContainerDevices{
+					{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpuAA"}},
+				},
+				DynamicResources: []*podresourcesv1.DynamicResource{
+					{
+						ClaimName: "claim-a",
+						ClaimResources: []*podresourcesv1.ClaimResource{
+							{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/dra=gpuAA"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sock := startFakePodResourcesServer(t, podRes)
+	devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{
+		oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA,
+	})
+	assert.Error(err)
+	assert.Nil(devices)
+	assert.Contains(err.Error(), bdf)
+}

--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2025 NVIDIA CORPORATION.
+// Copyright (c) 2026 NAVER Cloud Corp.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -6,13 +7,428 @@
 package containerdshim
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	podresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
+
+type fakePodResourcesServer struct {
+	podresourcesv1.UnimplementedPodResourcesListerServer
+	resp *podresourcesv1.GetPodResourcesResponse
+}
+
+func (f *fakePodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetPodResourcesRequest) (*podresourcesv1.GetPodResourcesResponse, error) {
+	return f.resp, nil
+}
+
+func startFakePodResourcesServer(t *testing.T, podRes *podresourcesv1.PodResources) string {
+	t.Helper()
+
+	sockPath := filepath.Join(t.TempDir(), "kubelet.sock")
+	lis, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	podresourcesv1.RegisterPodResourcesListerServer(server, &fakePodResourcesServer{
+		resp: &podresourcesv1.GetPodResourcesResponse{PodResources: podRes},
+	})
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	t.Cleanup(server.Stop)
+
+	return sockPath
+}
+
+func TestFormatCDIDevIDs(t *testing.T) {
+	assert := assert.New(t)
+
+	result := formatCDIDevIDs("vendor.com/gpu", []string{"gpu0", "gpu1"})
+	assert.Equal([]string{"vendor.com/gpu=gpu0", "vendor.com/gpu=gpu1"}, result)
+
+	result = formatCDIDevIDs("vendor.com/gpu", []string{})
+	assert.Nil(result)
+}
+
+func TestCollectPodResourceCDIDevices(t *testing.T) {
+	assert := assert.New(t)
+
+	deviceOnly := &podresourcesv1.ContainerResources{
+		Name: "ctr-device-only",
+		Devices: []*podresourcesv1.ContainerDevices{
+			{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpu0"}},
+		},
+	}
+	assert.Empty(collectPodResourceCDIDevices(deviceOnly))
+
+	draOnly := &podresourcesv1.ContainerResources{
+		Name: "ctr-dra-only",
+		DynamicResources: []*podresourcesv1.DynamicResource{
+			{
+				ClaimName:      "gpu-claim",
+				ClaimNamespace: "default",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{
+						CDIDevices: []*podresourcesv1.CDIDevice{
+							{Name: "vendor.com/gpu=gpu0"},
+							{Name: "vendor.com/gpu=gpu1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal([]string{"vendor.com/gpu=gpu0", "vendor.com/gpu=gpu1"}, collectPodResourceCDIDevices(draOnly))
+
+	mixed := &podresourcesv1.ContainerResources{
+		Name: "ctr-mixed",
+		DynamicResources: []*podresourcesv1.DynamicResource{
+			{
+				ClaimName:      "claim-a",
+				ClaimNamespace: "ns-a",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=gpu0"}}},
+				},
+			},
+			{
+				ClaimName:      "claim-b",
+				ClaimNamespace: "ns-b",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/nic=nic0"}}},
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/nic=nic1"}}},
+				},
+			},
+		},
+	}
+	assert.Equal(
+		[]string{"vendor.com/gpu=gpu0", "vendor.com/nic=nic0", "vendor.com/nic=nic1"},
+		collectPodResourceCDIDevices(mixed),
+	)
+
+	// duplicates are preserved here: dedup is getDeviceSpec's job, not this helper's
+	dup := &podresourcesv1.ContainerResources{
+		Name: "ctr-dup",
+		DynamicResources: []*podresourcesv1.DynamicResource{
+			{
+				ClaimName: "claim-dup",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=gpu0"}}},
+				},
+			},
+			{
+				ClaimName: "claim-dup-2",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=gpu0"}}},
+				},
+			},
+		},
+	}
+	assert.Equal([]string{"vendor.com/gpu=gpu0", "vendor.com/gpu=gpu0"}, collectPodResourceCDIDevices(dup))
+
+	// a CDIDevice with an empty Name must be skipped
+	withEmpty := &podresourcesv1.ContainerResources{
+		Name: "ctr-empty-name",
+		DynamicResources: []*podresourcesv1.DynamicResource{
+			{
+				ClaimName: "claim-empty",
+				ClaimResources: []*podresourcesv1.ClaimResource{
+					{CDIDevices: []*podresourcesv1.CDIDevice{{Name: ""}, {Name: "vendor.com/gpu=gpu0"}}},
+				},
+			},
+		},
+	}
+	assert.Equal([]string{"vendor.com/gpu=gpu0"}, collectPodResourceCDIDevices(withEmpty))
+
+	// container resources without any DynamicResources yield nothing
+	assert.Empty(collectPodResourceCDIDevices(&podresourcesv1.ContainerResources{Name: "ctr-nil"}))
+}
+
+func TestDedupStrings(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(
+		[]string{"a", "b", "c"},
+		dedupStrings([]string{"a", "b", "a", "c", "b"}),
+	)
+	assert.Nil(dedupStrings(nil))
+	assert.Equal([]string{"a"}, dedupStrings([]string{"a"}))
+}
+
+func TestContains(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(contains([]string{"a", "b"}, "a"))
+	assert.False(contains([]string{"a", "b"}, "c"))
+	assert.False(contains(nil, "a"))
+}
+
+func TestGetDeviceSpecSourceFiltering(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	specDir := t.TempDir()
+	setCDISpecDir(t, specDir)
+	writeCDISpec(t, specDir, "spec", "vendor.com/gpu", map[string]string{
+		"gpu0":     "/dev/vendor-gpu0",
+		"dra-gpu0": "/dev/vendor-dra-gpu0",
+	})
+	cdi.GetRegistry().Refresh()
+
+	podRes := &podresourcesv1.PodResources{
+		Name:      "pod-a",
+		Namespace: "ns-a",
+		Containers: []*podresourcesv1.ContainerResources{
+			{
+				Name: "ctr-a",
+				Devices: []*podresourcesv1.ContainerDevices{
+					{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpu0"}},
+				},
+				DynamicResources: []*podresourcesv1.DynamicResource{
+					{
+						ClaimName: "claim-a",
+						ClaimResources: []*podresourcesv1.ClaimResource{
+							{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=dra-gpu0"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("device-plugin only source returns only device-plugin devices", func(t *testing.T) {
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDevicePlugin})
+		// device-plugin source selected but DRA data present -> fail closed.
+		assert.Error(err)
+		assert.Nil(devices)
+	})
+
+	t.Run("dra only source returns only dra devices and fails closed on device-plugin data", func(t *testing.T) {
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+		// dra source selected but device-plugin data present -> fail closed.
+		assert.Error(err)
+		assert.Nil(devices)
+	})
+
+	t.Run("both sources returns the union", func(t *testing.T) {
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{
+			oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA,
+		})
+		assert.NoError(err)
+		assert.ElementsMatch([]string{"vendor.com/gpu=gpu0", "vendor.com/gpu=dra-gpu0"}, devices)
+	})
+}
+
+func TestGetDeviceSpecUnlistedSourceNoDeviceNodesExempt(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	specDir := t.TempDir()
+	setCDISpecDir(t, specDir)
+	// gpu0 resolves in the registry but declares no device nodes (env-only CDI):
+	// nothing gets cold-plugged for it, so an unlisted source must not fail closed.
+	writeCDISpecEnvOnly(t, specDir, "spec", "vendor.com/gpu", "gpu0")
+	cdi.GetRegistry().Refresh()
+
+	podRes := &podresourcesv1.PodResources{
+		Name:      "pod-a",
+		Namespace: "ns-a",
+		Containers: []*podresourcesv1.ContainerResources{
+			{
+				Name: "ctr-a",
+				Devices: []*podresourcesv1.ContainerDevices{
+					{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpu0"}},
+				},
+			},
+		},
+	}
+	sock := startFakePodResourcesServer(t, podRes)
+	devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+	assert.NoError(err)
+	assert.Empty(devices)
+}
+
+func TestGetDeviceSpecFailClosed(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	specDir := t.TempDir()
+	setCDISpecDir(t, specDir)
+	writeCDISpec(t, specDir, "spec", "vendor.com/gpu", map[string]string{
+		"gpu0":     "/dev/vendor-gpu0",
+		"dra-gpu0": "/dev/vendor-dra-gpu0",
+	})
+	cdi.GetRegistry().Refresh()
+
+	t.Run("device-plugin data present but sources=[dra] errors", func(t *testing.T) {
+		podRes := &podresourcesv1.PodResources{
+			Name:      "pod-a",
+			Namespace: "ns-a",
+			Containers: []*podresourcesv1.ContainerResources{
+				{
+					Name: "ctr-a",
+					Devices: []*podresourcesv1.ContainerDevices{
+						{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpu0"}},
+					},
+				},
+			},
+		}
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+		assert.Error(err)
+		assert.Nil(devices)
+		assert.Contains(err.Error(), "pod_resource_device_sources")
+		assert.Contains(err.Error(), oci.PodResourceDeviceSourceDevicePlugin)
+	})
+
+	t.Run("dra data present but default sources=[device-plugin] errors", func(t *testing.T) {
+		podRes := &podresourcesv1.PodResources{
+			Name:      "pod-a",
+			Namespace: "ns-a",
+			Containers: []*podresourcesv1.ContainerResources{
+				{
+					Name: "ctr-a",
+					DynamicResources: []*podresourcesv1.DynamicResource{
+						{
+							ClaimName: "claim-a",
+							ClaimResources: []*podresourcesv1.ClaimResource{
+								{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=dra-gpu0"}}},
+							},
+						},
+					},
+				},
+			},
+		}
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDevicePlugin})
+		assert.Error(err)
+		assert.Nil(devices)
+		assert.Contains(err.Error(), "pod_resource_device_sources")
+		assert.Contains(err.Error(), oci.PodResourceDeviceSourceDRA)
+	})
+
+	t.Run("unlisted device-plugin data that is not CDI-resolvable does not error", func(t *testing.T) {
+		// vendor.com/nic is never registered in the CDI registry, so it is
+		// not cold-pluggable and exempt from the fail-closed guard.
+		podRes := &podresourcesv1.PodResources{
+			Name:      "pod-a",
+			Namespace: "ns-a",
+			Containers: []*podresourcesv1.ContainerResources{
+				{
+					Name: "ctr-a",
+					Devices: []*podresourcesv1.ContainerDevices{
+						{ResourceName: "vendor.com/nic", DeviceIds: []string{"nic0"}},
+					},
+				},
+			},
+		}
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+		assert.NoError(err)
+		assert.Empty(devices)
+	})
+
+	t.Run("unlisted device-plugin data with one CDI-resolvable entry among non-resolvable ones still errors", func(t *testing.T) {
+		podRes := &podresourcesv1.PodResources{
+			Name:      "pod-a",
+			Namespace: "ns-a",
+			Containers: []*podresourcesv1.ContainerResources{
+				{
+					Name: "ctr-a",
+					Devices: []*podresourcesv1.ContainerDevices{
+						{ResourceName: "vendor.com/nic", DeviceIds: []string{"nic0"}},
+						{ResourceName: "vendor.com/gpu", DeviceIds: []string{"gpu0"}},
+					},
+				},
+			},
+		}
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+		assert.Error(err)
+		assert.Nil(devices)
+		assert.Contains(err.Error(), "vendor.com/gpu=gpu0")
+		assert.NotContains(err.Error(), "vendor.com/nic=nic0")
+	})
+}
+
+// TestGetDeviceSpecSharedClaimDedup: a claim shared across containers reports
+// the same CDI device once per container; the result must be deduplicated.
+func TestGetDeviceSpecSharedClaimDedup(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	podRes := &podresourcesv1.PodResources{
+		Name:      "pod-a",
+		Namespace: "ns-a",
+		Containers: []*podresourcesv1.ContainerResources{
+			{
+				Name: "ctr-a",
+				DynamicResources: []*podresourcesv1.DynamicResource{
+					{
+						ClaimName: "shared-claim",
+						ClaimResources: []*podresourcesv1.ClaimResource{
+							{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=gpu0"}}},
+						},
+					},
+				},
+			},
+			{
+				Name: "ctr-b",
+				DynamicResources: []*podresourcesv1.DynamicResource{
+					{
+						// Same claim shared with ctr-a, surfaces the same CDI device again.
+						ClaimName: "shared-claim",
+						ClaimResources: []*podresourcesv1.ClaimResource{
+							{CDIDevices: []*podresourcesv1.CDIDevice{{Name: "vendor.com/gpu=gpu0"}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sock := startFakePodResourcesServer(t, podRes)
+	devices, err := getDeviceSpec(ctx, sock, map[string]string{}, []string{oci.PodResourceDeviceSourceDRA})
+	assert.NoError(err)
+	assert.Equal([]string{"vendor.com/gpu=gpu0"}, devices)
+}
+
+func TestGetDeviceSpecNoDevices(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	podRes := &podresourcesv1.PodResources{
+		Name:      "pod-a",
+		Namespace: "ns-a",
+		Containers: []*podresourcesv1.ContainerResources{
+			{Name: "ctr-a"},
+		},
+	}
+
+	for _, sources := range [][]string{
+		{oci.PodResourceDeviceSourceDevicePlugin},
+		{oci.PodResourceDeviceSourceDRA},
+		{oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA},
+	} {
+		sock := startFakePodResourcesServer(t, podRes)
+		devices, err := getDeviceSpec(ctx, sock, map[string]string{}, sources)
+		assert.NoError(err, "sources=%v", sources)
+		assert.Empty(devices, "sources=%v", sources)
+	}
+}
 
 func TestKubeletPodResourceSocketAvailable(t *testing.T) {
 	assert.False(t, kubeletPodResourceSocketAvailable(""))

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -210,6 +210,38 @@ type runtime struct {
 	ForceGuestPull            bool     `toml:"experimental_force_guest_pull"`
 	PodResourceAPISock        string   `toml:"pod_resource_api_sock"`
 	KubeletRootDir            string   `toml:"kubelet_root_dir"`
+	PodResourceDeviceSources  []string `toml:"pod_resource_device_sources"`
+}
+
+// podResourceDeviceSources validates pod_resource_device_sources, defaulting
+// to ["device-plugin"] (the historical behavior) when the key is unset.
+func (r runtime) podResourceDeviceSources() ([]string, error) {
+	sources := r.PodResourceDeviceSources
+	if sources == nil {
+		return []string{oci.PodResourceDeviceSourceDevicePlugin}, nil
+	}
+
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("pod_resource_device_sources: must not be empty, allowed values: %q, %q",
+			oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA)
+	}
+
+	seen := make(map[string]struct{}, len(sources))
+	for _, s := range sources {
+		switch s {
+		case oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA:
+		default:
+			return nil, fmt.Errorf("pod_resource_device_sources: invalid source %q, allowed values: %q, %q",
+				s, oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA)
+		}
+
+		if _, ok := seen[s]; ok {
+			return nil, fmt.Errorf("pod_resource_device_sources: duplicate source %q", s)
+		}
+		seen[s] = struct{}{}
+	}
+
+	return sources, nil
 }
 
 // emptyDirMode returns a valid emptydir_mode value, defaulting to shared-fs
@@ -1550,6 +1582,12 @@ func updateRuntimeConfigRuntime(configPath string, tomlConf tomlConfig, config *
 		return fmt.Errorf("%v: %v", configPath, err)
 	}
 	config.EmptyDirMode = emptyDirMode
+
+	podResourceDeviceSources, err := tomlConf.Runtime.podResourceDeviceSources()
+	if err != nil {
+		return fmt.Errorf("%v: %v", configPath, err)
+	}
+	config.PodResourceDeviceSources = podResourceDeviceSources
 
 	return nil
 }

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -219,6 +219,8 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (testConfig testRuntime
 
 		FactoryConfig: factoryConfig,
 		EmptyDirMode:  vc.EmptyDirModeSharedFs,
+
+		PodResourceDeviceSources: []string{oci.PodResourceDeviceSourceDevicePlugin},
 	}
 
 	err = SetKernelParams(&runtimeConfig)
@@ -601,6 +603,8 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 
 		FactoryConfig: expectedFactoryConfig,
 		EmptyDirMode:  vc.EmptyDirModeSharedFs,
+
+		PodResourceDeviceSources: []string{oci.PodResourceDeviceSourceDevicePlugin},
 	}
 	err = SetKernelParams(&expectedConfig)
 	if err != nil {
@@ -1686,6 +1690,65 @@ func TestCheckEmptyDirMode(t *testing.T) {
 	r = runtime{EmptyDirMode: "block_plain"}
 	_, err = r.emptyDirMode()
 	assert.Error(err)
+}
+
+func TestPodResourceDeviceSources(t *testing.T) {
+	assert := assert.New(t)
+
+	// nolint: govet
+	testCases := []struct {
+		name        string
+		sources     []string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:     "key absent defaults to device-plugin",
+			sources:  nil,
+			expected: []string{oci.PodResourceDeviceSourceDevicePlugin},
+		},
+		{
+			name:     "explicit device-plugin",
+			sources:  []string{oci.PodResourceDeviceSourceDevicePlugin},
+			expected: []string{oci.PodResourceDeviceSourceDevicePlugin},
+		},
+		{
+			name:     "explicit dra",
+			sources:  []string{oci.PodResourceDeviceSourceDRA},
+			expected: []string{oci.PodResourceDeviceSourceDRA},
+		},
+		{
+			name:     "both listed",
+			sources:  []string{oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA},
+			expected: []string{oci.PodResourceDeviceSourceDevicePlugin, oci.PodResourceDeviceSourceDRA},
+		},
+		{
+			name:        "empty slice is an error",
+			sources:     []string{},
+			expectError: true,
+		},
+		{
+			name:        "unknown token is an error",
+			sources:     []string{"bogus"},
+			expectError: true,
+		},
+		{
+			name:        "duplicate token is an error",
+			sources:     []string{oci.PodResourceDeviceSourceDRA, oci.PodResourceDeviceSourceDRA},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		r := runtime{PodResourceDeviceSources: tc.sources}
+		got, err := r.podResourceDeviceSources()
+		if tc.expectError {
+			assert.Error(err, tc.name)
+			continue
+		}
+		assert.NoError(err, tc.name)
+		assert.Equal(tc.expected, got, tc.name)
+	}
 }
 
 func TestCheckFactoryConfig(t *testing.T) {

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -201,7 +201,21 @@ type RuntimeConfig struct {
 	// KubeletRootDir is the kubelet root directory used to match ConfigMap/Secret
 	// volume paths (e.g. /var/lib/k0s/kubelet for k0s). If empty, default is used.
 	KubeletRootDir string
+
+	// PodResourceDeviceSources selects which PodResources API sources feed
+	// the cold-plug device list. Defaults to ["device-plugin"].
+	PodResourceDeviceSources []string
 }
+
+const (
+	// PodResourceDeviceSourceDevicePlugin selects devices allocated via the
+	// legacy device-plugin API (container.Devices).
+	PodResourceDeviceSourceDevicePlugin = "device-plugin"
+
+	// PodResourceDeviceSourceDRA selects devices allocated via Dynamic
+	// Resource Allocation (container.DynamicResources, KEP-3695).
+	PodResourceDeviceSourceDRA = "dra"
+)
 
 // AddKernelParam allows the addition of new kernel parameters to an existing
 // hypervisor configuration stored inside the current runtime configuration.


### PR DESCRIPTION
### Summary

`getDeviceSpec()` (sandbox-time cold-plug via the kubelet PodResources API) only reads `container.Devices` — the legacy device-plugin resources. Devices allocated through **Dynamic Resource Allocation (DRA, KEP-3695)** are surfaced separately under `container.DynamicResources[].ClaimResources[].CDIDevices[]` and were being ignored, so a DRA-allocated VFIO/GPU device is never cold-plugged into the sandbox.

This PR collects the fully-qualified CDI device IDs from `DynamicResources` as well, merges them with the device-plugin list, and deduplicates. The legacy path is unchanged.

Fixes #13322 

### Why

With `cold_plug_vfio` + `pod_resource_api_sock`, a DRA-allocated GPU currently fails one of two ways:

- **cold-plug**: sandbox boots without the device; container creation then hits
  `device /dev/vfio/devices/vfioN is a known CDI device type but failed to match any sibling by path or BDF`
- **hot-plug**: the device arrives after the guest kernel/NVRC boot-time PCI scan, so the in-guest CDI spec never materializes and the agent aborts with
  `failed to inject devices after CDI timeout of 100 seconds`

Reading `DynamicResources` at sandbox creation lets the existing cold-plug machinery handle DRA devices exactly like device-plugin ones.

### What changed

`pkg/containerd-shim-v2/device_cold_plug.go`:

- New `collectPodResourceCDIDevices(container)` — walks `DynamicResources[].ClaimResources[].CDIDevices[].Name` (skips empty names, debug-logs claim name/namespace).
- New `dedupStrings()` — order-preserving dedup.
- `getDeviceSpec()` now appends DRA CDI devices to the existing device-plugin list and dedups before returning.

Field path confirmed against `k8s.io/kubelet@v0.33.0` PodResources v1:
`ContainerResources.DynamicResources → ClaimResources → CDIDevices → Name`.

### Diff

```
 src/runtime/pkg/containerd-shim-v2/device_cold_plug.go      | +46 -1
 src/runtime/pkg/containerd-shim-v2/device_cold_plug_test.go | +131 (new)
```

Core:
```go
for _, container := range podRes.Containers {
    for _, d := range container.Devices {
        devices = append(devices, formatCDIDevIDs(d.ResourceName, d.DeviceIds)...)
    }
    devices = append(devices, collectPodResourceCDIDevices(container)...)  // NEW: DRA
}
return dedupStrings(devices), nil                                          // NEW: dedup
```

### Tests

`device_cold_plug_test.go` (new):
- `TestFormatCDIDevIDs` — existing behavior.
- `TestCollectPodResourceCDIDevices` — device-plugin-only / DRA-only / mixed / duplicate / empty-name / nil cases.
- `TestDedupStrings` — order-preserving dedup.

Run:
```
cd src/runtime && go test ./pkg/containerd-shim-v2/ -run 'TestFormatCDIDevIDs|TestCollectPodResourceCDIDevices|TestDedupStrings'
```
(native `go test` for the full package needs Linux; cross-compiled linux/amd64 test binary passes the above.)

### Manual verification

Kata 3.32.0, containerd `enable_cdi=true`, K8s 1.35 DRA + `DRAPartitionableDevices`, a DRA driver publishing GPU devices via ResourceSlice:

- **Before**: guest `nvidia-smi -L` → 0 GPUs; container create fails ("failed to match any sibling").
- **After**: the DRA-allocated GPU is cold-plugged at sandbox boot; the guest sees it and the workload runs.
- Allocate/release lifecycle verified: device cold-plugged on `NodePrepareResources`, released on `NodeUnprepareResources`.

### Backward compatibility

- Device-plugin path is read first and unchanged; only an additional source is merged.
- No new config knobs, no API changes. `DynamicResources` is simply empty on clusters without DRA.