### PR TITLE
runtime-rs: validate net model with host net pods

### DIFF
--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -79,8 +79,7 @@ pub struct Runtime {
     /// This option may have some potential impacts to your host. It should only be used when you
     /// know what you're doing.
     ///
-    /// `disable_new_netns` conflicts with `internetworking_model=tcfilter` and
-    /// `internetworking_model=macvtap`. It works only with `internetworking_model=none`.
+    /// `disable_new_netns` only works with `internetworking_model=none`.
     /// The tap device will be in the host network namespace and can connect to a bridge (like OVS)
     /// directly.
     ///
@@ -271,6 +270,16 @@ impl ConfigOps for Runtime {
             )));
         }
 
+        // `disable_new_netns` leaves the runtime operating in whichever network
+        // namespace it is started in (typically the host netns), so it is only
+        // safe with `internetworking_model=none`, which does not touch that
+        // namespace.
+        if conf.runtime.disable_new_netns && net_model != "none" {
+            return Err(std::io::Error::other(format!(
+                "disable_new_netns only works with internetworking_model=none, not `{net_model}`",
+            )));
+        }
+
         let vfio_mode = &conf.runtime.vfio_mode;
         if !vfio_mode.is_empty() && vfio_mode != "vfio" && vfio_mode != "guest-kernel" {
             return Err(std::io::Error::other(format!(
@@ -361,6 +370,45 @@ internetworking_model = "macvtap,none"
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap_err();
 
+        // disable_new_netns is only valid with internetworking_model=none.
+        let content = r#"
+[runtime]
+enable_debug = true
+internetworking_model = "tcfilter"
+disable_new_netns = true
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+internetworking_model = "macvtap"
+disable_new_netns = true
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // An empty internetworking_model defaults to tcfilter, so
+        // disable_new_netns must be rejected there too.
+        let content = r#"
+[runtime]
+enable_debug = true
+disable_new_netns = true
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // disable_new_netns with internetworking_model=none is allowed.
+        let content = r#"
+[runtime]
+enable_debug = true
+internetworking_model = "none"
+disable_new_netns = true
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+
         let content = r#"
 [runtime]
 enable_debug = true
@@ -440,7 +488,7 @@ emptydir_mode = "block-plain"
 name = "virt-container"
 enable_debug = true
 experimental = ["a", "b"]
-internetworking_model = "macvtap"
+internetworking_model = "none"
 disable_new_netns = true
 sandbox_bind_mounts = []
 sandbox_cgroup_only = true
@@ -461,7 +509,7 @@ field_should_be_ignored = true
         assert_eq!(config.runtime.experimental.len(), 2);
         assert_eq!(&config.runtime.experimental[0], "a");
         assert_eq!(&config.runtime.experimental[1], "b");
-        assert_eq!(&config.runtime.internetworking_model, "macvtap");
+        assert_eq!(&config.runtime.internetworking_model, "none");
         assert!(config.runtime.disable_new_netns);
         assert_eq!(config.runtime.sandbox_bind_mounts.len(), 0);
         assert!(config.runtime.sandbox_cgroup_only);

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -508,9 +508,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -508,9 +508,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -509,9 +509,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -639,9 +639,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -753,9 +753,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -685,9 +685,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -661,9 +661,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -736,9 +736,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -621,9 +621,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -668,9 +668,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -646,9 +646,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -222,9 +222,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 # Note: The remote hypervisor has a different networking model, which requires true
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -373,9 +373,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-clh-azure.toml.in
+++ b/src/runtime/config/configuration-clh-azure.toml.in
@@ -415,9 +415,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -415,9 +415,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -327,9 +327,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -651,9 +651,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
@@ -669,9 +669,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -697,9 +697,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -674,9 +674,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -676,9 +676,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -629,9 +629,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -659,9 +659,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -636,9 +636,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -645,9 +645,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -211,9 +211,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 # Note: The remote hypervisor has a different networking model, which requires true
 disable_new_netns = true

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -380,9 +380,8 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
-# (like OVS) directly.
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network
+# namespace and can connect to a bridge (like OVS) directly.
 # (default: false)
 disable_new_netns = false
 


### PR DESCRIPTION
We should not allow any internetworking model other than `none` if we don't create a netns.