### PR TITLE
hypervisor/qemu: Platform Phase 1 -- constructors and topology builder

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/ARCHITECTURE.md
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/ARCHITECTURE.md
@@ -644,6 +644,11 @@ Final PR in Phase 2: remove all remaining `#[cfg(target_arch)]` blocks from
   `MemoryBackend::File`.
 - Wire hugepages via `Platform::with_hugepages`.
 - Lift `ObjectIoThread` / `ObjectRngRandom` into `Objects`.
+- Consider wiring `seccompsandbox` (QEMU `-sandbox`) through `Platform`:
+  the config field `seccomp_sandbox: Option<String>` already maps to
+  `-sandbox` in `cmdline_generator.rs`, but the new path needs a typed
+  `Objects::seccomp_sandbox: Option<SeccompSandbox>` so the emission
+  is controlled by `Platform` rather than the legacy generator.
 
 This is the phase that enables hugepages for `runtime-rs` (issue #12125).
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
@@ -2,11 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 
 use super::{
-    probe::HostTopology, pseries::Pseries, q35::Q35, s390x::S390xCcwVirtio, topology::PciTopology,
+    probe::{HostTopology, SocketInfo},
+    pseries::Pseries,
+    q35::Q35,
+    s390x::S390xCcwVirtio,
+    topology::{BusIommu, PciRootComplex, PciRootPort, PciTopology, SmmuV3Config, VfioDevice, VfioDeviceKind},
     virt::Virt,
 };
 
@@ -23,7 +27,6 @@ pub(crate) enum Machine {
     S390xCcwVirtio(S390xCcwVirtio),
 }
 
-/// Fields common to all machine types.
 pub(crate) struct BaseMachine {
     pub accel: String,
     /// ID of the primary memory backend, written as `-machine memory-backend=<id>`.
@@ -138,38 +141,168 @@ pub(crate) struct ObjectRngRandom {
     pub filename: String,
 }
 
+const PRIMARY_RAM_ID: &str = "ram0";
+
 impl Platform {
-    pub fn from_config(_config: &HypervisorConfig) -> Result<Self> {
-        todo!("Phase 1")
+    pub fn from_config(config: &HypervisorConfig) -> Result<Self> {
+        let memory_size = u64::from(config.memory_info.default_memory) << 20;
+        Self::build(&config.machine_info.machine_type, memory_size)
     }
 
-    /// Test-only constructor; produces a minimal Virt platform with RAM-backed
-    /// memory. Replaced in Phase 1 by from_config once the builder exists.
     #[cfg(test)]
-    pub(crate) fn from_config_defaults(_memory_size: u64) -> Result<Self> {
-        todo!("Phase 1")
+    pub(crate) fn from_config_defaults(memory_size: u64) -> Result<Self> {
+        Self::build("virt", memory_size)
     }
 
-    pub fn apply_host_defaults(&mut self, _topo: &HostTopology) {
-        todo!("Phase 4")
+    fn build(machine_type: &str, memory_size: u64) -> Result<Self> {
+        let base = BaseMachine {
+            accel: "kvm".to_owned(),
+            memory_backend: Some(PRIMARY_RAM_ID.to_owned()),
+            cpu: CpuConfig {
+                model: CpuModel::Host { extra_features: vec![] },
+            },
+        };
+
+        let machine = match machine_type {
+            "q35" => Machine::Q35(Q35 {
+                base,
+                kernel_irqchip: Some("on".to_owned()),
+                intel_iommu: None,
+            }),
+            "virt" => Machine::Virt(Virt {
+                base,
+                gic_version: None,
+                ras: false,
+                highmem_mmio_size: None,
+            }),
+            "pseries" => Machine::Pseries(Pseries { base }),
+            "s390-ccw-virtio" => Machine::S390xCcwVirtio(S390xCcwVirtio { base }),
+            other => bail!("unknown machine type: {other}"),
+        };
+
+        Ok(Self {
+            machine,
+            pci: PciTopology { default_bus: None, roots: vec![] },
+            objects: Objects {
+                iommufd: None,
+                memory_backends: vec![MemoryBackend::Ram {
+                    id: PRIMARY_RAM_ID.to_owned(),
+                    size: memory_size,
+                }],
+                thread_contexts: vec![],
+                acpi_links: vec![],
+                rng: None,
+            },
+        })
     }
 
-    pub fn with_hugepages(self, _path: &str) -> Self {
-        todo!("Phase 3")
+    pub fn apply_host_defaults(&mut self, topo: &HostTopology) {
+        let has_gpus = topo.gpu_smmu_groups.iter().any(|g| !g.pci_bus_addrs.is_empty());
+        if has_gpus {
+            self.objects.iommufd = Some(IommufdBackend { id: "iommufd0".to_owned() });
+        }
+
+        for (idx, egm) in topo.egm_sockets.iter().enumerate() {
+            self.objects.memory_backends.push(MemoryBackend::File {
+                id: format!("egm{idx}"),
+                size: egm.total_size,
+                path: egm.path.clone(),
+                prealloc: false,
+                share: true,
+            });
+        }
+
+        let n_cpu_nodes = topo.sockets.len();
+        let mut gpu_idx = 0usize;
+
+        for (group_idx, group) in topo.gpu_smmu_groups.iter().enumerate() {
+            // 0x40 is the conventional start for pxb-pcie to avoid the primary bus range.
+            let bus_nr = 0x40u8.saturating_add((group_idx as u8).saturating_mul(0x20));
+            let cpu_mem_node = socket_numa_node(&topo.sockets, group.socket);
+            let has_egm = topo.egm_sockets.iter().any(|e| e.socket == group.socket);
+
+            let mut root_ports = Vec::new();
+            for pci_addr in &group.pci_bus_addrs {
+                let dev_id = format!("gpu{gpu_idx}");
+                let port_id = format!("rp{gpu_idx}");
+
+                for i in 0..8u32 {
+                    let node = (n_cpu_nodes + gpu_idx * 8 + i as usize) as u32;
+                    self.objects.acpi_links.push(AcpiPciNodeLink::GenericInitiator {
+                        id: format!("{dev_id}_{i}"),
+                        pci_dev: dev_id.clone(),
+                        node,
+                    });
+                }
+
+                if has_egm {
+                    self.objects.acpi_links.push(AcpiPciNodeLink::EgmMemory {
+                        id: format!("egm_{dev_id}"),
+                        pci_dev: dev_id.clone(),
+                        node: cpu_mem_node,
+                    });
+                }
+
+                root_ports.push(PciRootPort {
+                    id: port_id,
+                    chassis: (gpu_idx + 1) as u8,
+                    device: Some(VfioDevice {
+                        id: dev_id,
+                        host: pci_addr.clone(),
+                        rombar: false,
+                        kind: VfioDeviceKind::Gpu,
+                    }),
+                });
+
+                gpu_idx += 1;
+            }
+
+            self.pci.roots.push(PciRootComplex {
+                id: format!("pxb{group_idx}"),
+                bus_nr,
+                numa_node: Some(cpu_mem_node),
+                iommu: if root_ports.is_empty() {
+                    None
+                } else {
+                    Some(BusIommu::SmmuV3(SmmuV3Config::default()))
+                },
+                root_ports,
+            });
+        }
     }
 
-    /// Emit the complete QEMU command-line argument list.
-    ///
-    /// Emission order:
-    ///   1. iommufd object
-    ///   2. remaining objects (memory backends, thread contexts, rng)
-    ///   3. -machine (picks up memory-backend=)
-    ///   4. CpuMem -numa node entries (cpus= + memdev=)
-    ///   5. GPU initiator -numa node entries (8 per GPU, no cpus/memdev)
-    ///   6. EGM / hotplug -numa node entries (memory-only)
-    ///   7. PciTopology (pxb-pcie, arm-smmuv3, root ports, vfio devices)
-    ///   8. acpi_links (acpi-generic-initiator x8 per GPU, acpi-egm-memory x1 per GPU)
+    pub fn with_hugepages(self, path: &str) -> Self {
+        let backends = self
+            .objects
+            .memory_backends
+            .into_iter()
+            .map(|b| match b {
+                MemoryBackend::Ram { id, size } => MemoryBackend::File {
+                    id,
+                    size,
+                    path: path.to_owned(),
+                    prealloc: true,
+                    share: false,
+                },
+                other => other,
+            })
+            .collect();
+
+        Platform {
+            objects: Objects { memory_backends: backends, ..self.objects },
+            ..self
+        }
+    }
+
     pub fn to_qemu_args(&self) -> Result<Vec<String>> {
         todo!("Phase 2+")
     }
+}
+
+// Socket IDs are not guaranteed contiguous; use position to get a dense NUMA node number.
+fn socket_numa_node(sockets: &[SocketInfo], socket_id: u32) -> u32 {
+    sockets
+        .iter()
+        .position(|s| s.id == socket_id)
+        .unwrap_or(socket_id as usize) as u32
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/probe.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/probe.rs
@@ -4,8 +4,6 @@
 
 use std::ops::Range;
 
-/// Host topology discovered from sysfs and IOMMU group layout.
-/// Consumed by Platform::apply_host_defaults to build PciTopology and Objects.
 pub(crate) struct HostTopology {
     pub sockets: Vec<SocketInfo>,
     pub gpu_smmu_groups: Vec<GpuSmmuGroup>,
@@ -18,13 +16,11 @@ pub(crate) struct SocketInfo {
 }
 
 /// GPUs sharing a physical SMMU must be placed on the same pxb-pcie + arm-smmuv3.
-/// Grouping is derived from /sys/kernel/iommu_groups.
 pub(crate) struct GpuSmmuGroup {
     pub pci_bus_addrs: Vec<String>,
     pub socket: u32,
 }
 
-/// One entry per /dev/egmN device created by the nvgrace-egm kernel module.
 pub(crate) struct EgmSocketInfo {
     pub path: String,
     pub socket: u32,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/q35.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/q35.rs
@@ -7,8 +7,7 @@ use super::platform::BaseMachine;
 pub(crate) struct Q35 {
     pub base: BaseMachine,
     pub kernel_irqchip: Option<String>,
-    /// Global IOMMU for Q35. Emitted as a top-level -device intel-iommu,
-    /// not attached to any pxb-pcie. Contrast with BusIommu on PciRootComplex.
+    /// Not bus-attached; contrast with BusIommu on PciRootComplex.
     pub intel_iommu: Option<IntelIommuConfig>,
 }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use super::platform::Platform;
+use super::platform::{AcpiPciNodeLink, Machine, MemoryBackend, Platform};
 use super::probe::{EgmSocketInfo, GpuSmmuGroup, HostTopology, SocketInfo};
 
 // Each fixture file contains one Vec<String> element per line.
@@ -46,6 +46,150 @@ fn smmu_groups(addrs: &[&[&str]], socket: u32) -> Vec<GpuSmmuGroup> {
             socket,
         })
         .collect()
+}
+
+// ---- Phase 1: structural unit tests (not ignored) ----
+
+#[test]
+fn from_config_defaults_produces_virt_with_ram() {
+    let p = Platform::from_config_defaults(16 << 30).expect("build");
+    assert!(matches!(p.machine, Machine::Virt(_)));
+    assert_eq!(p.objects.memory_backends.len(), 1);
+    assert!(matches!(
+        p.objects.memory_backends[0],
+        MemoryBackend::Ram { size: s, .. } if s == 16 << 30
+    ));
+    assert!(p.pci.roots.is_empty());
+    assert!(p.objects.iommufd.is_none());
+}
+
+#[test]
+fn apply_host_defaults_single_gpu() {
+    let mut p = Platform::from_config_defaults(16 << 30).unwrap();
+    p.apply_host_defaults(&HostTopology {
+        sockets: single_socket(0..4),
+        gpu_smmu_groups: smmu_groups(&[&["0008:06:00.0"]], 0),
+        egm_sockets: vec![],
+    });
+
+    assert!(p.objects.iommufd.is_some());
+    assert_eq!(p.pci.roots.len(), 1);
+    assert_eq!(p.pci.roots[0].root_ports.len(), 1);
+    // 8 GenericInitiator NUMA nodes for 1 GPU
+    let gi_count = p
+        .objects
+        .acpi_links
+        .iter()
+        .filter(|l| matches!(l, AcpiPciNodeLink::GenericInitiator { .. }))
+        .count();
+    assert_eq!(gi_count, 8);
+    // No EGM links when egm_sockets is empty
+    let egm_count = p
+        .objects
+        .acpi_links
+        .iter()
+        .filter(|l| matches!(l, AcpiPciNodeLink::EgmMemory { .. }))
+        .count();
+    assert_eq!(egm_count, 0);
+}
+
+#[test]
+fn apply_host_defaults_four_gpus_two_per_smmu() {
+    let mut p = Platform::from_config_defaults(16 << 30).unwrap();
+    p.apply_host_defaults(&HostTopology {
+        sockets: single_socket(0..4),
+        gpu_smmu_groups: smmu_groups(
+            &[
+                &["0008:06:00.0", "0009:06:00.0"],
+                &["0010:06:00.0", "0011:06:00.0"],
+            ],
+            0,
+        ),
+        egm_sockets: vec![],
+    });
+
+    // 2 PciRootComplexes, each with 2 ports
+    assert_eq!(p.pci.roots.len(), 2);
+    assert_eq!(p.pci.roots[0].root_ports.len(), 2);
+    assert_eq!(p.pci.roots[1].root_ports.len(), 2);
+    // 4 GPUs × 8 = 32 GenericInitiator nodes
+    let gi_count = p
+        .objects
+        .acpi_links
+        .iter()
+        .filter(|l| matches!(l, AcpiPciNodeLink::GenericInitiator { .. }))
+        .count();
+    assert_eq!(gi_count, 32);
+}
+
+#[test]
+fn apply_host_defaults_egm_adds_backends_and_links() {
+    let mut p = Platform::from_config_defaults(16 << 30).unwrap();
+    p.apply_host_defaults(&HostTopology {
+        sockets: vec![
+            SocketInfo { id: 0, cpu_range: 0..1 },
+            SocketInfo { id: 1, cpu_range: 1..2 },
+        ],
+        gpu_smmu_groups: vec![
+            GpuSmmuGroup { pci_bus_addrs: vec!["0008:06:00.0".into()], socket: 0 },
+            GpuSmmuGroup { pci_bus_addrs: vec!["0009:06:00.0".into()], socket: 1 },
+        ],
+        egm_sockets: vec![
+            EgmSocketInfo { path: "/dev/egm4".into(), socket: 0, total_size: 56896 << 20 },
+            EgmSocketInfo { path: "/dev/egm5".into(), socket: 1, total_size: 56896 << 20 },
+        ],
+    });
+
+    // Primary RAM + 2 EGM file backends
+    assert_eq!(p.objects.memory_backends.len(), 3);
+    assert!(matches!(p.objects.memory_backends[1], MemoryBackend::File { ref path, .. } if path == "/dev/egm4"));
+    assert!(matches!(p.objects.memory_backends[2], MemoryBackend::File { ref path, .. } if path == "/dev/egm5"));
+
+    // 2 GPUs × 1 EgmMemory link each
+    let egm_count = p
+        .objects
+        .acpi_links
+        .iter()
+        .filter(|l| matches!(l, AcpiPciNodeLink::EgmMemory { .. }))
+        .count();
+    assert_eq!(egm_count, 2);
+}
+
+#[test]
+fn with_hugepages_replaces_ram_backend() {
+    let p = Platform::from_config_defaults(16 << 30).unwrap();
+    let p = p.with_hugepages("/dev/hugepages");
+    assert_eq!(p.objects.memory_backends.len(), 1);
+    assert!(matches!(
+        p.objects.memory_backends[0],
+        MemoryBackend::File { ref path, prealloc: true, .. } if path == "/dev/hugepages"
+    ));
+}
+
+#[test]
+fn with_hugepages_preserves_egm_backends() {
+    let mut p = Platform::from_config_defaults(16 << 30).unwrap();
+    p.apply_host_defaults(&HostTopology {
+        sockets: single_socket(0..4),
+        gpu_smmu_groups: smmu_groups(&[&["0008:06:00.0"]], 0),
+        egm_sockets: vec![EgmSocketInfo {
+            path: "/dev/egm4".into(),
+            socket: 0,
+            total_size: 56896 << 20,
+        }],
+    });
+    let p = p.with_hugepages("/dev/hugepages");
+
+    // RAM backend swapped, EGM file backend preserved
+    assert_eq!(p.objects.memory_backends.len(), 2);
+    assert!(matches!(
+        p.objects.memory_backends[0],
+        MemoryBackend::File { ref path, prealloc: true, .. } if path == "/dev/hugepages"
+    ));
+    assert!(matches!(
+        p.objects.memory_backends[1],
+        MemoryBackend::File { ref path, .. } if path == "/dev/egm4"
+    ));
 }
 
 // ---- Grace Config 1: single GPU, 1 SMMU, 9 NUMA nodes ----

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/topology.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/topology.rs
@@ -10,12 +10,10 @@ pub(crate) struct PciTopology {
 pub(crate) struct PciRootComplex {
     pub id: String,
     pub bus_nr: u8,
-    /// Written as pxb-pcie `numa_node=N`. Required on Grace; omitting it
-    /// triggers "Unknown NUMA node; performance will be reduced" in the guest.
+    /// Omitting this triggers "Unknown NUMA node; performance will be reduced" in the guest kernel.
     pub numa_node: Option<u32>,
-    /// Bus-attached IOMMU. Intel IOMMU is a Q35-global device; see Q35::intel_iommu.
+    /// Intel IOMMU is Q35-global, not bus-attached; see Q35::intel_iommu.
     pub iommu: Option<BusIommu>,
-    /// One entry per passthrough device sharing this SMMU.
     pub root_ports: Vec<PciRootPort>,
 }
 
@@ -33,14 +31,11 @@ pub(crate) struct VfioDevice {
 }
 
 pub(crate) enum VfioDeviceKind {
-    /// Emits 8 acpi-generic-initiator objects after the device.
     Gpu,
-    /// No acpi-generic-initiator objects.
     Nic,
 }
 
-/// IOMMU that attaches to a specific PCIe expander bus (pxb-pcie).
-/// Intel IOMMU is a Q35-global device and is not represented here.
+/// Intel IOMMU is Q35-global and is not represented here; see Q35::intel_iommu.
 pub(crate) enum BusIommu {
     SmmuV3(SmmuV3Config),
 }
@@ -51,8 +46,7 @@ pub(crate) struct SmmuV3Config {
     pub pasid: bool,
     pub oas: u8,
     pub ril: bool,
-    /// Enable SMMU command-queue virtualisation. Requires physically
-    /// contiguous guest memory (hugepages or EGM).
+    /// Requires physically contiguous guest memory (hugepages or EGM).
     pub cmdqv: bool,
 }
 


### PR DESCRIPTION
Implements Phase 1 of the machine-centric QEMU refactor (issue #12187).
Stacks on #13357 (Phase 0 -- typed machine module and golden test harness).

### What changes

`Platform::from_config` and `from_config_defaults` now build real values
instead of `todo!()`. `apply_host_defaults` populates `PciTopology` from
`HostTopology`: one `PciRootComplex` + `arm-smmuv3` per `GpuSmmuGroup`,
one `PciRootPort` per GPU, 8 `GenericInitiator` NUMA nodes per GPU
(numbered after all CpuMem nodes), and EGM `File` backends plus
`EgmMemory` links when `egm_sockets` is present.
`with_hugepages` swaps the primary `Ram` backend for a `File` backend;
EGM backends are left untouched.

### Tests

Six structural unit tests added (all passing):

- `from_config_defaults_produces_virt_with_ram`
- `apply_host_defaults_single_gpu`
- `apply_host_defaults_four_gpus_two_per_smmu`
- `apply_host_defaults_egm_adds_backends_and_links`
- `with_hugepages_replaces_ram_backend`
- `with_hugepages_preserves_egm_backends`

Golden fixture tests (`grace_1` through `grace_7`) remain `#[ignore]`d
until `to_qemu_args` is wired in Phase 2+.

### What is not changed

The existing `cmdline_generator.rs` hot path is untouched. No external
dependencies added.
