### PR TITLE
runtime-rs: support containerd binary:// stdio logger URIs

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 slog = { workspace = true }
 slog-scope = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["process", "time"] }
 tokio-util = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
@@ -557,3 +557,166 @@ impl AsyncWrite for ShimIoWrite {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    //! Unit tests focused on the `unsafe` FFI paths added for the
+    //! `binary://` logger backend: the readiness handshake in
+    //! [`wait_logger_ready`] and the fd-ownership guarantees of
+    //! [`PipeFd`]. End-to-end tests that actually spawn a logger process
+    //! live in the integration test suite instead.
+    use super::*;
+    use std::io::Write;
+    use std::time::Instant;
+
+    /// Create a `pipe2(O_CLOEXEC)` pair for use in tests.
+    ///
+    /// This keeps the `libc::pipe2` `unsafe` block contained to a single
+    /// helper so each test case reads clean.
+    fn make_pipe() -> (RawFd, RawFd) {
+        let mut fds = [0 as libc::c_int; 2];
+        // SAFETY: `fds` is a valid stack array of length 2; `pipe2` only
+        // writes into those two slots.
+        let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+        assert_eq!(ret, 0, "pipe2 failed: {}", std::io::Error::last_os_error());
+        (fds[0], fds[1])
+    }
+
+    /// Close an fd, ignoring any error. Used at test tear-down.
+    fn close_fd(fd: RawFd) {
+        // SAFETY: called at most once per fd from a single test thread.
+        unsafe {
+            libc::close(fd);
+        }
+    }
+
+    #[test]
+    fn wait_logger_ready_returns_when_byte_written() {
+        let (r, w) = make_pipe();
+
+        // Take ownership of the write end via std::fs::File; writing +
+        // dropping closes it.
+        // SAFETY: `w` is owned by us and handed off to `File` exactly once.
+        let mut wf = unsafe { std::fs::File::from_raw_fd(w) };
+        wf.write_all(b"x").expect("write readiness byte");
+        drop(wf);
+
+        let start = Instant::now();
+        wait_logger_ready(r, Duration::from_secs(5));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "should return promptly, took {:?}",
+            start.elapsed()
+        );
+
+        close_fd(r);
+    }
+
+    #[test]
+    fn wait_logger_ready_returns_on_eof() {
+        let (r, w) = make_pipe();
+
+        // Close the write end to signal EOF; poll must treat this as readable.
+        close_fd(w);
+
+        let start = Instant::now();
+        wait_logger_ready(r, Duration::from_secs(5));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "should return on EOF, took {:?}",
+            start.elapsed()
+        );
+
+        close_fd(r);
+    }
+
+    #[test]
+    fn wait_logger_ready_times_out() {
+        let (r, w) = make_pipe();
+
+        // Neither write nor close: force the timeout branch. Use a small
+        // timeout so the test stays fast, but assert a reasonable upper
+        // bound so a regression that ignores the timeout is caught.
+        let start = Instant::now();
+        wait_logger_ready(r, Duration::from_millis(200));
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "returned too early: {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "must not hang, took {:?}",
+            elapsed
+        );
+
+        close_fd(w);
+        close_fd(r);
+    }
+
+    #[test]
+    fn wait_logger_ready_handles_bad_fd() {
+        // -1 is guaranteed invalid: poll returns -1 with errno=EBADF. The
+        // function must log and return, not panic or hang.
+        let start = Instant::now();
+        wait_logger_ready(-1, Duration::from_millis(500));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "bad-fd path must return promptly, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Returns true if `libc::fcntl(fd, F_GETFD) < 0 && errno == EBADF`,
+    /// i.e. the fd is no longer valid in the current process.
+    fn fd_is_closed(fd: RawFd) -> bool {
+        // SAFETY: F_GETFD is a pure read of the fd's flags; safe with any
+        // integer, including a stale value.
+        let ret = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        ret < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EBADF)
+    }
+
+    #[test]
+    fn pipefd_closes_on_drop() {
+        let (r, w) = make_pipe();
+
+        {
+            // Move ownership into the guard; scope end triggers Drop.
+            let _guard = PipeFd(w);
+        }
+
+        assert!(fd_is_closed(w), "PipeFd::drop should have closed fd {}", w);
+
+        close_fd(r);
+    }
+
+    #[test]
+    fn pipefd_into_raw_disarms_close() {
+        let (r, w) = make_pipe();
+
+        let guard = PipeFd(w);
+        let raw = guard.into_raw();
+        // Drop of `guard` at end of statement above must NOT close the fd.
+
+        assert_eq!(raw, w, "into_raw should return the same fd");
+        assert!(
+            !fd_is_closed(raw),
+            "into_raw must disarm the destructor; fd {} was closed",
+            raw
+        );
+
+        // We are now the owner and must close it ourselves.
+        close_fd(raw);
+        close_fd(r);
+    }
+
+    #[test]
+    fn pipefd_negative_sentinel_is_not_closed() {
+        // A guard whose slot has been zeroed out (via `into_raw` semantics)
+        // must be a no-op on drop; constructing one with -1 is the direct
+        // way to exercise that branch.
+        let guard = PipeFd(-1);
+        drop(guard); // must not attempt libc::close(-1)
+    }
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
@@ -8,28 +8,82 @@ use std::{
     io,
     os::unix::{
         fs::{FileTypeExt, OpenOptionsExt},
-        io::RawFd,
+        io::{FromRawFd, IntoRawFd, RawFd},
         prelude::AsRawFd,
     },
     pin::Pin,
+    process::Stdio,
+    sync::{Arc, Mutex},
     task::{Context as TaskContext, Poll},
+    time::Duration,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncRead, AsyncWrite},
+    process::{Child, Command},
 };
 use url::Url;
 
+/// Grace period given to a binary logger process to flush and exit after we
+/// close its input pipes, before we forcibly kill it. Matches the Go runtime's
+/// `binaryIOProcTermTimeout` (12s).
+const BINARY_IO_PROC_TERM_TIMEOUT: Duration = Duration::from_secs(12);
+
+/// Bounded time to wait for the binary logger's readiness signal on fd 5.
+/// The Go runtime blocks unconditionally; we add a timeout so a misbehaving
+/// logger cannot hang container start indefinitely.
+const BINARY_IO_READY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Block until the logger signals readiness on `sync_r` (a byte written or the
+/// fd closed = EOF), or until `timeout` elapses. Returns regardless; readiness
+/// is best-effort. Does NOT close `sync_r`.
+fn wait_logger_ready(sync_r: RawFd, timeout: Duration) {
+    let mut pfd = libc::pollfd {
+        fd: sync_r,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let millis = timeout.as_millis().min(i32::MAX as u128) as libc::c_int;
+    // SAFETY: `pfd` is a fully-initialized local `pollfd` of length 1; the
+    // pointer we pass is valid for `nfds=1`. The kernel only reads/writes
+    // that single struct. `millis` is a well-formed c_int.
+    let ret = unsafe { libc::poll(&mut pfd, 1, millis) };
+    match ret {
+        0 => warn!(
+            sl!(),
+            "binary logger readiness timed out after {:?}, proceeding", timeout
+        ),
+        r if r < 0 => {
+            let e = io::Error::last_os_error();
+            // EINTR etc.: don't fail start over a readiness poll.
+            warn!(sl!(), "binary logger readiness poll failed: {:?}", e);
+        }
+        _ => {
+            // Readable (data or EOF). Drain the single readiness byte if any.
+            let mut buf = [0u8; 1];
+            // SAFETY: `buf` is a stack array of exactly 1 byte and lives for
+            // the duration of the call; the kernel writes at most 1 byte
+            // into it. A short read or EOF is fine (we ignore the count).
+            let _ = unsafe { libc::read(sync_r, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+            info!(sl!(), "binary logger ready");
+        }
+    }
+}
+
 /// Clear O_NONBLOCK for an fd (turn it into blocking mode).
 fn set_flag_with_blocking(fd: RawFd) {
+    // SAFETY: `F_GETFL` is a pure read of the fd's flags; passing an invalid
+    // fd is well-defined (returns -1 with errno set) and handled below.
     let flag = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     if flag < 0 {
         error!(sl!(), "failed to fcntl(F_GETFL) fd {} ret {}", fd, flag);
         return;
     }
 
+    // SAFETY: `F_SETFL` writes the given flags to the fd; failure is
+    // non-fatal and just logged.
     let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flag & !libc::O_NONBLOCK) };
     if ret < 0 {
         error!(sl!(), "failed to fcntl(F_SETFL) fd {} ret {}", fd, ret);
@@ -56,6 +110,241 @@ fn open_fifo_write(path: &str) -> Result<File> {
     Ok(File::from_std(std_file))
 }
 
+/// A minimal RAII guard over a raw fd: closes on drop unless ownership is
+/// released via [`PipeFd::into_raw`]. Used to keep pipe fds leak-free across
+/// the `?` early returns in [`open_binary_io`].
+struct PipeFd(RawFd);
+
+impl PipeFd {
+    fn as_raw(&self) -> RawFd {
+        self.0
+    }
+
+    /// Take ownership of the raw fd; the caller becomes responsible for
+    /// closing it (or handing it off to another owner such as `File` or
+    /// `Stdio`). The guard's destructor becomes a no-op.
+    fn into_raw(mut self) -> RawFd {
+        let fd = self.0;
+        self.0 = -1;
+        fd
+    }
+}
+
+impl Drop for PipeFd {
+    fn drop(&mut self) {
+        if self.0 >= 0 {
+            // SAFETY: `self.0` is a fd we exclusively own (created by
+            // `create_pipe` and not handed to any other owner, since
+            // `into_raw` sets it to -1). Double-close is prevented by the
+            // guard above.
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+}
+
+/// Create a blocking pipe, returning `(read, write)` wrapped in [`PipeFd`]
+/// guards that will close the fds on drop unless released.
+fn create_pipe() -> Result<(PipeFd, PipeFd)> {
+    use nix::unistd::pipe;
+    let (r, w) = pipe().context("pipe()")?;
+    Ok((PipeFd(r.into_raw_fd()), PipeFd(w.into_raw_fd())))
+}
+
+/// A handle to a spawned shim v2 "binary" logger process. A single logger
+/// process handles both stdout and stderr for one container, following the
+/// containerd binary IO convention.
+#[derive(Debug)]
+struct BinaryLoggerProc {
+    child: Option<Child>,
+}
+
+impl BinaryLoggerProc {
+    /// Reap the logger process gracefully in the background: SIGTERM, wait up
+    /// to the grace period, then SIGKILL. Called once, when the last stream
+    /// sink referencing this logger is dropped.
+    fn reap(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let pid = child.id();
+            tokio::spawn(async move {
+                if let Some(pid) = pid {
+                    // SAFETY: `kill(2)` with SIGTERM to our own child pid is
+                    // safe; if the child has already been reaped by the
+                    // kernel or waited on, kill returns ESRCH which we
+                    // intentionally ignore.
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                    }
+                }
+                match tokio::time::timeout(BINARY_IO_PROC_TERM_TIMEOUT, child.wait()).await {
+                    Ok(Ok(status)) => info!(sl!(), "binary logger exited: {:?}", status),
+                    Ok(Err(e)) => warn!(sl!(), "failed to wait binary logger: {:?}", e),
+                    Err(_) => {
+                        warn!(sl!(), "binary logger did not exit in time, killing");
+                        let _ = child.kill().await;
+                        let _ = child.wait().await;
+                    }
+                }
+            });
+        }
+    }
+}
+
+impl Drop for BinaryLoggerProc {
+    fn drop(&mut self) {
+        self.reap();
+    }
+}
+
+/// Result of spawning a binary logger: the stdout and stderr write ends (fed
+/// into the container IO copy loop) plus a shared handle to the logger process
+/// that is reaped when both sinks are dropped.
+struct BinaryIo {
+    stdout: File,
+    stderr: File,
+    proc: Arc<Mutex<BinaryLoggerProc>>,
+}
+
+/// Spawn a shim v2 "binary" logging process.
+///
+/// The URI looks like:
+///     binary:///usr/bin/nerdctl?_NERDCTL_INTERNAL_LOGGING=%2Fvar%2Flib%2Fnerdctl%2F<id>
+///
+/// Following containerd's binary IO convention:
+/// - the binary path is taken from the URI path/host;
+/// - query parameters become `key value` command line arguments;
+/// - `CONTAINER_ID` / `CONTAINER_NAMESPACE` are injected as environment vars;
+/// - the container stdout/stderr read ends are passed as fd 3 / fd 4, and a
+///   "ready" sync pipe write end as fd 5 (i.e. `ExtraFiles[0..3]`);
+/// - one logger process serves both stdout and stderr.
+///
+/// The write ends of the stdout/stderr pipes are returned as the IO sinks.
+fn open_binary_io(url: &Url, container_id: &str, namespace: &str) -> Result<BinaryIo> {
+    // Reconstruct the binary path. nerdctl uses `binary:///usr/bin/nerdctl`
+    // (empty host, path holds everything); others may use `binary://host/path`.
+    let host = url.host_str().unwrap_or("");
+    let path = url.path();
+    let bin = if host.is_empty() {
+        path.to_string()
+    } else {
+        format!("/{}{}", host, path)
+    };
+    if bin.is_empty() {
+        return Err(anyhow!("binary logger uri has empty path: {}", url));
+    }
+
+    // Query pairs become `key value` argv, matching containerd/Go.
+    let mut args: Vec<String> = Vec::new();
+    for (k, v) in url.query_pairs() {
+        args.push(k.to_string());
+        if !v.is_empty() {
+            args.push(v.to_string());
+        }
+    }
+
+    info!(
+        sl!(),
+        "spawn binary logger: bin={} args={:?} id={} ns={}", bin, args, container_id, namespace
+    );
+
+    // Data pipes: container stdout/stderr flow from the write end (kept in the
+    // shim) to the read end (handed to the logger as fd 3 / fd 4).
+    let (out_r, out_w) = create_pipe().context("create stdout pipe")?;
+    let (err_r, err_w) = create_pipe().context("create stderr pipe")?;
+    // Sync pipe: logger signals readiness by writing/closing its fd 5; the
+    // shim reads the read end.
+    let (sync_r, sync_w) = create_pipe().context("create sync pipe")?;
+
+    // No CLOEXEC dance is needed: parent-held ends are never passed to the
+    // child (tokio's Command closes non-stdio fds before exec), and dup2
+    // clears FD_CLOEXEC on its target, so fd 3/4/5 inherit across exec.
+
+    let mut cmd = Command::new(&bin);
+    cmd.args(&args)
+        .env("CONTAINER_ID", container_id)
+        .env("CONTAINER_NAMESPACE", namespace)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    // Release the child-side fds from their guards; spawn-failure path below
+    // closes them explicitly, and on success the child inherits their dup'd
+    // copies via pre_exec.
+    let out_r_raw = out_r.into_raw();
+    let err_r_raw = err_r.into_raw();
+    let sync_w_raw = sync_w.into_raw();
+
+    // Place fd 3/4/5 in the child, matching containerd's ExtraFiles[0..3].
+    // SAFETY: pre_exec runs in the forked child before exec; only
+    // async-signal-safe libc calls are used.
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::dup2(out_r_raw, 3) < 0
+                || libc::dup2(err_r_raw, 4) < 0
+                || libc::dup2(sync_w_raw, 5) < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            // SAFETY: on spawn failure `pre_exec` never ran, so these three
+            // fds are still exclusively owned by us (their `PipeFd` guards
+            // were disarmed just above by `into_raw`). Close them here to
+            // avoid an fd leak.
+            unsafe {
+                libc::close(out_r_raw);
+                libc::close(err_r_raw);
+                libc::close(sync_w_raw);
+            }
+            return Err(anyhow::Error::from(e))
+                .with_context(|| format!("spawn binary logger {}", bin));
+        }
+    };
+
+    // Spawn succeeded: close the parent-side originals of the child-inherited fds.
+    // SAFETY: the child now holds its own dup'd copies (fd 3/4/5); the
+    // parent-side originals are exclusively owned by us and unused.
+    unsafe {
+        libc::close(out_r_raw);
+        libc::close(err_r_raw);
+        libc::close(sync_w_raw);
+    }
+
+    // Readiness handshake (mirrors containerd's Go `newBinaryIO`).
+    //
+    // The logger signals readiness via fd 5: it either writes a byte or closes
+    // the fd (EOF) once it has finished initializing and is ready to consume
+    // fd 3 / fd 4. We MUST block here until that happens, before the IO copy
+    // loop starts and before `TaskStart` is published. Otherwise, for a very
+    // short-lived container, the copy loop can push the single output line and
+    // close the write end before the logger has started reading, so the logger
+    // exits without draining and the log file ends up empty.
+    //
+    // A bounded timeout guards against a misbehaving logger hanging container
+    // start forever; on timeout we proceed anyway (best-effort logging).
+    wait_logger_ready(sync_r.as_raw(), BINARY_IO_READY_TIMEOUT);
+    drop(sync_r);
+
+    // SAFETY: `out_w` / `err_w` are pipe fds we exclusively own; `into_raw`
+    // disarms their `PipeFd` destructor so no double-close can occur, and
+    // ownership is transferred to the returned `File` which will close them
+    // on drop.
+    let stdout = File::from_std(unsafe { std::fs::File::from_raw_fd(out_w.into_raw()) });
+    let stderr = File::from_std(unsafe { std::fs::File::from_raw_fd(err_w.into_raw()) });
+
+    Ok(BinaryIo {
+        stdout,
+        stderr,
+        proc: Arc::new(Mutex::new(BinaryLoggerProc { child: Some(child) })),
+    })
+}
+
 pub struct ShimIo {
     pub stdin: Option<Box<dyn AsyncRead + Send + Unpin>>,
     pub stdout: Option<Box<dyn AsyncWrite + Send + Unpin>>,
@@ -67,6 +356,8 @@ impl ShimIo {
         stdin: &Option<String>,
         stdout: &Option<String>,
         stderr: &Option<String>,
+        container_id: &str,
+        namespace: &str,
     ) -> Result<Self> {
         info!(
             sl!(),
@@ -108,7 +399,7 @@ impl ShimIo {
                         Url::parse(&format!("fifo://{}", out)).ok()
                     }
                     Err(err) => {
-                        warn!(sl!(), "unable to parse stdout uri: {}", err);
+                        warn!(sl!(), "unable to parse stdio uri: {}", err);
                         None
                     }
                     Ok(u) => Some(u),
@@ -116,24 +407,82 @@ impl ShimIo {
             }
         };
 
+        let stdout_url = get_url(stdout);
+        let stderr_url = get_url(stderr);
+
+        // Determine the scheme. A binary logger serves both stdout and stderr
+        // with a single process, so it is handled specially. In practice (see
+        // containerd's cio.BinaryIO and nerdctl's usage) stdout and stderr URIs
+        // are identical when this mode is used, but we defensively pick either
+        // one so that a stderr-only binary URI still works.
+        let is_binary = |u: &Option<Url>| -> bool {
+            u.as_ref().map(|u| u.scheme() == "binary").unwrap_or(false)
+        };
+
+        if is_binary(&stdout_url) || is_binary(&stderr_url) {
+            let url = if is_binary(&stdout_url) {
+                stdout_url.clone().unwrap()
+            } else {
+                stderr_url.clone().unwrap()
+            };
+            let cid = container_id.to_string();
+            let ns = namespace.to_string();
+            // `open_binary_io` blocks on the logger readiness handshake, so run
+            // it on a blocking thread to avoid stalling the tokio worker.
+            let result = tokio::task::spawn_blocking(move || open_binary_io(&url, &cid, &ns))
+                .await
+                .context("join open_binary_io")?;
+            match result {
+                Ok(bio) => {
+                    let proc = bio.proc.clone();
+                    let stdout_sink = ShimIoWrite::Binary {
+                        file: Some(bio.stdout),
+                        proc: proc.clone(),
+                    };
+                    let stderr_sink = ShimIoWrite::Binary {
+                        file: Some(bio.stderr),
+                        proc,
+                    };
+                    return Ok(Self {
+                        stdin: stdin_fd,
+                        stdout: Some(Box::new(stdout_sink)),
+                        stderr: Some(Box::new(stderr_sink)),
+                    });
+                }
+                Err(err) => {
+                    error!(sl!(), "failed to open binary logger, error {:?}", err);
+                    // Fall through: no stdout/stderr sink. The container still
+                    // runs and can be stopped; logs are just dropped.
+                    return Ok(Self {
+                        stdin: stdin_fd,
+                        stdout: None,
+                        stderr: None,
+                    });
+                }
+            }
+        }
+
+        // FIFO / other schemes: open each stream independently.
         let get_fd = |url: &Option<Url>| -> Option<Box<dyn AsyncWrite + Send + Unpin>> {
             info!(sl!(), "get fd for {:?}", &url);
             if let Some(url) = url {
-                if url.scheme() == "fifo" {
-                    let path = url.path();
-                    match open_fifo_write(path) {
-                        Ok(f) => return Some(Box::new(ShimIoWrite::File(f))),
-                        Err(err) => error!(sl!(), "failed to open fifo {} error {:?}", path, err),
+                match url.scheme() {
+                    "fifo" => {
+                        let path = url.path();
+                        match open_fifo_write(path) {
+                            Ok(f) => return Some(Box::new(ShimIoWrite::File(f))),
+                            Err(err) => {
+                                error!(sl!(), "failed to open fifo {} error {:?}", path, err)
+                            }
+                        }
                     }
-                } else {
-                    warn!(sl!(), "unsupported io scheme {}", url.scheme());
+                    other => {
+                        warn!(sl!(), "unsupported io scheme {}", other);
+                    }
                 }
             }
             None
         };
-
-        let stdout_url = get_url(stdout);
-        let stderr_url = get_url(stderr);
 
         Ok(Self {
             stdin: stdin_fd,
@@ -143,10 +492,33 @@ impl ShimIo {
     }
 }
 
-#[derive(Debug)]
 enum ShimIoWrite {
     File(File),
-    // TODO: support other type
+    Binary {
+        file: Option<File>,
+        // Shared logger process handle; reaped when the last sink drops.
+        proc: Arc<Mutex<BinaryLoggerProc>>,
+    },
+}
+
+impl Drop for ShimIoWrite {
+    fn drop(&mut self) {
+        if let ShimIoWrite::Binary { file, proc } = self {
+            // Close our write end so the logger sees EOF on the corresponding
+            // stream.
+            file.take();
+            // Reap the logger when the last sink drops. Only the stdout and
+            // stderr sinks ever hold this Arc (both created in `ShimIo::new`
+            // and immediately handed to the caller); no other clones exist,
+            // so `strong_count <= 1` reliably identifies the final drop
+            // without a TOCTOU concern.
+            if Arc::strong_count(proc) <= 1 {
+                if let Ok(mut p) = proc.lock() {
+                    p.reap();
+                }
+            }
+        }
+    }
 }
 
 impl AsyncWrite for ShimIoWrite {
@@ -157,18 +529,31 @@ impl AsyncWrite for ShimIoWrite {
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
             ShimIoWrite::File(f) => Pin::new(f).poll_write(cx, buf),
+            ShimIoWrite::Binary { file, .. } => match file.as_mut() {
+                Some(f) => Pin::new(f).poll_write(cx, buf),
+                None => Poll::Ready(Ok(0)),
+            },
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             ShimIoWrite::File(f) => Pin::new(f).poll_flush(cx),
+            ShimIoWrite::Binary { file, .. } => match file.as_mut() {
+                Some(f) => Pin::new(f).poll_flush(cx),
+                None => Poll::Ready(Ok(())),
+            },
         }
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             ShimIoWrite::File(f) => Pin::new(f).poll_shutdown(cx),
+            ShimIoWrite::Binary { file, .. } => match file.as_mut() {
+                Some(f) => Pin::new(f).poll_shutdown(cx),
+                None => Poll::Ready(Ok(())),
+            },
         }
     }
 }
+

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
@@ -97,6 +97,18 @@ fn open_fifo_write(path: &str) -> Result<File> {
     open_fifo(path, false, true)
 }
 
+/// Whether the given stdio value should be treated as a host FIFO path.
+fn is_fifo_stdio(value: &str) -> bool {
+    match url::Url::parse(value) {
+        // No scheme -> it is a bare FIFO path.
+        Err(url::ParseError::RelativeUrlWithoutBase) => true,
+        // Parsed with a scheme: only `fifo://` denotes a real FIFO.
+        Ok(u) => u.scheme() == "fifo",
+        // Anything else: leave it to ShimIo, don't pre-open.
+        Err(_) => false,
+    }
+}
+
 impl Process {
     pub fn new(
         process: &ContainerProcess,
@@ -133,12 +145,26 @@ impl Process {
 
     pub fn pre_fifos_open(&mut self) -> Result<()> {
         if let Some(ref stdout) = self.stdout {
-            self.stdout_r = Some(open_fifo_read(stdout).context("open stdout")?);
+            if is_fifo_stdio(stdout) {
+                self.stdout_r = Some(open_fifo_read(stdout).context("open stdout")?);
+            } else {
+                info!(
+                    self.logger,
+                    "stdout is not a fifo, skip pre-open (handled by ShimIo): {}", stdout
+                );
+            }
         }
 
         if !self.terminal {
             if let Some(ref stderr) = self.stderr {
-                self.stderr_r = Some(open_fifo_read(stderr).context("open stderr")?);
+                if is_fifo_stdio(stderr) {
+                    self.stderr_r = Some(open_fifo_read(stderr).context("open stderr")?);
+                } else {
+                    info!(
+                        self.logger,
+                        "stderr is not a fifo, skip pre-open (handled by ShimIo): {}", stderr
+                    );
+                }
             }
         }
 
@@ -147,7 +173,14 @@ impl Process {
 
     pub fn post_fifos_open(&mut self) -> Result<()> {
         if let Some(ref stdin) = self.stdin {
-            self.stdin_w = Some(open_fifo_write(stdin)?);
+            if is_fifo_stdio(stdin) {
+                self.stdin_w = Some(open_fifo_write(stdin)?);
+            } else {
+                info!(
+                    self.logger,
+                    "stdin is not a fifo, skip pre-open (handled by ShimIo): {}", stdin
+                );
+            }
         }
         Ok(())
     }
@@ -248,10 +281,18 @@ impl Process {
         info!(self.logger, "start io and wait");
 
         self.pre_fifos_open()?;
-        // new shim io
-        let shim_io = ShimIo::new(&self.stdin, &self.stdout, &self.stderr)
-            .await
-            .context("new shim io")?;
+        let container_id = self.process.container_id().to_string();
+        // NAMESPACE is set by containerd when spawning the shim.
+        let namespace = std::env::var("NAMESPACE").unwrap_or_default();
+        let shim_io = ShimIo::new(
+            &self.stdin,
+            &self.stdout,
+            &self.stderr,
+            &container_id,
+            &namespace,
+        )
+        .await
+        .context("new shim io")?;
         self.post_fifos_open()?;
 
         // start io copy for stdin


### PR DESCRIPTION
## Summary

Detached containers started via `nerdctl -d` (and other containerd clients that use `cio.BinaryIO`) advertise their stdout/stderr as `binary://<path>?<args>` URIs rather than host FIFOs.

`runtime-rs`'s shim IO layer today treats every stdio string as a FIFO path in `pre_fifos_open`, and only opens `fifo://` in `ShimIo::new` while silently dropping other schemes. `binary://` therefore aborts the whole start path with `ENOENT`, so `nerdctl run -d ...` fails with:

~~~
FATA[open stdout: No such file or directory]
~~~

and leaves the container stuck in `Created`: `run_io_wait` never spawns, the exit watcher is never released, and subsequent `nerdctl stop` hangs until timeout.

This PR adds a `binary://` logger backend that mirrors containerd's Go implementation: a single logger process consumes both container stdout/stderr via `fd 3` / `fd 4` and signals readiness via `fd 5`. See individual commits for the full rationale.

## What's in this PR

1. **`runtime-rs: support containerd binary:// stdio logger URIs`**
    - `open_binary_io` spawns the logger, hands it fd 3/4/5, and performs a bounded readiness handshake.
    - `PipeFd` RAII guard prevents fd leaks across the multiple `?` early returns.
    - `BinaryLoggerProc` reaps the logger gracefully (SIGTERM → 12s grace → SIGKILL) when the last sink drops, using `Arc::strong_count` to identify the final drop.
    - `ShimIo::new` gains `container_id` / `namespace` params, exposed to the logger as `CONTAINER_ID` / `CONTAINER_NAMESPACE` env vars per the containerd convention.
    - `process.rs` gates FIFO pre-open on `is_fifo_stdio` so non-FIFO schemes are left to `ShimIo`.
    - Every `unsafe` block has a `// SAFETY:` justification.

2. **`runtime-rs: shim io: add unit tests for binary logger FFI`**
    - 7 unit tests covering the readiness `poll` (byte / EOF / timeout / bad fd) and `PipeFd` (drop / into_raw / -1 sentinel).
    - No external binaries or tokio runtime required; runs cleanly under `cargo test`.

## Testing

Ran in `src/runtime-rs`:

~~~sh
cargo fmt -p virt_container -- --check
cargo clippy -p virt_container --tests -- -D warnings
cargo test -p virt_container --lib container_manager::io::shim_io::tests
~~~

All green locally (7 passed, 0 failed).

Manually verified with:

~~~sh
nerdctl run -d --runtime io.containerd.kata.v2 alpine:3 tail -f /dev/null
nerdctl logs -f <id>
nerdctl stop <id>
~~~

## Fixes

Fixes: #4391

## Porting

bug
no-backport-needed
no-forward-port-needed

## AI-assisted development

Portions of this change were produced with the help of an AI coding assistant (CodeBuddy / Claude Opus 4.7). The author has fully reviewed, tested, and debugged the resulting code; each commit carries an `Assisted-By:` trailer per the OpenInfra Foundation AI Policy.
