### PR TITLE
versions: bump golang to 1.25.12

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/runtime
 
 // Keep in sync with version in versions.yaml
-go 1.25.11
+go 1.25.12
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/csi-kata-directvolume/go.mod
+++ b/src/tools/csi-kata-directvolume/go.mod
@@ -1,7 +1,7 @@
 module kata-containers/csi-kata-directvolume
 
 // Keep in sync with version in versions.yaml
-go 1.25.11
+go 1.25.12
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/log-parser/go.mod
+++ b/src/tools/log-parser/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/tools/log-parser
 
 // Keep in sync with version in versions.yaml
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/tests
 
 // Keep in sync with version in versions.yaml
-go 1.25.11
+go 1.25.12
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/tools/testing/kata-webhook/go.mod
+++ b/tools/testing/kata-webhook/go.mod
@@ -1,7 +1,7 @@
 module module-path
 
 // Keep in sync with version in versions.yaml
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/sirupsen/logrus v1.9.4

--- a/versions.yaml
+++ b/versions.yaml
@@ -459,12 +459,12 @@ languages:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
     # When updating this, also update in go.mod files.
-    version: "1.25.11"
+    version: "1.25.12"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.25.11"
+      newest-version: "1.25.12"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
Bump the go version to fix GO-2026-5856 (CVE-2026-42505).

Generated-By: IBM Bob