### PR TITLE
kata-deploy: Bump NFD to its ~0.19.x releases

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/Chart.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/Chart.yaml
@@ -25,6 +25,6 @@ appVersion: "3.32.0"
 
 dependencies:
   - name: node-feature-discovery
-    version: "~0.18.0"
+    version: "~0.19.0"
     repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
     condition: node-feature-discovery.enabled


### PR DESCRIPTION
NFD has been released last week, just in time for our new release.