### PR TITLE
tests: skip large image pod tests on s390x zVSI

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -134,7 +134,7 @@ jobs:
         if: ${{ startsWith(matrix.vmm, 'qemu-coco-dev') }}
 
       - name: Install `kbs-client`
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
         if: ${{ startsWith(matrix.vmm, 'qemu-coco-dev') }}
 

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -105,6 +105,10 @@ setup() {
     # The image pulled in the guest will be downloaded and unpacked in the `/run/kata-containers/image` directory.
     # The tests will use `cryptsetup` to encrypt a block device and mount it at `/run/kata-containers/image`.
 
+    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
+        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
+    fi
+
     storage_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${storage_config_template}").XXXXXX.yaml")
     local_device=$(create_loop_device)
     PV_NAME=trusted-block-pv PVC_NAME=trusted-pvc \
@@ -153,6 +157,10 @@ setup() {
 }
 
 @test "Test we cannot pull a large image that pull time exceeds createcontainer timeout inside the guest" {
+    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
+        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
+    fi
+
     storage_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${storage_config_template}").XXXXXX.yaml")
     local_device=$(create_loop_device)
     PV_NAME=trusted-block-pv PVC_NAME=trusted-pvc \
@@ -208,6 +216,9 @@ setup() {
 }
 
 @test "Test we can pull a large image inside the guest with large createcontainer timeout" {
+    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
+        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
+    fi
     if [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] && [ "${KBS_INGRESS}" = "aks" ]; then
         skip "skip this specific one due to issue https://github.com/kata-containers/kata-containers/issues/10299"
     fi


### PR DESCRIPTION
3 trusted-storage guest-pull tests require a pod that demands more CPU than is available on the downgraded zVSI profile (4 vCPU x 8 GB) used for IBM Cloud s390x CI, causing scheduling to fail with:

```
1 Insufficient cpu. no new claims to deallocate, preemption: 0/1 nodes
are available: 1 No preemption victims found for incoming pod.
```

Skip all three tests when running on s390x with KATA_HYPERVISOR=qemu-coco-dev* to avoid false failures on this instance profile.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>