### PR TITLE
config: enable QEMU seccomp sandbox for nvidia-gpu configuration

### DIFF
--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -78,7 +78,7 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
 # Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
-seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
+seccompsandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
 
 # CPU features
 # comma-separated list of cpu features to pass to the cpu


### PR DESCRIPTION
Without sandbox enforcement QEMU runs with unrestricted syscall access.
Enabling \`-sandbox\` restricts:
- \`obsolete=deny\` — obsolete syscalls blocked
- \`spawn=deny\` — prevents QEMU from forking child processes
- \`resourcecontrol=deny\` — blocks cgroup/rlimit manipulation

\`elevateprivileges=deny\` is intentionally omitted; it conflicts with
QEMU's daemonize mode and breaks startup.

The value \`"on,obsolete=deny,spawn=deny,resourcecontrol=deny"\` matches
the upstream recommended setting from the comment block above the option.