### PR TITLE
Dragonball: fix intermittent ENODATA/ENOENT from getdents64 during container startup

### DIFF
--- a/src/dragonball/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/dbs_virtio_devices/src/fs/device.rs
@@ -190,6 +190,19 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         let vfs_opts = VfsOptions {
             no_writeback: !writeback_cache,
             no_open,
+            // Must be false: when no_opendir is enabled, the VFS advertises
+            // ZERO_MESSAGE_OPENDIR to the kernel, which then skips
+            // FUSE_OPENDIR/FUSE_RELEASEDIR. The passthroughfs backend is
+            // forced (via do_import=false in init()) to open the directory
+            // by inode on every FUSE_READDIR, creating a new file descriptor
+            // each time. Directory offsets (cookies) returned by the first
+            // batch are invalid for the new fd, causing getdents64 to return
+            // ENODATA on the second batch. Additionally, inodes may be
+            // forgotten via FUSE_FORGET between readdir calls, causing
+            // open_inode() to fail with ENOENT. Both errors are intermittent
+            // and occur primarily during container startup when many
+            // directories are read concurrently.
+            no_opendir: false,
             killpriv_v2,
             no_readdir,
             ..VfsOptions::default()


### PR DESCRIPTION
# Dragonball: fix intermittent ENODATA/ENOENT from getdents64 during container startup

Fixes #13329

## Problem

When using Dragonball with `shared_fs = "inline-virtio-fs"`, `getdents64` intermittently returns `ENODATA` (errno 61) or `ENOENT` (errno 2) during container startup. The error occurs on any directory inside the container rootfs, is not reproducible after the pod is fully started, and does not affect `runc` or `runsc`.

## Root Cause

`VfsOptions::default()` sets `no_opendir: true`, which makes the VFS advertise `ZERO_MESSAGE_OPENDIR` to the kernel. Combined with `do_import: false` (required for Dragonball's VFS architecture), `PassthroughFs::init()` is forced to enable `no_opendir` unconditionally:

```rust
// fuse-backend-rs sync_io.rs init():
if (!self.cfg.do_import || self.cfg.no_opendir)
    && capable.contains(FsOptions::ZERO_MESSAGE_OPENDIR)
{
    opts |= FsOptions::ZERO_MESSAGE_OPENDIR;
    self.no_opendir.store(true, Ordering::Relaxed);
}
```

When `no_opendir` is active, the kernel skips `FUSE_OPENDIR`/`FUSE_RELEASEDIR`. The FUSE server must open the directory by inode (`open_inode()`) on every `FUSE_READDIR` request, creating a **new file descriptor** each time. This breaks multi-batch readdir:

1. **ENODATA**: Directory offsets (cookies) from the first batch are invalid for the new fd. `lseek64` may succeed but `getdents64` returns `ENODATA` because the offset is stale.
2. **ENOENT**: Inodes are aggressively forgotten via `FUSE_FORGET` during startup. `open_inode()` fails to find the inode in `inode_map`.

strace evidence:
```
getdents64(13, ..., 32768) = 3000                          # first batch: OK (62 entries)
getdents64(13, ..., 32768) = -1 ENODATA (No data available) # second batch: FAIL
```

## Fix

Explicitly set `no_opendir: false` in Dragonball's `VfsOptions` construction so the kernel sends `FUSE_OPENDIR`/`FUSE_RELEASEDIR` normally. This creates persistent directory handles that are reused across `FUSE_READDIR` requests, keeping offsets valid and preventing inode forgetting.

`no_opendir` is hardcoded to `false` (not made configurable) because:

1. **It is a pessimization for this use case**: each `FUSE_READDIR` with `no_opendir` does `openat()` + `lseek64()` + `getdents64()` + close, while without it the directory is opened once and the fd is reused.
2. **User configuration cannot override it**: `PassthroughFs::init()` unconditionally forces `no_opendir` when `do_import: false`, regardless of `cfg.no_opendir`.
3. **`do_readdir()` does not handle offset invalidation**: fuse-backend-rs `do_readdir()` does not fall back to rewind-and-scan when `getdents64` fails due to a stale offset on a newly opened fd.

## Testing

- Built with `cargo build --release --target x86_64-unknown-linux-musl -p runtime-rs --features dragonball`
- Deployed to a k3s cluster with Dragonball runtime
- Pod restarts repeatedly (previously failed ~10-30% of the time with `OSError: [Errno 61] No data available`)
- After fix: 0 failures across 50+ restarts
- `strace -f -e trace=getdents64` confirms no `ENODATA` or `ENOENT` errors
