### PR TITLE
build: Bump oci-spec to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -419,6 +419,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -933,19 +955,6 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgroups-rs"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db7c2f5545da4c12c5701455d9471da5f07db52e49b9cccb4f5512226dd0836"
-dependencies = [
- "libc",
- "log",
- "nix 0.25.1",
- "regex",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cgroups-rs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae79ba89081d30804e3312bb1163ab82cc8dca0a1b16275e55fb19fce4e89b"
@@ -1193,23 +1202,20 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b16da01f5ea209d00a0a53342a748491e2b50b1d8cfa96e0c5c5f262f3dd270"
+checksum = "a886cc76f89aab452d78a9034a62426468175d795d0fb2ee57338fe075cbdc0a"
 dependencies = [
  "async-trait",
- "cgroups-rs 0.3.4",
+ "cgroups-rs",
  "containerd-shim-protos",
  "futures",
  "go-flag",
- "lazy_static",
  "libc",
  "log",
  "mio 1.2.0",
- "nix 0.29.0",
- "oci-spec 0.7.1",
- "page_size",
- "prctl",
+ "nix 0.31.3",
+ "oci-spec 0.9.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1218,15 +1224,15 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "which 7.0.3",
+ "which 8.0.4",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "containerd-shim-protos"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de174e763d62b6b1aaed7d9ec7f21369e18d4f4098ae1f11f2ea1a3eb4a31c61"
+checksum = "f714d7ff4f5e9d5f9b57d27152d70c8cab6639284e5c4f7dfaca774a7b94fa52"
 dependencies = [
  "async-trait",
  "protobuf",
@@ -2016,12 +2022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2957,7 +2957,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3304,7 +3304,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3554,7 +3554,7 @@ dependencies = [
  "base64 0.22.1",
  "capctl",
  "cfg-if 1.0.4",
- "cgroups-rs 0.5.1",
+ "cgroups-rs",
  "clap",
  "const_format",
  "container-device-interface",
@@ -4257,7 +4257,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4487,19 +4486,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if 1.0.4",
- "cfg_aliases",
- "libc",
- "memoffset 0.9.1",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4548,7 +4534,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4829,22 +4815,6 @@ dependencies = [
  "tokio",
  "tracing",
  "unicase",
-]
-
-[[package]]
-name = "oci-spec"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
-dependencies = [
- "derive_builder",
- "getset",
- "regex",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5555,16 +5525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prctl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
-dependencies = [
- "libc",
- "nix 0.31.3",
-]
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6028,7 +5988,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6066,7 +6026,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6449,7 +6409,7 @@ dependencies = [
  "base64 0.22.1",
  "byte-unit",
  "bytes 1.11.1",
- "cgroups-rs 0.5.1",
+ "cgroups-rs",
  "flate2",
  "futures",
  "futures-lite 2.6.1",
@@ -6783,7 +6743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6797,7 +6757,7 @@ dependencies = [
  "capctl",
  "caps",
  "cfg-if 1.0.4",
- "cgroups-rs 0.5.1",
+ "cgroups-rs",
  "futures",
  "inotify 0.9.6",
  "kata-sys-util",
@@ -6884,7 +6844,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7596,7 +7556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7631,12 +7591,6 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
  "strum_macros 0.24.3",
 ]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
@@ -7851,10 +7805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7863,7 +7817,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8131,15 +8085,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-vsock"
-version = "0.4.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
 dependencies = [
  "bytes 1.11.1",
  "futures",
  "libc",
  "tokio",
- "vsock 0.3.0",
+ "vsock 0.5.4",
 ]
 
 [[package]]
@@ -8519,15 +8473,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttrpc"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85d9a9e7a0a32232cb5beb2a58e37661ef67d39a12af483ae575c6a27ad8a1"
+checksum = "9f12efe237328bbe3b3b50503627f7cc9e74cfae34ffa8438561916623cd8f50"
 dependencies = [
+ "async-stream",
  "async-trait",
  "byteorder",
  "crossbeam",
  "futures",
- "home",
  "libc",
  "log",
  "nix 0.26.4",
@@ -8535,7 +8489,7 @@ dependencies = [
  "protobuf-codegen",
  "thiserror 1.0.69",
  "tokio",
- "tokio-vsock 0.4.0",
+ "tokio-vsock 0.7.2",
  "windows-sys 0.48.0",
 ]
 
@@ -8586,7 +8540,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8896,12 +8850,12 @@ dependencies = [
 
 [[package]]
 name = "vsock"
-version = "0.3.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
- "nix 0.24.3",
+ "nix 0.31.3",
 ]
 
 [[package]]
@@ -9143,14 +9097,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix 1.1.4",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -9175,7 +9126,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9562,12 +9513,6 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,9 +1169,9 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "container-device-interface"
-version = "0.1.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2605001b0e8214dae8af146a43ccaa965d960403e330f174c21327154530df8b"
+checksum = "11505f8c11b055cf6cd8758da8b85a3d9a1e651ccf1237ab201d0ba729870cc6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1173,15 +1179,12 @@ dependencies = [
  "jsonschema",
  "lazy_static",
  "libc",
- "nix 0.24.3",
- "notify",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "once_cell",
  "path-clean",
  "regex",
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
 ]
@@ -2152,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2218,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-uri"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
@@ -2238,6 +2241,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2288,15 +2297,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2645,7 +2645,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3470,29 +3481,40 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.33.0"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
 dependencies = [
  "ahash 0.8.12",
- "base64 0.22.1",
  "bytecount",
+ "data-encoding",
  "email_address",
  "fancy-regex",
  "fraction",
+ "getrandom 0.3.4",
  "idna",
  "itoa",
+ "jsonschema-regex",
  "num-cmp",
  "num-traits",
- "once_cell",
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
+ "rustls",
  "serde",
  "serde_json",
+ "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3837,26 +3859,6 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
-]
 
 [[package]]
 name = "kube"
@@ -4221,6 +4223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4535,33 +4543,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.11.1",
- "fsevent-sys",
- "inotify 0.11.1",
- "kqueue",
- "libc",
- "log",
- "mio 1.2.0",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6319,13 +6300,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.33.0"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
- "once_cell",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",
@@ -6451,6 +6435,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -8640,6 +8625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8755,7 +8746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
 dependencies = [
  "outref",
- "uuid 1.23.1",
  "vsimd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,27 +946,15 @@ dependencies = [
 
 [[package]]
 name = "cgroups-rs"
-version = "0.3.5"
-source = "git+https://github.com/kata-containers/cgroups-rs?rev=v0.3.5#de9625ff57d156967b5b2a637c2c41bb2366e39b"
-dependencies = [
- "libc",
- "log",
- "nix 0.25.1",
- "regex",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cgroups-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc46cf39fc5922b840030e0e5b378ce5caa9a824a675a95c6dec2c2c9ce9468"
+checksum = "25ae79ba89081d30804e3312bb1163ab82cc8dca0a1b16275e55fb19fce4e89b"
 dependencies = [
  "bit-vec 0.6.3",
  "libc",
  "log",
  "nix 0.25.1",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "thiserror 1.0.69",
  "zbus 5.15.0",
 ]
@@ -3566,7 +3554,7 @@ dependencies = [
  "base64 0.22.1",
  "capctl",
  "cfg-if 1.0.4",
- "cgroups-rs 0.3.5",
+ "cgroups-rs 0.5.1",
  "clap",
  "const_format",
  "container-device-interface",
@@ -4856,23 +4844,6 @@ dependencies = [
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "oci-spec"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
-dependencies = [
- "const_format",
- "derive_builder",
- "getset",
- "regex",
- "serde",
- "serde_json",
- "strum 0.27.2",
- "strum_macros 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -6478,7 +6449,7 @@ dependencies = [
  "base64 0.22.1",
  "byte-unit",
  "bytes 1.11.1",
- "cgroups-rs 0.5.0",
+ "cgroups-rs 0.5.1",
  "flate2",
  "futures",
  "futures-lite 2.6.1",
@@ -6826,7 +6797,7 @@ dependencies = [
  "capctl",
  "caps",
  "cfg-if 1.0.4",
- "cgroups-rs 0.3.5",
+ "cgroups-rs 0.5.1",
  "futures",
  "inotify 0.9.6",
  "kata-sys-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "kata-types",
  "logging",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "protobuf",
  "protocols",
  "serde",
@@ -1092,7 +1092,7 @@ dependencies = [
  "kata-sys-util",
  "kata-types",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "protobuf",
  "protocols",
  "resource",
@@ -2483,7 +2483,7 @@ dependencies = [
  "kata-types",
  "log",
  "oci-client",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "openssl",
  "protobuf",
  "protocols",
@@ -3563,7 +3563,7 @@ dependencies = [
  "netlink-packet-route 0.19.0",
  "netlink-sys 0.7.0",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "opentelemetry 0.17.0",
  "procfs 0.12.0",
  "prometheus",
@@ -3619,7 +3619,7 @@ dependencies = [
  "libc",
  "logging",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "protobuf",
  "protocols",
  "rand 0.10.1",
@@ -3751,7 +3751,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "pci-ids",
  "rand 0.10.1",
  "rstest",
@@ -3803,7 +3803,7 @@ dependencies = [
  "lazy_static",
  "nix 0.31.3",
  "num_cpus",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "regex",
  "rstest",
  "safe-path",
@@ -4913,6 +4913,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-spec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5503,7 +5520,7 @@ dependencies = [
  "anyhow",
  "container-device-interface",
  "hyper-util",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "prost 0.14.3",
  "serde",
  "serde_json",
@@ -5949,7 +5966,7 @@ name = "protocols"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "protobuf",
  "serde",
  "serde_json",
@@ -6496,7 +6513,7 @@ dependencies = [
  "netlink-packet-route 0.30.0",
  "netns-rs",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "persist",
  "rand 0.10.1",
  "rstest",
@@ -6702,7 +6719,7 @@ dependencies = [
  "logging",
  "netns-rs",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "opentelemetry 0.18.0",
  "opentelemetry-jaeger",
  "persist",
@@ -6832,7 +6849,7 @@ dependencies = [
  "libc",
  "libseccomp",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "path-absolutize",
  "protobuf",
  "protocols",
@@ -7389,7 +7406,7 @@ dependencies = [
  "log",
  "logging",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "protobuf",
  "runtime-spec",
  "serial_test 0.10.0",
@@ -8818,7 +8835,7 @@ dependencies = [
  "libc",
  "logging",
  "nix 0.31.3",
- "oci-spec 0.8.4",
+ "oci-spec 0.10.0",
  "persist",
  "pod-resources-rs",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ async-trait = "0.1.48"
 bilge = "0.3.0"
 capctl = "0.2.0"
 cfg-if = "1.0.0"
-cgroups = { package = "cgroups-rs", git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }
+cgroups = { package = "cgroups-rs", version = "0.5.1", features = ["oci"] }
 clap = { version = "4.5.40", features = ["derive"] }
 const_format = "0.2.30"
 container-device-interface = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ netlink-sys = { version = "0.7.0", features = ["tokio_socket"] }
 netns-rs = "0.1.0"
 # Note: nix needs to stay sync'd with libs versions
 nix = { version = "0.31.3", features = ["fs", "mount", "sched", "process", "ioctl", "signal", "socket", "feature", "user", "hostname", "term", "event", "mman", "reboot"] }
-oci-spec = { version = "0.8.1", features = ["runtime"] }
+oci-spec = { version = "0.10.0", features = ["runtime"] }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 procfs = "0.12.0"
 prometheus = { version = "0.14.0", features = ["process"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,8 +161,8 @@ cgroups = { package = "cgroups-rs", version = "0.5.1", features = ["oci"] }
 clap = { version = "4.5.40", features = ["derive"] }
 const_format = "0.2.30"
 container-device-interface = "1.1.1"
-containerd-shim = { version = "0.10.0", features = ["async"] }
-containerd-shim-protos = { version = "0.10.0", features = ["async"] }
+containerd-shim = { version = "0.11.0", features = ["async"] }
+containerd-shim-protos = { version = "0.11.0", features = ["async"] }
 derivative = "2.2.0"
 futures = "0.3.30"
 go-flag = "0.1.0"
@@ -213,7 +213,7 @@ toml = "1.1.2"
 tracing = "0.1.44"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = "0.3.20"
-ttrpc = "0.8.4"
+ttrpc = "0.9.0"
 url = "2.5.4"
 which = "4.3.0"
 gpt = "4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ cfg-if = "1.0.0"
 cgroups = { package = "cgroups-rs", git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }
 clap = { version = "4.5.40", features = ["derive"] }
 const_format = "0.2.30"
+container-device-interface = "1.1.1"
 containerd-shim = { version = "0.10.0", features = ["async"] }
 containerd-shim-protos = { version = "0.10.0", features = ["async"] }
 derivative = "2.2.0"
@@ -227,4 +228,3 @@ devicemapper = { git = "https://github.com/stratis-storage/devicemapper-rs", rev
 [profile.release.package."kata-deploy"]
 opt-level = "z"
 codegen-units = 1
-

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -87,7 +87,7 @@ base64 = { workspace = true }
 sha2 = { workspace = true }
 async-compression = { version = "0.4.22", features = ["tokio", "gzip"] }
 
-container-device-interface = "0.1.1"
+container-device-interface.workspace = true
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504a9a2977d49989a5e5b7c1c8e07dc0fa41", package = "s390_pv_core" }

--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::cgroups_rs as cgroups;
 use cgroups::blkio::{BlkIoController, BlkIoData, IoService};
 use cgroups::cpu::CpuController;
 use cgroups::cpuacct::CpuAcctController;
@@ -1418,6 +1419,7 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use crate::cgroups_rs as cgroups;
     use cgroups::devices::{DevicePermissions, DeviceType};
     use oci::{
         LinuxBuilder, LinuxDeviceCgroup, LinuxDeviceCgroupBuilder, LinuxDeviceType,

--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -8,6 +8,7 @@ use protobuf::MessageField;
 use crate::cgroups::Manager as CgroupManager;
 use crate::protocols::agent::{BlkioStats, CgroupStats, CpuStats, MemoryStats, PidsStats};
 use anyhow::Result;
+use crate::cgroups_rs as cgroups;
 use cgroups::freezer::FreezerState;
 use libc::{self, pid_t};
 use oci::{LinuxResources, Spec};

--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -9,6 +9,7 @@ use oci_spec::runtime::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 use protocols::agent::CgroupStats;
 use std::any::Any;
 
+use crate::cgroups_rs as cgroups;
 use cgroups::freezer::FreezerState;
 
 pub mod fs;

--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -15,6 +15,7 @@ use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc::{channel, Receiver};
 
 use crate::pipestream::PipeStream;
+use crate::cgroups_rs as cgroups;
 
 // Convenience function to obtain the scope logger.
 fn sl() -> slog::Logger {

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -6,6 +6,7 @@
 use crate::cgroups::Manager as CgroupManager;
 use crate::protocols::agent::CgroupStats;
 use anyhow::{anyhow, Result};
+use crate::cgroups_rs as cgroups;
 use cgroups::freezer::FreezerState;
 use libc::{self, pid_t};
 use oci::LinuxResources;

--- a/src/agent/rustjail/src/cgroups_rs.rs
+++ b/src/agent/rustjail/src/cgroups_rs.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Re-exports for cgroups-rs 0.5.x.
+//!
+//! The legacy cgroupfs API moved under `cgroups::fs` in 0.5.x. Agent code
+//! was written against the 0.3.x layout where those types lived at the crate
+//! root; this module preserves the old paths.
+
+pub use cgroups::fs::{
+    blkio, cpu, cpuacct, cpuset, devices, hierarchies, hugetlb, memory, pid,
+    BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, Controller, DeviceResource,
+    DeviceResources, Hierarchy, HugePageResource, MaxValue, NetworkPriority, Resources,
+};
+pub use cgroups::CgroupPid;
+pub use cgroups::FreezerState;
+
+pub mod freezer {
+    pub use cgroups::fs::freezer::FreezerController;
+    pub use cgroups::FreezerState;
+}

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tokio::fs::File;
 
+use crate::cgroups_rs as cgroups;
 use cgroups::freezer::FreezerState;
 
 use crate::capabilities;

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -27,6 +27,7 @@ extern crate regex;
 
 pub mod capabilities;
 pub mod cgroups;
+pub mod cgroups_rs;
 pub mod container;
 pub mod mount;
 pub mod pipestream;

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -33,6 +33,7 @@ use crate::sync::write_count;
 use std::string::ToString;
 
 use crate::log_child;
+use crate::cgroups_rs as cgroups;
 use safe_path::scoped_join;
 
 // Info reveals information about a particular mounted filesystem. This

--- a/src/agent/src/confidential_data_hub/mod.rs
+++ b/src/agent/src/confidential_data_hub/mod.rs
@@ -53,8 +53,8 @@ pub struct CDHClient {
 }
 
 impl CDHClient {
-    pub fn new(cdh_socket_uri: &str) -> Result<Self> {
-        let client = ttrpc::asynchronous::Client::connect(cdh_socket_uri)?;
+    pub async fn new(cdh_socket_uri: &str) -> Result<Self> {
+        let client = ttrpc::asynchronous::Client::connect(cdh_socket_uri).await?;
         let sealed_secret_client =
             confidential_data_hub_ttrpc_async::SealedSecretServiceClient::new(client.clone());
         let image_pull_client =
@@ -145,7 +145,9 @@ impl CDHClient {
 pub async fn init_cdh_client(cdh_socket_uri: &str) -> Result<()> {
     CDH_CLIENT
         .get_or_try_init(|| async {
-            CDHClient::new(cdh_socket_uri).context("Failed to create CDH Client")
+            CDHClient::new(cdh_socket_uri)
+                .await
+                .context("Failed to create CDH Client")
         })
         .await?;
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -29,7 +29,7 @@ use ttrpc::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use cgroups::freezer::FreezerState;
+use cgroups::FreezerState;
 use oci::{Hooks, LinuxNamespace, Spec};
 use oci_spec::runtime as oci;
 #[cfg(feature = "agent-policy")]

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2671,7 +2671,6 @@ mod tests {
 
     fn mk_ttrpc_context() -> TtrpcContext {
         TtrpcContext {
-            fd: -1,
             mh: MessageHeader::default(),
             metadata: std::collections::HashMap::new(),
             timeout_nano: 0,

--- a/src/libs/kata-sys-util/Cargo.toml
+++ b/src/libs/kata-sys-util/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.3"
 pci-ids = "0.2.6"
 
 kata-types = { path = "../kata-types" }
-oci-spec = { version = "0.8.1", features = ["runtime"] }
+oci-spec = { workspace = true }
 runtime-spec = { path = "../runtime-spec" }
 
 [dev-dependencies]

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -30,7 +30,7 @@ sysinfo = { workspace = true }
 sha2 = { workspace = true }
 flate2 = "1.1"
 nix = { workspace = true }
-oci-spec = { version = "0.8.1", features = ["runtime"] }
+oci-spec = { workspace = true }
 gpt = "4.1.0"
 scopeguard = "1.0.0"
 crc = "3.4.0"

--- a/src/libs/pod-resources-rs/Cargo.toml
+++ b/src/libs/pod-resources-rs/Cargo.toml
@@ -15,7 +15,7 @@ tonic = "0.14"
 prost = "0.14"
 tonic-prost = "0.14"
 oci-spec = { workspace = true }
-container-device-interface = "0.1.2"
+container-device-interface.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }

--- a/src/libs/protocols/Cargo.toml
+++ b/src/libs/protocols/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = { version = "0.1.42", optional = true }
 protobuf = { version = "3.7.2" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-oci-spec = { version = "0.8.1", features = ["runtime"] }
+oci-spec = { workspace = true }
 
 [build-dependencies]
 ttrpc-codegen = "0.6.0"

--- a/src/libs/protocols/Cargo.toml
+++ b/src/libs/protocols/Cargo.toml
@@ -11,7 +11,7 @@ with-serde = []
 async = ["ttrpc/async", "async-trait"]
 
 [dependencies]
-ttrpc = "0.8.4"
+ttrpc = { workspace = true }
 async-trait = { version = "0.1.42", optional = true }
 protobuf = { version = "3.7.2" }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -8,13 +8,12 @@ mod agent;
 mod trans;
 
 use std::{
-    os::unix::io::{IntoRawFd, RawFd},
+    os::unix::io::RawFd,
     sync::Arc,
 };
 
 use anyhow::{Context, Result};
 use kata_types::config::Agent as AgentConfig;
-use nix::unistd;
 use protocols::{agent_ttrpc_async as agent_ttrpc, health_ttrpc_async as health_ttrpc};
 use tokio::sync::RwLock;
 use ttrpc::asynchronous::Client;
@@ -114,17 +113,17 @@ impl KataAgent {
             sock::new(&inner.socket_address, inner.config.server_port).context("new sock")?;
         info!(sl!(), "try to connect agent server through {:?}", sock);
         let stream = sock.connect(&config).await.context("connect")?;
-        let fd = stream.into_raw_fd();
+        let client_fd = stream.raw_fd();
         info!(
             sl!(),
             "get stream raw fd {:?} with socket address: {:?} and server_port {:?}",
-            fd,
+            client_fd,
             &inner.socket_address,
             inner.config.server_port
         );
-        let c = Client::new(fd);
+        let c = Client::new(stream.into_ttrpc_socket());
         inner.client = Some(c);
-        inner.client_fd = fd;
+        inner.client_fd = client_fd;
         Ok(())
     }
 
@@ -168,14 +167,9 @@ impl KataAgent {
         let mut inner = self.inner.write().await;
         inner.log_forwarder.stop();
 
-        // If there is a valid client, drop it
+        // If there is a valid client, drop it (closes the connection).
         inner.client.take();
-
-        // If fd is valid (> 0), close it
-        if inner.client_fd >= 0 {
-            unistd::close(inner.client_fd).context("failed to close agent client fd")?;
-            inner.client_fd = -1;
-        }
+        inner.client_fd = -1;
 
         Ok(())
     }

--- a/src/runtime-rs/crates/agent/src/sock/mod.rs
+++ b/src/runtime-rs/crates/agent/src/sock/mod.rs
@@ -15,7 +15,7 @@ use std::{
     pin::Pin,
     task::{Context as TaskContext, Poll},
     {
-        os::unix::{io::IntoRawFd, prelude::RawFd},
+        os::unix::io::{AsRawFd, RawFd},
         sync::Arc,
     },
 };
@@ -26,6 +26,7 @@ use tokio::{
     io::{AsyncRead, ReadBuf},
     net::UnixStream,
 };
+use ttrpc::asynchronous::transport::Socket as TtrpcSocket;
 use url::Url;
 
 const VSOCK_SCHEME: &str = "vsock";
@@ -53,18 +54,15 @@ impl Stream {
             Stream::Unix(stream) | Stream::Vsock(stream) => Pin::new(stream).poll_read(cx, buf),
         }
     }
-}
-
-impl IntoRawFd for Stream {
-    fn into_raw_fd(self) -> RawFd {
+    pub(crate) fn raw_fd(&self) -> RawFd {
         match self {
-            Stream::Unix(stream) | Stream::Vsock(stream) => match stream.into_std() {
-                Ok(stream) => stream.into_raw_fd(),
-                Err(err) => {
-                    error!(sl!(), "failed to into std unix stream {:?}", err);
-                    -1
-                }
-            },
+            Stream::Unix(stream) | Stream::Vsock(stream) => stream.as_raw_fd(),
+        }
+    }
+
+    pub(crate) fn into_ttrpc_socket(self) -> TtrpcSocket {
+        match self {
+            Stream::Unix(stream) | Stream::Vsock(stream) => TtrpcSocket::from(stream),
         }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -75,7 +75,7 @@ impl RemoteInner {
         }
     }
 
-    fn get_ttrpc_client(&mut self) -> Result<HypervisorClient> {
+    async fn get_ttrpc_client(&mut self) -> Result<HypervisorClient> {
         match self.client {
             Some(ref c) => Ok(HypervisorClient::new(c.clone())),
             None => {
@@ -83,6 +83,7 @@ impl RemoteInner {
                     "unix://{}",
                     &self.config.remote_info.hypervisor_socket
                 ))
+                .await
                 .context("connect to ")?;
                 self.client = Some(c.clone());
                 Ok(HypervisorClient::new(c))
@@ -163,7 +164,7 @@ impl RemoteInner {
             std::fs::metadata(netns_path).context("check netns path")?;
         }
 
-        let client = self.get_ttrpc_client()?;
+        let client = self.get_ttrpc_client().await?;
 
         let ctx = context::Context::default();
         let req = CreateVMRequest {
@@ -192,7 +193,7 @@ impl RemoteInner {
         }
         let timeout = min_timeout;
 
-        let client = self.get_ttrpc_client()?;
+        let client = self.get_ttrpc_client().await?;
 
         let req = StartVMRequest {
             id: self.id.clone(),
@@ -208,7 +209,7 @@ impl RemoteInner {
     pub(crate) async fn stop_vm(&mut self) -> Result<()> {
         info!(sl!(), "Stopping REMOTE VM");
 
-        let client = self.get_ttrpc_client()?;
+        let client = self.get_ttrpc_client().await?;
 
         let ctx = context::with_timeout(time::Duration::from_secs(1).as_nanos() as i64);
         let req = StopVMRequest {

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -17,7 +17,7 @@ actix-rt = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 byte-unit = "5.1.6"
-cgroups-rs = { version = "0.5.0", features = ["oci"] }
+cgroups.workspace = true
 futures = "0.3.11"
 lazy_static = { workspace = true }
 libc = { workspace = true }

--- a/src/runtime-rs/crates/resource/src/cgroups/mod.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/mod.rs
@@ -11,7 +11,7 @@ mod resource_inner;
 mod utils;
 
 use anyhow::{anyhow, Result};
-use cgroups_rs::manager::is_systemd_cgroup;
+use cgroups::manager::is_systemd_cgroup;
 use hypervisor::HYPERVISOR_DRAGONBALL;
 use kata_sys_util::spec::load_oci_spec;
 use kata_types::config::TomlConfig;

--- a/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use cgroups_rs::manager::is_systemd_cgroup;
-use cgroups_rs::{CgroupPid, FsManager, Manager, SystemdManager};
+use cgroups::manager::is_systemd_cgroup;
+use cgroups::{CgroupPid, FsManager, Manager, SystemdManager};
 use hypervisor::{Hypervisor, VcpuThreadIds};
 use kata_types::cpu::CpuSet;
 use nix::sched::{sched_setaffinity, CpuSet as NixCpuSet};
@@ -42,7 +42,7 @@ pub(crate) struct CgroupsResourceInner {
 }
 
 impl CgroupsResourceInner {
-    fn is_already_exists_error(err: &cgroups_rs::manager::Error) -> bool {
+    fn is_already_exists_error(err: &cgroups::manager::Error) -> bool {
         let mut source = err.source();
 
         while let Some(inner_err) = source {

--- a/src/runtime-rs/crates/service/src/event.rs
+++ b/src/runtime-rs/crates/service/src/event.rs
@@ -12,10 +12,11 @@ use async_trait::async_trait;
 use common::message::Event;
 use containerd_shim::publisher::RemotePublisher;
 use containerd_shim::util::timestamp;
-use containerd_shim::TtrpcContext;
 use containerd_shim_protos::protobuf::well_known_types::any::Any;
+use containerd_shim_protos::shim::event::Envelope;
 use containerd_shim_protos::shim::events;
 use containerd_shim_protos::shim_async::Events;
+use ttrpc::r#async::TtrpcContext;
 use ttrpc::MessageHeader;
 
 // Ttrpc address passed from container runtime.
@@ -71,7 +72,7 @@ impl ContainerdForwarder {
         &self,
         event: &Arc<dyn Event + Send + Sync>,
     ) -> Result<events::ForwardRequest> {
-        let mut envelope = events::Envelope::new();
+        let mut envelope = Envelope::new();
         envelope.set_topic(event.r#type().clone());
         envelope.set_namespace(self.namespace.to_string());
         envelope.set_timestamp(
@@ -137,7 +138,6 @@ impl Forwarder for LogForwarder {
 #[inline]
 fn default_ttrpc_context() -> TtrpcContext {
     TtrpcContext {
-        fd: 0,
         mh: MessageHeader::default(),
         metadata: HashMap::default(),
         timeout_nano: 0,

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -5,7 +5,7 @@
 //
 
 use std::fs;
-use std::os::unix::io::{FromRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -62,8 +62,8 @@ impl ServiceManager {
         let (sender, receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
         let rt_mgr = RuntimeHandlerManager::new(id, sender).context("new runtime handler")?;
         let handler = Arc::new(rt_mgr);
-        let mut server = unsafe { Server::from_raw_fd(task_server_fd) };
-        server = server.set_domain_unix();
+        // SAFETY: containerd passes a valid unix listener fd when starting the shim.
+        let server = unsafe { Server::new().add_unix_listener(task_server_fd)? };
         let event_publisher = new_event_publisher(namespace)
             .await
             .context("new event publisher")?;


### PR DESCRIPTION
Bump the workspace to oci-spec 0.10.0. Also switch `kata-types`, `protocols` and `kata-sys-util` to `oci-spec.workspace = true`, they still carried their own 0.8.1 pins, which split the oci-spec types across the tree and broke the agent build after the bump.

The two crates that consumed oci-spec 0.8 types through external dependencies are now handled as well:

- **kata-agent / pod-resources-rs**: bumped `container-device-interface` to 1.1.1, the first cdi-rs release built against oci-spec 0.10 (we drove that bump upstream). The dependency is hoisted to the root workspace like oci-spec itself.
- **resource**: `cgroups-rs` main has the oci-spec 0.10 bump merged (kata-containers/cgroups-rs#167) but no release cut yet, so the crate is pinned to the exact merge commit — same interim pattern as the existing `cgroups` v0.3.5 git pin. Will switch back to a crates.io version once a release is published.

No old oci-spec (0.8.x) remains in the dependency graph; the remaining 0.7.1/0.9.0 duplicates come from `containerd-shim` and `oci-client` and are out of scope here.

All touched crates (`kata-agent`, `rustjail`, `pod-resources-rs`, `resource`, libs) compile; the only local `cargo check --workspace` failures are the pre-existing Makefile-generated module gaps (`shim`, `kata-ctl`, `genpolicy`), unrelated to this change.