### PR TITLE
dragonball: Add support for template save and restore on x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test 0.10.0",
  "slog",
  "slog-async",
  "slog-scope",
@@ -3874,7 +3875,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
+ "serde",
  "vmm-sys-util 0.15.0",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -8812,6 +8815,8 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -28,7 +28,7 @@ dbs-virtio-devices = { workspace = true, optional = true, features = [
 ] }
 dbs-pci = { workspace = true, optional = true }
 derivative = "2.2.0"
-kvm-bindings = { workspace = true }
+kvm-bindings = { workspace = true, features = ["fam-wrappers", "serde"] }
 kvm-ioctls = { workspace = true }
 lazy_static = "1.2"
 libc = "0.2.39"
@@ -45,7 +45,7 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = { workspace = true }
 tracing = "0.1.41"
-vmm-sys-util = { workspace = true }
+vmm-sys-util = { workspace = true, features = ["with-serde"] }
 virtio-queue = { workspace = true, optional = true }
 vm-memory = { workspace = true, features = ["backend-mmap"] }
 crossbeam-channel = "0.5.6"
@@ -57,6 +57,7 @@ kata-sys-util = { path = "../libs/kata-sys-util" }
 tdx = { workspace = true }
 
 [dev-dependencies]
+serial_test = { workspace = true }
 slog-async = "2.7.0"
 slog-term = "2.9.0"
 test-utils = { workspace = true }

--- a/src/dragonball/dbs_interrupt/src/manager.rs
+++ b/src/dragonball/dbs_interrupt/src/manager.rs
@@ -351,6 +351,22 @@ impl<T: InterruptManager> DeviceInterruptManager<T> {
         Err(Error::from_raw_os_error(libc::EINVAL))
     }
 
+    /// Get the (low_addr, high_addr, data) of a MSI message.
+    #[allow(irrefutable_let_patterns)]
+    pub fn get_msi_config(&self, index: u32) -> Result<(u32, u32, u32)> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref msi) = self.msi_config[index as usize] {
+                return Ok((msi.low_addr, msi.high_addr, msi.data));
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Number of MSI vectors in the configuration space.
+    pub fn msi_config_count(&self) -> u32 {
+        self.msi_config.len() as u32
+    }
+
     /// Set msi irq MASK bit
     #[allow(irrefutable_let_patterns)]
     pub fn set_msi_mask(&mut self, index: u32, mask: bool) -> Result<()> {

--- a/src/dragonball/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/dbs_virtio_devices/Cargo.toml
@@ -34,7 +34,7 @@ nydus-api = "0.4.1"
 nydus-rafs = "0.4.1"
 nydus-storage = "0.7.2"
 rlimit = "0.7.0"
-serde = "1.0.27"
+serde = { version = "1.0.27", features = ["derive"] }
 serde_json = "1.0.9"
 thiserror = { workspace = true }
 threadpool = "1"

--- a/src/dragonball/dbs_virtio_devices/src/balloon.rs
+++ b/src/dragonball/dbs_virtio_devices/src/balloon.rs
@@ -566,6 +566,24 @@ impl<AS: GuestAddressSpace> Balloon<AS> {
     }
 }
 
+impl<AS: GuestAddressSpace> Balloon<AS> {
+    /// Capture the guest-negotiated state of this device.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device_info.restore_from_state(state)
+    }
+}
+
 impl<AS, Q, R> VirtioDevice<AS, Q, R> for Balloon<AS>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/dbs_virtio_devices/src/block/device.rs
+++ b/src/dragonball/dbs_virtio_devices/src/block/device.rs
@@ -193,6 +193,22 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
 
         Ok(())
     }
+
+    /// Capture the guest-negotiated state of this device.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> Result<()> {
+        self.device_info.restore_from_state(state)
+    }
 }
 
 impl<AS, Q, R> VirtioDevice<AS, Q, R> for Block<AS>

--- a/src/dragonball/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/dbs_virtio_devices/src/fs/device.rs
@@ -726,6 +726,27 @@ fn set_default_rlimit_nofile() -> Result<()> {
     }
 }
 
+impl<AS: GuestAddressSpace> VirtioFs<AS> {
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Backend filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: a snapshot must be taken at a clean quiesce point.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device_info.restore_from_state(state)
+    }
+}
+
 impl<AS, Q> VirtioDevice<AS, Q, GuestRegionMmap> for VirtioFs<AS>
 where
     AS: 'static + GuestAddressSpace + Clone + Send + Sync,

--- a/src/dragonball/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/dbs_virtio_devices/src/lib.rs
@@ -18,6 +18,8 @@ pub use self::device::*;
 mod notifier;
 pub use self::notifier::*;
 
+pub mod persist;
+
 pub mod epoll_helper;
 
 #[cfg(feature = "virtio-mmio")]

--- a/src/dragonball/dbs_virtio_devices/src/mem.rs
+++ b/src/dragonball/dbs_virtio_devices/src/mem.rs
@@ -895,6 +895,27 @@ pub struct Mem<AS: GuestAddressSpace> {
 }
 
 impl<AS: GuestAddressSpace> Mem<AS> {
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// The plugged-memory-block runtime state is not captured: a snapshot
+    /// must be taken before any virtio-mem resize request.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device_info.restore_from_state(state)
+    }
+}
+
+impl<AS: GuestAddressSpace> Mem<AS> {
     /// Create a new virtio-mem device.
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/src/dragonball/dbs_virtio_devices/src/mmio/mmio_state.rs
+++ b/src/dragonball/dbs_virtio_devices/src/mmio/mmio_state.rs
@@ -342,6 +342,58 @@ where
     }
 
     #[inline]
+    pub(crate) fn msi_enabled(&self) -> bool {
+        self.msi.is_some()
+    }
+
+    /// Capture the per-vector MSI configuration programmed by the guest.
+    pub(crate) fn get_msi_vectors(&self) -> Vec<crate::persist::MsiVectorState> {
+        let mut vectors = Vec::new();
+        if self.msi.is_some() {
+            for index in 0..self.intr_mgr.msi_config_count() {
+                if let Ok((address_low, address_high, data)) = self.intr_mgr.get_msi_config(index)
+                {
+                    vectors.push(crate::persist::MsiVectorState {
+                        address_low,
+                        address_high,
+                        data,
+                    });
+                }
+            }
+        }
+        vectors
+    }
+
+    /// Replay the guest's MSI interrupt setup from a snapshot: switch the
+    /// interrupt manager to MSI mode and re-program every vector. Must run
+    /// before device activation is replayed (activation commits the
+    /// configuration when it enables the interrupt manager).
+    pub(crate) fn restore_msi(
+        &mut self,
+        vectors: &[crate::persist::MsiVectorState],
+    ) -> Result<()> {
+        self.intr_mgr
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .map_err(Error::InterruptError)?;
+        if self.msi.is_none() {
+            self.msi = Some(Msi::default());
+        }
+        for (index, vector) in vectors.iter().enumerate() {
+            let index = index as u32;
+            self.intr_mgr
+                .set_msi_low_address(index, vector.address_low)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_high_address(index, vector.address_high)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_data(index, vector.data)
+                .map_err(Error::InterruptError)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
     pub(crate) fn doorbell(&self) -> Option<&DoorBell> {
         self.doorbell.as_ref()
     }

--- a/src/dragonball/dbs_virtio_devices/src/mmio/mmio_v2.rs
+++ b/src/dragonball/dbs_virtio_devices/src/mmio/mmio_v2.rs
@@ -171,6 +171,63 @@ where
         self.driver_status.load(Ordering::SeqCst)
     }
 
+    /// Capture the transport state of this MMIO virtio device.
+    ///
+    /// The virtual machine must be paused when this is called.
+    pub fn persist_state(&self) -> crate::persist::MmioV2TransportState {
+        let mut state = self.state();
+        crate::persist::MmioV2TransportState {
+            driver_status: self.driver_status(),
+            config_generation: self.config_generation.load(Ordering::SeqCst),
+            interrupt_status: self.interrupt_status.read(),
+            features_select: state.features_select(),
+            acked_features_select: state.acked_features_select(),
+            queue_select: state.queue_select(),
+            queues: state.queues().iter().map(|q| q.persist_state()).collect(),
+            device_activated: state.device_activated(),
+            msi_enabled: state.msi_enabled(),
+            msi_vectors: state.get_msi_vectors(),
+        }
+    }
+
+    /// Restore the transport state of this MMIO virtio device, replaying
+    /// device activation if the guest had activated it.
+    ///
+    /// `self` must be a freshly created, never-activated device built from
+    /// the same configuration the state was saved with. Must be called
+    /// before the guest vCPUs resume.
+    pub fn restore_from_state(
+        &self,
+        state: &crate::persist::MmioV2TransportState,
+    ) -> Result<()> {
+        let mut inner = self.state();
+        inner.set_features_select(state.features_select);
+        inner.set_acked_features_select(state.acked_features_select);
+        inner.set_queue_select(state.queue_select);
+        // Replay the guest's MSI setup before activation: activation enables
+        // the interrupt manager, which commits the vector configuration.
+        if state.msi_enabled {
+            inner.restore_msi(&state.msi_vectors)?;
+        }
+        {
+            let queues = inner.queues_mut();
+            if queues.len() != state.queues.len() {
+                return Err(Error::InvalidInput);
+            }
+            for (queue, queue_state) in queues.iter_mut().zip(state.queues.iter()) {
+                queue.restore_from_state(queue_state)?;
+            }
+        }
+        self.interrupt_status.write(state.interrupt_status);
+        self.config_generation
+            .store(state.config_generation, Ordering::SeqCst);
+        self.driver_status.store(state.driver_status, Ordering::SeqCst);
+        if state.device_activated {
+            inner.activate(self)?;
+        }
+        Ok(())
+    }
+
     #[inline]
     fn check_driver_status(&self, set: u32, clr: u32) -> bool {
         self.driver_status() & (set | clr) == set

--- a/src/dragonball/dbs_virtio_devices/src/net.rs
+++ b/src/dragonball/dbs_virtio_devices/src/net.rs
@@ -694,6 +694,24 @@ impl<AS: GuestAddressSpace> Net<AS> {
     }
 }
 
+impl<AS: GuestAddressSpace> Net<AS> {
+    /// Capture the guest-negotiated state of this device.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device_info.restore_from_state(state)
+    }
+}
+
 impl<AS: GuestAddressSpace + 'static> Net<AS> {
     pub fn set_patch_rate_limiters(
         &self,

--- a/src/dragonball/dbs_virtio_devices/src/persist.rs
+++ b/src/dragonball/dbs_virtio_devices/src/persist.rs
@@ -1,0 +1,253 @@
+// Copyright (C) 2026 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot state definitions shared by all virtio devices.
+//!
+//! These are plain-old-data mirrors of the runtime structures, serializable
+//! with serde. Compatibility policy: only append new fields (with
+//! `#[serde(default)]`); never remove or repurpose existing ones.
+
+use serde::{Deserialize, Serialize};
+use virtio_queue::QueueT;
+
+use crate::{Error, Result, VirtioDeviceInfo, VirtioQueueConfig};
+
+/// Serializable state of a virtio queue (mirror of
+/// `virtio_queue::QueueState` with serde support).
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioQueueState {
+    /// The maximum size in elements offered by the device.
+    pub max_size: u16,
+    /// Tail position of the available ring.
+    pub next_avail: u16,
+    /// Head position of the used ring.
+    pub next_used: u16,
+    /// VIRTIO_F_RING_EVENT_IDX negotiated.
+    pub event_idx_enabled: bool,
+    /// The queue size in elements the driver selected.
+    pub size: u16,
+    /// Indicates if the queue finished with configuration.
+    pub ready: bool,
+    /// Guest physical address of the descriptor table.
+    pub desc_table: u64,
+    /// Guest physical address of the available ring.
+    pub avail_ring: u64,
+    /// Guest physical address of the used ring.
+    pub used_ring: u64,
+}
+
+impl VirtioQueueState {
+    /// Capture the state of a virtio queue.
+    pub fn save<Q: QueueT>(queue: &Q) -> Self {
+        VirtioQueueState {
+            max_size: queue.max_size(),
+            next_avail: queue.next_avail(),
+            next_used: queue.next_used(),
+            event_idx_enabled: queue.event_idx_enabled(),
+            size: queue.size(),
+            ready: queue.ready(),
+            desc_table: queue.desc_table(),
+            avail_ring: queue.avail_ring(),
+            used_ring: queue.used_ring(),
+        }
+    }
+
+    /// Apply this state to a freshly created virtio queue.
+    ///
+    /// The target queue must have been created with the same `max_size`,
+    /// otherwise the state is refused.
+    pub fn restore<Q: QueueT>(&self, queue: &mut Q) -> Result<()> {
+        if queue.max_size() != self.max_size {
+            return Err(Error::InvalidInput);
+        }
+        queue.set_size(self.size);
+        queue.set_desc_table_address(
+            Some(self.desc_table as u32),
+            Some((self.desc_table >> 32) as u32),
+        );
+        queue.set_avail_ring_address(
+            Some(self.avail_ring as u32),
+            Some((self.avail_ring >> 32) as u32),
+        );
+        queue.set_used_ring_address(
+            Some(self.used_ring as u32),
+            Some((self.used_ring >> 32) as u32),
+        );
+        queue.set_event_idx(self.event_idx_enabled);
+        queue.set_next_avail(self.next_avail);
+        queue.set_next_used(self.next_used);
+        // Set ready last: with all addresses in place the queue becomes valid.
+        queue.set_ready(self.ready);
+        Ok(())
+    }
+}
+
+/// Serializable state of a `VirtioQueueConfig`.
+///
+/// The queue notification eventfd and the interrupt notifier are live
+/// resources re-created by the transport on restore.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioQueueConfigState {
+    /// Queue index into the queue array.
+    pub index: u16,
+    /// State of the virtio queue itself.
+    pub queue: VirtioQueueState,
+}
+
+impl<Q: QueueT> VirtioQueueConfig<Q> {
+    /// Capture the state of this queue configuration.
+    pub fn persist_state(&self) -> VirtioQueueConfigState {
+        VirtioQueueConfigState {
+            index: self.index(),
+            queue: VirtioQueueState::save(&self.queue),
+        }
+    }
+
+    /// Apply a previously saved state to this queue configuration.
+    ///
+    /// `self` must be a freshly created queue configuration with the same
+    /// index and maximum queue size as the saved one.
+    pub fn restore_from_state(&mut self, state: &VirtioQueueConfigState) -> Result<()> {
+        if self.index() != state.index {
+            return Err(Error::InvalidInput);
+        }
+        state.queue.restore(&mut self.queue)
+    }
+}
+
+/// Serializable state of a `VirtioDeviceInfo`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioDeviceInfoState {
+    /// Features offered by the device when the snapshot was taken.
+    pub avail_features: u64,
+    /// Features acknowledged by the guest driver.
+    pub acked_features: u64,
+    /// Device specific configuration space.
+    pub config_space: Vec<u8>,
+}
+
+impl VirtioDeviceInfo {
+    /// Capture the guest-negotiated state of this device.
+    pub fn persist_state(&self) -> VirtioDeviceInfoState {
+        VirtioDeviceInfoState {
+            avail_features: self.avail_features,
+            acked_features: self.acked_features,
+            config_space: self.config_space.clone(),
+        }
+    }
+
+    /// Apply a previously saved state to this device.
+    ///
+    /// The device must have been re-created with the same configuration: if
+    /// the offered feature set differs from the one the guest negotiated
+    /// against, the state is refused (regenerate the snapshot instead).
+    pub fn restore_from_state(&mut self, state: &VirtioDeviceInfoState) -> Result<()> {
+        if self.avail_features != state.avail_features {
+            return Err(Error::InvalidInput);
+        }
+        self.acked_features = state.acked_features;
+        self.config_space = state.config_space.clone();
+        Ok(())
+    }
+}
+
+/// Serializable state of one MSI vector programmed by the guest.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MsiVectorState {
+    /// Low 32 bits of the MSI message address.
+    pub address_low: u32,
+    /// High 32 bits of the MSI message address.
+    pub address_high: u32,
+    /// MSI message data.
+    pub data: u32,
+}
+
+/// Serializable state of a `MmioV2Device` transport.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MmioV2TransportState {
+    /// Virtio device status register.
+    pub driver_status: u32,
+    /// Configuration generation counter.
+    pub config_generation: u32,
+    /// Pending interrupt status bits.
+    pub interrupt_status: u32,
+    /// Device features word currently selected by the driver.
+    pub features_select: u32,
+    /// Driver features word currently selected by the driver.
+    pub acked_features_select: u32,
+    /// Queue currently selected by the driver.
+    pub queue_select: u32,
+    /// Per-queue state, in queue index order (including the control queue,
+    /// if any).
+    pub queues: Vec<VirtioQueueConfigState>,
+    /// Whether the device had been activated by the guest.
+    pub device_activated: bool,
+    /// Whether the guest had switched the device to MSI interrupt mode.
+    /// Without replaying this, device-to-guest interrupts never fire after
+    /// restore and the guest waits forever on virtio completions.
+    #[serde(default)]
+    pub msi_enabled: bool,
+    /// Per-vector MSI configuration programmed by the guest, in vector
+    /// order.
+    #[serde(default)]
+    pub msi_vectors: Vec<MsiVectorState>,
+}
+
+#[cfg(test)]
+mod tests {
+    use virtio_queue::{Queue, QueueSync};
+
+    use super::*;
+
+    #[test]
+    fn test_virtio_queue_state_roundtrip() {
+        let mut src: Queue = Queue::new(256).unwrap();
+        src.set_size(128);
+        src.set_desc_table_address(Some(0x1000), Some(0x1));
+        src.set_avail_ring_address(Some(0x2000), Some(0));
+        src.set_used_ring_address(Some(0x3000), Some(0));
+        src.set_event_idx(true);
+        src.set_next_avail(10);
+        src.set_next_used(5);
+        src.set_ready(true);
+
+        let state = VirtioQueueState::save(&src);
+        assert_eq!(state.max_size, 256);
+        assert_eq!(state.size, 128);
+        assert_eq!(state.desc_table, 0x1_0000_1000);
+        assert_eq!(state.next_avail, 10);
+        assert_eq!(state.next_used, 5);
+        assert!(state.ready);
+        assert!(state.event_idx_enabled);
+
+        // JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: VirtioQueueState = serde_json::from_str(&json).unwrap();
+
+        let mut dst: Queue = Queue::new(256).unwrap();
+        state.restore(&mut dst).unwrap();
+        assert_eq!(VirtioQueueState::save(&dst), state);
+
+        // Mismatched max size must be refused.
+        let mut small: Queue = Queue::new(128).unwrap();
+        assert!(state.restore(&mut small).is_err());
+    }
+
+    #[test]
+    fn test_virtio_queue_config_state_roundtrip() {
+        let mut src: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 3).unwrap();
+        src.queue.set_size(64);
+        src.queue.set_next_avail(7);
+        let state = src.persist_state();
+        assert_eq!(state.index, 3);
+        assert_eq!(state.queue.size, 64);
+
+        let mut dst: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 3).unwrap();
+        dst.restore_from_state(&state).unwrap();
+        assert_eq!(dst.persist_state(), state);
+
+        // Wrong index must be refused.
+        let mut other: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 4).unwrap();
+        assert!(other.restore_from_state(&state).is_err());
+    }
+}

--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
@@ -18,6 +18,7 @@ use dbs_utils::epoll_manager::{
 use dbs_utils::metric::IncMetric;
 use dbs_utils::net::{net_gen, MacAddr, Tap};
 use log::{debug, error, info, trace, warn};
+use serde::{Deserialize, Serialize};
 #[cfg(not(test))]
 use vhost_rs::net::VhostNet as VhostNetTrait;
 #[cfg(not(test))]
@@ -56,6 +57,21 @@ pub enum Error {
     TapError(#[source] TapError),
     #[error("vhost error: {0}")]
     VhostError(#[source] vhost_rs::Error),
+}
+
+/// Snapshot state of a vhost-net device: guest-negotiated virtio state plus
+/// the vring bases read back from the in-kernel vhost backend.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VhostNetState {
+    /// Guest-negotiated virtio device state.
+    pub device_info: crate::persist::VirtioDeviceInfoState,
+    /// Per queue pair `(rx, tx)` vring bases fetched from the in-kernel
+    /// vhost backend at save time, `None` if the device had not been
+    /// activated.
+    pub kernel_vring_bases: Option<Vec<(u32, u32)>>,
 }
 
 /// Vhost-net device implementation
@@ -131,6 +147,51 @@ where
     Q: QueueT + Send + 'static,
     R: GuestMemoryRegion + Sync + Send + 'static,
 {
+    /// Capture the state of this device.
+    ///
+    /// If the device has been activated, the current vring base of each
+    /// queue is read back from the in-kernel vhost backend so that ring
+    /// progress survives restore. Note that `VHOST_GET_VRING_BASE` stops
+    /// the vring, so the virtual machine must be paused when this is
+    /// called.
+    pub fn persist_state(&self) -> VirtioResult<VhostNetState> {
+        let kernel_vring_bases = if self.handles.is_empty() {
+            // Never activated: the rings start at base 0 on restore.
+            None
+        } else {
+            let mut bases = Vec::with_capacity(self.handles.len());
+            for handle in self.handles.iter() {
+                // Fetch the bases in the same (rx, tx) order that
+                // `init_vhost_queues` programs them.
+                let rx = handle
+                    .get_vring_base(0)
+                    .map_err(|err| VirtioError::VhostNet(Error::VhostError(err)))?;
+                let tx = handle
+                    .get_vring_base(1)
+                    .map_err(|err| VirtioError::VhostNet(Error::VhostError(err)))?;
+                bases.push((rx, tx));
+            }
+            Some(bases)
+        };
+
+        Ok(VhostNetState {
+            device_info: self.device_info.persist_state(),
+            kernel_vring_bases,
+        })
+    }
+
+    /// Restore the state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet. The saved vring bases are
+    /// programmed into the in-kernel vhost backend when device activation
+    /// is replayed.
+    pub fn restore_from_state(&mut self, state: &VhostNetState) -> crate::Result<()> {
+        self.device_info.restore_from_state(&state.device_info)?;
+        self.kernel_vring_bases = state.kernel_vring_bases.clone();
+        Ok(())
+    }
+
     /// Create a new vhost-net device with a given tap interface.
     pub fn new_with_tap(
         tap: Tap,
@@ -242,9 +303,12 @@ where
             }
         }
 
-        if self.kernel_vring_bases.is_none() {
-            self.setup_vhost_backend(config, mem)?
-        }
+        // Always program the vhost backend: the vhost fds are freshly
+        // created, both on a cold boot and on snapshot restore. When
+        // `kernel_vring_bases` was populated from a restored state,
+        // `init_vhost_queues` replays the saved ring positions instead of
+        // starting from 0.
+        self.setup_vhost_backend(config, mem)?;
 
         Ok(())
     }

--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_kern/test_utils.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_kern/test_utils.rs
@@ -52,7 +52,7 @@ pub trait MockVhostBackend: std::marker::Sized {
     fn set_vring_num(&mut self, queue_index: usize, num: u16) -> Result<()>;
     fn set_vring_addr(&mut self, queue_index: usize, config_data: &VringConfigData) -> Result<()>;
     fn set_vring_base(&mut self, queue_index: usize, base: u16) -> Result<()>;
-    fn get_vring_base(&mut self, queue_index: usize) -> Result<u32>;
+    fn get_vring_base(&self, queue_index: usize) -> Result<u32>;
     fn set_vring_call(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
     fn set_vring_kick(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
     fn set_vring_err(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
@@ -103,7 +103,7 @@ impl<T: VhostKernBackend> MockVhostBackend for T {
         Ok(())
     }
 
-    fn get_vring_base(&mut self, _queue_index: usize) -> Result<u32> {
+    fn get_vring_base(&self, _queue_index: usize) -> Result<u32> {
         Ok(0)
     }
 

--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/net.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/net.rs
@@ -322,6 +322,29 @@ impl<AS> VhostUserNet<AS>
 where
     AS: DbsGuestAddressSpace,
 {
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// The vhost-user backend connection is re-established and reconfigured
+    /// when device activation is replayed on restore.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device.lock().unwrap().device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device
+            .lock()
+            .unwrap()
+            .device_info
+            .restore_from_state(state)
+    }
+
     /// Create a new vhost-user net device.
     ///
     /// Create a Unix Domain Socket listener and wait until the the first incoming connection is

--- a/src/dragonball/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vsock/device.rs
@@ -112,6 +112,27 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     }
 }
 
+impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Live vsock connection state is not captured: a snapshot must be taken
+    /// at a clean quiesce point with no active connections.
+    pub fn persist_state(&self) -> crate::persist::VirtioDeviceInfoState {
+        self.device_info.persist_state()
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    pub fn restore_from_state(
+        &mut self,
+        state: &crate::persist::VirtioDeviceInfoState,
+    ) -> crate::Result<()> {
+        self.device_info.restore_from_state(state)
+    }
+}
+
 impl<AS, Q, R, M> VirtioDevice<AS, Q, R> for Vsock<AS, M>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/src/address_space_manager.rs
+++ b/src/dragonball/src/address_space_manager.rs
@@ -17,6 +17,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
+use std::io::{Seek, SeekFrom};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
@@ -39,11 +40,13 @@ use kvm_ioctls::VmFd;
 use log::{debug, error, info, warn};
 use nix::sys::mman;
 use nix::unistd::dup;
+use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "atomic-guest-memory")]
 use vm_memory::GuestMemoryAtomic;
 use vm_memory::{
-    address::Address, FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryMmap,
-    GuestMemoryRegion, GuestRegionMmap, GuestUsize, MemoryRegionAddress, MmapRegion,
+    address::Address, Bytes, FileOffset, GuestAddress, GuestAddressSpace, GuestMemory,
+    GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap, GuestUsize, MemoryRegionAddress,
+    MmapRegion,
 };
 
 use crate::resource_manager::ResourceManager;
@@ -158,6 +161,14 @@ pub enum AddressManagerError {
     /// Failed to create Address Space Region
     #[error("address manager failed to create Address Space Region {0}")]
     CreateAddressSpaceRegion(#[source] AddressSpaceError),
+
+    /// Failure in accessing the memory snapshot file.
+    #[error("address manager failed to access the memory snapshot file")]
+    SnapshotFile(#[source] std::io::Error),
+
+    /// The memory snapshot layout doesn't match the current address space.
+    #[error("memory snapshot layout mismatch for guest address 0x{0:x}")]
+    SnapshotLayoutMismatch(u64),
 
     /// Failed to create VM-bound memfd
     #[error("address manager failed to create VM-bound memfd: {0}")]
@@ -774,6 +785,104 @@ impl AddressSpaceMgr {
     }
 }
 
+/// Location of one guest memory region's contents within the snapshot
+/// memory file.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GuestMemoryRegionState {
+    /// Guest physical address of the region.
+    pub guest_addr: u64,
+    /// Size of the region in bytes.
+    pub size: u64,
+    /// Offset of the region's contents in the memory file.
+    pub file_offset: u64,
+}
+
+/// State of the guest RAM contents in the snapshot memory file.
+///
+/// The guest memory *layout* is not restored from this state: it is
+/// re-created from the VM configuration (which the snapshot also carries),
+/// producing an identical layout. This state maps that layout onto the
+/// memory file and is validated against it on restore.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct GuestMemoryState {
+    /// Per-region contents location, in guest address order.
+    pub regions: Vec<GuestMemoryRegionState>,
+}
+
+impl AddressSpaceMgr {
+    /// Dump the guest RAM contents to the snapshot memory file.
+    ///
+    /// The virtual machine must be paused when this is called. Regions are
+    /// written sequentially to `file` starting at its current beginning.
+    pub fn save_memory(&self, file: &mut File) -> Result<GuestMemoryState> {
+        let vm_as = self
+            .get_vm_as()
+            .ok_or(AddressManagerError::GuestMemoryNotInitialized)?;
+        let guard = vm_as.memory();
+
+        let mut regions = Vec::new();
+        let mut file_offset = 0u64;
+        for region in guard.iter() {
+            let size = region.len();
+            region
+                .write_all_volatile_to(MemoryRegionAddress(0), file, size as usize)
+                .map_err(|e| {
+                    AddressManagerError::AccessGuestMemory(region.start_addr().raw_value(), e)
+                })?;
+            regions.push(GuestMemoryRegionState {
+                guest_addr: region.start_addr().raw_value(),
+                size,
+                file_offset,
+            });
+            file_offset += size;
+        }
+
+        Ok(GuestMemoryState { regions })
+    }
+
+    /// Load the guest RAM contents back from the snapshot memory file.
+    ///
+    /// The address space must already have been re-created from the same VM
+    /// configuration the snapshot was taken with; `state` is validated
+    /// against the resulting layout and a mismatch is refused.
+    pub fn restore_memory(&self, state: &GuestMemoryState, file: &mut File) -> Result<()> {
+        let vm_as = self
+            .get_vm_as()
+            .ok_or(AddressManagerError::GuestMemoryNotInitialized)?;
+        let guard = vm_as.memory();
+
+        for region_state in &state.regions {
+            let guest_addr = GuestAddress(region_state.guest_addr);
+            let region = guard
+                .find_region(guest_addr)
+                .ok_or(AddressManagerError::SnapshotLayoutMismatch(
+                    region_state.guest_addr,
+                ))?;
+            if region.start_addr() != guest_addr || region.len() != region_state.size {
+                return Err(AddressManagerError::SnapshotLayoutMismatch(
+                    region_state.guest_addr,
+                ));
+            }
+            file.seek(SeekFrom::Start(region_state.file_offset))
+                .map_err(AddressManagerError::SnapshotFile)?;
+            region
+                .read_exact_volatile_from(
+                    MemoryRegionAddress(0),
+                    file,
+                    region_state.size as usize,
+                )
+                .map_err(|e| {
+                    AddressManagerError::AccessGuestMemory(region_state.guest_addr, e)
+                })?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Default for AddressSpaceMgr {
     /// Create a new empty AddressSpaceMgr
     fn default() -> Self {
@@ -798,6 +907,76 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+
+    #[test]
+    fn test_memory_save_restore_roundtrip() {
+        let numa_region_infos = vec![NumaRegionInfo {
+            size: 16,
+            host_numa_node_id: None,
+            guest_numa_node_id: Some(0),
+            vcpu_ids: vec![0],
+        }];
+        let create_mgr = || {
+            let res_mgr = ResourceManager::new(None);
+            AddressSpaceMgrBuilder::new("shmem", "")
+                .unwrap()
+                .build(&res_mgr, &numa_region_infos)
+                .unwrap()
+        };
+
+        // Plant recognizable values in the source guest memory.
+        let src_mgr = create_mgr();
+        {
+            let vm_as = src_mgr.get_vm_as().unwrap();
+            let guard = vm_as.memory();
+            guard
+                .write_obj(0xdbdbdbdbu32, GuestAddress(GUEST_MEM_START))
+                .unwrap();
+            guard
+                .write_obj(0xa5u8, GuestAddress(GUEST_MEM_START + (8 << 20)))
+                .unwrap();
+        }
+
+        let mut file = TempFile::new().unwrap().into_file();
+        let state = src_mgr.save_memory(&mut file).unwrap();
+        assert_eq!(state.regions.len(), 1);
+        assert_eq!(state.regions[0].guest_addr, GUEST_MEM_START);
+        assert_eq!(state.regions[0].size, 16 << 20);
+        assert_eq!(state.regions[0].file_offset, 0);
+
+        // The state must survive a JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: GuestMemoryState = serde_json::from_str(&json).unwrap();
+
+        // Restore into a fresh address space with the same layout.
+        let dst_mgr = create_mgr();
+        dst_mgr.restore_memory(&state, &mut file).unwrap();
+        let vm_as = dst_mgr.get_vm_as().unwrap();
+        let guard = vm_as.memory();
+        let val: u32 = guard.read_obj(GuestAddress(GUEST_MEM_START)).unwrap();
+        assert_eq!(val, 0xdbdbdbdb);
+        let val: u8 = guard
+            .read_obj(GuestAddress(GUEST_MEM_START + (8 << 20)))
+            .unwrap();
+        assert_eq!(val, 0xa5);
+
+        // A layout mismatch must be refused.
+        let small_infos = vec![NumaRegionInfo {
+            size: 8,
+            host_numa_node_id: None,
+            guest_numa_node_id: Some(0),
+            vcpu_ids: vec![0],
+        }];
+        let res_mgr = ResourceManager::new(None);
+        let small_mgr = AddressSpaceMgrBuilder::new("shmem", "")
+            .unwrap()
+            .build(&res_mgr, &small_infos)
+            .unwrap();
+        assert!(matches!(
+            small_mgr.restore_memory(&state, &mut file),
+            Err(AddressManagerError::SnapshotLayoutMismatch(_))
+        ));
+    }
 
     #[test]
     fn test_create_address_space() {

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -94,6 +94,11 @@ pub enum VmmActionError {
     #[error("failed to shutdown the VM: {0}")]
     StopMicrovm(#[source] StopMicrovmError),
 
+    /// The action `SaveMicrovm` failed either because of bad user input or an internal error.
+    #[cfg(target_arch = "x86_64")]
+    #[error("failed to save the VM snapshot: {0}")]
+    SaveMicrovm(#[source] crate::persist::SnapshotError),
+
     /// One of the actions `GetVmConfiguration` or `SetVmConfiguration` failed either because of bad
     /// input or an internal error.
     #[error("failed to set configuration for the VM: {0}")]
@@ -179,6 +184,30 @@ pub enum VmmAction {
     /// When vmm is used as the crate by the other process, which is need to
     /// shutdown the vcpu threads and destory all of the object.
     ShutdownMicroVm,
+
+    /// Save the microVM state into a snapshot: a state file (vCPU/device
+    /// metadata, JSON) plus a memory file (guest RAM contents). This action
+    /// can only be called after the microVM has booted; it pauses all vCPUs
+    /// and leaves them paused.
+    #[cfg(target_arch = "x86_64")]
+    SaveMicrovm {
+        /// Path of the snapshot state file to write.
+        state_path: String,
+        /// Path of the guest memory file to write.
+        mem_path: String,
+    },
+
+    /// Launch the microVM by restoring it from a snapshot instead of cold
+    /// booting. The microVM must have been configured with the same
+    /// configuration the snapshot was taken with. This action can only be
+    /// called before the microVM has booted.
+    #[cfg(target_arch = "x86_64")]
+    StartMicroVmFromSnapshot {
+        /// Path of the snapshot state file to read.
+        state_path: String,
+        /// Path of the guest memory file to read.
+        mem_path: String,
+    },
 
     /// Get the configuration of the microVM.
     GetVmConfiguration,
@@ -344,6 +373,16 @@ impl VmmService {
             }
             VmmAction::StartMicroVm => self.start_microvm(vmm, event_mgr),
             VmmAction::ShutdownMicroVm => self.shutdown_microvm(vmm),
+            #[cfg(target_arch = "x86_64")]
+            VmmAction::SaveMicrovm {
+                state_path,
+                mem_path,
+            } => self.save_microvm(vmm, state_path, mem_path),
+            #[cfg(target_arch = "x86_64")]
+            VmmAction::StartMicroVmFromSnapshot {
+                state_path,
+                mem_path,
+            } => self.start_microvm_from_snapshot(vmm, event_mgr, state_path, mem_path),
             VmmAction::GetVmConfiguration => Ok(VmmData::MachineConfiguration(Box::new(
                 self.machine_config.clone(),
             ))),
@@ -502,6 +541,51 @@ impl VmmService {
         vmm.event_ctx.exit_evt_triggered = true;
 
         Ok(VmmData::Empty)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[instrument(skip(self))]
+    fn save_microvm(
+        &mut self,
+        vmm: &mut Vmm,
+        state_path: String,
+        mem_path: String,
+    ) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        vm.save_microvm(
+            std::path::Path::new(&state_path),
+            std::path::Path::new(&mem_path),
+        )
+        .map(|_| VmmData::Empty)
+        .map_err(VmmActionError::SaveMicrovm)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[instrument(skip(self, event_mgr))]
+    fn start_microvm_from_snapshot(
+        &mut self,
+        vmm: &mut Vmm,
+        event_mgr: &mut EventManager,
+        state_path: String,
+        mem_path: String,
+    ) -> VmmRequestResult {
+        use self::StartMicroVmError::MicroVMAlreadyRunning;
+        use self::VmmActionError::StartMicroVm;
+
+        let seccomp_filters = vmm.seccomp_filters();
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        if vm.is_vm_initialized() {
+            return Err(StartMicroVm(MicroVMAlreadyRunning));
+        }
+
+        vm.start_microvm_from_snapshot(
+            event_mgr,
+            seccomp_filters,
+            std::path::Path::new(&state_path),
+            std::path::Path::new(&mem_path),
+        )
+        .map(|_| VmmData::Empty)
+        .map_err(StartMicroVm)
     }
 
     /// Get prometheus metrics.

--- a/src/dragonball/src/device_manager/balloon_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/balloon_dev_mgr.rs
@@ -10,7 +10,7 @@ use virtio::Error as VirtioError;
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::DbsMmioV2Device;
-use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
+use crate::device_manager::{virtio_persist, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::metric::METRICS;
 
 // The flag of whether to use the shared irq.
@@ -24,6 +24,10 @@ pub enum BalloonDeviceError {
     /// The balloon device was already used.
     #[error("the virtio-balloon ID was already added to a different device")]
     BalloonDeviceAlreadyExists,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// Cannot perform the requested operation after booting the microVM.
     #[error("the update operation is not allowed after boot")]
@@ -274,6 +278,91 @@ impl BalloonDeviceMgr {
             .iter()
             .position(|info| info.config.balloon_id.eq(balloon_id))
     }
+
+    /// Capture the state of all virtio-balloon devices.
+    ///
+    /// The virtual machine must be paused when this is called.
+    pub fn save_states(&self) -> std::result::Result<BalloonDeviceMgrState, BalloonDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(BalloonDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                Balloon<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(BalloonDeviceError::Virtio)?;
+            devices.push(BalloonDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(BalloonDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-balloon devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by balloon id) and must not have been activated yet. Must
+    /// be called before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &BalloonDeviceMgrState,
+    ) -> std::result::Result<(), BalloonDeviceError> {
+        for dev_state in &state.devices {
+            let index = self
+                .get_index_of_balloon_dev(dev_state.config.id())
+                .ok_or(BalloonDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = self.info_list[index]
+                .device
+                .as_ref()
+                .ok_or(BalloonDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<Balloon<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+            )
+            .map_err(BalloonDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for Balloon<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> virtio::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &virtio::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one virtio-balloon device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BalloonDevState {
+    /// Static configuration of the device.
+    pub config: BalloonDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: virtio::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: virtio::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the virtio-balloon device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct BalloonDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<BalloonDevState>,
 }
 
 impl Default for BalloonDeviceMgr {

--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -24,6 +24,7 @@ use dbs_pci::VirtioPciDevice;
 use dbs_upcall::{DevMgrResponse, UpcallClientResponse};
 use dbs_virtio_devices as virtio;
 use dbs_virtio_devices::block::{aio::Aio, io_uring::IoUring, Block, LocalFile, Ufile};
+use dbs_virtio_devices::persist::{MmioV2TransportState, VirtioDeviceInfoState};
 #[cfg(feature = "vhost-user-blk")]
 use dbs_virtio_devices::vhost::vhost_user::block::VhostUserBlock;
 use serde_derive::{Deserialize, Serialize};
@@ -960,6 +961,116 @@ impl BlockDeviceMgr {
             None => Err(BlockDeviceError::InvalidDeviceId(new_cfg.drive_id)),
         }
     }
+
+    /// Capture the state of all block devices.
+    ///
+    /// The virtual machine must be paused when this is called. Only MMIO
+    /// virtio-blk devices are supported; vhost-user/PCI block devices are
+    /// refused.
+    pub fn save_states(&self) -> std::result::Result<BlockDeviceMgrState, BlockDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(info.config.drive_id.clone()))?;
+            let mmio_dev = device
+                .as_any()
+                .downcast_ref::<DbsMmioV2Device>()
+                .ok_or(BlockDeviceError::InvalidBlockDeviceType)?;
+            let transport = mmio_dev.persist_state();
+            let guard = mmio_dev.state();
+            let block_dev = guard
+                .get_inner_device()
+                .as_any()
+                .downcast_ref::<Block<GuestAddressSpaceImpl>>()
+                .ok_or(BlockDeviceError::InvalidBlockDeviceType)?;
+            devices.push(BlockDevState {
+                config: info.config.clone(),
+                device_info: block_dev.persist_state(),
+                transport,
+            });
+        }
+        Ok(BlockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all block devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by drive id) and must not have been activated yet. Replays
+    /// device activation for devices the guest had activated. Must be called
+    /// before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &BlockDeviceMgrState,
+    ) -> std::result::Result<(), BlockDeviceError> {
+        for (pos, dev_state) in state.devices.iter().enumerate() {
+            // Drive ids may be generated per-run (e.g. the VM rootfs drive
+            // id), so an id miss is expected across template create/restore
+            // boundaries. Fall back to positional matching when the device
+            // sets align; the transport/device state validation still
+            // refuses incompatible devices.
+            let index = match self.get_index_of_drive_id(&dev_state.config.drive_id) {
+                Some(index) => index,
+                None if self.info_list.len() == state.devices.len() => {
+                    log::warn!(
+                        "block device id '{}' not found, matching by position {}",
+                        dev_state.config.drive_id,
+                        pos
+                    );
+                    pos
+                }
+                None => return Err(InvalidDeviceId(dev_state.config.drive_id.clone())),
+            };
+            let device = self.info_list[index]
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(dev_state.config.drive_id.clone()))?;
+            let mmio_dev = device
+                .as_any()
+                .downcast_ref::<DbsMmioV2Device>()
+                .ok_or(BlockDeviceError::InvalidBlockDeviceType)?;
+            {
+                let mut guard = mmio_dev.state();
+                let block_dev = guard
+                    .get_inner_device_mut()
+                    .as_any_mut()
+                    .downcast_mut::<Block<GuestAddressSpaceImpl>>()
+                    .ok_or(BlockDeviceError::InvalidBlockDeviceType)?;
+                // Restore the guest-negotiated device state before the
+                // transport state: activation replay reads it.
+                block_dev
+                    .restore_from_state(&dev_state.device_info)
+                    .map_err(BlockDeviceError::Virtio)?;
+            }
+            mmio_dev
+                .restore_from_state(&dev_state.transport)
+                .map_err(BlockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one block device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BlockDevState {
+    /// Static configuration of the device.
+    pub config: BlockDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: MmioV2TransportState,
+}
+
+/// Snapshot state of the block device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct BlockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<BlockDevState>,
 }
 
 impl Default for BlockDeviceMgr {

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -15,7 +15,8 @@ use crate::config_manager::{
     ConfigItem, DeviceConfigInfo, DeviceConfigInfos, RateLimiterConfigInfo,
 };
 use crate::device_manager::{
-    DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext, DeviceVirtioRegionHandler,
+    virtio_persist, DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext,
+    DeviceVirtioRegionHandler,
 };
 use crate::get_bucket_update;
 
@@ -38,6 +39,10 @@ pub enum FsDeviceError {
     /// Invalid fs, "virtio" or "vhostuser" is allowed.
     #[error("the fs type is invalid, virtio or vhostuser is allowed")]
     InvalidFs,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// Cannot access address space.
     #[error("Cannot access address space.")]
@@ -547,6 +552,94 @@ impl FsDeviceMgr {
             None => Err(FsDeviceError::TagNotExists(new_cfg.tag)),
         }
     }
+
+    /// Capture the state of all virtio-fs devices.
+    ///
+    /// The virtual machine must be paused when this is called. Backend
+    /// filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: snapshots must be taken at a clean quiesce point.
+    /// vhost-user-fs devices are refused.
+    pub fn save_states(&self) -> std::result::Result<FsDeviceMgrState, FsDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                virtio::fs::VirtioFs<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(FsDeviceError::Virtio)?;
+            devices.push(FsDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(FsDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-fs devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by tag) and must not have been activated yet. Must be
+    /// called before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &FsDeviceMgrState,
+    ) -> std::result::Result<(), FsDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| FsDeviceError::TagNotExists(dev_state.config.id().to_owned()))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<
+                virtio::fs::VirtioFs<GuestAddressSpaceImpl>,
+            >(device, &dev_state.device_info, &dev_state.transport)
+            .map_err(FsDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for virtio::fs::VirtioFs<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> virtio::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &virtio::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one virtio-fs device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FsDevState {
+    /// Static configuration of the device.
+    pub config: FsDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: virtio::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: virtio::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the virtio-fs device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FsDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<FsDevState>,
 }
 
 impl Default for FsDeviceMgr {

--- a/src/dragonball/src/device_manager/mem_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/mem_dev_mgr.rs
@@ -23,7 +23,7 @@ use vm_memory::{
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::DbsMmioV2Device;
-use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
+use crate::device_manager::{virtio_persist, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::vm::VmConfigInfo;
 
 // The flag of whether to use the shared irq.
@@ -42,6 +42,10 @@ pub enum MemDeviceError {
     /// The mem device was already used.
     #[error("the virtio-mem ID was already added to a different device")]
     MemDeviceAlreadyExists,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// Cannot perform the requested operation after booting the microVM.
     #[error("the update operation is not allowed after boot")]
@@ -340,6 +344,95 @@ impl MemDeviceMgr {
         }
         Ok(())
     }
+
+    /// Capture the state of all virtio-mem devices.
+    ///
+    /// The virtual machine must be paused when this is called. The
+    /// plugged-memory-block runtime state is not captured: snapshots must
+    /// be taken before any virtio-mem resize request.
+    pub fn save_states(&self) -> std::result::Result<MemDeviceMgrState, MemDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(MemDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                Mem<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(MemDeviceError::Virtio)?;
+            devices.push(MemDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(MemDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-mem devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by id) and must not have been activated yet. Must be called
+    /// before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &MemDeviceMgrState,
+    ) -> std::result::Result<(), MemDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(MemDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(MemDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<Mem<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+            )
+            .map_err(MemDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for Mem<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> virtio::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &virtio::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one virtio-mem device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MemDevState {
+    /// Static configuration of the device.
+    pub config: MemDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: virtio::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: virtio::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the virtio-mem device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct MemDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<MemDevState>,
 }
 
 impl Default for MemDeviceMgr {

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -660,7 +660,7 @@ pub struct DeviceManager {
     pub(crate) virtio_net_manager: VirtioNetDeviceMgr,
 
     #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
-    fs_manager: Arc<Mutex<FsDeviceMgr>>,
+    pub(crate) fs_manager: Arc<Mutex<FsDeviceMgr>>,
 
     #[cfg(feature = "virtio-mem")]
     pub(crate) mem_manager: MemDeviceMgr,
@@ -669,10 +669,10 @@ pub struct DeviceManager {
     pub(crate) balloon_manager: BalloonDeviceMgr,
 
     #[cfg(feature = "vhost-net")]
-    vhost_net_manager: VhostNetDeviceMgr,
+    pub(crate) vhost_net_manager: VhostNetDeviceMgr,
 
     #[cfg(feature = "vhost-user-net")]
-    vhost_user_net_manager: VhostUserNetDeviceMgr,
+    pub(crate) vhost_user_net_manager: VhostUserNetDeviceMgr,
     #[cfg(feature = "host-device")]
     pub(crate) vfio_manager: Arc<Mutex<VfioDeviceMgr>>,
     #[cfg(feature = "host-device")]
@@ -1578,6 +1578,78 @@ impl DeviceManager {
         {
             return None;
         }
+    }
+}
+
+#[cfg(feature = "dbs-virtio-devices")]
+pub(crate) mod virtio_persist {
+    //! Helpers shared by the device managers to save/restore the state of
+    //! MMIO virtio devices (see `crate::persist`).
+
+    use std::sync::Arc;
+
+    use dbs_device::DeviceIo;
+    use dbs_virtio_devices::persist::{MmioV2TransportState, VirtioDeviceInfoState};
+    use dbs_virtio_devices::Error as VirtioError;
+
+    use super::DbsMmioV2Device;
+
+    /// A virtio device whose guest-negotiated state can be captured and
+    /// restored.
+    pub(crate) trait VirtioDevicePersist {
+        /// Capture the guest-negotiated device state.
+        fn persist_device_info(&self) -> VirtioDeviceInfoState;
+
+        /// Restore the guest-negotiated device state.
+        fn restore_device_info(
+            &mut self,
+            state: &VirtioDeviceInfoState,
+        ) -> std::result::Result<(), VirtioError>;
+    }
+
+    /// Capture the device and transport state of an MMIO virtio device of
+    /// concrete type `D`.
+    pub(crate) fn save_mmio_device_state<D: VirtioDevicePersist + 'static>(
+        device: &Arc<dyn DeviceIo>,
+    ) -> std::result::Result<(VirtioDeviceInfoState, MmioV2TransportState), VirtioError> {
+        let mmio_dev = device
+            .as_any()
+            .downcast_ref::<DbsMmioV2Device>()
+            .ok_or(VirtioError::InvalidInput)?;
+        let transport = mmio_dev.persist_state();
+        let guard = mmio_dev.state();
+        let inner = guard
+            .get_inner_device()
+            .as_any()
+            .downcast_ref::<D>()
+            .ok_or(VirtioError::InvalidInput)?;
+        Ok((inner.persist_device_info(), transport))
+    }
+
+    /// Restore the device and transport state of a freshly re-created MMIO
+    /// virtio device of concrete type `D`, replaying device activation if
+    /// the guest had activated it. Must be called before the vCPUs resume.
+    pub(crate) fn restore_mmio_device_state<D: VirtioDevicePersist + 'static>(
+        device: &Arc<dyn DeviceIo>,
+        device_info: &VirtioDeviceInfoState,
+        transport: &MmioV2TransportState,
+    ) -> std::result::Result<(), VirtioError> {
+        let mmio_dev = device
+            .as_any()
+            .downcast_ref::<DbsMmioV2Device>()
+            .ok_or(VirtioError::InvalidInput)?;
+        {
+            let mut guard = mmio_dev.state();
+            let inner = guard
+                .get_inner_device_mut()
+                .as_any_mut()
+                .downcast_mut::<D>()
+                .ok_or(VirtioError::InvalidInput)?;
+            // Restore the guest-negotiated device state before the
+            // transport state: activation replay reads it.
+            inner.restore_device_info(device_info)?;
+        }
+        mmio_dev.restore_from_state(transport)
     }
 }
 

--- a/src/dragonball/src/device_manager/vhost_net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vhost_net_dev_mgr.rs
@@ -6,15 +6,20 @@
 use std::result::Result;
 use std::sync::Arc;
 
+use dbs_device::DeviceIo;
 use dbs_utils::net::MacAddr;
-use dbs_virtio_devices::vhost::vhost_kern::net::Net;
+use dbs_virtio_devices::persist::MmioV2TransportState;
+use dbs_virtio_devices::vhost::vhost_kern::net::{Net, VhostNetState};
 use dbs_virtio_devices::Error as VirtioError;
 use serde::{Deserialize, Serialize};
 use virtio_queue::QueueSync;
 
-use super::{DeviceManager, DeviceMgrError, DeviceOpContext};
+use super::{DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::address_space_manager::{GuestAddressSpaceImpl, GuestRegionImpl};
 use crate::config_manager::{ConfigItem, DeviceConfigInfos};
+
+/// Concrete vhost-net device type managed by this device manager.
+type VhostKernNet = Net<GuestAddressSpaceImpl, QueueSync, GuestRegionImpl>;
 
 /// Default number of virtio queues, one rx/tx pair.
 pub const DEFAULT_NUM_QUEUES: usize = 2;
@@ -146,7 +151,7 @@ impl VhostNetDeviceMgr {
     fn create_device(
         cfg: &VhostNetDeviceConfigInfo,
         ctx: &mut DeviceOpContext,
-    ) -> Result<Box<Net<GuestAddressSpaceImpl, QueueSync, GuestRegionImpl>>, VirtioError> {
+    ) -> Result<Box<VhostKernNet>, VirtioError> {
         slog::info!(
             ctx.logger(),
             "create a vhost-net device";
@@ -262,6 +267,130 @@ impl VhostNetDeviceMgr {
 
         Ok(())
     }
+
+    /// Capture the state of all vhost-net devices.
+    ///
+    /// The virtual machine must be paused when this is called. Beyond the
+    /// guest-negotiated state, the current vring bases are read back from
+    /// the in-kernel vhost backend (which stops the vrings) so that ring
+    /// progress survives restore.
+    pub fn save_states(&self) -> std::result::Result<VhostNetDeviceMgrState, VhostNetDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VhostNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_state, transport) =
+                Self::save_device_state(device).map_err(VhostNetDeviceError::Virtio)?;
+            devices.push(VhostNetDevState {
+                config: info.config.clone(),
+                device_state,
+                transport,
+            });
+        }
+        Ok(VhostNetDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all vhost-net devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by interface id) and must not have been activated yet.
+    /// Must be called before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &VhostNetDeviceMgrState,
+    ) -> std::result::Result<(), VhostNetDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(VhostNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VhostNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            Self::restore_device_state(device, &dev_state.device_state, &dev_state.transport)
+                .map_err(VhostNetDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+
+    /// Capture the device and transport state of one vhost-net MMIO device.
+    ///
+    /// This mirrors `virtio_persist::save_mmio_device_state`, but uses the
+    /// vhost-net specific `VhostNetState` which additionally carries the
+    /// kernel vring bases.
+    fn save_device_state(
+        device: &Arc<dyn DeviceIo>,
+    ) -> Result<(VhostNetState, MmioV2TransportState), VirtioError> {
+        let mmio_dev = device
+            .as_any()
+            .downcast_ref::<DbsMmioV2Device>()
+            .ok_or(VirtioError::InvalidInput)?;
+        let transport = mmio_dev.persist_state();
+        let guard = mmio_dev.state();
+        let inner = guard
+            .get_inner_device()
+            .as_any()
+            .downcast_ref::<VhostKernNet>()
+            .ok_or(VirtioError::InvalidInput)?;
+        Ok((inner.persist_state()?, transport))
+    }
+
+    /// Restore the device and transport state of a freshly re-created
+    /// vhost-net MMIO device, replaying device activation if the guest had
+    /// activated it. Must be called before the vCPUs resume.
+    ///
+    /// This mirrors `virtio_persist::restore_mmio_device_state`, but uses
+    /// the vhost-net specific `VhostNetState` which additionally carries
+    /// the kernel vring bases.
+    fn restore_device_state(
+        device: &Arc<dyn DeviceIo>,
+        state: &VhostNetState,
+        transport: &MmioV2TransportState,
+    ) -> Result<(), VirtioError> {
+        let mmio_dev = device
+            .as_any()
+            .downcast_ref::<DbsMmioV2Device>()
+            .ok_or(VirtioError::InvalidInput)?;
+        {
+            let mut guard = mmio_dev.state();
+            let inner = guard
+                .get_inner_device_mut()
+                .as_any_mut()
+                .downcast_mut::<VhostKernNet>()
+                .ok_or(VirtioError::InvalidInput)?;
+            // Restore the device state (including the kernel vring bases)
+            // before the transport state: activation replay reads it.
+            inner.restore_from_state(state)?;
+        }
+        mmio_dev.restore_from_state(transport)
+    }
+}
+
+/// Snapshot state of one vhost-net device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VhostNetDevState {
+    /// Static configuration of the device.
+    pub config: VhostNetDeviceConfigInfo,
+    /// Guest-negotiated virtio device state plus the vring bases read back
+    /// from the in-kernel vhost backend.
+    pub device_state: VhostNetState,
+    /// MMIO transport state.
+    pub transport: MmioV2TransportState,
+}
+
+/// Snapshot state of the vhost-net device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VhostNetDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VhostNetDevState>,
 }
 
 impl Default for VhostNetDeviceMgr {

--- a/src/dragonball/src/device_manager/vhost_user_net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vhost_user_net_dev_mgr.rs
@@ -10,7 +10,7 @@ use dbs_virtio_devices::vhost::vhost_user::net::VhostUserNet;
 use dbs_virtio_devices::Error as VirtioError;
 use serde::{Deserialize, Serialize};
 
-use super::{DeviceManager, DeviceMgrError, DeviceOpContext};
+use super::{virtio_persist, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfos};
 
@@ -204,6 +204,97 @@ impl VhostUserNetDeviceMgr {
         }
         Ok(())
     }
+
+    /// Capture the state of all vhost-user-net devices.
+    ///
+    /// The virtual machine must be paused when this is called. The
+    /// vhost-user backend connection is re-established and reconfigured
+    /// when device activation is replayed on restore.
+    pub fn save_states(
+        &self,
+    ) -> std::result::Result<VhostUserNetDeviceMgrState, VhostUserNetDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.configs.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VhostUserNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                VhostUserNet<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(VhostUserNetDeviceError::Virtio)?;
+            devices.push(VhostUserNetDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(VhostUserNetDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all vhost-user-net devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by interface id) and must not have been activated yet.
+    /// Must be called before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &VhostUserNetDeviceMgrState,
+    ) -> std::result::Result<(), VhostUserNetDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .configs
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(VhostUserNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VhostUserNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<VhostUserNet<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+            )
+            .map_err(VhostUserNetDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for VhostUserNet<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> dbs_virtio_devices::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &dbs_virtio_devices::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one vhost-user-net device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VhostUserNetDevState {
+    /// Static configuration of the device.
+    pub config: VhostUserNetDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: dbs_virtio_devices::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: dbs_virtio_devices::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the vhost-user-net device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VhostUserNetDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VhostUserNetDevState>,
 }
 
 impl Default for VhostUserNetDeviceMgr {

--- a/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
@@ -23,7 +23,7 @@ use crate::config_manager::{
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
 
-use super::DbsMmioV2Device;
+use super::{virtio_persist, DbsMmioV2Device};
 
 /// Default number of virtio queues, one rx/tx pair.
 pub const DEFAULT_NUM_QUEUES: usize = 2;
@@ -387,6 +387,97 @@ impl VirtioNetDeviceMgr {
         }
         Ok(())
     }
+
+    /// Capture the state of all virtio-net devices.
+    ///
+    /// The virtual machine must be paused when this is called.
+    pub fn save_states(
+        &self,
+    ) -> std::result::Result<VirtioNetDeviceMgrState, VirtioNetDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VirtioNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                Net<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(VirtioNetDeviceError::Virtio)?;
+            devices.push(VirtioNetDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(VirtioNetDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-net devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by interface id) and must not have been activated yet.
+    /// Must be called before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &VirtioNetDeviceMgrState,
+    ) -> std::result::Result<(), VirtioNetDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| {
+                    VirtioNetDeviceError::InvalidIfaceId(dev_state.config.id().to_owned())
+                })?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VirtioNetDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<Net<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+            )
+            .map_err(VirtioNetDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for Net<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> virtio::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &virtio::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one virtio-net device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VirtioNetDevState {
+    /// Static configuration of the device.
+    pub config: VirtioNetDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: virtio::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: virtio::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the virtio-net device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VirtioNetDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VirtioNetDevState>,
 }
 
 impl Default for VirtioNetDeviceMgr {

--- a/src/dragonball/src/device_manager/vsock_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vsock_dev_mgr.rs
@@ -17,7 +17,8 @@ use dbs_virtio_devices::vsock::Vsock;
 use dbs_virtio_devices::Error as VirtioError;
 use serde_derive::{Deserialize, Serialize};
 
-use super::{DeviceMgrError, StartMicroVmError};
+use super::{virtio_persist, DeviceMgrError, StartMicroVmError};
+use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::{DeviceManager, DeviceOpContext};
 
@@ -35,6 +36,10 @@ pub enum VsockDeviceError {
     /// The virtual machine instance ID is invalid.
     #[error("the virtual machine instance ID is invalid")]
     InvalidVMID,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// The Context Identifier is already in use.
     #[error("the device ID {0} already exists")]
@@ -299,6 +304,95 @@ impl VsockDeviceMgr {
         }
         Ok(())
     }
+
+    /// Capture the state of all vsock devices.
+    ///
+    /// The virtual machine must be paused when this is called. Live vsock
+    /// connection state is not captured: snapshots must be taken at a clean
+    /// quiesce point with no active connections.
+    pub fn save_states(&self) -> std::result::Result<VsockDeviceMgrState, VsockDeviceError> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) = virtio_persist::save_mmio_device_state::<
+                Vsock<GuestAddressSpaceImpl>,
+            >(device)
+            .map_err(VsockDeviceError::Virtio)?;
+            devices.push(VsockDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(VsockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all vsock devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by id) and must not have been activated yet. Must be called
+    /// before the guest vCPUs resume.
+    pub fn restore_states(
+        &mut self,
+        state: &VsockDeviceMgrState,
+    ) -> std::result::Result<(), VsockDeviceError> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            virtio_persist::restore_mmio_device_state::<Vsock<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+            )
+            .map_err(VsockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+impl virtio_persist::VirtioDevicePersist for Vsock<GuestAddressSpaceImpl> {
+    fn persist_device_info(&self) -> virtio::persist::VirtioDeviceInfoState {
+        self.persist_state()
+    }
+
+    fn restore_device_info(
+        &mut self,
+        state: &virtio::persist::VirtioDeviceInfoState,
+    ) -> std::result::Result<(), VirtioError> {
+        self.restore_from_state(state)
+    }
+}
+
+/// Snapshot state of one vsock device: static configuration plus
+/// guest-negotiated runtime state.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VsockDevState {
+    /// Static configuration of the device.
+    pub config: VsockDeviceConfigInfo,
+    /// Guest-negotiated virtio device state.
+    pub device_info: virtio::persist::VirtioDeviceInfoState,
+    /// MMIO transport state.
+    pub transport: virtio::persist::MmioV2TransportState,
+}
+
+/// Snapshot state of the vsock device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VsockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VsockDevState>,
 }
 
 impl Default for VsockDeviceMgr {

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -112,6 +112,10 @@ pub enum StartMicroVmError {
     #[error("the virtual machine is already running")]
     MicroVMAlreadyRunning,
 
+    /// Failed to restore the virtual machine from a snapshot.
+    #[error("cannot restore the virtual machine from snapshot: {0}")]
+    RestoreMicroVm(String),
+
     /// Cannot start the VM because the kernel was not configured.
     #[error("cannot start the virtual machine without kernel configuration")]
     MissingKernelConfig,

--- a/src/dragonball/src/lib.rs
+++ b/src/dragonball/src/lib.rs
@@ -28,6 +28,8 @@ pub mod hypervisor_metrics;
 pub mod kvm_context;
 /// Metrics system.
 pub mod metric;
+/// Checkpoint/restore (snapshot) support.
+pub mod persist;
 /// Resource manager for virtual machines.
 pub mod resource_manager;
 /// Signal handler for virtual machines.

--- a/src/dragonball/src/persist/mod.rs
+++ b/src/dragonball/src/persist/mod.rs
@@ -30,7 +30,21 @@ use std::path::Path;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::address_space_manager::GuestMemoryState;
+#[cfg(feature = "virtio-blk")]
+use crate::device_manager::blk_dev_mgr::BlockDeviceMgrState;
 use crate::vcpu::VcpuState;
+
+/// Aggregated snapshot state of the device manager.
+///
+/// Device classes are added progressively; a class whose snapshot support is
+/// not implemented yet is simply absent (`None`).
+#[derive(Default, Deserialize, Serialize)]
+pub struct DeviceManagerState {
+    /// State of the block device manager.
+    #[cfg(feature = "virtio-blk")]
+    #[serde(default)]
+    pub block: Option<BlockDeviceMgrState>,
+}
 
 /// Current snapshot format epoch.
 ///
@@ -129,6 +143,9 @@ pub struct MicrovmState {
     /// Guest RAM contents state, present once memory has been saved.
     #[serde(default)]
     pub memory_state: Option<GuestMemoryState>,
+    /// Device manager state.
+    #[serde(default)]
+    pub device_states: DeviceManagerState,
 }
 
 impl MicrovmState {

--- a/src/dragonball/src/persist/mod.rs
+++ b/src/dragonball/src/persist/mod.rs
@@ -30,8 +30,22 @@ use std::path::Path;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::address_space_manager::GuestMemoryState;
+#[cfg(feature = "virtio-balloon")]
+use crate::device_manager::balloon_dev_mgr::BalloonDeviceMgrState;
 #[cfg(feature = "virtio-blk")]
 use crate::device_manager::blk_dev_mgr::BlockDeviceMgrState;
+#[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+use crate::device_manager::fs_dev_mgr::FsDeviceMgrState;
+#[cfg(feature = "virtio-mem")]
+use crate::device_manager::mem_dev_mgr::MemDeviceMgrState;
+#[cfg(feature = "vhost-net")]
+use crate::device_manager::vhost_net_dev_mgr::VhostNetDeviceMgrState;
+#[cfg(feature = "vhost-user-net")]
+use crate::device_manager::vhost_user_net_dev_mgr::VhostUserNetDeviceMgrState;
+#[cfg(feature = "virtio-net")]
+use crate::device_manager::virtio_net_dev_mgr::VirtioNetDeviceMgrState;
+#[cfg(feature = "virtio-vsock")]
+use crate::device_manager::vsock_dev_mgr::VsockDeviceMgrState;
 use crate::vcpu::VcpuState;
 
 /// Aggregated snapshot state of the device manager.
@@ -44,6 +58,34 @@ pub struct DeviceManagerState {
     #[cfg(feature = "virtio-blk")]
     #[serde(default)]
     pub block: Option<BlockDeviceMgrState>,
+    /// State of the virtio-net device manager.
+    #[cfg(feature = "virtio-net")]
+    #[serde(default)]
+    pub virtio_net: Option<VirtioNetDeviceMgrState>,
+    /// State of the vsock device manager.
+    #[cfg(feature = "virtio-vsock")]
+    #[serde(default)]
+    pub vsock: Option<VsockDeviceMgrState>,
+    /// State of the virtio-fs device manager.
+    #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+    #[serde(default)]
+    pub fs: Option<FsDeviceMgrState>,
+    /// State of the virtio-balloon device manager.
+    #[cfg(feature = "virtio-balloon")]
+    #[serde(default)]
+    pub balloon: Option<BalloonDeviceMgrState>,
+    /// State of the virtio-mem device manager.
+    #[cfg(feature = "virtio-mem")]
+    #[serde(default)]
+    pub mem: Option<MemDeviceMgrState>,
+    /// State of the vhost-net device manager.
+    #[cfg(feature = "vhost-net")]
+    #[serde(default)]
+    pub vhost_net: Option<VhostNetDeviceMgrState>,
+    /// State of the vhost-user-net device manager.
+    #[cfg(feature = "vhost-user-net")]
+    #[serde(default)]
+    pub vhost_user_net: Option<VhostUserNetDeviceMgrState>,
 }
 
 /// Current snapshot format epoch.

--- a/src/dragonball/src/persist/mod.rs
+++ b/src/dragonball/src/persist/mod.rs
@@ -1,0 +1,234 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Checkpoint/restore (snapshot) support for Dragonball.
+//!
+//! This module provides the [`Persist`] trait implemented by stateful VMM
+//! components, plus the top-level [`MicrovmState`] aggregating the states of
+//! all components and helpers to save/load it as a JSON state file.
+//!
+//! The snapshot consists of two files:
+//! - a *state file* (JSON, produced from [`MicrovmState`]) holding vCPU,
+//!   device and VM metadata state, and
+//! - a *memory file* holding the guest RAM contents (managed by the address
+//!   space manager, not this module).
+//!
+//! # Compatibility policy
+//!
+//! State structs are serialized with `serde_json`. Snapshots are expected to
+//! be produced and consumed by the same Dragonball version (regenerate the
+//! template whenever Dragonball is updated). Newly-added fields must use
+//! `#[serde(default)]`; fields must never be removed or repurposed
+//! (deprecate-don't-delete). [`FORMAT_EPOCH`] is bumped only on a genuinely
+//! incompatible change, causing old snapshots to be refused loudly instead of
+//! being misinterpreted.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
+
+use serde_derive::{Deserialize, Serialize};
+
+use crate::vcpu::VcpuState;
+
+/// Current snapshot format epoch.
+///
+/// Bump this only for a deliberately incompatible change to the persisted
+/// state format that append-only evolution cannot absorb. On restore, an
+/// epoch mismatch causes the snapshot to be refused with a clear error.
+pub const FORMAT_EPOCH: u16 = 1;
+
+/// A component that can serialize its runtime state (`save`) and be
+/// reconstructed from that state (`restore`).
+///
+/// - `State` is a plain-old-data struct holding the serializable state,
+///   deriving `Serialize`/`Deserialize`.
+/// - `ConstructorArgs` carries the live, non-serializable dependencies needed
+///   to rebuild `Self` (fds, guest memory handles, managers, ...). They are
+///   re-created by the caller and injected on restore.
+pub trait Persist<'a>
+where
+    Self: Sized,
+{
+    /// Serializable state of the component.
+    type State;
+    /// Live dependencies needed to reconstruct the component.
+    type ConstructorArgs;
+    /// Error type returned by save/restore.
+    type Error;
+
+    /// Capture the current state of the component.
+    fn save(&self) -> std::result::Result<Self::State, Self::Error>;
+
+    /// Rebuild the component from a previously saved state plus live
+    /// constructor arguments.
+    fn restore(
+        constructor_args: Self::ConstructorArgs,
+        state: &Self::State,
+    ) -> std::result::Result<Self, Self::Error>;
+}
+
+/// Errors related to saving/loading a microVM snapshot.
+#[derive(Debug, thiserror::Error)]
+pub enum PersistError {
+    /// Snapshot file I/O failure.
+    #[error("snapshot I/O error")]
+    Io(#[from] std::io::Error),
+
+    /// Snapshot (de)serialization failure.
+    #[error("snapshot serialization error")]
+    Json(#[from] serde_json::Error),
+
+    /// The snapshot was produced with an incompatible format epoch.
+    #[error(
+        "incompatible snapshot: found format epoch {found}, supported {supported}; \
+         regenerate the snapshot/template with this Dragonball version"
+    )]
+    EpochMismatch {
+        /// Epoch found in the snapshot file.
+        found: u64,
+        /// Epoch supported by this Dragonball build.
+        supported: u16,
+    },
+}
+
+/// Header identifying a snapshot state file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SnapshotHeader {
+    /// Snapshot format epoch, checked against [`FORMAT_EPOCH`] on load.
+    pub format_epoch: u16,
+    /// Version of the Dragonball crate that produced the snapshot.
+    /// Diagnostics only; not used for compatibility decisions.
+    #[serde(default)]
+    pub producer_version: String,
+}
+
+impl Default for SnapshotHeader {
+    fn default() -> Self {
+        SnapshotHeader {
+            format_epoch: FORMAT_EPOCH,
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Aggregated state of a microVM.
+///
+/// Components are added progressively: a component whose `Persist` support is
+/// not implemented yet simply keeps its `Default` value in the snapshot and
+/// is ignored on restore.
+#[derive(Default, Deserialize, Serialize)]
+pub struct MicrovmState {
+    /// Snapshot header.
+    #[serde(default)]
+    pub header: SnapshotHeader,
+    /// Per-vCPU state, ordered by vCPU id.
+    #[serde(default)]
+    pub vcpu_states: Vec<VcpuState>,
+}
+
+impl MicrovmState {
+    /// Serialize the state to a JSON file at `path`.
+    pub fn save_to_file(&self, path: &Path) -> std::result::Result<(), PersistError> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer(&mut writer, self)?;
+        // Flush explicitly: BufWriter's drop swallows I/O errors (e.g.
+        // ENOSPC), which would report a truncated state file as success.
+        writer.flush()?;
+        Ok(())
+    }
+
+    /// Load a state previously written by [`MicrovmState::save_to_file`].
+    ///
+    /// The format epoch is validated *before* deserializing the full state so
+    /// that an incompatible snapshot fails with [`PersistError::EpochMismatch`]
+    /// instead of an obscure deserialization error.
+    pub fn load_from_file(path: &Path) -> std::result::Result<Self, PersistError> {
+        let file = File::open(path)?;
+        let value: serde_json::Value = serde_json::from_reader(BufReader::new(file))?;
+        let found = value
+            .get("header")
+            .and_then(|h| h.get("format_epoch"))
+            .and_then(|e| e.as_u64())
+            .unwrap_or(0);
+        if found != u64::from(FORMAT_EPOCH) {
+            return Err(PersistError::EpochMismatch {
+                found,
+                supported: FORMAT_EPOCH,
+            });
+        }
+        Ok(serde_json::from_value(value)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_microvm_state_json_roundtrip() {
+        let state = MicrovmState::default();
+        let file = TempFile::new().unwrap();
+        state.save_to_file(file.as_path()).unwrap();
+
+        let loaded = MicrovmState::load_from_file(file.as_path()).unwrap();
+        assert_eq!(loaded.header.format_epoch, FORMAT_EPOCH);
+        assert_eq!(loaded.header.producer_version, env!("CARGO_PKG_VERSION"));
+        assert!(loaded.vcpu_states.is_empty());
+    }
+
+    #[test]
+    fn test_microvm_state_epoch_mismatch() {
+        let file = TempFile::new().unwrap();
+        let json = serde_json::json!({
+            "header": { "format_epoch": FORMAT_EPOCH + 1 },
+            "vcpu_states": [],
+        });
+        serde_json::to_writer(File::create(file.as_path()).unwrap(), &json).unwrap();
+
+        match MicrovmState::load_from_file(file.as_path()) {
+            Err(PersistError::EpochMismatch { found, supported }) => {
+                assert_eq!(found, u64::from(FORMAT_EPOCH + 1));
+                assert_eq!(supported, FORMAT_EPOCH);
+            }
+            other => panic!("expected EpochMismatch, got {:?}", other.map(|_| ())),
+        }
+    }
+
+    #[test]
+    fn test_microvm_state_epoch_not_truncated() {
+        // An epoch congruent to FORMAT_EPOCH mod 2^16 must still be refused.
+        let file = TempFile::new().unwrap();
+        let epoch = u64::from(FORMAT_EPOCH) + (1 << 16);
+        let json = serde_json::json!({
+            "header": { "format_epoch": epoch },
+            "vcpu_states": [],
+        });
+        serde_json::to_writer(File::create(file.as_path()).unwrap(), &json).unwrap();
+
+        assert!(matches!(
+            MicrovmState::load_from_file(file.as_path()),
+            Err(PersistError::EpochMismatch { found, .. }) if found == epoch
+        ));
+    }
+
+    #[test]
+    fn test_microvm_state_missing_header_refused() {
+        // A state file without a header (e.g. produced by a pre-epoch build)
+        // must be refused, not silently defaulted.
+        let file = TempFile::new().unwrap();
+        serde_json::to_writer(
+            File::create(file.as_path()).unwrap(),
+            &serde_json::json!({ "vcpu_states": [] }),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            MicrovmState::load_from_file(file.as_path()),
+            Err(PersistError::EpochMismatch { found: 0, .. })
+        ));
+    }
+}

--- a/src/dragonball/src/persist/mod.rs
+++ b/src/dragonball/src/persist/mod.rs
@@ -29,6 +29,7 @@ use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::address_space_manager::GuestMemoryState;
 use crate::vcpu::VcpuState;
 
 /// Current snapshot format epoch.
@@ -125,6 +126,9 @@ pub struct MicrovmState {
     /// Per-vCPU state, ordered by vCPU id.
     #[serde(default)]
     pub vcpu_states: Vec<VcpuState>,
+    /// Guest RAM contents state, present once memory has been saved.
+    #[serde(default)]
+    pub memory_state: Option<GuestMemoryState>,
 }
 
 impl MicrovmState {

--- a/src/dragonball/src/persist/mod.rs
+++ b/src/dragonball/src/persist/mod.rs
@@ -149,6 +149,70 @@ pub enum PersistError {
     },
 }
 
+/// Errors from the top-level microVM save/restore orchestration.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    /// vCPU manager failure while saving/restoring vCPU state.
+    #[error("vcpu manager error: {0}")]
+    Vcpu(#[from] crate::vcpu::VcpuManagerError),
+
+    /// Address space manager failure while saving/restoring guest memory.
+    #[error("guest memory error: {0}")]
+    Memory(#[from] crate::address_space_manager::AddressManagerError),
+
+    /// Block device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-blk")]
+    #[error("block device error: {0}")]
+    Block(#[from] crate::device_manager::blk_dev_mgr::BlockDeviceError),
+
+    /// virtio-net device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-net")]
+    #[error("virtio-net device error: {0}")]
+    VirtioNet(#[from] crate::device_manager::virtio_net_dev_mgr::VirtioNetDeviceError),
+
+    /// Vsock device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-vsock")]
+    #[error("vsock device error: {0}")]
+    Vsock(#[from] crate::device_manager::vsock_dev_mgr::VsockDeviceError),
+
+    /// virtio-fs device manager failure while saving/restoring device state.
+    #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+    #[error("virtio-fs device error: {0}")]
+    Fs(#[from] crate::device_manager::fs_dev_mgr::FsDeviceError),
+
+    /// Balloon device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-balloon")]
+    #[error("virtio-balloon device error: {0}")]
+    Balloon(#[from] crate::device_manager::balloon_dev_mgr::BalloonDeviceError),
+
+    /// virtio-mem device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-mem")]
+    #[error("virtio-mem device error: {0}")]
+    Mem(#[from] crate::device_manager::mem_dev_mgr::MemDeviceError),
+
+    /// vhost-net device manager failure while saving/restoring device state.
+    #[cfg(feature = "vhost-net")]
+    #[error("vhost-net device error: {0}")]
+    VhostNet(#[from] crate::device_manager::vhost_net_dev_mgr::VhostNetDeviceError),
+
+    /// vhost-user-net device manager failure while saving/restoring state.
+    #[cfg(feature = "vhost-user-net")]
+    #[error("vhost-user-net device error: {0}")]
+    VhostUserNet(#[from] crate::device_manager::vhost_user_net_dev_mgr::VhostUserNetDeviceError),
+
+    /// State file (de)serialization failure.
+    #[error(transparent)]
+    Persist(#[from] PersistError),
+
+    /// Snapshot file I/O failure.
+    #[error("snapshot I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// KVM ioctl failure.
+    #[error("KVM error: {0}")]
+    Kvm(#[source] kvm_ioctls::Error),
+}
+
 /// Header identifying a snapshot state file.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SnapshotHeader {
@@ -169,6 +233,27 @@ impl Default for SnapshotHeader {
     }
 }
 
+/// VM-scoped KVM state (x86_64): PIT, kvmclock, the PIC pair and the IOAPIC.
+///
+/// Without restoring these, a restored guest never receives legacy IRQs (the
+/// fresh KVM IOAPIC/PIC come up with all lines masked, discarding the
+/// redirection tables the guest programmed at boot) and the guest clock is
+/// wrong.
+#[cfg(target_arch = "x86_64")]
+#[derive(Deserialize, Serialize)]
+pub struct VmKvmState {
+    /// PIT state.
+    pub pit: kvm_bindings::kvm_pit_state2,
+    /// kvmclock state.
+    pub clock: kvm_bindings::kvm_clock_data,
+    /// PIC master state.
+    pub pic_master: kvm_bindings::kvm_irqchip,
+    /// PIC slave state.
+    pub pic_slave: kvm_bindings::kvm_irqchip,
+    /// IOAPIC state.
+    pub ioapic: kvm_bindings::kvm_irqchip,
+}
+
 /// Aggregated state of a microVM.
 ///
 /// Components are added progressively: a component whose `Persist` support is
@@ -179,6 +264,10 @@ pub struct MicrovmState {
     /// Snapshot header.
     #[serde(default)]
     pub header: SnapshotHeader,
+    /// VM-scoped KVM state.
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub vm_kvm_state: Option<VmKvmState>,
     /// Per-vCPU state, ordered by vCPU id.
     #[serde(default)]
     pub vcpu_states: Vec<VcpuState>,

--- a/src/dragonball/src/vcpu/aarch64.rs
+++ b/src/dragonball/src/vcpu/aarch64.rs
@@ -17,11 +17,25 @@ use kvm_ioctls::{VcpuFd, VmFd};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
+use serde_derive::{Deserialize, Serialize};
+
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::metric::VcpuMetrics;
 use crate::vcpu::vcpu_impl::{Result, Vcpu, VcpuError, VcpuStateEvent};
 use crate::vcpu::VcpuConfig;
 use crate::IoManagerCached;
+
+/// Snapshot state of an aarch64 vCPU.
+///
+/// Placeholder: aarch64 vCPU save/restore is not implemented yet. The struct
+/// exists so that architecture-independent snapshot code compiles on
+/// aarch64; fields (core registers, GIC state, MPIDR, ...) will be added
+/// when aarch64 support lands.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct VcpuState {
+    /// vCPU id.
+    pub id: u8,
+}
 
 #[allow(unused)]
 impl Vcpu {

--- a/src/dragonball/src/vcpu/mod.rs
+++ b/src/dragonball/src/vcpu/mod.rs
@@ -8,6 +8,7 @@ mod vcpu_impl;
 mod vcpu_manager;
 
 use dbs_arch::VpmuFeatureLevel;
+pub use vcpu_impl::VcpuState;
 pub use vcpu_manager::{VcpuManager, VcpuManagerError, VcpuResizeInfo};
 
 #[cfg(feature = "hotplug")]

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -36,9 +36,15 @@ use crate::IoManagerCached;
 #[path = "x86_64.rs"]
 mod x86_64;
 
+#[cfg(target_arch = "x86_64")]
+pub use self::x86_64::VcpuState;
+
 #[cfg(target_arch = "aarch64")]
 #[path = "aarch64.rs"]
 mod aarch64;
+
+#[cfg(target_arch = "aarch64")]
+pub use self::aarch64::VcpuState;
 
 #[cfg(target_arch = "x86_64")]
 const MAGIC_IOPORT_BASE: u16 = 0xdbdb;
@@ -119,6 +125,18 @@ pub enum VcpuError {
     /// The call to KVM_SET_CPUID2 failed on x86_64.
     #[error("failure while calling KVM_SET_CPUID2 on x86_64")]
     SetSupportedCpusFailed(#[source] kvm_ioctls::Error),
+
+    /// KVM processed fewer MSRs than requested while saving or restoring
+    /// vCPU state; continuing would silently corrupt the remaining MSRs.
+    #[error("vCPU {id}: KVM processed only {processed} of {requested} MSRs")]
+    MsrsIncomplete {
+        /// vCPU id.
+        id: u8,
+        /// Number of MSRs actually processed by KVM.
+        processed: usize,
+        /// Number of MSRs requested.
+        requested: usize,
+    },
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -199,6 +217,11 @@ pub enum VcpuEvent {
 
     /// Event to revalidate vcpu IoManager cache
     RevalidateCache,
+
+    /// Event to save the vCPU state. The vCPU must be paused. Carries the
+    /// indices of the MSRs to save.
+    #[cfg(target_arch = "x86_64")]
+    SaveState(Vec<u32>),
 }
 
 /// List of responses that the Vcpu reports.
@@ -215,6 +238,9 @@ pub enum VcpuResponse {
     Error(VcpuError),
     /// Vcpu IoManager cache is revalidated
     CacheRevalidated,
+    /// Saved vCPU state.
+    #[cfg(target_arch = "x86_64")]
+    SavedState(Box<super::VcpuState>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -692,6 +718,13 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
             }
+            // Saving state requires a paused vCPU.
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(_)) => {
+                self.response_sender
+                    .send(VcpuResponse::NotAllowed)
+                    .expect("failed to send save state status");
+            }
             // Unhandled exit of the other end.
             Err(TryRecvError::Disconnected) => {
                 // Move to 'exited' state.
@@ -743,6 +776,17 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
 
+                StateMachine::next(Self::paused)
+            }
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(msr_index_list)) => {
+                let response = match self.save_state(&msr_index_list) {
+                    Ok(state) => VcpuResponse::SavedState(Box::new(state)),
+                    Err(e) => VcpuResponse::Error(e),
+                };
+                self.response_sender
+                    .send(response)
+                    .expect("failed to send saved vcpu state");
                 StateMachine::next(Self::paused)
             }
             // Unhandled exit of the other end.
@@ -815,6 +859,7 @@ pub mod tests {
     #[cfg(target_arch = "x86_64")]
     use dbs_interrupt::KvmIrqManager;
     use lazy_static::lazy_static;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
 
     use super::*;
@@ -928,6 +973,7 @@ pub mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_run_emulation() {
         skip_if_kvm_unaccessable!();
 

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -38,6 +38,8 @@ use crate::metric::METRICS;
 use crate::vcpu::vcpu_impl::{
     Vcpu, VcpuError, VcpuEvent, VcpuHandle, VcpuResizeResult, VcpuResponse, VcpuStateEvent,
 };
+#[cfg(target_arch = "x86_64")]
+use crate::vcpu::VcpuState;
 use crate::vcpu::VcpuConfig;
 use crate::vm::VmConfigInfo;
 use crate::IoManagerCached;
@@ -490,6 +492,94 @@ impl VcpuManager {
     /// revalidate IoManager cache of all vcpus
     pub fn revalidate_all_vcpus_cache(&mut self) -> Result<()> {
         self.revalidate_vcpus_cache(&self.present_vcpus())
+    }
+
+    /// Save the states of all started vCPUs.
+    ///
+    /// All vCPUs must be paused (see [`VcpuManager::pause_all_vcpus`])
+    /// before calling this.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    #[cfg(target_arch = "x86_64")]
+    pub fn save_vcpu_states(&mut self, msr_index_list: &[u32]) -> Result<Vec<VcpuState>> {
+        let cpu_indexes = self.present_vcpus();
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                handle
+                    .send_event(VcpuEvent::SaveState(msr_index_list.to_vec()))
+                    .map_err(VcpuManagerError::VcpuEvent)?;
+            } else {
+                return Err(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        // Collect a response from every vCPU even after a failure: the
+        // SaveState events were already broadcast, so bailing out early
+        // would leave SavedState replies queued in the shared response
+        // channels, to be misread by whatever recv()s them next.
+        let mut states = Vec::with_capacity(cpu_indexes.len());
+        let mut first_error = None;
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                let deadline = std::time::Instant::now()
+                    + Duration::from_millis(CPU_RECV_TIMEOUT_MS);
+                loop {
+                    let remaining = deadline
+                        .checked_duration_since(std::time::Instant::now())
+                        .unwrap_or_default();
+                    match handle.response_receiver().recv_timeout(remaining) {
+                        Ok(VcpuResponse::SavedState(state)) => {
+                            states.push(*state);
+                            break;
+                        }
+                        // Pause/resume acknowledgements are fire-and-forget
+                        // and may still sit in the channel; drain them.
+                        Ok(VcpuResponse::Paused) | Ok(VcpuResponse::Resumed) => continue,
+                        Ok(VcpuResponse::Error(e)) => {
+                            first_error.get_or_insert(VcpuManagerError::Vcpu(e));
+                            break;
+                        }
+                        Ok(_) => {
+                            first_error.get_or_insert(VcpuManagerError::UnexpectedVcpuResponse);
+                            break;
+                        }
+                        Err(e) => {
+                            error!("vCPU save state error! {e:?}");
+                            first_error.get_or_insert(VcpuManagerError::VcpuSave);
+                            break;
+                        }
+                    }
+                }
+            } else {
+                first_error.get_or_insert(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(states),
+        }
+    }
+
+    /// Restore previously saved vCPU states.
+    ///
+    /// The target vCPUs must have been created (see
+    /// [`VcpuManager::create_vcpus`]) but not started yet: the state is
+    /// applied before the vCPU threads spawn.
+    #[cfg(target_arch = "x86_64")]
+    pub fn restore_vcpu_states(&mut self, states: &[VcpuState]) -> Result<()> {
+        for state in states {
+            let info = self
+                .vcpu_infos
+                .get_mut(state.id as usize)
+                .ok_or(VcpuManagerError::VcpuNotFound(state.id))?;
+            let vcpu = info.vcpu.as_mut().ok_or(VcpuManagerError::VcpuNotCreate)?;
+            vcpu.restore_state(state).map_err(VcpuManagerError::Vcpu)?;
+        }
+        Ok(())
     }
 
     /// return all present vcpus
@@ -1126,6 +1216,7 @@ mod tests {
     #[cfg(feature = "hotplug")]
     use dbs_virtio_devices::vsock::backend::VsockInnerBackend;
     use seccompiler::BpfProgram;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -1295,6 +1386,7 @@ mod tests {
             .is_ok());
     }
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_pause_resume_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1336,7 +1428,60 @@ mod tests {
         assert!(vcpu_manager.resume_all_vcpus().is_ok());
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[test]
+    #[serial(emulate_res)]
+    fn test_vcpu_manager_save_restore_states() {
+        skip_if_kvm_unaccessable!();
+        *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
+
+        let vm = get_vm();
+        // An in-kernel irqchip is required for LAPIC state access, and it
+        // must be created before the vCPUs. Tolerate EEXIST: the test VM
+        // setup may already have created it.
+        let _ = vm.vm_fd().create_irq_chip();
+        let msr_list = crate::kvm_context::KvmContext::new(None)
+            .unwrap()
+            .supported_msrs(0)
+            .unwrap();
+
+        let mut vcpu_manager = vm.vcpu_manager().unwrap();
+        assert!(vcpu_manager
+            .create_boot_vcpus(TimestampUs::default(), GuestAddress(0))
+            .is_ok());
+
+        // Save directly from the not-yet-started vCPU and restore into it:
+        // exercises the pre-start restore path.
+        let state = vcpu_manager.vcpu_infos[0]
+            .vcpu
+            .as_ref()
+            .unwrap()
+            .save_state(msr_list.as_slice())
+            .unwrap();
+        assert_eq!(state.id, 0);
+        vcpu_manager.restore_vcpu_states(&[state]).unwrap();
+
+        // Threaded save: start, pause, save via the event round-trip.
+        assert!(vcpu_manager.start_boot_vcpus(BpfProgram::default()).is_ok());
+
+        // Saving while running is refused.
+        let res = vcpu_manager.save_vcpu_states(msr_list.as_slice());
+        assert!(
+            matches!(res, Err(VcpuManagerError::UnexpectedVcpuResponse)),
+            "expected UnexpectedVcpuResponse, got {:?}",
+            res.as_ref().map(|states| states.len())
+        );
+
+        assert!(vcpu_manager.pause_all_vcpus().is_ok());
+        let states = vcpu_manager.save_vcpu_states(msr_list.as_slice()).unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].id, 0);
+        assert!(!states[0].msrs.is_empty());
+        assert!(vcpu_manager.resume_all_vcpus().is_ok());
+    }
+
+    #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1368,6 +1513,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_all_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1394,6 +1540,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1425,6 +1572,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_all_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -15,9 +15,14 @@ use dbs_boot::FirmwareType;
 use dbs_interrupt::InterruptManager;
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
-use kvm_bindings::CpuId;
+use kvm_bindings::{
+    kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_msr_entry, kvm_regs, kvm_sregs,
+    kvm_vcpu_events, kvm_xcrs, kvm_xsave, CpuId, Msrs, KVM_MAX_CPUID_ENTRIES,
+    KVM_MAX_MSR_ENTRIES,
+};
 use kvm_ioctls::{VcpuFd, VmFd};
-use log::error;
+use log::{error, warn};
+use serde_derive::{Deserialize, Serialize};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -157,5 +162,249 @@ impl Vcpu {
         self.fd
             .set_cpuid2(&self.cpuid)
             .map_err(VcpuError::SetSupportedCpusFailed)
+    }
+}
+
+/// Snapshot state of a x86_64 vCPU: guest-visible registers plus
+/// KVM-internal state needed to transparently resume execution.
+///
+/// Compatibility policy (see `crate::persist`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+// No `Clone`: `kvm_xsave` contains an incomplete array field.
+#[derive(Deserialize, Serialize)]
+pub struct VcpuState {
+    /// vCPU id.
+    pub id: u8,
+    /// CPUID configuration of this vCPU.
+    pub cpuid: CpuId,
+    /// Model specific registers, chunked by `KVM_MAX_MSR_ENTRIES`.
+    pub msrs: Vec<Msrs>,
+    /// General purpose registers.
+    pub regs: kvm_regs,
+    /// Special registers.
+    pub sregs: kvm_sregs,
+    /// XSAVE area (contains FPU/SSE/AVX state, superset of `kvm_fpu`).
+    pub xsave: kvm_xsave,
+    /// Extended control registers.
+    pub xcrs: kvm_xcrs,
+    /// Debug registers.
+    pub debug_regs: kvm_debugregs,
+    /// Local APIC state.
+    pub lapic: kvm_lapic_state,
+    /// Multiprocessing state.
+    pub mp_state: kvm_mp_state,
+    /// Pending vCPU events.
+    pub vcpu_events: kvm_vcpu_events,
+    /// Guest TSC frequency in kHz, if the host supports retrieving it.
+    #[serde(default)]
+    pub tsc_khz: Option<u32>,
+}
+
+impl Vcpu {
+    /// Save the KVM state of this vCPU.
+    ///
+    /// The vCPU must be quiesced (not running) when this is called; use the
+    /// vCPU manager's pause machinery first.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    pub fn save_state(&self, msr_index_list: &[u32]) -> Result<VcpuState> {
+        // Ordering matters (mirrors Firecracker):
+        // - KVM_GET_MP_STATE calls kvm_apic_accept_events(), which might
+        //   modify vCPU/LAPIC state, so it must run before everything else.
+        // - KVM_GET_VCPU_EVENTS is read last as the other GET ioctls may
+        //   modify internal pending-event state.
+        let mp_state = self.fd.get_mp_state().map_err(VcpuError::Kvm)?;
+        let regs = self.fd.get_regs().map_err(VcpuError::Kvm)?;
+        let sregs = self.fd.get_sregs().map_err(VcpuError::Kvm)?;
+        let xsave = self.fd.get_xsave().map_err(VcpuError::Kvm)?;
+        let xcrs = self.fd.get_xcrs().map_err(VcpuError::Kvm)?;
+        let debug_regs = self.fd.get_debug_regs().map_err(VcpuError::Kvm)?;
+        let lapic = self.fd.get_lapic().map_err(VcpuError::Kvm)?;
+        let cpuid = self
+            .fd
+            .get_cpuid2(KVM_MAX_CPUID_ENTRIES)
+            .map_err(VcpuError::Kvm)?;
+        let tsc_khz = self.fd.get_tsc_khz().ok();
+
+        let mut msrs = Vec::new();
+        for chunk in msr_index_list.chunks(KVM_MAX_MSR_ENTRIES) {
+            let entries: Vec<kvm_msr_entry> = chunk
+                .iter()
+                .map(|index| kvm_msr_entry {
+                    index: *index,
+                    ..Default::default()
+                })
+                .collect();
+            let mut chunk_msrs = Msrs::from_entries(&entries).map_err(VcpuError::Msr)?;
+            let nmsrs = self.fd.get_msrs(&mut chunk_msrs).map_err(VcpuError::Kvm)?;
+            if nmsrs != entries.len() {
+                // KVM stops at the first unreadable MSR, leaving the rest of
+                // the chunk zeroed; persisting it would write those zeros
+                // into the restored guest. Refuse the save instead.
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: entries.len(),
+                });
+            }
+            msrs.push(chunk_msrs);
+        }
+
+        let vcpu_events = self.fd.get_vcpu_events().map_err(VcpuError::Kvm)?;
+
+        Ok(VcpuState {
+            id: self.id,
+            cpuid,
+            msrs,
+            regs,
+            sregs,
+            xsave,
+            xcrs,
+            debug_regs,
+            lapic,
+            mp_state,
+            vcpu_events,
+            tsc_khz,
+        })
+    }
+
+    /// Restore the KVM state of this vCPU from a previously saved state.
+    ///
+    /// Must be called on a freshly created, unconfigured vCPU before it runs.
+    pub fn restore_state(&mut self, state: &VcpuState) -> Result<()> {
+        // Ordering matters (mirrors Firecracker): CPUID first as it gates
+        // MSR/XSAVE validation, events last.
+        self.cpuid = state.cpuid.clone();
+        self.fd
+            .set_cpuid2(&state.cpuid)
+            .map_err(VcpuError::SetSupportedCpusFailed)?;
+        for chunk in &state.msrs {
+            let expected = chunk.as_fam_struct_ref().nmsrs as usize;
+            let nmsrs = self.fd.set_msrs(chunk).map_err(VcpuError::Kvm)?;
+            if nmsrs != expected {
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: expected,
+                });
+            }
+        }
+        self.fd.set_sregs(&state.sregs).map_err(VcpuError::Kvm)?;
+        // SAFETY: the xsave area was obtained from KVM_GET_XSAVE with the
+        // standard fixed-size `kvm_xsave` region, so it cannot exceed the
+        // buffer the kernel copies from.
+        unsafe {
+            self.fd.set_xsave(&state.xsave).map_err(VcpuError::Kvm)?;
+        }
+        self.fd.set_xcrs(&state.xcrs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_debug_regs(&state.debug_regs)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_lapic(&state.lapic).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_mp_state(state.mp_state)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_regs(&state.regs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_vcpu_events(&state.vcpu_events)
+            .map_err(VcpuError::Kvm)?;
+        if let Some(tsc_khz) = state.tsc_khz {
+            // Best effort: hosts without KVM_CAP_TSC_CONTROL cannot set it.
+            if let Err(e) = self.fd.set_tsc_khz(tsc_khz) {
+                warn!("vcpu {}: failed to restore TSC frequency: {}", self.id, e);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use arc_swap::ArcSwap;
+    use dbs_device::device_manager::IoManager;
+    use dbs_interrupt::KvmIrqManager;
+    use kvm_bindings::MsrList;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    use super::*;
+    use crate::kvm_context::KvmContext;
+
+    // A vCPU on its own VM with an in-kernel irqchip (required by
+    // KVM_GET/SET_LAPIC).
+    fn create_vcpu_with_irqchip() -> (Vcpu, MsrList) {
+        let kvm_context = KvmContext::new(None).unwrap();
+        let vm = kvm_context.create_vm().unwrap();
+        vm.create_irq_chip().unwrap();
+        let msr_list = kvm_context.supported_msrs(0).unwrap();
+        let supported_cpuid = kvm_context
+            .supported_cpuid(KVM_MAX_CPUID_ENTRIES)
+            .unwrap();
+        let vm = Arc::new(vm);
+        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let io_manager = IoManagerCached::new(Arc::new(ArcSwap::new(Arc::new(IoManager::new()))));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm)));
+        let (tx, _rx) = channel();
+
+        let vcpu = Vcpu::new_x86_64(
+            0,
+            vcpu_fd,
+            io_manager,
+            supported_cpuid,
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            tx,
+            TimestampUs::default(),
+            false,
+            irq_manager,
+        )
+        .unwrap();
+
+        (vcpu, msr_list)
+    }
+
+    #[test]
+    fn test_vcpu_save_restore_roundtrip() {
+        skip_if_kvm_unaccessable!();
+
+        let (src, msr_list) = create_vcpu_with_irqchip();
+
+        // Plant recognizable register values on the source vCPU.
+        let mut regs = src.fd.get_regs().unwrap();
+        regs.rbx = 0xdbdb;
+        regs.rip = 0x1000;
+        src.fd.set_regs(&regs).unwrap();
+
+        let state = src.save_state(msr_list.as_slice()).unwrap();
+        assert_eq!(state.id, 0);
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+        assert!(!state.msrs.is_empty());
+
+        // The state itself must survive a JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: VcpuState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+
+        // Restore into a fresh vCPU on a fresh VM and verify the KVM state.
+        let (mut dst, _) = create_vcpu_with_irqchip();
+        dst.restore_state(&state).unwrap();
+
+        let dst_regs = dst.fd.get_regs().unwrap();
+        assert_eq!(dst_regs.rbx, 0xdbdb);
+        assert_eq!(dst_regs.rip, 0x1000);
+        let dst_sregs = dst.fd.get_sregs().unwrap();
+        assert_eq!(dst_sregs.cr0, state.sregs.cr0);
+        assert_eq!(dst_sregs.cs.base, state.sregs.cs.base);
+        assert_eq!(
+            dst.fd.get_mp_state().unwrap().mp_state,
+            state.mp_state.mp_state
+        );
     }
 }

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -856,6 +856,101 @@ impl Vm {
         info!(self.logger, "VM started");
         Ok(())
     }
+
+    /// Start a microVM by restoring it from a snapshot (see
+    /// [`Vm::save_microvm`]) instead of cold booting.
+    ///
+    /// The VM must have been configured with the *same configuration*
+    /// (machine config, boot source, devices) the snapshot was taken with.
+    /// This mirrors [`Vm::start_microvm`] but skips the boot-time system
+    /// configuration and applies the snapshot before the vCPUs start:
+    /// guest memory contents, device runtime state (replaying virtio
+    /// activation) and vCPU register state.
+    #[cfg(target_arch = "x86_64")]
+    pub fn start_microvm_from_snapshot(
+        &mut self,
+        event_mgr: &mut EventManager,
+        seccomp_filters: HashMap<String, BpfProgram>,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), StartMicroVmError> {
+        info!(self.logger, "VM: received restore-from-snapshot command");
+
+        if let Some(process_seccomp_filter) = seccomp_filters.get(ALL_THREADS) {
+            if let Err(e) = apply_filter_all_threads(process_seccomp_filter) {
+                if !matches!(e, SecError::EmptyFilter) {
+                    error!(
+                        self.logger,
+                        "VM: failed to apply process-wide seccomp filters: {}", e
+                    );
+                    return Err(StartMicroVmError::SeccompFilters(e));
+                }
+            }
+        }
+
+        if self.is_vm_initialized() {
+            return Err(StartMicroVmError::MicroVMAlreadyRunning);
+        }
+
+        let request_ts = TimestampUs::default();
+        self.start_instance_request_ts = request_ts.time_us;
+        self.start_instance_request_cpu_ts = request_ts.cputime_us;
+
+        self.init_dmesg_logger();
+        self.check_health()?;
+
+        // Use expect() to crash if the other thread poisoned this lock.
+        self.shared_info
+            .write()
+            .expect("Failed to start microVM because shared info couldn't be written due to poisoned lock")
+            .state = InstanceState::Starting;
+
+        self.init_guest_memory()?;
+        let vm_as = self
+            .vm_as()
+            .cloned()
+            .ok_or(StartMicroVmError::AddressManagerError(
+                AddressManagerError::GuestMemoryNotInitialized,
+            ))?;
+
+        self.init_vcpu_manager(
+            vm_as.clone(),
+            seccomp_filters
+                .get(VCPU_THREAD)
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .map_err(StartMicroVmError::Vcpu)?;
+        // Creates devices and boot vCPUs. The boot-time vCPU register setup
+        // performed here is overwritten by the snapshot state below; the
+        // boot-time system configuration (`init_configure_system`) is
+        // skipped entirely since guest memory is reloaded from the snapshot.
+        self.init_microvm(event_mgr.epoll_manager(), vm_as.clone(), request_ts)?;
+        #[cfg(feature = "dbs-upcall")]
+        self.init_upcall()?;
+
+        info!(self.logger, "VM: restoring snapshot state");
+        self.restore_microvm(state_path, mem_path)
+            .map_err(|e| StartMicroVmError::RestoreMicroVm(e.to_string()))?;
+
+        info!(self.logger, "VM: register events");
+        self.register_events(event_mgr)?;
+
+        info!(self.logger, "VM: start vcpus");
+        self.vcpu_manager()
+            .map_err(StartMicroVmError::Vcpu)?
+            .start_boot_vcpus(seccomp_filters.get(VMM_THREAD).cloned().unwrap_or_default())
+            .map_err(StartMicroVmError::Vcpu)?;
+
+        // Use expect() to crash if the other thread poisoned this lock.
+        self.shared_info
+            .write()
+            .expect("Failed to start microVM because shared info couldn't be written due to poisoned lock")
+            .state = InstanceState::Running;
+
+        info!(self.logger, "VM restored from snapshot");
+        Ok(())
+    }
 }
 
 #[cfg(feature = "hotplug")]
@@ -965,6 +1060,253 @@ impl Vm {
         _epoll_mgr: Option<EpollManager>,
     ) -> std::result::Result<DeviceOpContext, StartMicroVmError> {
         Err(StartMicroVmError::MicroVMAlreadyRunning)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Vm {
+    /// Save the state of the running microVM into a snapshot: a state file
+    /// at `state_path` (vCPU/device metadata state, JSON) plus a memory file
+    /// at `mem_path` (guest RAM contents).
+    ///
+    /// All vCPUs are paused while the state is captured and resumed
+    /// afterwards (branch semantics): the snapshot is a consistent
+    /// point-in-time capture and the source VM keeps running. Exception:
+    /// saving stops in-kernel vhost rings on the source (a
+    /// VHOST_GET_VRING_BASE side effect), so its vhost devices stay
+    /// quiesced. The boot-to-be-template flow simply tears the source VM
+    /// down afterwards.
+    pub fn save_microvm(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), crate::persist::SnapshotError> {
+        use crate::persist::SnapshotError;
+
+        let msr_list = self.kvm.supported_msrs(0).map_err(SnapshotError::Kvm)?;
+
+        self.vcpu_manager()?.pause_all_vcpus()?;
+        // Resume the vCPUs whether or not the capture succeeded: a failed
+        // snapshot must not leave the source VM frozen (there is no API
+        // action a caller could use to resume it).
+        let save_result = self.save_microvm_paused(state_path, mem_path, msr_list.as_slice());
+        let resume_result = self
+            .vcpu_manager()
+            .and_then(|mut mgr| mgr.resume_all_vcpus());
+        save_result?;
+        resume_result.map_err(SnapshotError::Vcpu)?;
+        Ok(())
+    }
+
+    /// Capture the microVM state while all vCPUs are paused.
+    ///
+    /// Device (queue) state is captured *before* guest memory: the vCPUs are
+    /// paused and userspace virtio backends run on the VMM event-loop thread
+    /// executing this action, so captured queue state cannot change
+    /// afterwards, and saving a vhost device stops its in-kernel rings (a
+    /// VHOST_GET_VRING_BASE side effect), so kernel backends stop writing
+    /// guest memory before the dump below. Backends processing queues on
+    /// other threads must be idle; the boot-to-be-template flow quiesces
+    /// guest I/O before saving.
+    fn save_microvm_paused(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+        msr_list: &[u32],
+    ) -> std::result::Result<(), crate::persist::SnapshotError> {
+        use crate::persist::{DeviceManagerState, MicrovmState, SnapshotError};
+
+        let vcpu_states = self.vcpu_manager()?.save_vcpu_states(msr_list)?;
+
+        // VM-scoped KVM state, captured while the vCPUs are paused.
+        let vm_kvm_state = {
+            let vm_fd = self.vm_fd();
+            let pit = vm_fd.get_pit2().map_err(SnapshotError::Kvm)?;
+            let mut clock = vm_fd.get_clock().map_err(SnapshotError::Kvm)?;
+            // Per the KVM API, the KVM_CLOCK_TSC_STABLE flag returned by
+            // KVM_GET_CLOCK must not be fed back into KVM_SET_CLOCK.
+            clock.flags = 0;
+            let mut pic_master = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_PIC_MASTER,
+                ..Default::default()
+            };
+            vm_fd
+                .get_irqchip(&mut pic_master)
+                .map_err(SnapshotError::Kvm)?;
+            let mut pic_slave = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_PIC_SLAVE,
+                ..Default::default()
+            };
+            vm_fd
+                .get_irqchip(&mut pic_slave)
+                .map_err(SnapshotError::Kvm)?;
+            let mut ioapic = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_IOAPIC,
+                ..Default::default()
+            };
+            vm_fd.get_irqchip(&mut ioapic).map_err(SnapshotError::Kvm)?;
+            crate::persist::VmKvmState {
+                pit,
+                clock,
+                pic_master,
+                pic_slave,
+                ioapic,
+            }
+        };
+
+        #[allow(unused_mut)]
+        let mut device_states = DeviceManagerState::default();
+        #[cfg(feature = "virtio-blk")]
+        {
+            device_states.block = Some(self.device_manager.block_manager.save_states()?);
+        }
+        #[cfg(feature = "virtio-net")]
+        {
+            device_states.virtio_net =
+                Some(self.device_manager.virtio_net_manager.save_states()?);
+        }
+        #[cfg(feature = "virtio-vsock")]
+        {
+            device_states.vsock = Some(self.device_manager.vsock_manager.save_states()?);
+        }
+        #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+        {
+            device_states.fs =
+                Some(self.device_manager.fs_manager.lock().unwrap().save_states()?);
+        }
+        #[cfg(feature = "virtio-balloon")]
+        {
+            device_states.balloon = Some(self.device_manager.balloon_manager.save_states()?);
+        }
+        #[cfg(feature = "virtio-mem")]
+        {
+            device_states.mem = Some(self.device_manager.mem_manager.save_states()?);
+        }
+        #[cfg(feature = "vhost-net")]
+        {
+            device_states.vhost_net =
+                Some(self.device_manager.vhost_net_manager.save_states()?);
+        }
+        #[cfg(feature = "vhost-user-net")]
+        {
+            device_states.vhost_user_net =
+                Some(self.device_manager.vhost_user_net_manager.save_states()?);
+        }
+
+        let mut mem_file = std::fs::File::create(mem_path)?;
+        let memory_state = self.address_space.save_memory(&mut mem_file)?;
+
+        let state = MicrovmState {
+            vm_kvm_state: Some(vm_kvm_state),
+            vcpu_states,
+            memory_state: Some(memory_state),
+            device_states,
+            ..Default::default()
+        };
+        state.save_to_file(state_path)?;
+        Ok(())
+    }
+
+    /// Restore the runtime state of a freshly built microVM from a snapshot.
+    ///
+    /// Expected calling sequence (mirroring the normal boot flow, driven by
+    /// the VMM/API layer):
+    /// 1. Create the VM from the *same configuration* the snapshot was taken
+    ///    with: address space, devices and vCPUs are created (but the vCPUs
+    ///    not yet started, and no boot code runs).
+    /// 2. Call this method: it loads guest RAM from `mem_path` and applies
+    ///    the vCPU and device states from `state_path`, replaying virtio
+    ///    device activation.
+    /// 3. Start the vCPU threads and resume execution.
+    pub fn restore_microvm(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), crate::persist::SnapshotError> {
+        use crate::persist::MicrovmState;
+
+        let state = MicrovmState::load_from_file(state_path)?;
+
+        // Restore the VM-scoped KVM state first: interrupt delivery for
+        // everything below depends on the IOAPIC/PIC redirection tables the
+        // guest had programmed.
+        if let Some(kvm_state) = &state.vm_kvm_state {
+            let vm_fd = self.vm_fd();
+            vm_fd
+                .set_pit2(&kvm_state.pit)
+                .map_err(crate::persist::SnapshotError::Kvm)?;
+            vm_fd
+                .set_clock(&kvm_state.clock)
+                .map_err(crate::persist::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.pic_master)
+                .map_err(crate::persist::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.pic_slave)
+                .map_err(crate::persist::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.ioapic)
+                .map_err(crate::persist::SnapshotError::Kvm)?;
+        }
+
+        if let Some(memory_state) = &state.memory_state {
+            let mut mem_file = std::fs::File::open(mem_path)?;
+            self.address_space
+                .restore_memory(memory_state, &mut mem_file)?;
+        }
+
+        #[cfg(feature = "virtio-blk")]
+        if let Some(block_state) = &state.device_states.block {
+            self.device_manager
+                .block_manager
+                .restore_states(block_state)?;
+        }
+        #[cfg(feature = "virtio-net")]
+        if let Some(net_state) = &state.device_states.virtio_net {
+            self.device_manager
+                .virtio_net_manager
+                .restore_states(net_state)?;
+        }
+        #[cfg(feature = "virtio-vsock")]
+        if let Some(vsock_state) = &state.device_states.vsock {
+            self.device_manager
+                .vsock_manager
+                .restore_states(vsock_state)?;
+        }
+        #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+        if let Some(fs_state) = &state.device_states.fs {
+            self.device_manager
+                .fs_manager
+                .lock()
+                .unwrap()
+                .restore_states(fs_state)?;
+        }
+        #[cfg(feature = "virtio-balloon")]
+        if let Some(balloon_state) = &state.device_states.balloon {
+            self.device_manager
+                .balloon_manager
+                .restore_states(balloon_state)?;
+        }
+        #[cfg(feature = "virtio-mem")]
+        if let Some(mem_state) = &state.device_states.mem {
+            self.device_manager.mem_manager.restore_states(mem_state)?;
+        }
+        #[cfg(feature = "vhost-net")]
+        if let Some(vhost_net_state) = &state.device_states.vhost_net {
+            self.device_manager
+                .vhost_net_manager
+                .restore_states(vhost_net_state)?;
+        }
+        #[cfg(feature = "vhost-user-net")]
+        if let Some(vhost_user_net_state) = &state.device_states.vhost_user_net {
+            self.device_manager
+                .vhost_user_net_manager
+                .restore_states(vhost_user_net_state)?;
+        }
+
+        self.vcpu_manager()?
+            .restore_vcpu_states(&state.vcpu_states)?;
+        Ok(())
     }
 }
 

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -318,6 +318,37 @@ impl DragonballInner {
 
     fn start_vmm_instance(&mut self) -> Result<()> {
         info!(sl!(), "Starting VM");
+        // Boot from a VM template snapshot instead of cold booting when
+        // configured (mirrors the QEMU boot_from_template flow).
+        #[cfg(target_arch = "x86_64")]
+        if self.config.vm_template.boot_from_template {
+            let template = &self.config.vm_template;
+            if template.device_state_path.is_empty() || template.memory_path.is_empty() {
+                return Err(anyhow!(
+                    "vm_template memory_path/device_state_path are not configured"
+                ));
+            }
+            info!(
+                sl!(),
+                "Starting VM from template snapshot";
+                "device_state_path" => &template.device_state_path,
+                "memory_path" => &template.memory_path,
+            );
+            self.vmm_instance
+                .instance_start_from_snapshot(
+                    template.device_state_path.clone(),
+                    template.memory_path.clone(),
+                )
+                .context("Failed to start vmm from template snapshot")?;
+            self.state = VmmState::VmRunning;
+            return Ok(());
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        if self.config.vm_template.boot_from_template {
+            return Err(anyhow!(
+                "boot_from_template is not supported on this architecture"
+            ));
+        }
         self.vmm_instance
             .instance_start()
             .context("Failed to start vmm")?;

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -82,8 +82,34 @@ impl DragonballInner {
         Ok(())
     }
 
+    /// Save the microVM state into the VM template files configured in
+    /// `[hypervisor].vm_template` (boot-to-be-template flow): guest memory
+    /// contents to `memory_path`, vCPU/device state to `device_state_path`.
+    /// All vCPUs are paused and left paused.
     pub(crate) async fn save_vm(&self) -> Result<()> {
-        todo!()
+        #[cfg(target_arch = "x86_64")]
+        {
+            let template = &self.config.vm_template;
+            if template.device_state_path.is_empty() || template.memory_path.is_empty() {
+                return Err(anyhow!(
+                    "vm_template memory_path/device_state_path are not configured"
+                ));
+            }
+            info!(
+                sl!(),
+                "saving microVM snapshot to template";
+                "device_state_path" => &template.device_state_path,
+                "memory_path" => &template.memory_path,
+            );
+            self.vmm_instance
+                .save_microvm(
+                    template.device_state_path.clone(),
+                    template.memory_path.clone(),
+                )
+                .context("save microvm")
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        Err(anyhow!("save_vm is not supported on this architecture"))
     }
 
     pub(crate) async fn get_agent_socket(&self) -> Result<String> {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -184,6 +184,18 @@ impl VmmInstance {
         Ok(())
     }
 
+    /// Start the microVM by restoring it from a snapshot (VM template)
+    /// instead of cold booting.
+    #[cfg(target_arch = "x86_64")]
+    pub fn instance_start_from_snapshot(&self, state_path: String, mem_path: String) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::StartMicroVmFromSnapshot {
+            state_path,
+            mem_path,
+        }))
+        .context("Failed to start MicroVm from snapshot")?;
+        Ok(())
+    }
+
     pub fn is_uninitialized(&self) -> bool {
         let share_info = self
             .vmm_shared_info
@@ -350,6 +362,19 @@ impl VmmInstance {
 
     pub fn resume(&self) -> Result<()> {
         todo!()
+    }
+
+    /// Save the microVM state into a snapshot: a state file (vCPU/device
+    /// metadata, JSON) plus a guest memory contents file. Pauses all vCPUs
+    /// and leaves them paused.
+    #[cfg(target_arch = "x86_64")]
+    pub fn save_microvm(&self, state_path: String, mem_path: String) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::SaveMicrovm {
+            state_path,
+            mem_path,
+        }))
+        .context("Failed to save microvm")?;
+        Ok(())
     }
 
     pub fn pid(&self) -> u32 {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1061,6 +1061,38 @@ impl Sandbox for VirtSandbox {
             .context(format!("connect to address {:?}", &address))?;
         self.set_agent_policy().await.context("set agent policy")?;
 
+        // Boot-to-be-template: the sandbox VM has booted and the guest agent
+        // answered — dump the VM as a template now, BEFORE any guest sandbox
+        // is created (the restored VM must receive its first create_sandbox
+        // from the consuming pod). Mirrors the RunD/kata-go "template dumped
+        // at sandbox boot" semantics.
+        //
+        // The guest agent must not hold a live connection in the snapshot,
+        // otherwise the restored VM's agent never listens and the next shim
+        // cannot connect: disconnect first and give the agent time to clean
+        // up and return to listening (see factory/template.rs for the same
+        // dance in the VM factory). The template pod is a throwaway, so
+        // sandbox startup is aborted here with an explicit error once the
+        // snapshot is on disk; the caller is expected to remove the pod.
+        let hypervisor_config = self.hypervisor.hypervisor_config().await;
+        if hypervisor_config.vm_template.boot_to_be_template {
+            self.agent.stop().await;
+            self.agent
+                .disconnect()
+                .await
+                .context("disconnect agent before saving template")?;
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            self.hypervisor
+                .save_vm()
+                .await
+                .context("save vm template (boot_to_be_template)")?;
+            info!(sl!(), "sandbox VM saved as template");
+            return Err(anyhow!(
+                "VM template saved; this boot_to_be_template sandbox is a \
+                 throwaway and was intentionally aborted"
+            ));
+        }
+
         self.resource_manager
             .setup_after_start_vm()
             .await


### PR DESCRIPTION
This series adds checkpoint/restore (snapshot) support to the dragonball
VMM and wires it into the runtime-rs dragonball backend, so a sandbox VM
can be dumped once as a template and subsequent pods can be restored
from it instead of cold booting. The template is captured at a clean
quiesce point — after the sandbox VM has booted and its agent has
answered, but before any guest sandbox is created — giving the snapshot
branch semantics: the source VM keeps running and the restored VM
receives its first create_sandbox from the consuming pod.