### PR TITLE
kata-deploy: shift erofs dm-verity mode to on

### DIFF
--- a/tests/integration/kubernetes/k8s-erofs-dmverity.bats
+++ b/tests/integration/kubernetes/k8s-erofs-dmverity.bats
@@ -5,19 +5,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Verifies that, when the erofs snapshotter is configured with dm-verity,
-# kata-agent activates dm-verity for every EROFS layer in the guest rootfs.
+# kata-agent activates dm-verity for every workload EROFS layer mounted
+# inside the guest.
 #
 # Verification strategy:
-#   The pod's container command (defined in the manifest) checks dmesg for
-#   BOTH:
-#     * "device-mapper: verity: sha256 using ..."  — emitted by
-#       drivers/md/dm-verity-target.c when a verity target is loaded.
-#     * "erofs (device dm-N): mounted ..."         — emitted by
-#       fs/erofs/super.c on a successful mount.
-#   The presence of both implies each EROFS layer went through a dm-verity
-#   device on the I/O path. The command exits 0 on success and 1 on
-#   failure; with restartPolicy: Never the pod reaches Succeeded or Failed
-#   respectively, which the test polls for.
+#   The pod derives the expected workload layer count from the root overlay's
+#   lowerdirs, then requires the same number of kata-verity devices and
+#   dm-backed EROFS mounts. The guest rootfs and pause container are outside
+#   this test's scope. The command exits 0 on success and 1 on failure; with
+#   restartPolicy: Never the pod reaches Succeeded or Failed respectively,
+#   which the test polls for.
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/lib.sh"
@@ -94,4 +91,3 @@ teardown() {
 		teardown_common "${node:-}" "${node_start_time:-}"
 	fi
 }
-

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-erofs-dmverity-probe.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-erofs-dmverity-probe.yaml
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Probe pod used by k8s-erofs-dmverity.bats.
-# The container command verifies that every EROFS layer was mounted through
-# a dm-verity device by checking dmesg for both dm-verity and erofs mount
-# records, then exits 0 on success or 1 on failure.
+# The container command verifies that every workload EROFS lower layer was
+# mounted through a dm-verity device by checking the root overlay lowerdirs and
+# their backing devices, then exits 0 on success or 1 on failure.
 
 apiVersion: v1
 kind: Pod
@@ -22,12 +22,48 @@ spec:
       - sh
       - -c
       - |-
-        log=$(dmesg 2>&1 | tail -n 100)
-        verity_lines=$(printf "%s\n" "$log" | grep -c "device-mapper: verity")
-        erofs_lines=$(printf "%s\n" "$log" | grep -cE "erofs \(device dm-[0-9]+\): mounted")
-        echo "verity_lines=${verity_lines} erofs_lines=${erofs_lines}"
-        if [ "${verity_lines}" -lt 1 ] || [ "${erofs_lines}" -lt 1 ]; then
-          echo "--- last 100 lines of dmesg ---"
-          printf "%s\n" "$log"
+        root_options=$(awk '$2 == "/" && $3 == "overlay" { print $4; exit }' /proc/mounts)
+        lowerdirs=${root_options#*lowerdir=}
+        lowerdirs=${lowerdirs%%,*}
+        if [ -z "${lowerdirs}" ] || [ "${lowerdirs}" = "${root_options}" ]; then
+          echo "unable to determine workload lower layers from the root overlay"
+          cat /proc/mounts
+          exit 1
+        fi
+
+        lower_count=$(printf "%s\n" "${lowerdirs}" | awk -F: '{ print NF }')
+        erofs_devices=$(dmesg 2>&1 |
+          sed -n 's/.*erofs (device \([^)]*\)): mounted.*/\1/p' |
+          sort -u)
+
+        verity_count=0
+        mounted_count=0
+        for dm_path in /sys/class/block/dm-*; do
+          [ -e "${dm_path}" ] || continue
+          dm_name=$(cat "${dm_path}/dm/name" 2>/dev/null || true)
+          case "${dm_name}" in
+            kata-verity-*)
+              verity_count=$((verity_count + 1))
+              dm_device=${dm_path##*/}
+              if printf "%s\n" "${erofs_devices}" | grep -qx "${dm_device}"; then
+                mounted_count=$((mounted_count + 1))
+              else
+                echo "dm-verity workload device ${dm_device} was not mounted as EROFS"
+              fi
+              ;;
+          esac
+        done
+
+        echo "workload_lower_layers=${lower_count} kata_verity_devices=${verity_count} dm_erofs_mounts=${mounted_count}"
+        if [ "${lower_count}" -ne "${verity_count}" ] ||
+          [ "${lower_count}" -ne "${mounted_count}" ]; then
+          echo "--- EROFS devices from dmesg ---"
+          printf "%s\n" "${erofs_devices}"
+          echo "--- device-mapper devices ---"
+          for dm_path in /sys/class/block/dm-*; do
+            [ -e "${dm_path}" ] || continue
+            printf "%s " "${dm_path##*/}"
+            cat "${dm_path}/dm/name" 2>/dev/null || true
+          done
           exit 1
         fi

--- a/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
@@ -79,6 +79,8 @@ pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &P
     // disk or in memory. When dm-verity is enabled, fsverity and immutable are
     // disabled on the snapshotter side in favor of dm-verity.
     let use_dmverity = config.erofs_dmverity;
+    let dmverity_mode = if use_dmverity { "\"on\"" } else { "\"off\"" };
+    let enable_dmverity = if use_dmverity { "true" } else { "false" };
 
     toml_utils::set_toml_value(
         configuration_file,
@@ -91,13 +93,16 @@ pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &P
         "true",
     )?;
 
-    if use_dmverity {
-        toml_utils::set_toml_value(
-            configuration_file,
-            ".plugins.\"io.containerd.snapshotter.v1.erofs\".dmverity_mode",
-            "\"auto\"",
-        )?;
-    }
+    toml_utils::set_toml_value(
+        configuration_file,
+        ".plugins.\"io.containerd.snapshotter.v1.erofs\".dmverity_mode",
+        dmverity_mode,
+    )?;
+    toml_utils::set_toml_value(
+        configuration_file,
+        ".plugins.\"io.containerd.differ.v1.erofs\".enable_dmverity",
+        enable_dmverity,
+    )?;
 
     // Erofs differ plugin options (requires erofs-utils >= 1.8.2 on the host).
     toml_utils::set_toml_value(
@@ -110,14 +115,6 @@ pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &P
         ".plugins.\"io.containerd.differ.v1.erofs\".enable_tar_index",
         "false",
     )?;
-
-    if use_dmverity {
-        toml_utils::set_toml_value(
-            configuration_file,
-            ".plugins.\"io.containerd.differ.v1.erofs\".enable_dmverity",
-            "true",
-        )?;
-    }
 
     toml_utils::set_toml_value(
         configuration_file,


### PR DESCRIPTION
## Summary
Shift kata-deploy’s EROFS dm-verity configuration from `dmverity_mode = "auto"` to `dmverity_mode = "on"`.

`dmverity_mode = "auto"` can preserve existing EROFS layers without dm-verity metadata, which lets mixed-mode nodes keep running with partially unprotected image layers. With `dmverity_mode = "on"`, missing dm-verity metadata is reported instead of silently accepted when kata-deploy enables EROFS dm-verity.

This change also tightens the Kubernetes EROFS dm-verity probe. Instead of checking for at least one dm-verity line and one EROFS dm mount in `dmesg`, the test now derives the expected workload layer count from the root overlay `lowerdir=` list and requires matching `kata-verity-*` devices and dm-backed EROFS mounts.

## Outlook: Follow-up work

At least one follow-up PR will document EROFS snapshotter deployment gotchas/requirements, especially around the dm-verity enablement path. I also plan to increase kata-deploy validation around EROFS snapshotter deployment.
This work is part of a larger initiative to shift the NVIDIA GPU runtime-rs handler to using the EROFS snapshotter for which various pieces need to come in place.

## Probe logic example

The probe now validates three numbers:

```text
workload_lower_layers=9 kata_verity_devices=9 dm_erofs_mounts=9
```

Meaning:

- `workload_lower_layers`: expected workload image layer count, derived   from the root overlay `lowerdir=` list.
- `kata_verity_devices`: number of workload layer dm-verity devices,   identified via `/sys/class/block/dm-*/dm/name == kata-verity-*`.
- `dm_erofs_mounts`: number of those `kata-verity-*` dm devices that actually appear as mounted EROFS devices in `dmesg`.

This intentionally filters out unrelated EROFS mounts such as the guest rootfs:

```text
erofs_devices="dm-0 dm-1 dm-2 dm-3 dm-4 dm-5 dm-6 dm-7 dm-8 dm-9 sda"

[    0.965647] erofs (device sda): mounted with root inode @ nid 36.
[    1.375475] erofs (device dm-1): mounted with root inode @ nid 36.
```

For example, `sda` is visible as an EROFS mount but is not counted, because the test only counts EROFS mounts for devices whose dm name is `kata-verity-*`:

```text
/sys/class/block/dm-0/dm/name: dm-verity
/sys/class/block/dm-1/dm/name: kata-verity-sdb1-off4096-...
```

The expected count comes from the root overlay lowerdirs, for example:

```text
/run/kata-containers/.../multi-layer/lower-0:
...
/run/kata-containers/.../multi-layer/lower-8
```