### PR TITLE
dragonball: Support VM template save and restore on x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbs-snapshot"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dbs-upcall"
 version = "0.3.0"
 dependencies = [
@@ -1907,6 +1915,7 @@ dependencies = [
  "dbs-interrupt",
  "dbs-legacy-devices",
  "dbs-pci",
+ "dbs-snapshot",
  "dbs-upcall",
  "dbs-utils",
  "dbs-virtio-devices",
@@ -1925,6 +1934,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test 0.10.0",
  "slog",
  "slog-async",
  "slog-scope",
@@ -3931,7 +3941,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
+ "serde",
  "vmm-sys-util 0.15.0",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -8889,6 +8901,8 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
  "dbs-boot",
  "dbs-device",
  "dbs-interrupt",
+ "dbs-snapshot",
  "dbs-utils",
  "epoll",
  "fuse-backend-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ dependencies = [
  "dbs-boot",
  "dbs-device",
  "dbs-interrupt",
+ "dbs-snapshot",
  "dbs-utils",
  "epoll",
  "fuse-backend-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "bytes 1.11.1",
  "chrono",
  "clap",
+ "common",
  "csv",
  "epoll",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbs-snapshot"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dbs-upcall"
 version = "0.3.0"
 dependencies = [
@@ -1901,6 +1909,7 @@ dependencies = [
  "dbs-interrupt",
  "dbs-legacy-devices",
  "dbs-pci",
+ "dbs-snapshot",
  "dbs-upcall",
  "dbs-utils",
  "dbs-virtio-devices",
@@ -1919,6 +1928,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test 0.10.0",
  "slog",
  "slog-async",
  "slog-scope",
@@ -3936,7 +3946,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
+ "serde",
  "vmm-sys-util 0.15.0",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -8893,6 +8905,8 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "src/dragonball/crates/dbs_interrupt",
   "src/dragonball/crates/dbs_legacy_devices",
   "src/dragonball/crates/dbs_pci",
+  "src/dragonball/crates/dbs_snapshot",
   "src/dragonball/crates/dbs_upcall",
   "src/dragonball/crates/dbs_utils",
   "src/dragonball/crates/dbs_virtio_devices",
@@ -113,6 +114,7 @@ dbs-interrupt = { path = "src/dragonball/crates/dbs_interrupt" }
 dbs-legacy-devices = { path = "src/dragonball/crates/dbs_legacy_devices" }
 dbs-pci = { path = "src/dragonball/crates/dbs_pci" }
 dbs-upcall = { path = "src/dragonball/crates/dbs_upcall" }
+dbs-snapshot = { path = "src/dragonball/crates/dbs_snapshot" }
 dbs-utils = { path = "src/dragonball/crates/dbs_utils" }
 dbs-virtio-devices = { path = "src/dragonball/crates/dbs_virtio_devices" }
 

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -32,6 +32,7 @@ use std::ops::Deref;
 use std::str::{self, FromStr};
 
 /// Search criteria to use when looking for a link in `find_link`.
+#[derive(Clone, Copy)]
 pub enum LinkFilter<'a> {
     /// Find by link name.
     Name(&'a str),
@@ -113,7 +114,28 @@ impl Handle {
         // target link. filter using name or family is supported, but
         // we cannot use that to find target link.
         // let's try if hardware address filter works. -_-
-        let link = self.find_link(LinkFilter::Address(&iface.hwAddr)).await?;
+        //
+        // A NIC captured in a VM template is the exception. VMMs without
+        // device hot-plug -- e.g. Dragonball, whose virtio-mmio transport has
+        // no native hot-plug -- cannot attach a fresh NIC to the restored VM
+        // per pod, so the NIC is baked into the template. A pod restored from
+        // that template keeps the template creator's MAC, frozen in the
+        // snapshotted guest RAM, and can never be matched by this pod's MAC.
+        // Fall back to finding the interface by its (stable) name and
+        // retargeting it to the requested MAC, then look it up again. This
+        // assumes a deterministic interface name (true for a single-NIC pod,
+        // where both sides use "eth0").
+        let link = match self
+            .try_find_link(LinkFilter::Address(&iface.hwAddr))
+            .await?
+        {
+            Some(link) => link,
+            None => {
+                self.set_link_mac_by_name(&iface.name, &iface.hwAddr)
+                    .await?;
+                self.find_link(LinkFilter::Address(&iface.hwAddr)).await?
+            }
+        };
 
         // Bring down interface if it is UP
         if link.is_up() {
@@ -256,7 +278,6 @@ impl Handle {
         Ok(None)
     }
 
-    #[cfg(not(target_arch = "s390x"))]
     pub async fn set_link_mac_by_name(&self, ifname: &str, mac: &str) -> Result<String> {
         let link = self.find_link(LinkFilter::Name(ifname)).await?;
         let prev_mac = link.address();
@@ -315,6 +336,15 @@ impl Handle {
     }
 
     async fn find_link(&self, filter: LinkFilter<'_>) -> Result<Link> {
+        self.try_find_link(filter)
+            .await?
+            .ok_or_else(|| anyhow!("Link not found ({})", filter))
+    }
+
+    /// Like [`Self::find_link`], but returns `Ok(None)` when the link is not
+    /// found instead of an error, so callers can distinguish "not found" from
+    /// a genuine netlink/parse failure.
+    async fn try_find_link(&self, filter: LinkFilter<'_>) -> Result<Option<Link>> {
         let request = self.handle.link().get();
 
         let filtered = match filter {
@@ -348,8 +378,7 @@ impl Handle {
             stream.try_next().await?
         };
 
-        next.map(|msg| msg.into())
-            .ok_or_else(|| anyhow!("Link not found ({})", filter))
+        Ok(next.map(|msg| msg.into()))
     }
 
     async fn list_links(&self) -> Result<Vec<Link>> {
@@ -984,6 +1013,57 @@ mod tests {
             .expect("Failed to query link by address");
 
         assert_eq!(result.header.index, link.header.index);
+    }
+
+    #[tokio::test]
+    #[serial(template_mac_retarget)]
+    async fn update_interface_retargets_mac_by_name() {
+        skip_if_not_root!();
+
+        const LINK_NAME: &str = "tmpl-mac-test";
+        const OLD_MAC: &str = "02:00:00:00:00:01";
+        const NEW_MAC: &str = "02:00:00:00:00:02";
+
+        let _ = Command::new("ip")
+            .args(["link", "delete", LINK_NAME])
+            .output();
+        let add_result = Command::new("ip")
+            .args([
+                "link", "add", LINK_NAME, "address", OLD_MAC, "type", "dummy",
+            ])
+            .output()
+            .expect("failed to run ip link add");
+        if !add_result.status.success() {
+            println!(
+                "INFO: skipping test - cannot create dummy link: {}",
+                String::from_utf8_lossy(&add_result.stderr)
+            );
+            return;
+        }
+        struct LinkCleanup(&'static str);
+        impl Drop for LinkCleanup {
+            fn drop(&mut self) {
+                let _ = Command::new("ip").args(["link", "delete", self.0]).output();
+            }
+        }
+        let _link_cleanup = LinkCleanup(LINK_NAME);
+
+        let mut handle = Handle::new().unwrap();
+        let iface = Interface {
+            name: LINK_NAME.to_string(),
+            hwAddr: NEW_MAC.to_string(),
+            mtu: 1500,
+            ..Default::default()
+        };
+
+        let update_result = handle.update_interface(&iface).await;
+        let observed_mac = handle
+            .find_link(LinkFilter::Name(LINK_NAME))
+            .await
+            .map(|link| link.address());
+
+        update_result.expect("failed to update interface with a restored MAC");
+        assert_eq!(observed_mac.unwrap().to_lowercase(), NEW_MAC);
     }
 
     #[tokio::test]

--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -27,8 +27,9 @@ dbs-virtio-devices = { workspace = true, optional = true, features = [
   "virtio-mmio",
 ] }
 dbs-pci = { workspace = true, optional = true }
+dbs-snapshot = { workspace = true }
 derivative = "2.2.0"
-kvm-bindings = { workspace = true }
+kvm-bindings = { workspace = true, features = ["fam-wrappers", "serde"] }
 kvm-ioctls = { workspace = true }
 lazy_static = "1.2"
 libc = "0.2.39"
@@ -45,7 +46,7 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = { workspace = true }
 tracing = "0.1.41"
-vmm-sys-util = { workspace = true }
+vmm-sys-util = { workspace = true, features = ["with-serde"] }
 virtio-queue = { workspace = true, optional = true }
 vm-memory = { workspace = true, features = ["backend-mmap"] }
 crossbeam-channel = "0.5.6"
@@ -57,6 +58,7 @@ kata-sys-util = { path = "../libs/kata-sys-util" }
 tdx = { workspace = true }
 
 [dev-dependencies]
+serial_test = { workspace = true }
 slog-async = "2.7.0"
 slog-term = "2.9.0"
 test-utils = { workspace = true }

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -32,7 +32,7 @@ clippy:
 format:
 	@echo "INFO: rust fmt..."
 	# This is kinda dirty step here simply because cargo fmt --all will apply fmt to all dependencies of dragonball which will include /src/libs/protocols with some file generated during compilation time and could not be formatted when you use cargo fmt --all before building the whole project. In order to avoid this problem, we do fmt check in this following way.
-	rustfmt --edition 2018 ./crates/dbs_address_space/src/lib.rs ./crates/dbs_allocator/src/lib.rs ./crates/dbs_arch/src/lib.rs ./crates/dbs_boot/src/lib.rs ./crates/dbs_device/src/lib.rs ./crates/dbs_interrupt/src/lib.rs ./crates/dbs_legacy_devices/src/lib.rs ./crates/dbs_pci/src/lib.rs ./crates/dbs_upcall/src/lib.rs ./crates/dbs_utils/src/lib.rs ./crates/dbs_virtio_devices/src/lib.rs ./src/lib.rs --check
+	rustfmt --edition 2018 ./crates/dbs_address_space/src/lib.rs ./crates/dbs_allocator/src/lib.rs ./crates/dbs_arch/src/lib.rs ./crates/dbs_boot/src/lib.rs ./crates/dbs_device/src/lib.rs ./crates/dbs_interrupt/src/lib.rs ./crates/dbs_legacy_devices/src/lib.rs ./crates/dbs_pci/src/lib.rs ./crates/dbs_snapshot/src/lib.rs ./crates/dbs_upcall/src/lib.rs ./crates/dbs_utils/src/lib.rs ./crates/dbs_virtio_devices/src/lib.rs ./src/lib.rs --check
 
 clean:
 	cargo clean

--- a/src/dragonball/crates/dbs_interrupt/src/manager.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/manager.rs
@@ -351,6 +351,22 @@ impl<T: InterruptManager> DeviceInterruptManager<T> {
         Err(Error::from_raw_os_error(libc::EINVAL))
     }
 
+    /// Get the (low_addr, high_addr, data) of a MSI message.
+    #[allow(irrefutable_let_patterns)]
+    pub fn get_msi_config(&self, index: u32) -> Result<(u32, u32, u32)> {
+        if (index as usize) < self.msi_config.len() {
+            if let InterruptSourceConfig::MsiIrq(ref msi) = self.msi_config[index as usize] {
+                return Ok((msi.low_addr, msi.high_addr, msi.data));
+            }
+        }
+        Err(Error::from_raw_os_error(libc::EINVAL))
+    }
+
+    /// Number of MSI vectors in the configuration space.
+    pub fn msi_config_count(&self) -> u32 {
+        self.msi_config.len() as u32
+    }
+
     /// Set msi irq MASK bit
     #[allow(irrefutable_let_patterns)]
     pub fn set_msi_mask(&mut self, index: u32, mask: bool) -> Result<()> {

--- a/src/dragonball/crates/dbs_snapshot/Cargo.toml
+++ b/src/dragonball/crates/dbs_snapshot/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dbs-snapshot"
+version = "0.1.0"
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+description = "Snapshot (checkpoint/restore) contract shared by dragonball components"
+keywords = ["kata-containers", "sandbox", "vmm", "dragonball", "snapshot"]
+homepage = "https://katacontainers.io/"
+repository = "https://github.com/kata-containers/kata-containers.git"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/src/dragonball/crates/dbs_snapshot/src/lib.rs
+++ b/src/dragonball/crates/dbs_snapshot/src/lib.rs
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot (checkpoint/restore) contract shared by dragonball components.
+//!
+//! This crate exists so that every layer of the VMM — vCPUs, guest memory,
+//! virtio devices and their managers — can agree on one save/restore
+//! vocabulary. The device crates cannot depend on the VMM crate, so the
+//! contract lives below both of them here.
+//!
+//! # Compatibility policy
+//!
+//! Snapshot state structs are serialized with `serde`. Newly-added fields
+//! must use `#[serde(default)]`; fields must never be removed or repurposed
+//! (deprecate-don't-delete). A genuinely incompatible change is signalled by
+//! bumping the producer's format epoch, so old snapshots are refused loudly
+//! instead of being misinterpreted.
+
+#![deny(missing_docs)]
+
+/// A component whose state can be captured into a snapshot and restored from
+/// one.
+///
+/// Implemented across every layer of the VMM so the snapshot subsystem shares
+/// one vocabulary. Components differ in what they need beyond the receiver, so
+/// the extra inputs are associated types rather than fixed parameters:
+/// capturing guest memory needs the memory file, capturing a vCPU needs the
+/// MSR index list, and a device needs nothing (`()`).
+///
+/// Snapshots are a tree: a manager implements this trait by aggregating the
+/// state of the components it owns, each of which implements it in turn.
+///
+/// [`restore_state`](Self::restore_state) applies state to an *existing*
+/// instance already re-created from the same configuration the snapshot was
+/// taken with; it is not a constructor. Implementations validate the state
+/// against the live object and refuse a mismatch rather than silently
+/// misinterpreting it.
+///
+/// The `'a` lifetime lets implementations borrow in their argument types
+/// (e.g. `&'a mut File`).
+pub trait Persist<'a> {
+    /// Serializable state captured from this component.
+    type State;
+    /// Extra input needed to capture the state.
+    type SaveArgs;
+    /// Extra input needed to apply a previously captured state.
+    type RestoreArgs;
+    /// Error reported by both directions.
+    type Error;
+
+    /// Capture the state of this component.
+    fn save_state(&mut self, args: Self::SaveArgs) -> Result<Self::State, Self::Error>;
+
+    /// Apply a previously captured state to this component.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        args: Self::RestoreArgs,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Errors related to saving/loading a snapshot state file.
+#[derive(Debug, thiserror::Error)]
+pub enum PersistError {
+    /// Snapshot file I/O failure.
+    #[error("snapshot I/O error")]
+    Io(#[from] std::io::Error),
+
+    /// Snapshot (de)serialization failure.
+    #[error("snapshot serialization error")]
+    Json(#[from] serde_json::Error),
+
+    /// The snapshot was produced with an incompatible format epoch.
+    #[error(
+        "incompatible snapshot: found format epoch {found}, supported {supported}; \
+         regenerate the snapshot/template with this version"
+    )]
+    EpochMismatch {
+        /// Epoch found in the snapshot file.
+        found: u64,
+        /// Epoch supported by this build.
+        supported: u16,
+    },
+}
+
+/// Refuse a snapshot whose format epoch this build cannot interpret.
+pub fn check_epoch(found: u64, supported: u16) -> Result<(), PersistError> {
+    if found != u64::from(supported) {
+        return Err(PersistError::EpochMismatch { found, supported });
+    }
+    Ok(())
+}

--- a/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["dragonball", "secure-sandbox", "devices", "virtio"]
 readme = "README.md"
 
 [dependencies]
+dbs-snapshot = { workspace = true }
 byteorder = "1.4.3"
 caps = "0.5.3"
 dbs-device = { workspace = true }
@@ -34,7 +35,7 @@ nydus-api = "0.4.1"
 nydus-rafs = "0.4.1"
 nydus-storage = "0.7.2"
 rlimit = "0.7.0"
-serde = "1.0.27"
+serde = { version = "1.0.27", features = ["derive"] }
 serde_json = "1.0.9"
 thiserror = { workspace = true }
 threadpool = "1"

--- a/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
@@ -217,6 +217,26 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
     }
 }
 
+impl<'a, AS: DbsGuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for Block<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q, R> VirtioDevice<AS, Q, R> for Block<AS>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
@@ -222,6 +222,26 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
     }
 }
 
+impl<'a, AS: DbsGuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for Block<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q, R> VirtioDevice<AS, Q, R> for Block<AS>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
@@ -726,6 +726,29 @@ fn set_default_rlimit_nofile() -> Result<()> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for VirtioFs<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Backend filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: a snapshot must be taken at a clean quiesce point.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q> VirtioDevice<AS, Q, GuestRegionMmap> for VirtioFs<AS>
 where
     AS: 'static + GuestAddressSpace + Clone + Send + Sync,

--- a/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
@@ -733,6 +733,29 @@ fn set_default_rlimit_nofile() -> Result<()> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for VirtioFs<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Backend filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: a snapshot must be taken at a clean quiesce point.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q> VirtioDevice<AS, Q, GuestRegionMmap> for VirtioFs<AS>
 where
     AS: 'static + GuestAddressSpace + Clone + Send + Sync,

--- a/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
@@ -18,6 +18,8 @@ pub use self::device::*;
 mod notifier;
 pub use self::notifier::*;
 
+pub mod persist;
+
 pub mod epoll_helper;
 
 #[cfg(feature = "virtio-mmio")]

--- a/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
@@ -1345,7 +1345,6 @@ where
 pub(crate) mod tests {
     use std::ffi::CString;
     use std::fs::File;
-    use std::os::unix::io::FromRawFd;
     use test_utils::skip_if_kvm_unaccessable;
 
     use dbs_device::resources::DeviceResources;

--- a/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
@@ -1340,7 +1340,6 @@ where
 pub(crate) mod tests {
     use std::ffi::CString;
     use std::fs::File;
-    use std::os::unix::io::FromRawFd;
     use test_utils::skip_if_kvm_unaccessable;
 
     use dbs_device::resources::DeviceResources;

--- a/src/dragonball/crates/dbs_virtio_devices/src/mmio/mmio_state.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/mmio/mmio_state.rs
@@ -342,6 +342,54 @@ where
     }
 
     #[inline]
+    pub(crate) fn msi_enabled(&self) -> bool {
+        self.msi.is_some()
+    }
+
+    /// Capture the per-vector MSI configuration programmed by the guest.
+    pub(crate) fn get_msi_vectors(&self) -> Vec<crate::persist::MsiVectorState> {
+        let mut vectors = Vec::new();
+        if self.msi.is_some() {
+            for index in 0..self.intr_mgr.msi_config_count() {
+                if let Ok((address_low, address_high, data)) = self.intr_mgr.get_msi_config(index) {
+                    vectors.push(crate::persist::MsiVectorState {
+                        address_low,
+                        address_high,
+                        data,
+                    });
+                }
+            }
+        }
+        vectors
+    }
+
+    /// Replay the guest's MSI interrupt setup from a snapshot: switch the
+    /// interrupt manager to MSI mode and re-program every vector. Must run
+    /// before device activation is replayed (activation commits the
+    /// configuration when it enables the interrupt manager).
+    pub(crate) fn restore_msi(&mut self, vectors: &[crate::persist::MsiVectorState]) -> Result<()> {
+        self.intr_mgr
+            .set_working_mode(DeviceInterruptMode::GenericMsiIrq)
+            .map_err(Error::InterruptError)?;
+        if self.msi.is_none() {
+            self.msi = Some(Msi::default());
+        }
+        for (index, vector) in vectors.iter().enumerate() {
+            let index = index as u32;
+            self.intr_mgr
+                .set_msi_low_address(index, vector.address_low)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_high_address(index, vector.address_high)
+                .map_err(Error::InterruptError)?;
+            self.intr_mgr
+                .set_msi_data(index, vector.data)
+                .map_err(Error::InterruptError)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
     pub(crate) fn doorbell(&self) -> Option<&DoorBell> {
         self.doorbell.as_ref()
     }

--- a/src/dragonball/crates/dbs_virtio_devices/src/mmio/mmio_v2.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/mmio/mmio_v2.rs
@@ -171,6 +171,61 @@ where
         self.driver_status.load(Ordering::SeqCst)
     }
 
+    /// Capture the transport state of this MMIO virtio device.
+    ///
+    /// The virtual machine must be paused when this is called.
+    pub fn save_state(&self) -> crate::persist::MmioV2TransportState {
+        let mut state = self.state();
+        crate::persist::MmioV2TransportState {
+            driver_status: self.driver_status(),
+            config_generation: self.config_generation.load(Ordering::SeqCst),
+            interrupt_status: self.interrupt_status.read(),
+            features_select: state.features_select(),
+            acked_features_select: state.acked_features_select(),
+            queue_select: state.queue_select(),
+            queues: state.queues().iter().map(|q| q.save_state()).collect(),
+            device_activated: state.device_activated(),
+            msi_enabled: state.msi_enabled(),
+            msi_vectors: state.get_msi_vectors(),
+        }
+    }
+
+    /// Restore the transport state of this MMIO virtio device, replaying
+    /// device activation if the guest had activated it.
+    ///
+    /// `self` must be a freshly created, never-activated device built from
+    /// the same configuration the state was saved with. Must be called
+    /// before the guest vCPUs resume.
+    pub fn restore_state(&self, state: &crate::persist::MmioV2TransportState) -> Result<()> {
+        let mut inner = self.state();
+        inner.set_features_select(state.features_select);
+        inner.set_acked_features_select(state.acked_features_select);
+        inner.set_queue_select(state.queue_select);
+        // Replay the guest's MSI setup before activation: activation enables
+        // the interrupt manager, which commits the vector configuration.
+        if state.msi_enabled {
+            inner.restore_msi(&state.msi_vectors)?;
+        }
+        {
+            let queues = inner.queues_mut();
+            if queues.len() != state.queues.len() {
+                return Err(Error::InvalidInput);
+            }
+            for (queue, queue_state) in queues.iter_mut().zip(state.queues.iter()) {
+                queue.restore_state(queue_state)?;
+            }
+        }
+        self.interrupt_status.write(state.interrupt_status);
+        self.config_generation
+            .store(state.config_generation, Ordering::SeqCst);
+        self.driver_status
+            .store(state.driver_status, Ordering::SeqCst);
+        if state.device_activated {
+            inner.activate(self)?;
+        }
+        Ok(())
+    }
+
     #[inline]
     fn check_driver_status(&self, set: u32, clr: u32) -> bool {
         self.driver_status() & (set | clr) == set

--- a/src/dragonball/crates/dbs_virtio_devices/src/net.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/net.rs
@@ -694,6 +694,26 @@ impl<AS: GuestAddressSpace> Net<AS> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for Net<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS: GuestAddressSpace + 'static> Net<AS> {
     pub fn set_patch_rate_limiters(
         &self,

--- a/src/dragonball/crates/dbs_virtio_devices/src/net.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/net.rs
@@ -701,6 +701,26 @@ impl<AS: GuestAddressSpace> Net<AS> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for Net<AS> {
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS: GuestAddressSpace + 'static> Net<AS> {
     pub fn set_patch_rate_limiters(
         &self,

--- a/src/dragonball/crates/dbs_virtio_devices/src/persist.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/persist.rs
@@ -1,0 +1,266 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot state definitions shared by all virtio devices.
+//!
+//! These are plain-old-data mirrors of the runtime structures, serializable
+//! with serde. Compatibility policy: only append new fields (with
+//! `#[serde(default)]`); never remove or repurpose existing ones.
+
+use serde::{Deserialize, Serialize};
+use virtio_queue::QueueT;
+
+use crate::{Error, Result, VirtioDeviceInfo, VirtioQueueConfig};
+
+/// The snapshot contract as implemented by virtio devices.
+///
+/// An alias for [`dbs_snapshot::Persist`], spelled this way at virtio device
+/// impl sites so the contract reads in terms of the device rather than the
+/// generic VMM-wide trait. Devices choose their own `State`; nothing here
+/// constrains them to a shared shape.
+///
+/// Devices only: the transport ([`crate::mmio::MmioV2Device`]) is not a
+/// device, so it must not be spelled with this alias. Should it ever
+/// implement the contract, it should use [`dbs_snapshot::Persist`] directly
+/// or its own transport-specific alias.
+pub use dbs_snapshot::Persist as VirtioDevicePersist;
+
+/// Serializable state of a virtio queue (mirror of
+/// `virtio_queue::QueueState` with serde support).
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioQueueState {
+    /// The maximum size in elements offered by the device.
+    pub max_size: u16,
+    /// Tail position of the available ring.
+    pub next_avail: u16,
+    /// Head position of the used ring.
+    pub next_used: u16,
+    /// VIRTIO_F_RING_EVENT_IDX negotiated.
+    pub event_idx_enabled: bool,
+    /// The queue size in elements the driver selected.
+    pub size: u16,
+    /// Indicates if the queue finished with configuration.
+    pub ready: bool,
+    /// Guest physical address of the descriptor table.
+    pub desc_table: u64,
+    /// Guest physical address of the available ring.
+    pub avail_ring: u64,
+    /// Guest physical address of the used ring.
+    pub used_ring: u64,
+}
+
+impl VirtioQueueState {
+    /// Capture the state of a virtio queue.
+    pub fn save<Q: QueueT>(queue: &Q) -> Self {
+        VirtioQueueState {
+            max_size: queue.max_size(),
+            next_avail: queue.next_avail(),
+            next_used: queue.next_used(),
+            event_idx_enabled: queue.event_idx_enabled(),
+            size: queue.size(),
+            ready: queue.ready(),
+            desc_table: queue.desc_table(),
+            avail_ring: queue.avail_ring(),
+            used_ring: queue.used_ring(),
+        }
+    }
+
+    /// Apply this state to a freshly created virtio queue.
+    ///
+    /// The target queue must have been created with the same `max_size`,
+    /// otherwise the state is refused.
+    pub fn restore<Q: QueueT>(&self, queue: &mut Q) -> Result<()> {
+        if queue.max_size() != self.max_size {
+            return Err(Error::InvalidInput);
+        }
+        queue.set_size(self.size);
+        queue.set_desc_table_address(
+            Some(self.desc_table as u32),
+            Some((self.desc_table >> 32) as u32),
+        );
+        queue.set_avail_ring_address(
+            Some(self.avail_ring as u32),
+            Some((self.avail_ring >> 32) as u32),
+        );
+        queue.set_used_ring_address(
+            Some(self.used_ring as u32),
+            Some((self.used_ring >> 32) as u32),
+        );
+        queue.set_event_idx(self.event_idx_enabled);
+        queue.set_next_avail(self.next_avail);
+        queue.set_next_used(self.next_used);
+        // Set ready last: with all addresses in place the queue becomes valid.
+        queue.set_ready(self.ready);
+        Ok(())
+    }
+}
+
+/// Serializable state of a `VirtioQueueConfig`.
+///
+/// The queue notification eventfd and the interrupt notifier are live
+/// resources re-created by the transport on restore.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioQueueConfigState {
+    /// Queue index into the queue array.
+    pub index: u16,
+    /// State of the virtio queue itself.
+    pub queue: VirtioQueueState,
+}
+
+impl<Q: QueueT> VirtioQueueConfig<Q> {
+    /// Capture the state of this queue configuration.
+    pub fn save_state(&self) -> VirtioQueueConfigState {
+        VirtioQueueConfigState {
+            index: self.index(),
+            queue: VirtioQueueState::save(&self.queue),
+        }
+    }
+
+    /// Apply a previously saved state to this queue configuration.
+    ///
+    /// `self` must be a freshly created queue configuration with the same
+    /// index and maximum queue size as the saved one.
+    pub fn restore_state(&mut self, state: &VirtioQueueConfigState) -> Result<()> {
+        if self.index() != state.index {
+            return Err(Error::InvalidInput);
+        }
+        state.queue.restore(&mut self.queue)
+    }
+}
+
+/// Serializable state of a `VirtioDeviceInfo`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VirtioDeviceInfoState {
+    /// Features offered by the device when the snapshot was taken.
+    pub avail_features: u64,
+    /// Features acknowledged by the guest driver.
+    pub acked_features: u64,
+    /// Device specific configuration space.
+    pub config_space: Vec<u8>,
+}
+
+impl VirtioDeviceInfo {
+    /// Capture the guest-negotiated state of this device.
+    pub fn save_state(&self) -> VirtioDeviceInfoState {
+        VirtioDeviceInfoState {
+            avail_features: self.avail_features,
+            acked_features: self.acked_features,
+            config_space: self.config_space.clone(),
+        }
+    }
+
+    /// Apply a previously saved state to this device.
+    ///
+    /// The device must have been re-created with the same configuration: if
+    /// the offered feature set differs from the one the guest negotiated
+    /// against, the state is refused (regenerate the snapshot instead).
+    pub fn restore_state(&mut self, state: &VirtioDeviceInfoState) -> Result<()> {
+        if self.avail_features != state.avail_features {
+            return Err(Error::InvalidInput);
+        }
+        self.acked_features = state.acked_features;
+        self.config_space = state.config_space.clone();
+        Ok(())
+    }
+}
+
+/// Serializable state of one MSI vector programmed by the guest.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MsiVectorState {
+    /// Low 32 bits of the MSI message address.
+    pub address_low: u32,
+    /// High 32 bits of the MSI message address.
+    pub address_high: u32,
+    /// MSI message data.
+    pub data: u32,
+}
+
+/// Serializable state of a `MmioV2Device` transport.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MmioV2TransportState {
+    /// Virtio device status register.
+    pub driver_status: u32,
+    /// Configuration generation counter.
+    pub config_generation: u32,
+    /// Pending interrupt status bits.
+    pub interrupt_status: u32,
+    /// Device features word currently selected by the driver.
+    pub features_select: u32,
+    /// Driver features word currently selected by the driver.
+    pub acked_features_select: u32,
+    /// Queue currently selected by the driver.
+    pub queue_select: u32,
+    /// Per-queue state, in queue index order (including the control queue,
+    /// if any).
+    pub queues: Vec<VirtioQueueConfigState>,
+    /// Whether the device had been activated by the guest.
+    pub device_activated: bool,
+    /// Whether the guest had switched the device to MSI interrupt mode.
+    /// Without replaying this, device-to-guest interrupts never fire after
+    /// restore and the guest waits forever on virtio completions.
+    #[serde(default)]
+    pub msi_enabled: bool,
+    /// Per-vector MSI configuration programmed by the guest, in vector
+    /// order.
+    #[serde(default)]
+    pub msi_vectors: Vec<MsiVectorState>,
+}
+
+#[cfg(test)]
+mod tests {
+    use virtio_queue::{Queue, QueueSync};
+
+    use super::*;
+
+    #[test]
+    fn test_virtio_queue_state_roundtrip() {
+        let mut src: Queue = Queue::new(256).unwrap();
+        src.set_size(128);
+        src.set_desc_table_address(Some(0x1000), Some(0x1));
+        src.set_avail_ring_address(Some(0x2000), Some(0));
+        src.set_used_ring_address(Some(0x3000), Some(0));
+        src.set_event_idx(true);
+        src.set_next_avail(10);
+        src.set_next_used(5);
+        src.set_ready(true);
+
+        let state = VirtioQueueState::save(&src);
+        assert_eq!(state.max_size, 256);
+        assert_eq!(state.size, 128);
+        assert_eq!(state.desc_table, 0x1_0000_1000);
+        assert_eq!(state.next_avail, 10);
+        assert_eq!(state.next_used, 5);
+        assert!(state.ready);
+        assert!(state.event_idx_enabled);
+
+        // JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: VirtioQueueState = serde_json::from_str(&json).unwrap();
+
+        let mut dst: Queue = Queue::new(256).unwrap();
+        state.restore(&mut dst).unwrap();
+        assert_eq!(VirtioQueueState::save(&dst), state);
+
+        // Mismatched max size must be refused.
+        let mut small: Queue = Queue::new(128).unwrap();
+        assert!(state.restore(&mut small).is_err());
+    }
+
+    #[test]
+    fn test_virtio_queue_config_state_roundtrip() {
+        let mut src: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 3).unwrap();
+        src.queue.set_size(64);
+        src.queue.set_next_avail(7);
+        let state = src.save_state();
+        assert_eq!(state.index, 3);
+        assert_eq!(state.queue.size, 64);
+
+        let mut dst: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 3).unwrap();
+        dst.restore_state(&state).unwrap();
+        assert_eq!(dst.save_state(), state);
+
+        // Wrong index must be refused.
+        let mut other: VirtioQueueConfig<QueueSync> = VirtioQueueConfig::create(256, 4).unwrap();
+        assert!(other.restore_state(&state).is_err());
+    }
+}

--- a/src/dragonball/crates/dbs_virtio_devices/src/vhost/vhost_kern/test_utils.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vhost/vhost_kern/test_utils.rs
@@ -52,7 +52,7 @@ pub trait MockVhostBackend: std::marker::Sized {
     fn set_vring_num(&mut self, queue_index: usize, num: u16) -> Result<()>;
     fn set_vring_addr(&mut self, queue_index: usize, config_data: &VringConfigData) -> Result<()>;
     fn set_vring_base(&mut self, queue_index: usize, base: u16) -> Result<()>;
-    fn get_vring_base(&mut self, queue_index: usize) -> Result<u32>;
+    fn get_vring_base(&self, queue_index: usize) -> Result<u32>;
     fn set_vring_call(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
     fn set_vring_kick(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
     fn set_vring_err(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
@@ -103,7 +103,7 @@ impl<T: VhostKernBackend> MockVhostBackend for T {
         Ok(())
     }
 
-    fn get_vring_base(&mut self, _queue_index: usize) -> Result<u32> {
+    fn get_vring_base(&self, _queue_index: usize) -> Result<u32> {
         Ok(0)
     }
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
@@ -112,6 +112,31 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace, M: VsockGenericMuxer> crate::persist::VirtioDevicePersist<'a>
+    for Vsock<AS, M>
+{
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Live vsock connection state is not captured: a snapshot must be taken
+    /// at a clean quiesce point with no active connections.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q, R, M> VirtioDevice<AS, Q, R> for Vsock<AS, M>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
@@ -124,6 +124,31 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     }
 }
 
+impl<'a, AS: GuestAddressSpace, M: VsockGenericMuxer> crate::persist::VirtioDevicePersist<'a>
+    for Vsock<AS, M>
+{
+    type State = crate::persist::VirtioDeviceInfoState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = crate::Error;
+
+    /// Capture the guest-negotiated state of this device.
+    ///
+    /// Live vsock connection state is not captured: a snapshot must be taken
+    /// at a clean quiesce point with no active connections.
+    fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
+        Ok(self.device_info.save_state())
+    }
+
+    /// Restore the guest-negotiated state of this device.
+    ///
+    /// The device must have been re-created with the same configuration and
+    /// must not have been activated yet.
+    fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
+        self.device_info.restore_state(state)
+    }
+}
+
 impl<AS, Q, R, M> VirtioDevice<AS, Q, R> for Vsock<AS, M>
 where
     AS: DbsGuestAddressSpace,

--- a/src/dragonball/src/address_space_manager.rs
+++ b/src/dragonball/src/address_space_manager.rs
@@ -17,7 +17,8 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
-use std::os::unix::io::{FromRawFd, IntoRawFd};
+use std::io::{Seek, SeekFrom};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -39,11 +40,13 @@ use kvm_ioctls::VmFd;
 use log::{debug, error, info, warn};
 use nix::sys::mman;
 use nix::unistd::dup;
+use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "atomic-guest-memory")]
 use vm_memory::GuestMemoryAtomic;
 use vm_memory::{
-    address::Address, FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryMmap,
-    GuestMemoryRegion, GuestRegionMmap, GuestUsize, MemoryRegionAddress, MmapRegion,
+    address::Address, Bytes, FileOffset, GuestAddress, GuestAddressSpace, GuestMemory,
+    GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap, GuestUsize, MemoryRegionAddress,
+    MmapRegion,
 };
 
 use crate::resource_manager::ResourceManager;
@@ -158,6 +161,28 @@ pub enum AddressManagerError {
     /// Failed to create Address Space Region
     #[error("address manager failed to create Address Space Region {0}")]
     CreateAddressSpaceRegion(#[source] AddressSpaceError),
+
+    /// Failure in accessing the memory snapshot file.
+    #[error("address manager failed to access the memory snapshot file")]
+    SnapshotFile(#[source] std::io::Error),
+
+    /// The memory snapshot layout doesn't match the current address space.
+    #[error("memory snapshot layout mismatch for guest address 0x{0:x}")]
+    SnapshotLayoutMismatch(u64),
+
+    /// The memory snapshot file is smaller than the mapped regions require.
+    #[error(
+        "memory snapshot file too small: region at guest address 0x{guest_addr:x} \
+         needs {needed} bytes but the file is only {file_len}"
+    )]
+    SnapshotFileTooSmall {
+        /// Guest address of the region that runs past the end of the file.
+        guest_addr: u64,
+        /// Byte offset the region requires the file to reach.
+        needed: u64,
+        /// Actual length of the snapshot file.
+        file_len: u64,
+    },
 
     /// Failed to create VM-bound memfd
     #[error("address manager failed to create VM-bound memfd: {0}")]
@@ -774,6 +799,168 @@ impl AddressSpaceMgr {
     }
 }
 
+/// Location of one guest memory region's contents within the snapshot
+/// memory file.
+///
+/// Compatibility policy (see `crate::snapshot`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GuestMemoryRegionState {
+    /// Guest physical address of the region.
+    pub guest_addr: u64,
+    /// Size of the region in bytes.
+    pub size: u64,
+    /// Offset of the region's contents in the memory file.
+    pub file_offset: u64,
+}
+
+/// State of the guest RAM contents in the snapshot memory file.
+///
+/// The guest memory *layout* is not restored from this state: it is
+/// re-created from the VM configuration (which the snapshot also carries),
+/// producing an identical layout. This state maps that layout onto the
+/// memory file and is validated against it on restore.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct GuestMemoryState {
+    /// Per-region contents location, in guest address order.
+    pub regions: Vec<GuestMemoryRegionState>,
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for AddressSpaceMgr {
+    type State = GuestMemoryState;
+    type SaveArgs = &'a mut File;
+    type RestoreArgs = &'a mut File;
+    type Error = AddressManagerError;
+
+    /// Dump the guest RAM contents to the snapshot memory file.
+    ///
+    /// The virtual machine must be paused when this is called. Regions are
+    /// written sequentially to `file` starting at its current beginning.
+    fn save_state(&mut self, file: &'a mut File) -> Result<GuestMemoryState> {
+        let vm_as = self
+            .get_vm_as()
+            .ok_or(AddressManagerError::GuestMemoryNotInitialized)?;
+        let guard = vm_as.memory();
+
+        // Make the recorded offsets match the bytes we actually write: rewind
+        // to the start and drop any pre-existing contents, so save_state is
+        // correct regardless of the file's incoming cursor/length.
+        file.seek(SeekFrom::Start(0))
+            .map_err(AddressManagerError::SnapshotFile)?;
+        file.set_len(0).map_err(AddressManagerError::SnapshotFile)?;
+
+        let mut regions = Vec::new();
+        let mut file_offset = 0u64;
+        for region in guard.iter() {
+            let size = region.len();
+            region
+                .write_all_volatile_to(MemoryRegionAddress(0), file, size as usize)
+                .map_err(|e| {
+                    AddressManagerError::AccessGuestMemory(region.start_addr().raw_value(), e)
+                })?;
+            regions.push(GuestMemoryRegionState {
+                guest_addr: region.start_addr().raw_value(),
+                size,
+                file_offset,
+            });
+            file_offset += size;
+        }
+
+        Ok(GuestMemoryState { regions })
+    }
+
+    /// Load the guest RAM contents back from the snapshot memory file.
+    ///
+    /// The address space must already have been re-created from the same VM
+    /// configuration the snapshot was taken with; `state` is validated
+    /// against the resulting layout and a mismatch is refused.
+    fn restore_state(&mut self, state: &GuestMemoryState, file: &'a mut File) -> Result<()> {
+        let vm_as = self
+            .get_vm_as()
+            .ok_or(AddressManagerError::GuestMemoryNotInitialized)?;
+        let guard = vm_as.memory();
+
+        // Validate the snapshot file is large enough for every region *before*
+        // installing any mapping. mmap(MAP_PRIVATE) happily maps past the end
+        // of a truncated file; the shortfall only surfaces later as a SIGBUS
+        // in the VMM when the guest first touches a page beyond EOF. Refuse a
+        // too-small file up front with a clear error instead.
+        let file_len = file
+            .metadata()
+            .map_err(AddressManagerError::SnapshotFile)?
+            .len();
+        for region_state in &state.regions {
+            let needed = region_state
+                .file_offset
+                .checked_add(region_state.size)
+                .ok_or(AddressManagerError::SnapshotLayoutMismatch(
+                    region_state.guest_addr,
+                ))?;
+            if needed > file_len {
+                return Err(AddressManagerError::SnapshotFileTooSmall {
+                    guest_addr: region_state.guest_addr,
+                    needed,
+                    file_len,
+                });
+            }
+        }
+
+        for region_state in &state.regions {
+            let guest_addr = GuestAddress(region_state.guest_addr);
+            let region = guard.find_region(guest_addr).ok_or(
+                AddressManagerError::SnapshotLayoutMismatch(region_state.guest_addr),
+            )?;
+            if region.start_addr() != guest_addr || region.len() != region_state.size {
+                return Err(AddressManagerError::SnapshotLayoutMismatch(
+                    region_state.guest_addr,
+                ));
+            }
+            // Back this region with a copy-on-write mapping of the template
+            // file instead of copying it in: pages fault in lazily from the
+            // template, guest writes stay private (MAP_PRIVATE), and the
+            // template file is left pristine for reuse. The KVM memory slot
+            // already points at this region's host address, so replacing the
+            // mapping in place with MAP_FIXED needs no slot update.
+            let host_addr = region
+                .get_host_address(MemoryRegionAddress(0))
+                .map_err(|e| AddressManagerError::AccessGuestMemory(region_state.guest_addr, e))?;
+            // mmap requires a page-aligned file offset. Regions are written
+            // back-to-back at page-aligned sizes, so this holds by
+            // construction; validate it anyway and refuse a malformed snapshot
+            // with a clear error rather than letting mmap fail with EINVAL.
+            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+            if page_size == 0 || region_state.file_offset % page_size != 0 {
+                return Err(AddressManagerError::SnapshotLayoutMismatch(
+                    region_state.guest_addr,
+                ));
+            }
+            // SAFETY: `host_addr .. host_addr + size` is exactly this region's
+            // own existing mapping; we atomically replace it with a private,
+            // file-backed mapping of the same length and protection. The
+            // region retains ownership of the address range and unmaps it on
+            // drop. `file` outlives this call; a MAP_PRIVATE mapping keeps its
+            // own reference to the backing file regardless.
+            let ret = unsafe {
+                libc::mmap(
+                    host_addr as *mut libc::c_void,
+                    region_state.size as usize,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_FIXED | libc::MAP_PRIVATE,
+                    file.as_raw_fd(),
+                    region_state.file_offset as libc::off_t,
+                )
+            };
+            if ret == libc::MAP_FAILED {
+                return Err(AddressManagerError::SnapshotFile(
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl Default for AddressSpaceMgr {
     /// Create a new empty AddressSpaceMgr
     fn default() -> Self {
@@ -798,6 +985,76 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+
+    #[test]
+    fn test_memory_save_restore_roundtrip() {
+        let numa_region_infos = vec![NumaRegionInfo {
+            size: 16,
+            host_numa_node_id: None,
+            guest_numa_node_id: Some(0),
+            vcpu_ids: vec![0],
+        }];
+        let create_mgr = || {
+            let res_mgr = ResourceManager::new(None);
+            AddressSpaceMgrBuilder::new("shmem", "")
+                .unwrap()
+                .build(&res_mgr, &numa_region_infos)
+                .unwrap()
+        };
+
+        // Plant recognizable values in the source guest memory.
+        let mut src_mgr = create_mgr();
+        {
+            let vm_as = src_mgr.get_vm_as().unwrap();
+            let guard = vm_as.memory();
+            guard
+                .write_obj(0xdbdbdbdbu32, GuestAddress(GUEST_MEM_START))
+                .unwrap();
+            guard
+                .write_obj(0xa5u8, GuestAddress(GUEST_MEM_START + (8 << 20)))
+                .unwrap();
+        }
+
+        let mut file = TempFile::new().unwrap().into_file();
+        let state = dbs_snapshot::Persist::save_state(&mut src_mgr, &mut file).unwrap();
+        assert_eq!(state.regions.len(), 1);
+        assert_eq!(state.regions[0].guest_addr, GUEST_MEM_START);
+        assert_eq!(state.regions[0].size, 16 << 20);
+        assert_eq!(state.regions[0].file_offset, 0);
+
+        // The state must survive a JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: GuestMemoryState = serde_json::from_str(&json).unwrap();
+
+        // Restore into a fresh address space with the same layout.
+        let mut dst_mgr = create_mgr();
+        dbs_snapshot::Persist::restore_state(&mut dst_mgr, &state, &mut file).unwrap();
+        let vm_as = dst_mgr.get_vm_as().unwrap();
+        let guard = vm_as.memory();
+        let val: u32 = guard.read_obj(GuestAddress(GUEST_MEM_START)).unwrap();
+        assert_eq!(val, 0xdbdbdbdb);
+        let val: u8 = guard
+            .read_obj(GuestAddress(GUEST_MEM_START + (8 << 20)))
+            .unwrap();
+        assert_eq!(val, 0xa5);
+
+        // A layout mismatch must be refused.
+        let small_infos = vec![NumaRegionInfo {
+            size: 8,
+            host_numa_node_id: None,
+            guest_numa_node_id: Some(0),
+            vcpu_ids: vec![0],
+        }];
+        let res_mgr = ResourceManager::new(None);
+        let mut small_mgr = AddressSpaceMgrBuilder::new("shmem", "")
+            .unwrap()
+            .build(&res_mgr, &small_infos)
+            .unwrap();
+        assert!(matches!(
+            dbs_snapshot::Persist::restore_state(&mut small_mgr, &state, &mut file),
+            Err(AddressManagerError::SnapshotLayoutMismatch(_))
+        ));
+    }
 
     #[test]
     fn test_create_address_space() {

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -49,7 +49,6 @@ pub use crate::device_manager::net_dev_mgr::{
 use crate::device_manager::vfio_dev_mgr::{HostDeviceConfig, VfioDeviceError};
 #[cfg(feature = "virtio-vsock")]
 pub use crate::device_manager::vsock_dev_mgr::{VsockDeviceConfigInfo, VsockDeviceError};
-#[cfg(feature = "host-device")]
 use crate::vcpu::VcpuManagerError;
 #[cfg(feature = "hotplug")]
 pub use crate::vcpu::{VcpuResizeError, VcpuResizeInfo};
@@ -88,6 +87,19 @@ pub enum VmmActionError {
     /// The action `StopMicroVm` failed either because of bad user input or an internal error.
     #[error("failed to shutdown the VM: {0}")]
     StopMicrovm(#[source] StopMicrovmError),
+
+    /// The action `PauseMicroVm` failed.
+    #[error("failed to pause the VM: {0}")]
+    PauseMicrovm(#[source] VcpuManagerError),
+
+    /// The action `ResumeMicroVm` failed.
+    #[error("failed to resume the VM: {0}")]
+    ResumeMicrovm(#[source] VcpuManagerError),
+
+    /// The action `SaveMicrovm` failed either because of bad user input or an internal error.
+    #[cfg(target_arch = "x86_64")]
+    #[error("failed to save the VM snapshot: {0}")]
+    SaveMicrovm(#[source] crate::snapshot::SnapshotError),
 
     /// One of the actions `GetVmConfiguration` or `SetVmConfiguration` failed either because of bad
     /// input or an internal error.
@@ -168,6 +180,37 @@ pub enum VmmAction {
     /// When vmm is used as the crate by the other process, which is need to
     /// shutdown the vcpu threads and destory all of the object.
     ShutdownMicroVm,
+
+    /// Pause all vCPUs in the microVM.
+    PauseMicroVm,
+
+    /// Resume all vCPUs in the microVM.
+    ResumeMicroVm,
+
+    /// Save the microVM state into a snapshot: a state file (vCPU/device
+    /// metadata, JSON) plus a memory file (guest RAM contents). This action
+    /// can only be called after the microVM has booted. A running VM is paused
+    /// while capturing the state and resumed afterwards; an already-paused VM
+    /// remains paused.
+    #[cfg(target_arch = "x86_64")]
+    SaveMicrovm {
+        /// Path of the snapshot state file to write.
+        state_path: String,
+        /// Path of the guest memory file to write.
+        mem_path: String,
+    },
+
+    /// Launch the microVM by restoring it from a snapshot instead of cold
+    /// booting. The microVM must have been configured with the same
+    /// configuration the snapshot was taken with. This action can only be
+    /// called before the microVM has booted.
+    #[cfg(target_arch = "x86_64")]
+    StartMicroVmFromSnapshot {
+        /// Path of the snapshot state file to read.
+        state_path: String,
+        /// Path of the guest memory file to read.
+        mem_path: String,
+    },
 
     /// Get the configuration of the microVM.
     GetVmConfiguration,
@@ -333,6 +376,18 @@ impl VmmService {
             }
             VmmAction::StartMicroVm => self.start_microvm(vmm, event_mgr),
             VmmAction::ShutdownMicroVm => self.shutdown_microvm(vmm),
+            VmmAction::PauseMicroVm => self.pause_microvm(vmm),
+            VmmAction::ResumeMicroVm => self.resume_microvm(vmm),
+            #[cfg(target_arch = "x86_64")]
+            VmmAction::SaveMicrovm {
+                state_path,
+                mem_path,
+            } => self.save_microvm(vmm, state_path, mem_path),
+            #[cfg(target_arch = "x86_64")]
+            VmmAction::StartMicroVmFromSnapshot {
+                state_path,
+                mem_path,
+            } => self.start_microvm_from_snapshot(vmm, event_mgr, state_path, mem_path),
             VmmAction::GetVmConfiguration => Ok(VmmData::MachineConfiguration(Box::new(
                 self.machine_config.clone(),
             ))),
@@ -484,6 +539,67 @@ impl VmmService {
         vmm.event_ctx.exit_evt_triggered = true;
 
         Ok(VmmData::Empty)
+    }
+
+    #[instrument(skip(self))]
+    fn pause_microvm(&mut self, vmm: &mut Vmm) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        vm.pause_all_vcpus_with_downtime()
+            .map(|_| VmmData::Empty)
+            .map_err(VmmActionError::PauseMicrovm)
+    }
+
+    #[instrument(skip(self))]
+    fn resume_microvm(&mut self, vmm: &mut Vmm) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        vm.resume_all_vcpus_with_downtime()
+            .map(|_| VmmData::Empty)
+            .map_err(VmmActionError::ResumeMicrovm)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[instrument(skip(self))]
+    fn save_microvm(
+        &mut self,
+        vmm: &mut Vmm,
+        state_path: String,
+        mem_path: String,
+    ) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        vm.save_microvm(
+            std::path::Path::new(&state_path),
+            std::path::Path::new(&mem_path),
+        )
+        .map(|_| VmmData::Empty)
+        .map_err(VmmActionError::SaveMicrovm)
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[instrument(skip(self, event_mgr))]
+    fn start_microvm_from_snapshot(
+        &mut self,
+        vmm: &mut Vmm,
+        event_mgr: &mut EventManager,
+        state_path: String,
+        mem_path: String,
+    ) -> VmmRequestResult {
+        use self::StartMicroVmError::MicroVMAlreadyRunning;
+        use self::VmmActionError::StartMicroVm;
+
+        let seccomp_filters = vmm.seccomp_filters();
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+        if vm.is_vm_initialized() {
+            return Err(StartMicroVm(MicroVMAlreadyRunning));
+        }
+
+        vm.start_microvm_from_snapshot(
+            event_mgr,
+            seccomp_filters,
+            std::path::Path::new(&state_path),
+            std::path::Path::new(&mem_path),
+        )
+        .map(|_| VmmData::Empty)
+        .map_err(StartMicroVm)
     }
 
     /// Get prometheus metrics.

--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -37,7 +37,7 @@ use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
 use crate::vm::KernelConfigInfo;
 
-use super::DbsMmioV2Device;
+use super::{persist, DbsMmioV2Device};
 
 // The flag of whether to use the shared irq.
 const USE_SHARED_IRQ: bool = true;
@@ -73,6 +73,18 @@ pub enum BlockDeviceError {
     /// The block device type is invalid.
     #[error("invalid block device type")]
     InvalidBlockDeviceType,
+
+    /// Snapshotting this block device class is not supported.
+    #[error(
+        "cannot snapshot block device '{drive_id}': {device_type:?} devices are not supported; \
+         only RawBlock (virtio-blk) devices can be saved and restored"
+    )]
+    UnsupportedDeviceType {
+        /// Drive id of the offending device.
+        drive_id: String,
+        /// Low-level device type that cannot be snapshotted.
+        device_type: BlockDeviceType,
+    },
 
     /// The block device path was already used for a different drive.
     #[error("block device path '{0}' already exists")]
@@ -965,6 +977,132 @@ impl BlockDeviceMgr {
             None => Err(BlockDeviceError::InvalidDeviceId(new_cfg.drive_id)),
         }
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for BlockDeviceMgr {
+    type State = BlockDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = BlockDeviceError;
+
+    /// Capture the state of all block devices.
+    ///
+    /// The virtual machine must be paused when this is called. Only MMIO
+    /// virtio-blk devices are supported; vhost-user/PCI block devices are
+    /// refused.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(info.config.drive_id.clone()))?;
+            // Dispatch on the recorded device type rather than probing with a
+            // downcast: vhost-user drives (Spool/Spdk) share this info_list and
+            // this transport, and their backend state lives in another process,
+            // so they are refused by name instead of failing opaquely.
+            match info.config.device_type {
+                BlockDeviceType::RawBlock => {}
+                device_type => {
+                    return Err(BlockDeviceError::UnsupportedDeviceType {
+                        drive_id: info.config.drive_id.clone(),
+                        device_type,
+                    })
+                }
+            }
+            let (device_info, transport) =
+                persist::save_device_state::<Block<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(BlockDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info: BlockDeviceState::RawBlock(device_info),
+                transport,
+            });
+        }
+        Ok(BlockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all block devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by drive id) and must not have been activated yet. Replays
+    /// device activation for devices the guest had activated. Must be called
+    /// before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for (pos, dev_state) in state.devices.iter().enumerate() {
+            // Drive ids may be generated per-run (e.g. the VM rootfs drive
+            // id), so an id miss is expected across template create/restore
+            // boundaries. Fall back to positional matching, but only when the
+            // device sets align *and* the backing path at that position
+            // confirms it is the same device -- otherwise saved queue state
+            // could be applied to the wrong block device. A path mismatch is
+            // refused rather than guessed.
+            let index = match self.get_index_of_drive_id(&dev_state.config.drive_id) {
+                Some(index) => index,
+                None if self.info_list.len() == state.devices.len()
+                    && self.info_list[pos].config.path_on_host == dev_state.config.path_on_host =>
+                {
+                    log::warn!(
+                        "block device id '{}' not found, matched by position {} (backing path {:?})",
+                        dev_state.config.drive_id,
+                        pos,
+                        dev_state.config.path_on_host,
+                    );
+                    pos
+                }
+                None => return Err(InvalidDeviceId(dev_state.config.drive_id.clone())),
+            };
+            // The saved type must match the device that was re-created from
+            // config, or the saved state belongs to a different device.
+            if self.info_list[index].config.device_type != dev_state.config.device_type {
+                return Err(BlockDeviceError::UnsupportedDeviceType {
+                    drive_id: dev_state.config.drive_id.clone(),
+                    device_type: dev_state.config.device_type,
+                });
+            }
+            let BlockDeviceState::RawBlock(device_info) = &dev_state.device_info;
+            let device = self.info_list[index]
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(dev_state.config.drive_id.clone()))?;
+            persist::restore_device_state::<Block<GuestAddressSpaceImpl>>(
+                device,
+                device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(BlockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one block device, tagged by the low-level device kind.
+///
+/// Wired as an enum from the start so support for a further kind is an added
+/// variant rather than a change to [`persist::VirtioDevState`]'s shape. Only
+/// `RawBlock` (virtio-blk) can be snapshotted today: vhost-user drives
+/// (Spool/Spdk) keep their state in the backend process, so a `VhostUser`
+/// variant has to carry that too and is added with the support, not before.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum BlockDeviceState {
+    /// State of a local-file-backed virtio-blk device.
+    RawBlock(virtio::persist::VirtioDeviceInfoState),
+}
+
+/// Snapshot state of one block device (config + device state + transport
+/// state); see [`persist::VirtioDevState`].
+pub type BlockDevState = persist::VirtioDevState<BlockDeviceConfigInfo, BlockDeviceState>;
+
+/// Snapshot state of the block device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct BlockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<BlockDevState>,
 }
 
 impl Default for BlockDeviceMgr {

--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -39,7 +39,7 @@ use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
 use crate::vm::KernelConfigInfo;
 
-use super::DbsMmioV2Device;
+use super::{persist, DbsMmioV2Device};
 
 // The flag of whether to use the shared irq.
 const USE_SHARED_IRQ: bool = true;
@@ -75,6 +75,18 @@ pub enum BlockDeviceError {
     /// The block device type is invalid.
     #[error("invalid block device type")]
     InvalidBlockDeviceType,
+
+    /// Snapshotting this block device class is not supported.
+    #[error(
+        "cannot snapshot block device '{drive_id}': {device_type:?} devices are not supported; \
+         only RawBlock (virtio-blk) devices can be saved and restored"
+    )]
+    UnsupportedDeviceType {
+        /// Drive id of the offending device.
+        drive_id: String,
+        /// Low-level device type that cannot be snapshotted.
+        device_type: BlockDeviceType,
+    },
 
     /// The block device path was already used for a different drive.
     #[error("block device path '{0}' already exists")]
@@ -973,6 +985,132 @@ impl BlockDeviceMgr {
             None => Err(BlockDeviceError::InvalidDeviceId(new_cfg.drive_id)),
         }
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for BlockDeviceMgr {
+    type State = BlockDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = BlockDeviceError;
+
+    /// Capture the state of all block devices.
+    ///
+    /// The virtual machine must be paused when this is called. Only MMIO
+    /// virtio-blk devices are supported; vhost-user/PCI block devices are
+    /// refused.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(info.config.drive_id.clone()))?;
+            // Dispatch on the recorded device type rather than probing with a
+            // downcast: vhost-user drives (Spool/Spdk) share this info_list and
+            // this transport, and their backend state lives in another process,
+            // so they are refused by name instead of failing opaquely.
+            match info.config.device_type {
+                BlockDeviceType::RawBlock => {}
+                device_type => {
+                    return Err(BlockDeviceError::UnsupportedDeviceType {
+                        drive_id: info.config.drive_id.clone(),
+                        device_type,
+                    })
+                }
+            }
+            let (device_info, transport) =
+                persist::save_device_state::<Block<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(BlockDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info: BlockDeviceState::RawBlock(device_info),
+                transport,
+            });
+        }
+        Ok(BlockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all block devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by drive id) and must not have been activated yet. Replays
+    /// device activation for devices the guest had activated. Must be called
+    /// before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for (pos, dev_state) in state.devices.iter().enumerate() {
+            // Drive ids may be generated per-run (e.g. the VM rootfs drive
+            // id), so an id miss is expected across template create/restore
+            // boundaries. Fall back to positional matching, but only when the
+            // device sets align *and* the backing path at that position
+            // confirms it is the same device -- otherwise saved queue state
+            // could be applied to the wrong block device. A path mismatch is
+            // refused rather than guessed.
+            let index = match self.get_index_of_drive_id(&dev_state.config.drive_id) {
+                Some(index) => index,
+                None if self.info_list.len() == state.devices.len()
+                    && self.info_list[pos].config.path_on_host == dev_state.config.path_on_host =>
+                {
+                    log::warn!(
+                        "block device id '{}' not found, matched by position {} (backing path {:?})",
+                        dev_state.config.drive_id,
+                        pos,
+                        dev_state.config.path_on_host,
+                    );
+                    pos
+                }
+                None => return Err(InvalidDeviceId(dev_state.config.drive_id.clone())),
+            };
+            // The saved type must match the device that was re-created from
+            // config, or the saved state belongs to a different device.
+            if self.info_list[index].config.device_type != dev_state.config.device_type {
+                return Err(BlockDeviceError::UnsupportedDeviceType {
+                    drive_id: dev_state.config.drive_id.clone(),
+                    device_type: dev_state.config.device_type,
+                });
+            }
+            let BlockDeviceState::RawBlock(device_info) = &dev_state.device_info;
+            let device = self.info_list[index]
+                .device
+                .as_ref()
+                .ok_or_else(|| InvalidDeviceId(dev_state.config.drive_id.clone()))?;
+            persist::restore_device_state::<Block<GuestAddressSpaceImpl>>(
+                device,
+                device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(BlockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one block device, tagged by the low-level device kind.
+///
+/// Wired as an enum from the start so support for a further kind is an added
+/// variant rather than a change to [`persist::VirtioDevState`]'s shape. Only
+/// `RawBlock` (virtio-blk) can be snapshotted today: vhost-user drives
+/// (Spool/Spdk) keep their state in the backend process, so a `VhostUser`
+/// variant has to carry that too and is added with the support, not before.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum BlockDeviceState {
+    /// State of a local-file-backed virtio-blk device.
+    RawBlock(virtio::persist::VirtioDeviceInfoState),
+}
+
+/// Snapshot state of one block device (config + device state + transport
+/// state); see [`persist::VirtioDevState`].
+pub type BlockDevState = persist::VirtioDevState<BlockDeviceConfigInfo, BlockDeviceState>;
+
+/// Snapshot state of the block device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct BlockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<BlockDevState>,
 }
 
 impl Default for BlockDeviceMgr {

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -15,7 +15,8 @@ use crate::config_manager::{
     ConfigItem, DeviceConfigInfo, DeviceConfigInfos, RateLimiterConfigInfo,
 };
 use crate::device_manager::{
-    DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext, DeviceVirtioRegionHandler,
+    persist, DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext,
+    DeviceVirtioRegionHandler,
 };
 use crate::get_bucket_update;
 
@@ -35,9 +36,25 @@ const VIRTIO_FS_MODE: &str = "virtio";
 /// Errors associated with `FsDeviceConfig`.
 #[derive(Debug, thiserror::Error)]
 pub enum FsDeviceError {
+    /// Snapshotting this fs backend mode is not supported.
+    #[error(
+        "cannot snapshot fs device '{tag}': mode '{mode}' is not supported; \
+         only 'virtio' mode fs devices can be saved and restored"
+    )]
+    UnsupportedFsMode {
+        /// Tag of the offending fs device.
+        tag: String,
+        /// Backend mode that cannot be snapshotted.
+        mode: String,
+    },
+
     /// Invalid fs, "virtio" or "vhostuser" is allowed.
     #[error("the fs type is invalid, virtio or vhostuser is allowed")]
     InvalidFs,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// Cannot access address space.
     #[error("Cannot access address space.")]
@@ -547,6 +564,113 @@ impl FsDeviceMgr {
             None => Err(FsDeviceError::TagNotExists(new_cfg.tag)),
         }
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for FsDeviceMgr {
+    type State = FsDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = FsDeviceError;
+
+    /// Capture the state of all virtio-fs devices.
+    ///
+    /// The virtual machine must be paused when this is called. Backend
+    /// filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: snapshots must be taken at a clean quiesce point.
+    /// vhost-user-fs devices are refused.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            // Dispatch on the backend mode rather than probing with a
+            // downcast: vhost-user-fs shares this info_list and this
+            // transport, but its state lives in the daemon process, so it is
+            // refused by name instead of failing opaquely.
+            if info.config.mode.as_str() != VIRTIO_FS_MODE {
+                return Err(FsDeviceError::UnsupportedFsMode {
+                    tag: info.config.tag.clone(),
+                    mode: info.config.mode.clone(),
+                });
+            }
+            let (device_info, transport) = persist::save_device_state::<
+                virtio::fs::VirtioFs<GuestAddressSpaceImpl>,
+            >(device, ())
+            .map_err(FsDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info: FsDeviceState::VirtioFs(device_info),
+                transport,
+            });
+        }
+        Ok(FsDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-fs devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by tag) and must not have been activated yet. Must be
+    /// called before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| FsDeviceError::TagNotExists(dev_state.config.id().to_owned()))?;
+            // The saved kind must match the device re-created from config,
+            // or the saved state belongs to a different device.
+            if info.config.mode != dev_state.config.mode {
+                return Err(FsDeviceError::UnsupportedFsMode {
+                    tag: dev_state.config.tag.clone(),
+                    mode: dev_state.config.mode.clone(),
+                });
+            }
+            let FsDeviceState::VirtioFs(device_info) = &dev_state.device_info;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<virtio::fs::VirtioFs<GuestAddressSpaceImpl>>(
+                device,
+                device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(FsDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one fs device, tagged by the backend mode.
+///
+/// Wired as an enum from the start so support for a further mode is an added
+/// variant rather than a change to [`persist::VirtioDevState`]'s shape. Only
+/// `virtio` mode can be snapshotted today: a vhost-user-fs daemon keeps its
+/// state in another process, so a `VhostUser` variant has to carry that too
+/// and is added with the support, not before.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum FsDeviceState {
+    /// State of an in-VMM virtio-fs device (`mode = "virtio"`).
+    VirtioFs(virtio::persist::VirtioDeviceInfoState),
+}
+
+/// Snapshot state of one fs device (config + device state + transport state);
+/// see [`persist::VirtioDevState`].
+pub type FsDevState = persist::VirtioDevState<FsDeviceConfigInfo, FsDeviceState>;
+
+/// Snapshot state of the virtio-fs device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FsDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<FsDevState>,
 }
 
 impl Default for FsDeviceMgr {

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -17,7 +17,8 @@ use crate::config_manager::{
     ConfigItem, DeviceConfigInfo, DeviceConfigInfos, RateLimiterConfigInfo,
 };
 use crate::device_manager::{
-    DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext, DeviceVirtioRegionHandler,
+    persist, DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext,
+    DeviceVirtioRegionHandler,
 };
 use crate::get_bucket_update;
 
@@ -37,9 +38,25 @@ const VIRTIO_FS_MODE: &str = "virtio";
 /// Errors associated with `FsDeviceConfig`.
 #[derive(Debug, thiserror::Error)]
 pub enum FsDeviceError {
+    /// Snapshotting this fs backend mode is not supported.
+    #[error(
+        "cannot snapshot fs device '{tag}': mode '{mode}' is not supported; \
+         only 'virtio' mode fs devices can be saved and restored"
+    )]
+    UnsupportedFsMode {
+        /// Tag of the offending fs device.
+        tag: String,
+        /// Backend mode that cannot be snapshotted.
+        mode: String,
+    },
+
     /// Invalid fs, "virtio" or "vhostuser" is allowed.
     #[error("the fs type is invalid, virtio or vhostuser is allowed")]
     InvalidFs,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// Cannot access address space.
     #[error("Cannot access address space.")]
@@ -555,6 +572,113 @@ impl FsDeviceMgr {
             None => Err(FsDeviceError::TagNotExists(new_cfg.tag)),
         }
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for FsDeviceMgr {
+    type State = FsDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = FsDeviceError;
+
+    /// Capture the state of all virtio-fs devices.
+    ///
+    /// The virtual machine must be paused when this is called. Backend
+    /// filesystem state (open handles, inodes, DAX mappings) is not
+    /// captured: snapshots must be taken at a clean quiesce point.
+    /// vhost-user-fs devices are refused.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            // Dispatch on the backend mode rather than probing with a
+            // downcast: vhost-user-fs shares this info_list and this
+            // transport, but its state lives in the daemon process, so it is
+            // refused by name instead of failing opaquely.
+            if info.config.mode.as_str() != VIRTIO_FS_MODE {
+                return Err(FsDeviceError::UnsupportedFsMode {
+                    tag: info.config.tag.clone(),
+                    mode: info.config.mode.clone(),
+                });
+            }
+            let (device_info, transport) = persist::save_device_state::<
+                virtio::fs::VirtioFs<GuestAddressSpaceImpl>,
+            >(device, ())
+            .map_err(FsDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info: FsDeviceState::VirtioFs(device_info),
+                transport,
+            });
+        }
+        Ok(FsDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-fs devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by tag) and must not have been activated yet. Must be
+    /// called before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| FsDeviceError::TagNotExists(dev_state.config.id().to_owned()))?;
+            // The saved kind must match the device re-created from config,
+            // or the saved state belongs to a different device.
+            if info.config.mode != dev_state.config.mode {
+                return Err(FsDeviceError::UnsupportedFsMode {
+                    tag: dev_state.config.tag.clone(),
+                    mode: dev_state.config.mode.clone(),
+                });
+            }
+            let FsDeviceState::VirtioFs(device_info) = &dev_state.device_info;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(FsDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<virtio::fs::VirtioFs<GuestAddressSpaceImpl>>(
+                device,
+                device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(FsDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one fs device, tagged by the backend mode.
+///
+/// Wired as an enum from the start so support for a further mode is an added
+/// variant rather than a change to [`persist::VirtioDevState`]'s shape. Only
+/// `virtio` mode can be snapshotted today: a vhost-user-fs daemon keeps its
+/// state in another process, so a `VhostUser` variant has to carry that too
+/// and is added with the support, not before.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum FsDeviceState {
+    /// State of an in-VMM virtio-fs device (`mode = "virtio"`).
+    VirtioFs(virtio::persist::VirtioDeviceInfoState),
+}
+
+/// Snapshot state of one fs device (config + device state + transport state);
+/// see [`persist::VirtioDevState`].
+pub type FsDevState = persist::VirtioDevState<FsDeviceConfigInfo, FsDeviceState>;
+
+/// Snapshot state of the virtio-fs device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FsDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<FsDevState>,
 }
 
 impl Default for FsDeviceMgr {

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -661,7 +661,7 @@ pub struct DeviceManager {
     pub(crate) net_manager: NetworkDeviceMgr,
 
     #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
-    fs_manager: Arc<Mutex<FsDeviceMgr>>,
+    pub(crate) fs_manager: Arc<Mutex<FsDeviceMgr>>,
 
     #[cfg(feature = "virtio-mem")]
     pub(crate) mem_manager: MemDeviceMgr,
@@ -1570,6 +1570,9 @@ impl DeviceManager {
         }
     }
 }
+
+#[cfg(feature = "dbs-virtio-devices")]
+pub mod persist;
 
 #[cfg(test)]
 mod tests {

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -669,7 +669,7 @@ pub struct DeviceManager {
     pub(crate) net_manager: NetworkDeviceMgr,
 
     #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
-    fs_manager: Arc<Mutex<FsDeviceMgr>>,
+    pub(crate) fs_manager: Arc<Mutex<FsDeviceMgr>>,
 
     #[cfg(feature = "virtio-mem")]
     pub(crate) mem_manager: MemDeviceMgr,
@@ -1578,6 +1578,9 @@ impl DeviceManager {
         }
     }
 }
+
+#[cfg(feature = "dbs-virtio-devices")]
+pub mod persist;
 
 #[cfg(test)]
 mod tests {

--- a/src/dragonball/src/device_manager/net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/net_dev_mgr.rs
@@ -29,7 +29,7 @@ use crate::config_manager::{ConfigItem, DeviceConfigInfos, RateLimiterConfigInfo
 use crate::device_manager::{DbsVirtioDevice, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
 
-use super::DbsMmioV2Device;
+use super::{persist, DbsMmioV2Device};
 
 /// Default number of virtio queues, one rx/tx pair.
 pub const DEFAULT_NUM_QUEUES: usize = 2;
@@ -690,6 +690,109 @@ impl NetworkDeviceMgr {
                     );
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one network device (config + guest-negotiated device
+/// state + transport state); see [`persist::VirtioDevState`].
+///
+/// Only virtio-net devices are captured; see the [`Persist`] impl below.
+#[cfg(feature = "virtio-net")]
+pub type NetworkDevState = persist::VirtioDevState<NetworkInterfaceConfig>;
+
+/// Snapshot state of the network device manager.
+#[cfg(feature = "virtio-net")]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct NetworkDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<NetworkDevState>,
+}
+
+/// Only the in-VMM virtio-net backend is snapshotted. vhost-net keeps its
+/// state in the kernel vhost driver and vhost-user-net in the backend
+/// process, so neither can be captured here; both are refused rather than
+/// silently skipped, so a template that includes one fails loudly instead of
+/// restoring a guest with a missing interface.
+#[cfg(feature = "virtio-net")]
+impl<'a> dbs_snapshot::Persist<'a> for NetworkDeviceMgr {
+    type State = NetworkDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = NetworkDeviceError;
+
+    /// Capture the state of all virtio-net devices.
+    ///
+    /// The virtual machine must be paused when this is called.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            #[allow(unreachable_patterns)]
+            match &info.config.backend {
+                Backend::Virtio(_) => {}
+                other => {
+                    return Err(NetworkDeviceError::UnsupportedBackend {
+                        iface_id: info.config.id().to_owned(),
+                        backend: other.name(),
+                    });
+                }
+            }
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(NetworkDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) =
+                persist::save_device_state::<virtio::net::Net<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(NetworkDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(NetworkDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-net devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by interface id) and must not have been activated yet.
+    /// Must be called before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            #[allow(unreachable_patterns)]
+            match &dev_state.config.backend {
+                Backend::Virtio(_) => {}
+                other => {
+                    return Err(NetworkDeviceError::UnsupportedBackend {
+                        iface_id: dev_state.config.id().to_owned(),
+                        backend: other.name(),
+                    });
+                }
+            }
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| {
+                    NetworkDeviceError::InvalidIfaceId(dev_state.config.id().to_owned())
+                })?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(NetworkDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<virtio::net::Net<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(NetworkDeviceError::Virtio)?;
         }
         Ok(())
     }

--- a/src/dragonball/src/device_manager/net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/net_dev_mgr.rs
@@ -31,7 +31,7 @@ use crate::config_manager::{ConfigItem, DeviceConfigInfos, RateLimiterConfigInfo
 use crate::device_manager::{DbsVirtioDevice, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
 
-use super::DbsMmioV2Device;
+use super::{persist, DbsMmioV2Device};
 
 /// Default number of virtio queues, one rx/tx pair.
 pub const DEFAULT_NUM_QUEUES: usize = 2;
@@ -704,6 +704,109 @@ impl NetworkDeviceMgr {
                     );
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one network device (config + guest-negotiated device
+/// state + transport state); see [`persist::VirtioDevState`].
+///
+/// Only virtio-net devices are captured; see the [`Persist`] impl below.
+#[cfg(feature = "virtio-net")]
+pub type NetworkDevState = persist::VirtioDevState<NetworkInterfaceConfig>;
+
+/// Snapshot state of the network device manager.
+#[cfg(feature = "virtio-net")]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct NetworkDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<NetworkDevState>,
+}
+
+/// Only the in-VMM virtio-net backend is snapshotted. vhost-net keeps its
+/// state in the kernel vhost driver and vhost-user-net in the backend
+/// process, so neither can be captured here; both are refused rather than
+/// silently skipped, so a template that includes one fails loudly instead of
+/// restoring a guest with a missing interface.
+#[cfg(feature = "virtio-net")]
+impl<'a> dbs_snapshot::Persist<'a> for NetworkDeviceMgr {
+    type State = NetworkDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = NetworkDeviceError;
+
+    /// Capture the state of all virtio-net devices.
+    ///
+    /// The virtual machine must be paused when this is called.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            #[allow(unreachable_patterns)]
+            match &info.config.backend {
+                Backend::Virtio(_) => {}
+                other => {
+                    return Err(NetworkDeviceError::UnsupportedBackend {
+                        iface_id: info.config.id().to_owned(),
+                        backend: other.name(),
+                    });
+                }
+            }
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(NetworkDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) =
+                persist::save_device_state::<virtio::net::Net<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(NetworkDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(NetworkDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all virtio-net devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by interface id) and must not have been activated yet.
+    /// Must be called before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            #[allow(unreachable_patterns)]
+            match &dev_state.config.backend {
+                Backend::Virtio(_) => {}
+                other => {
+                    return Err(NetworkDeviceError::UnsupportedBackend {
+                        iface_id: dev_state.config.id().to_owned(),
+                        backend: other.name(),
+                    });
+                }
+            }
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or_else(|| {
+                    NetworkDeviceError::InvalidIfaceId(dev_state.config.id().to_owned())
+                })?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(NetworkDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<virtio::net::Net<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(NetworkDeviceError::Virtio)?;
         }
         Ok(())
     }

--- a/src/dragonball/src/device_manager/persist.rs
+++ b/src/dragonball/src/device_manager/persist.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared snapshot state and helpers for virtio devices (see
+//! `crate::snapshot`).
+
+use std::sync::Arc;
+
+use dbs_device::DeviceIo;
+use dbs_virtio_devices::persist::{MmioV2TransportState, VirtioDeviceInfoState};
+use dbs_virtio_devices::Error as VirtioError;
+use serde_derive::{Deserialize, Serialize};
+
+use super::DbsMmioV2Device;
+use dbs_virtio_devices::persist::VirtioDevicePersist;
+
+/// Transport-specific snapshot state of a virtio device.
+///
+/// The device-class config and the guest-negotiated
+/// [`VirtioDeviceInfoState`] are transport-independent; only this part
+/// differs between MMIO- and (future) PCI-attached devices.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum VirtioTransportState {
+    /// virtio-mmio (MMIO v2) transport state.
+    Mmio(MmioV2TransportState),
+    // TODO: Pci(VirtioPciTransportState) — dbs_pci has no snapshot support
+    // yet: it needs serde mirrors for VirtioPciCommonConfig (feature selects,
+    // per-queue enable and ring addresses), MsixState (table, PBA, per-vector
+    // masking) and BAR programming, plus activation replay on restore. Until
+    // then `save_device_state`/`restore_device_state` refuse PCI-attached
+    // devices via `VirtioError::InvalidInput` rather than silently dropping
+    // that state.
+}
+
+/// Common snapshot state for a virtio device, independent of class and
+/// transport: static configuration `C`, the guest-negotiated device
+/// state, and the transport state.
+///
+/// Compatibility policy (see `crate::snapshot`): only append new fields,
+/// with `#[serde(default)]`; never remove or repurpose existing ones.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct VirtioDevState<C, S = VirtioDeviceInfoState> {
+    /// Static configuration of the device.
+    pub config: C,
+    /// Device state, as captured by the device's own [`VirtioDevicePersist`]
+    /// impl. Defaults to [`VirtioDeviceInfoState`], which is all the device
+    /// classes snapshotted today need; a device with durable state of its own
+    /// (a balloon's size, virtio-mem's region map) names its own type here.
+    pub device_info: S,
+    /// Transport state.
+    pub transport: VirtioTransportState,
+}
+
+/// Capture the device and transport state of a virtio device of concrete
+/// type `D`, whichever transport it is attached to.
+///
+/// Dispatches on the transport: MMIO is supported; PCI-attached devices are
+/// refused (see [`VirtioTransportState`]).
+pub(crate) fn save_device_state<'a, D>(
+    device: &Arc<dyn DeviceIo>,
+    args: D::SaveArgs,
+) -> std::result::Result<(D::State, VirtioTransportState), VirtioError>
+where
+    D: VirtioDevicePersist<'a, Error = VirtioError> + 'static,
+{
+    // Transport dispatch. A device that is neither MMIO- nor (once
+    // supported) PCI-attached is refused rather than silently skipped.
+    let mmio_dev = device
+        .as_any()
+        .downcast_ref::<DbsMmioV2Device>()
+        .ok_or(VirtioError::InvalidInput)?;
+    let transport = mmio_dev.save_state();
+    let mut guard = mmio_dev.state();
+    let inner = guard
+        .get_inner_device_mut()
+        .as_any_mut()
+        .downcast_mut::<D>()
+        .ok_or(VirtioError::InvalidInput)?;
+    Ok((
+        inner.save_state(args)?,
+        VirtioTransportState::Mmio(transport),
+    ))
+}
+
+/// Restore the device and transport state of a freshly re-created virtio
+/// device of concrete type `D`, replaying device activation if the guest
+/// had activated it. Must be called before the vCPUs resume.
+///
+/// Dispatches on the transport, like [`save_device_state`].
+pub(crate) fn restore_device_state<'a, D>(
+    device: &Arc<dyn DeviceIo>,
+    device_info: &D::State,
+    transport: &VirtioTransportState,
+    args: D::RestoreArgs,
+) -> std::result::Result<(), VirtioError>
+where
+    D: VirtioDevicePersist<'a, Error = VirtioError> + 'static,
+{
+    // Transport dispatch, mirroring `save_device_state`.
+    let VirtioTransportState::Mmio(transport) = transport;
+    let mmio_dev = device
+        .as_any()
+        .downcast_ref::<DbsMmioV2Device>()
+        .ok_or(VirtioError::InvalidInput)?;
+    {
+        let mut guard = mmio_dev.state();
+        let inner = guard
+            .get_inner_device_mut()
+            .as_any_mut()
+            .downcast_mut::<D>()
+            .ok_or(VirtioError::InvalidInput)?;
+        // Restore the guest-negotiated device state before the
+        // transport state: activation replay reads it.
+        inner.restore_state(device_info, args)?;
+    }
+    mmio_dev.restore_state(transport)
+}

--- a/src/dragonball/src/device_manager/vsock_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vsock_dev_mgr.rs
@@ -17,7 +17,8 @@ use dbs_virtio_devices::vsock::Vsock;
 use dbs_virtio_devices::Error as VirtioError;
 use serde_derive::{Deserialize, Serialize};
 
-use super::{DeviceMgrError, StartMicroVmError};
+use super::{persist, DeviceMgrError, StartMicroVmError};
+use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::{DeviceManager, DeviceOpContext};
 
@@ -35,6 +36,10 @@ pub enum VsockDeviceError {
     /// The virtual machine instance ID is invalid.
     #[error("the virtual machine instance ID is invalid")]
     InvalidVMID,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// The Context Identifier is already in use.
     #[error("the device ID {0} already exists")]
@@ -299,6 +304,79 @@ impl VsockDeviceMgr {
         }
         Ok(())
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for VsockDeviceMgr {
+    type State = VsockDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = VsockDeviceError;
+
+    /// Capture the state of all vsock devices.
+    ///
+    /// The virtual machine must be paused when this is called. Live vsock
+    /// connection state is not captured: snapshots must be taken at a clean
+    /// quiesce point with no active connections.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) =
+                persist::save_device_state::<Vsock<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(VsockDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(VsockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all vsock devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by id) and must not have been activated yet. Must be called
+    /// before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<Vsock<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(VsockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one vsock device (config + guest-negotiated device state
+/// + transport state); see [`persist::VirtioDevState`].
+pub type VsockDevState = persist::VirtioDevState<VsockDeviceConfigInfo>;
+
+/// Snapshot state of the vsock device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VsockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VsockDevState>,
 }
 
 impl Default for VsockDeviceMgr {

--- a/src/dragonball/src/device_manager/vsock_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vsock_dev_mgr.rs
@@ -17,7 +17,8 @@ use dbs_virtio_devices::vsock::Vsock;
 use dbs_virtio_devices::Error as VirtioError;
 use serde_derive::{Deserialize, Serialize};
 
-use super::{DeviceMgrError, StartMicroVmError};
+use super::{persist, DeviceMgrError, StartMicroVmError};
+use crate::address_space_manager::GuestAddressSpaceImpl;
 #[cfg(target_arch = "x86_64")]
 use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
@@ -37,6 +38,10 @@ pub enum VsockDeviceError {
     /// The virtual machine instance ID is invalid.
     #[error("the virtual machine instance ID is invalid")]
     InvalidVMID,
+
+    /// Virtio device operation error.
+    #[error("virtio device operation error: {0}")]
+    Virtio(#[source] VirtioError),
 
     /// The Context Identifier is already in use.
     #[error("the device ID {0} already exists")]
@@ -307,6 +312,79 @@ impl VsockDeviceMgr {
         }
         Ok(())
     }
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for VsockDeviceMgr {
+    type State = VsockDeviceMgrState;
+    type SaveArgs = ();
+    type RestoreArgs = ();
+    type Error = VsockDeviceError;
+
+    /// Capture the state of all vsock devices.
+    ///
+    /// The virtual machine must be paused when this is called. Live vsock
+    /// connection state is not captured: snapshots must be taken at a clean
+    /// quiesce point with no active connections.
+    fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
+        let mut devices = Vec::new();
+        for info in self.info_list.iter() {
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let (device_info, transport) =
+                persist::save_device_state::<Vsock<GuestAddressSpaceImpl>>(device, ())
+                    .map_err(VsockDeviceError::Virtio)?;
+            devices.push(persist::VirtioDevState {
+                config: info.config.clone(),
+                device_info,
+                transport,
+            });
+        }
+        Ok(VsockDeviceMgrState { devices })
+    }
+
+    /// Restore the runtime state of all vsock devices.
+    ///
+    /// The devices must have been re-created from the same configuration
+    /// (matched by id) and must not have been activated yet. Must be called
+    /// before the guest vCPUs resume.
+    fn restore_state(
+        &mut self,
+        state: &Self::State,
+        _args: (),
+    ) -> std::result::Result<(), Self::Error> {
+        for dev_state in &state.devices {
+            let info = self
+                .info_list
+                .iter()
+                .find(|info| info.config.id() == dev_state.config.id())
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            let device = info
+                .device
+                .as_ref()
+                .ok_or(VsockDeviceError::Virtio(VirtioError::InvalidInput))?;
+            persist::restore_device_state::<Vsock<GuestAddressSpaceImpl>>(
+                device,
+                &dev_state.device_info,
+                &dev_state.transport,
+                (),
+            )
+            .map_err(VsockDeviceError::Virtio)?;
+        }
+        Ok(())
+    }
+}
+
+/// Snapshot state of one vsock device (config + guest-negotiated device state
+/// + transport state); see [`persist::VirtioDevState`].
+pub type VsockDevState = persist::VirtioDevState<VsockDeviceConfigInfo>;
+
+/// Snapshot state of the vsock device manager.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct VsockDeviceMgrState {
+    /// Per-device state, in insertion order.
+    pub devices: Vec<VsockDevState>,
 }
 
 impl Default for VsockDeviceMgr {

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -112,6 +112,10 @@ pub enum StartMicroVmError {
     #[error("the virtual machine is already running")]
     MicroVMAlreadyRunning,
 
+    /// Failed to restore the virtual machine from a snapshot.
+    #[error("cannot restore the virtual machine from snapshot: {0}")]
+    RestoreMicroVm(String),
+
     /// Cannot start the VM because the kernel was not configured.
     #[error("cannot start the virtual machine without kernel configuration")]
     MissingKernelConfig,

--- a/src/dragonball/src/lib.rs
+++ b/src/dragonball/src/lib.rs
@@ -32,6 +32,8 @@ pub mod metric;
 pub mod resource_manager;
 /// Signal handler for virtual machines.
 pub mod signal_handler;
+/// Checkpoint/restore (snapshot) support.
+pub mod snapshot;
 /// Dragonball Tracer.
 pub mod tracer;
 /// Virtual CPU manager for virtual machines.

--- a/src/dragonball/src/snapshot/mod.rs
+++ b/src/dragonball/src/snapshot/mod.rs
@@ -29,6 +29,7 @@ use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::address_space_manager::GuestMemoryState;
 use crate::vcpu::VcpuState;
 
 pub use dbs_snapshot::{check_epoch, PersistError};
@@ -73,6 +74,9 @@ pub struct MicrovmState {
     /// Per-vCPU state, ordered by vCPU id.
     #[serde(default)]
     pub vcpu_states: Vec<VcpuState>,
+    /// Guest RAM contents state, present once memory has been saved.
+    #[serde(default)]
+    pub memory_state: Option<GuestMemoryState>,
 }
 
 impl MicrovmState {

--- a/src/dragonball/src/snapshot/mod.rs
+++ b/src/dragonball/src/snapshot/mod.rs
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Checkpoint/restore (snapshot) support for Dragonball.
+//!
+//! This module provides the top-level [`MicrovmState`] aggregating the
+//! states of all components and helpers to save/load it as a JSON state
+//! file.
+//!
+//! The snapshot consists of two files:
+//! - a *state file* (JSON, produced from [`MicrovmState`]) holding vCPU,
+//!   device and VM metadata state, and
+//! - a *memory file* holding the guest RAM contents (managed by the address
+//!   space manager, not this module).
+//!
+//! # Compatibility policy
+//!
+//! State structs are serialized with `serde_json`. Snapshots are expected to
+//! be produced and consumed by the same Dragonball version (regenerate the
+//! template whenever Dragonball is updated). Newly-added fields must use
+//! `#[serde(default)]`; fields must never be removed or repurposed
+//! (deprecate-don't-delete). [`FORMAT_EPOCH`] is bumped only on a genuinely
+//! incompatible change, causing old snapshots to be refused loudly instead of
+//! being misinterpreted.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
+
+use serde_derive::{Deserialize, Serialize};
+
+use crate::vcpu::VcpuState;
+
+pub use dbs_snapshot::{check_epoch, PersistError};
+
+/// Current snapshot format epoch.
+///
+/// Bump this only for a deliberately incompatible change to the persisted
+/// state format that append-only evolution cannot absorb. On restore, an
+/// epoch mismatch causes the snapshot to be refused with a clear error.
+pub const FORMAT_EPOCH: u16 = 1;
+
+/// Header identifying a snapshot state file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SnapshotHeader {
+    /// Snapshot format epoch, checked against [`FORMAT_EPOCH`] on load.
+    pub format_epoch: u16,
+    /// Version of the Dragonball crate that produced the snapshot.
+    /// Diagnostics only; not used for compatibility decisions.
+    #[serde(default)]
+    pub producer_version: String,
+}
+
+impl Default for SnapshotHeader {
+    fn default() -> Self {
+        SnapshotHeader {
+            format_epoch: FORMAT_EPOCH,
+            producer_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+/// Aggregated state of a microVM.
+///
+/// Components are added progressively: a component whose `Persist` support is
+/// not implemented yet simply keeps its `Default` value in the snapshot and
+/// is ignored on restore.
+#[derive(Default, Deserialize, Serialize)]
+pub struct MicrovmState {
+    /// Snapshot header.
+    #[serde(default)]
+    pub header: SnapshotHeader,
+    /// Per-vCPU state, ordered by vCPU id.
+    #[serde(default)]
+    pub vcpu_states: Vec<VcpuState>,
+}
+
+impl MicrovmState {
+    /// Serialize the state to a JSON file at `path`.
+    pub fn save_to_file(&self, path: &Path) -> std::result::Result<(), PersistError> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer(&mut writer, self)?;
+        // Flush explicitly: BufWriter's drop swallows I/O errors (e.g.
+        // ENOSPC), which would report a truncated state file as success.
+        writer.flush()?;
+        Ok(())
+    }
+
+    /// Load a state previously written by [`MicrovmState::save_to_file`].
+    ///
+    /// The format epoch is validated *before* deserializing the full state so
+    /// that an incompatible snapshot fails with [`PersistError::EpochMismatch`]
+    /// instead of an obscure deserialization error.
+    pub fn load_from_file(path: &Path) -> std::result::Result<Self, PersistError> {
+        let file = File::open(path)?;
+        let value: serde_json::Value = serde_json::from_reader(BufReader::new(file))?;
+        let found = value
+            .get("header")
+            .and_then(|h| h.get("format_epoch"))
+            .and_then(|e| e.as_u64())
+            .unwrap_or(0);
+        check_epoch(found, FORMAT_EPOCH)?;
+        Ok(serde_json::from_value(value)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_microvm_state_json_roundtrip() {
+        let state = MicrovmState::default();
+        let file = TempFile::new().unwrap();
+        state.save_to_file(file.as_path()).unwrap();
+
+        let loaded = MicrovmState::load_from_file(file.as_path()).unwrap();
+        assert_eq!(loaded.header.format_epoch, FORMAT_EPOCH);
+        assert_eq!(loaded.header.producer_version, env!("CARGO_PKG_VERSION"));
+        assert!(loaded.vcpu_states.is_empty());
+    }
+
+    #[test]
+    fn test_microvm_state_epoch_mismatch() {
+        let file = TempFile::new().unwrap();
+        let json = serde_json::json!({
+            "header": { "format_epoch": FORMAT_EPOCH + 1 },
+            "vcpu_states": [],
+        });
+        serde_json::to_writer(File::create(file.as_path()).unwrap(), &json).unwrap();
+
+        match MicrovmState::load_from_file(file.as_path()) {
+            Err(PersistError::EpochMismatch { found, supported }) => {
+                assert_eq!(found, u64::from(FORMAT_EPOCH + 1));
+                assert_eq!(supported, FORMAT_EPOCH);
+            }
+            other => panic!("expected EpochMismatch, got {:?}", other.map(|_| ())),
+        }
+    }
+
+    #[test]
+    fn test_microvm_state_epoch_not_truncated() {
+        // An epoch congruent to FORMAT_EPOCH mod 2^16 must still be refused.
+        let file = TempFile::new().unwrap();
+        let epoch = u64::from(FORMAT_EPOCH) + (1 << 16);
+        let json = serde_json::json!({
+            "header": { "format_epoch": epoch },
+            "vcpu_states": [],
+        });
+        serde_json::to_writer(File::create(file.as_path()).unwrap(), &json).unwrap();
+
+        assert!(matches!(
+            MicrovmState::load_from_file(file.as_path()),
+            Err(PersistError::EpochMismatch { found, .. }) if found == epoch
+        ));
+    }
+
+    #[test]
+    fn test_microvm_state_missing_header_refused() {
+        // A state file without a header (e.g. produced by a pre-epoch build)
+        // must be refused, not silently defaulted.
+        let file = TempFile::new().unwrap();
+        serde_json::to_writer(
+            File::create(file.as_path()).unwrap(),
+            &serde_json::json!({ "vcpu_states": [] }),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            MicrovmState::load_from_file(file.as_path()),
+            Err(PersistError::EpochMismatch { found: 0, .. })
+        ));
+    }
+}

--- a/src/dragonball/src/snapshot/mod.rs
+++ b/src/dragonball/src/snapshot/mod.rs
@@ -30,9 +30,45 @@ use std::path::Path;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::address_space_manager::GuestMemoryState;
+#[cfg(feature = "virtio-blk")]
+use crate::device_manager::blk_dev_mgr::BlockDeviceMgrState;
+#[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+use crate::device_manager::fs_dev_mgr::FsDeviceMgrState;
+#[cfg(feature = "virtio-net")]
+use crate::device_manager::net_dev_mgr::NetworkDeviceMgrState;
+#[cfg(feature = "virtio-vsock")]
+use crate::device_manager::vsock_dev_mgr::VsockDeviceMgrState;
 use crate::vcpu::VcpuState;
 
 pub use dbs_snapshot::{check_epoch, PersistError};
+
+/// Aggregated snapshot state of the device manager.
+///
+/// Device classes are added progressively; a class whose snapshot support is
+/// not implemented yet is simply absent (`None`).
+#[derive(Default, Deserialize, Serialize)]
+pub struct DeviceManagerState {
+    /// State of the block device manager.
+    #[cfg(feature = "virtio-blk")]
+    #[serde(default)]
+    pub block: Option<BlockDeviceMgrState>,
+    /// State of the virtio-net device manager.
+    #[cfg(feature = "virtio-net")]
+    #[serde(default)]
+    pub virtio_net: Option<NetworkDeviceMgrState>,
+    /// State of the vsock device manager.
+    #[cfg(feature = "virtio-vsock")]
+    #[serde(default)]
+    pub vsock: Option<VsockDeviceMgrState>,
+    /// State of the virtio-fs device manager.
+    #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+    #[serde(default)]
+    pub fs: Option<FsDeviceMgrState>,
+    // TODO: balloon, virtio-mem, vhost-net and vhost-user-net are not yet
+    // snapshotted. kata-dragonball does not instantiate them, so template
+    // save/restore currently covers block, virtio-net, vsock and virtio-fs
+    // only; add the remaining device classes here as they are needed.
+}
 
 /// Current snapshot format epoch.
 ///
@@ -77,6 +113,9 @@ pub struct MicrovmState {
     /// Guest RAM contents state, present once memory has been saved.
     #[serde(default)]
     pub memory_state: Option<GuestMemoryState>,
+    /// Device manager state.
+    #[serde(default)]
+    pub device_states: DeviceManagerState,
 }
 
 impl MicrovmState {

--- a/src/dragonball/src/snapshot/mod.rs
+++ b/src/dragonball/src/snapshot/mod.rs
@@ -77,6 +77,68 @@ pub struct DeviceManagerState {
 /// epoch mismatch causes the snapshot to be refused with a clear error.
 pub const FORMAT_EPOCH: u16 = 1;
 
+/// Errors from the top-level microVM save/restore orchestration.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    /// Snapshot operations require a running or paused VM.
+    #[error("invalid VM state for snapshot: {0}")]
+    InvalidState(String),
+
+    /// vCPU manager failure while saving/restoring vCPU state.
+    #[error("vcpu manager error: {0}")]
+    Vcpu(#[from] crate::vcpu::VcpuManagerError),
+
+    /// Address space manager failure while saving/restoring guest memory.
+    #[error("guest memory error: {0}")]
+    Memory(#[from] crate::address_space_manager::AddressManagerError),
+
+    /// Block device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-blk")]
+    #[error("block device error: {0}")]
+    Block(#[from] crate::device_manager::blk_dev_mgr::BlockDeviceError),
+
+    /// Network device manager failure while saving/restoring device state.
+    #[cfg(any(
+        feature = "virtio-net",
+        feature = "vhost-net",
+        feature = "vhost-user-net"
+    ))]
+    #[error("network device error: {0}")]
+    Network(#[from] crate::device_manager::net_dev_mgr::NetworkDeviceError),
+
+    /// Vsock device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-vsock")]
+    #[error("vsock device error: {0}")]
+    Vsock(#[from] crate::device_manager::vsock_dev_mgr::VsockDeviceError),
+
+    /// virtio-fs device manager failure while saving/restoring device state.
+    #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+    #[error("virtio-fs device error: {0}")]
+    Fs(#[from] crate::device_manager::fs_dev_mgr::FsDeviceError),
+
+    /// Balloon device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-balloon")]
+    #[error("virtio-balloon device error: {0}")]
+    Balloon(#[from] crate::device_manager::balloon_dev_mgr::BalloonDeviceError),
+
+    /// virtio-mem device manager failure while saving/restoring device state.
+    #[cfg(feature = "virtio-mem")]
+    #[error("virtio-mem device error: {0}")]
+    Mem(#[from] crate::device_manager::mem_dev_mgr::MemDeviceError),
+
+    /// State file (de)serialization failure.
+    #[error(transparent)]
+    Persist(#[from] PersistError),
+
+    /// Snapshot file I/O failure.
+    #[error("snapshot I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// KVM ioctl failure.
+    #[error("KVM error: {0}")]
+    Kvm(#[source] kvm_ioctls::Error),
+}
+
 /// Header identifying a snapshot state file.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SnapshotHeader {
@@ -97,6 +159,27 @@ impl Default for SnapshotHeader {
     }
 }
 
+/// VM-scoped KVM state (x86_64): PIT, kvmclock, the PIC pair and the IOAPIC.
+///
+/// Without restoring these, a restored guest never receives legacy IRQs (the
+/// fresh KVM IOAPIC/PIC come up with all lines masked, discarding the
+/// redirection tables the guest programmed at boot) and the guest clock is
+/// wrong.
+#[cfg(target_arch = "x86_64")]
+#[derive(Deserialize, Serialize)]
+pub struct VmKvmState {
+    /// PIT state.
+    pub pit: kvm_bindings::kvm_pit_state2,
+    /// kvmclock state.
+    pub clock: kvm_bindings::kvm_clock_data,
+    /// PIC master state.
+    pub pic_master: kvm_bindings::kvm_irqchip,
+    /// PIC slave state.
+    pub pic_slave: kvm_bindings::kvm_irqchip,
+    /// IOAPIC state.
+    pub ioapic: kvm_bindings::kvm_irqchip,
+}
+
 /// Aggregated state of a microVM.
 ///
 /// Components are added progressively: a component whose `Persist` support is
@@ -107,6 +190,10 @@ pub struct MicrovmState {
     /// Snapshot header.
     #[serde(default)]
     pub header: SnapshotHeader,
+    /// VM-scoped KVM state.
+    #[cfg(target_arch = "x86_64")]
+    #[serde(default)]
+    pub vm_kvm_state: Option<VmKvmState>,
     /// Per-vCPU state, ordered by vCPU id.
     #[serde(default)]
     pub vcpu_states: Vec<VcpuState>,

--- a/src/dragonball/src/vcpu/aarch64.rs
+++ b/src/dragonball/src/vcpu/aarch64.rs
@@ -17,11 +17,25 @@ use kvm_ioctls::{VcpuFd, VmFd};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
+use serde_derive::{Deserialize, Serialize};
+
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::metric::VcpuMetrics;
 use crate::vcpu::vcpu_impl::{Result, Vcpu, VcpuError, VcpuStateEvent};
 use crate::vcpu::VcpuConfig;
 use crate::IoManagerCached;
+
+/// Snapshot state of an aarch64 vCPU.
+///
+/// Placeholder: aarch64 vCPU save/restore is not implemented yet. The struct
+/// exists so that architecture-independent snapshot code compiles on
+/// aarch64; fields (core registers, GIC state, MPIDR, ...) will be added
+/// when aarch64 support lands.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct VcpuState {
+    /// vCPU id.
+    pub id: u8,
+}
 
 #[allow(unused)]
 impl Vcpu {

--- a/src/dragonball/src/vcpu/mod.rs
+++ b/src/dragonball/src/vcpu/mod.rs
@@ -8,6 +8,7 @@ mod vcpu_impl;
 mod vcpu_manager;
 
 use dbs_arch::VpmuFeatureLevel;
+pub use vcpu_impl::VcpuState;
 pub use vcpu_manager::{VcpuManager, VcpuManagerError, VcpuResizeInfo};
 
 #[cfg(feature = "hotplug")]

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -36,9 +36,15 @@ use crate::IoManagerCached;
 #[path = "x86_64.rs"]
 mod x86_64;
 
+#[cfg(target_arch = "x86_64")]
+pub use self::x86_64::VcpuState;
+
 #[cfg(target_arch = "aarch64")]
 #[path = "aarch64.rs"]
 mod aarch64;
+
+#[cfg(target_arch = "aarch64")]
+pub use self::aarch64::VcpuState;
 
 #[cfg(target_arch = "x86_64")]
 const MAGIC_IOPORT_BASE: u16 = 0xdbdb;
@@ -119,6 +125,18 @@ pub enum VcpuError {
     /// The call to KVM_SET_CPUID2 failed on x86_64.
     #[error("failure while calling KVM_SET_CPUID2 on x86_64")]
     SetSupportedCpusFailed(#[source] kvm_ioctls::Error),
+
+    /// KVM processed fewer MSRs than requested while saving or restoring
+    /// vCPU state; continuing would silently corrupt the remaining MSRs.
+    #[error("vCPU {id}: KVM processed only {processed} of {requested} MSRs")]
+    MsrsIncomplete {
+        /// vCPU id.
+        id: u8,
+        /// Number of MSRs actually processed by KVM.
+        processed: usize,
+        /// Number of MSRs requested.
+        requested: usize,
+    },
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -199,6 +217,11 @@ pub enum VcpuEvent {
 
     /// Event to revalidate vcpu IoManager cache
     RevalidateCache,
+
+    /// Event to save the vCPU state. The vCPU must be paused. Carries the
+    /// indices of the MSRs to save.
+    #[cfg(target_arch = "x86_64")]
+    SaveState(Vec<u32>),
 }
 
 /// List of responses that the Vcpu reports.
@@ -215,6 +238,9 @@ pub enum VcpuResponse {
     Error(VcpuError),
     /// Vcpu IoManager cache is revalidated
     CacheRevalidated,
+    /// Saved vCPU state.
+    #[cfg(target_arch = "x86_64")]
+    SavedState(Box<super::VcpuState>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -692,6 +718,13 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
             }
+            // Saving state requires a paused vCPU.
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(_)) => {
+                self.response_sender
+                    .send(VcpuResponse::NotAllowed)
+                    .expect("failed to send save state status");
+            }
             // Unhandled exit of the other end.
             Err(TryRecvError::Disconnected) => {
                 // Move to 'exited' state.
@@ -743,6 +776,17 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
 
+                StateMachine::next(Self::paused)
+            }
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(msr_index_list)) => {
+                let response = match dbs_snapshot::Persist::save_state(self, &msr_index_list) {
+                    Ok(state) => VcpuResponse::SavedState(Box::new(state)),
+                    Err(e) => VcpuResponse::Error(e),
+                };
+                self.response_sender
+                    .send(response)
+                    .expect("failed to send saved vcpu state");
                 StateMachine::next(Self::paused)
             }
             // Unhandled exit of the other end.
@@ -815,6 +859,7 @@ pub mod tests {
     #[cfg(target_arch = "x86_64")]
     use dbs_interrupt::KvmIrqManager;
     use lazy_static::lazy_static;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
 
     use super::*;
@@ -928,6 +973,7 @@ pub mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_run_emulation() {
         skip_if_kvm_unaccessable!();
 

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -39,11 +39,14 @@ use crate::IoManagerCached;
 mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
-pub use x86_64::{KVM_HC_MAP_GPA_RANGE, KVM_MAP_GPA_RANGE_ENCRYPTED};
+pub use x86_64::{VcpuState, KVM_HC_MAP_GPA_RANGE, KVM_MAP_GPA_RANGE_ENCRYPTED};
 
 #[cfg(target_arch = "aarch64")]
 #[path = "aarch64.rs"]
 mod aarch64;
+
+#[cfg(target_arch = "aarch64")]
+pub use self::aarch64::VcpuState;
 
 #[cfg(target_arch = "x86_64")]
 const MAGIC_IOPORT_BASE: u16 = 0xdbdb;
@@ -129,6 +132,18 @@ pub enum VcpuError {
     /// Fail to set memory attributes for hypercall
     #[error("failure while setting memory attributes")]
     SetMemoryAttributes(#[source] kvm_ioctls::Error),
+
+    /// KVM processed fewer MSRs than requested while saving or restoring
+    /// vCPU state; continuing would silently corrupt the remaining MSRs.
+    #[error("vCPU {id}: KVM processed only {processed} of {requested} MSRs")]
+    MsrsIncomplete {
+        /// vCPU id.
+        id: u8,
+        /// Number of MSRs actually processed by KVM.
+        processed: usize,
+        /// Number of MSRs requested.
+        requested: usize,
+    },
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -209,6 +224,11 @@ pub enum VcpuEvent {
 
     /// Event to revalidate vcpu IoManager cache
     RevalidateCache,
+
+    /// Event to save the vCPU state. The vCPU must be paused. Carries the
+    /// indices of the MSRs to save.
+    #[cfg(target_arch = "x86_64")]
+    SaveState(Vec<u32>),
 }
 
 /// List of responses that the Vcpu reports.
@@ -225,6 +245,9 @@ pub enum VcpuResponse {
     Error(VcpuError),
     /// Vcpu IoManager cache is revalidated
     CacheRevalidated,
+    /// Saved vCPU state.
+    #[cfg(target_arch = "x86_64")]
+    SavedState(Box<super::VcpuState>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -728,6 +751,13 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
             }
+            // Saving state requires a paused vCPU.
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(_)) => {
+                self.response_sender
+                    .send(VcpuResponse::NotAllowed)
+                    .expect("failed to send save state status");
+            }
             // Unhandled exit of the other end.
             Err(TryRecvError::Disconnected) => {
                 // Move to 'exited' state.
@@ -779,6 +809,17 @@ impl Vcpu {
                     .map_err(|e| self.response_sender.send(VcpuResponse::Error(e)))
                     .expect("failed to revalidate vcpu IoManager cache");
 
+                StateMachine::next(Self::paused)
+            }
+            #[cfg(target_arch = "x86_64")]
+            Ok(VcpuEvent::SaveState(msr_index_list)) => {
+                let response = match dbs_snapshot::Persist::save_state(self, &msr_index_list) {
+                    Ok(state) => VcpuResponse::SavedState(Box::new(state)),
+                    Err(e) => VcpuResponse::Error(e),
+                };
+                self.response_sender
+                    .send(response)
+                    .expect("failed to send saved vcpu state");
                 StateMachine::next(Self::paused)
             }
             // Unhandled exit of the other end.
@@ -851,6 +892,7 @@ pub mod tests {
     #[cfg(target_arch = "x86_64")]
     use dbs_interrupt::KvmIrqManager;
     use lazy_static::lazy_static;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
 
     use super::*;
@@ -966,6 +1008,7 @@ pub mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_run_emulation() {
         skip_if_kvm_unaccessable!();
 

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -39,6 +39,8 @@ use crate::vcpu::vcpu_impl::{
     Vcpu, VcpuError, VcpuEvent, VcpuHandle, VcpuResizeResult, VcpuResponse, VcpuStateEvent,
 };
 use crate::vcpu::VcpuConfig;
+#[cfg(target_arch = "x86_64")]
+use crate::vcpu::VcpuState;
 use crate::vm::VmConfigInfo;
 use crate::IoManagerCached;
 
@@ -79,6 +81,10 @@ pub enum VcpuManagerError {
     /// vCPU save failed.
     #[error("failure while save vCPU state")]
     VcpuSave,
+
+    /// SaveState was requested while the vCPU was not paused.
+    #[error("cannot save vCPU state: the vCPU is not paused")]
+    SaveStateNotAllowed,
 
     /// Vcpu is in unexpected state.
     #[error("Vcpu is in unexpected state")]
@@ -491,7 +497,106 @@ impl VcpuManager {
     pub fn revalidate_all_vcpus_cache(&mut self) -> Result<()> {
         self.revalidate_vcpus_cache(&self.present_vcpus())
     }
+}
 
+#[cfg(target_arch = "x86_64")]
+impl<'a> dbs_snapshot::Persist<'a> for VcpuManager {
+    type State = Vec<VcpuState>;
+    type SaveArgs = &'a [u32];
+    type RestoreArgs = ();
+    type Error = VcpuManagerError;
+
+    /// Save the states of all started vCPUs.
+    ///
+    /// All vCPUs must be paused (see [`VcpuManager::pause_all_vcpus`])
+    /// before calling this.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    #[cfg(target_arch = "x86_64")]
+    fn save_state(&mut self, msr_index_list: &'a [u32]) -> Result<Vec<VcpuState>> {
+        let cpu_indexes = self.present_vcpus();
+        let mut first_error = None;
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                if let Err(e) = handle.send_event(VcpuEvent::SaveState(msr_index_list.to_vec())) {
+                    first_error.get_or_insert(VcpuManagerError::VcpuEvent(e));
+                }
+            } else {
+                first_error.get_or_insert(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        let mut states = Vec::with_capacity(cpu_indexes.len());
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                let deadline =
+                    std::time::Instant::now() + Duration::from_millis(CPU_RECV_TIMEOUT_MS);
+                loop {
+                    let remaining = deadline
+                        .checked_duration_since(std::time::Instant::now())
+                        .unwrap_or_default();
+                    match handle.response_receiver().recv_timeout(remaining) {
+                        Ok(VcpuResponse::SavedState(state)) => {
+                            states.push(*state);
+                            break;
+                        }
+                        // Pause/resume acknowledgements are fire-and-forget
+                        // and may still sit in the channel; drain them.
+                        Ok(VcpuResponse::Paused) | Ok(VcpuResponse::Resumed) => continue,
+                        Ok(VcpuResponse::Error(e)) => {
+                            first_error.get_or_insert(VcpuManagerError::Vcpu(e));
+                            break;
+                        }
+                        Ok(VcpuResponse::NotAllowed) => {
+                            first_error.get_or_insert(VcpuManagerError::SaveStateNotAllowed);
+                            break;
+                        }
+                        Ok(_) => {
+                            first_error.get_or_insert(VcpuManagerError::UnexpectedVcpuResponse);
+                            break;
+                        }
+                        Err(e) => {
+                            error!("vCPU save state error! {e:?}");
+                            first_error.get_or_insert(VcpuManagerError::VcpuResponseTimeout(e));
+                            break;
+                        }
+                    }
+                }
+            } else {
+                first_error.get_or_insert(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(states),
+        }
+    }
+
+    /// Restore previously saved vCPU states.
+    ///
+    /// The target vCPUs must have been created (see
+    /// [`VcpuManager::create_vcpus`]) but not started yet: the state is
+    /// applied before the vCPU threads spawn.
+    #[cfg(target_arch = "x86_64")]
+    fn restore_state(&mut self, states: &Vec<VcpuState>, _args: ()) -> Result<()> {
+        for state in states {
+            let info = self
+                .vcpu_infos
+                .get_mut(state.id as usize)
+                .ok_or(VcpuManagerError::VcpuNotFound(state.id))?;
+            let vcpu = info.vcpu.as_mut().ok_or(VcpuManagerError::VcpuNotCreate)?;
+            dbs_snapshot::Persist::restore_state(vcpu, state, ())
+                .map_err(VcpuManagerError::Vcpu)?;
+        }
+        Ok(())
+    }
+}
+
+impl VcpuManager {
     /// return all present vcpus
     pub fn present_vcpus(&self) -> Vec<u8> {
         self.vcpu_infos
@@ -1119,6 +1224,8 @@ impl MutEventSubscriber for VcpuEpollHandler {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86_64")]
+    use dbs_snapshot::Persist;
     use std::os::unix::io::AsRawFd;
     use std::sync::{Arc, RwLock};
 
@@ -1126,6 +1233,7 @@ mod tests {
     #[cfg(feature = "hotplug")]
     use dbs_virtio_devices::vsock::backend::VsockInnerBackend;
     use seccompiler::BpfProgram;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -1295,6 +1403,7 @@ mod tests {
             .is_ok());
     }
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_pause_resume_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1336,7 +1445,60 @@ mod tests {
         assert!(vcpu_manager.resume_all_vcpus().is_ok());
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[test]
+    #[serial(emulate_res)]
+    fn test_vcpu_manager_save_restore_states() {
+        skip_if_kvm_unaccessable!();
+        *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
+
+        let vm = get_vm();
+        // An in-kernel irqchip is required for LAPIC state access, and it
+        // must be created before the vCPUs. Tolerate EEXIST: the test VM
+        // setup may already have created it.
+        let _ = vm.vm_fd().create_irq_chip();
+        let msr_list = crate::kvm_context::KvmContext::new(None)
+            .unwrap()
+            .supported_msrs(0)
+            .unwrap();
+
+        let mut vcpu_manager = vm.vcpu_manager().unwrap();
+        assert!(vcpu_manager
+            .create_boot_vcpus(TimestampUs::default(), GuestAddress(0))
+            .is_ok());
+
+        // Save directly from the not-yet-started vCPU and restore into it:
+        // exercises the pre-start restore path.
+        let state = vcpu_manager.vcpu_infos[0]
+            .vcpu
+            .as_mut()
+            .unwrap()
+            .save_state(msr_list.as_slice())
+            .unwrap();
+        assert_eq!(state.id, 0);
+        vcpu_manager.restore_state(&vec![state], ()).unwrap();
+
+        // Threaded save: start, pause, save via the event round-trip.
+        assert!(vcpu_manager.start_boot_vcpus(BpfProgram::default()).is_ok());
+
+        // Saving while running is refused with the precondition error.
+        let res = vcpu_manager.save_state(msr_list.as_slice());
+        assert!(
+            matches!(res, Err(VcpuManagerError::SaveStateNotAllowed)),
+            "expected SaveStateNotAllowed, got {:?}",
+            res.as_ref().map(|states| states.len())
+        );
+
+        assert!(vcpu_manager.pause_all_vcpus().is_ok());
+        let states = vcpu_manager.save_state(msr_list.as_slice()).unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].id, 0);
+        assert!(!states[0].msrs.is_empty());
+        assert!(vcpu_manager.resume_all_vcpus().is_ok());
+    }
+
+    #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1368,6 +1530,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_all_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1394,6 +1557,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1425,6 +1589,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_all_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -39,6 +39,8 @@ use crate::vcpu::vcpu_impl::{
     Vcpu, VcpuError, VcpuEvent, VcpuHandle, VcpuResizeResult, VcpuResponse, VcpuStateEvent,
 };
 use crate::vcpu::VcpuConfig;
+#[cfg(target_arch = "x86_64")]
+use crate::vcpu::VcpuState;
 use crate::vm::VmConfigInfo;
 use crate::IoManagerCached;
 
@@ -79,6 +81,10 @@ pub enum VcpuManagerError {
     /// vCPU save failed.
     #[error("failure while save vCPU state")]
     VcpuSave,
+
+    /// SaveState was requested while the vCPU was not paused.
+    #[error("cannot save vCPU state: the vCPU is not paused")]
+    SaveStateNotAllowed,
 
     /// Vcpu is in unexpected state.
     #[error("Vcpu is in unexpected state")]
@@ -491,7 +497,106 @@ impl VcpuManager {
     pub fn revalidate_all_vcpus_cache(&mut self) -> Result<()> {
         self.revalidate_vcpus_cache(&self.present_vcpus())
     }
+}
 
+#[cfg(target_arch = "x86_64")]
+impl<'a> dbs_snapshot::Persist<'a> for VcpuManager {
+    type State = Vec<VcpuState>;
+    type SaveArgs = &'a [u32];
+    type RestoreArgs = ();
+    type Error = VcpuManagerError;
+
+    /// Save the states of all started vCPUs.
+    ///
+    /// All vCPUs must be paused (see [`VcpuManager::pause_all_vcpus`])
+    /// before calling this.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    #[cfg(target_arch = "x86_64")]
+    fn save_state(&mut self, msr_index_list: &'a [u32]) -> Result<Vec<VcpuState>> {
+        let cpu_indexes = self.present_vcpus();
+        let mut first_error = None;
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                if let Err(e) = handle.send_event(VcpuEvent::SaveState(msr_index_list.to_vec())) {
+                    first_error.get_or_insert(VcpuManagerError::VcpuEvent(e));
+                }
+            } else {
+                first_error.get_or_insert(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        let mut states = Vec::with_capacity(cpu_indexes.len());
+        for cpu_id in &cpu_indexes {
+            if let Some(handle) = &self.vcpu_infos[*cpu_id as usize].handle {
+                let deadline =
+                    std::time::Instant::now() + Duration::from_millis(CPU_RECV_TIMEOUT_MS);
+                loop {
+                    let remaining = deadline
+                        .checked_duration_since(std::time::Instant::now())
+                        .unwrap_or_default();
+                    match handle.response_receiver().recv_timeout(remaining) {
+                        Ok(VcpuResponse::SavedState(state)) => {
+                            states.push(*state);
+                            break;
+                        }
+                        // Pause/resume acknowledgements are fire-and-forget
+                        // and may still sit in the channel; drain them.
+                        Ok(VcpuResponse::Paused) | Ok(VcpuResponse::Resumed) => continue,
+                        Ok(VcpuResponse::Error(e)) => {
+                            first_error.get_or_insert(VcpuManagerError::Vcpu(e));
+                            break;
+                        }
+                        Ok(VcpuResponse::NotAllowed) => {
+                            first_error.get_or_insert(VcpuManagerError::SaveStateNotAllowed);
+                            break;
+                        }
+                        Ok(_) => {
+                            first_error.get_or_insert(VcpuManagerError::UnexpectedVcpuResponse);
+                            break;
+                        }
+                        Err(e) => {
+                            error!("vCPU save state error! {e:?}");
+                            first_error.get_or_insert(VcpuManagerError::VcpuResponseTimeout(e));
+                            break;
+                        }
+                    }
+                }
+            } else {
+                first_error.get_or_insert(VcpuManagerError::VcpuNotFound(*cpu_id));
+            }
+        }
+
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(states),
+        }
+    }
+
+    /// Restore previously saved vCPU states.
+    ///
+    /// The target vCPUs must have been created (see
+    /// [`VcpuManager::create_vcpus`]) but not started yet: the state is
+    /// applied before the vCPU threads spawn.
+    #[cfg(target_arch = "x86_64")]
+    fn restore_state(&mut self, states: &Vec<VcpuState>, _args: ()) -> Result<()> {
+        for state in states {
+            let info = self
+                .vcpu_infos
+                .get_mut(state.id as usize)
+                .ok_or(VcpuManagerError::VcpuNotFound(state.id))?;
+            let vcpu = info.vcpu.as_mut().ok_or(VcpuManagerError::VcpuNotCreate)?;
+            dbs_snapshot::Persist::restore_state(vcpu, state, ())
+                .map_err(VcpuManagerError::Vcpu)?;
+        }
+        Ok(())
+    }
+}
+
+impl VcpuManager {
     /// return all present vcpus
     pub fn present_vcpus(&self) -> Vec<u8> {
         self.vcpu_infos
@@ -1121,6 +1226,8 @@ impl MutEventSubscriber for VcpuEpollHandler {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "x86_64")]
+    use dbs_snapshot::Persist;
     use std::os::unix::io::AsRawFd;
     use std::sync::{Arc, RwLock};
 
@@ -1128,6 +1235,7 @@ mod tests {
     #[cfg(feature = "hotplug")]
     use dbs_virtio_devices::vsock::backend::VsockInnerBackend;
     use seccompiler::BpfProgram;
+    use serial_test::serial;
     use test_utils::skip_if_kvm_unaccessable;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -1297,6 +1405,7 @@ mod tests {
             .is_ok());
     }
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_pause_resume_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1338,7 +1447,60 @@ mod tests {
         assert!(vcpu_manager.resume_all_vcpus().is_ok());
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[test]
+    #[serial(emulate_res)]
+    fn test_vcpu_manager_save_restore_states() {
+        skip_if_kvm_unaccessable!();
+        *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
+
+        let vm = get_vm();
+        // An in-kernel irqchip is required for LAPIC state access, and it
+        // must be created before the vCPUs. Tolerate EEXIST: the test VM
+        // setup may already have created it.
+        let _ = vm.vm_fd().create_irq_chip();
+        let msr_list = crate::kvm_context::KvmContext::new(None)
+            .unwrap()
+            .supported_msrs(0)
+            .unwrap();
+
+        let mut vcpu_manager = vm.vcpu_manager().unwrap();
+        assert!(vcpu_manager
+            .create_boot_vcpus(TimestampUs::default(), GuestAddress(0))
+            .is_ok());
+
+        // Save directly from the not-yet-started vCPU and restore into it:
+        // exercises the pre-start restore path.
+        let state = vcpu_manager.vcpu_infos[0]
+            .vcpu
+            .as_mut()
+            .unwrap()
+            .save_state(msr_list.as_slice())
+            .unwrap();
+        assert_eq!(state.id, 0);
+        vcpu_manager.restore_state(&vec![state], ()).unwrap();
+
+        // Threaded save: start, pause, save via the event round-trip.
+        assert!(vcpu_manager.start_boot_vcpus(BpfProgram::default()).is_ok());
+
+        // Saving while running is refused with the precondition error.
+        let res = vcpu_manager.save_state(msr_list.as_slice());
+        assert!(
+            matches!(res, Err(VcpuManagerError::SaveStateNotAllowed)),
+            "expected SaveStateNotAllowed, got {:?}",
+            res.as_ref().map(|states| states.len())
+        );
+
+        assert!(vcpu_manager.pause_all_vcpus().is_ok());
+        let states = vcpu_manager.save_state(msr_list.as_slice()).unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].id, 0);
+        assert!(!states[0].msrs.is_empty());
+        assert!(vcpu_manager.resume_all_vcpus().is_ok());
+    }
+
+    #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1370,6 +1532,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_exit_all_vcpus() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1396,6 +1559,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);
@@ -1427,6 +1591,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(emulate_res)]
     fn test_vcpu_manager_revalidate_all_vcpus_cache() {
         skip_if_kvm_unaccessable!();
         *(EMULATE_RES.lock().unwrap()) = EmulationCase::Error(libc::EINTR);

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -15,9 +15,13 @@ use dbs_boot::FirmwareType;
 use dbs_interrupt::InterruptManager;
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
-use kvm_bindings::CpuId;
+use kvm_bindings::{
+    kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_msr_entry, kvm_regs, kvm_sregs,
+    kvm_vcpu_events, kvm_xcrs, kvm_xsave, CpuId, Msrs, KVM_MAX_CPUID_ENTRIES, KVM_MAX_MSR_ENTRIES,
+};
 use kvm_ioctls::{VcpuFd, VmFd};
-use log::error;
+use log::{error, warn};
+use serde_derive::{Deserialize, Serialize};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -157,5 +161,252 @@ impl Vcpu {
         self.fd
             .set_cpuid2(&self.cpuid)
             .map_err(VcpuError::SetSupportedCpusFailed)
+    }
+}
+
+/// Snapshot state of a x86_64 vCPU: guest-visible registers plus
+/// KVM-internal state needed to transparently resume execution.
+///
+/// Compatibility policy (see `crate::snapshot`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+// No `Clone`: `kvm_xsave` contains an incomplete array field.
+#[derive(Deserialize, Serialize)]
+pub struct VcpuState {
+    /// vCPU id.
+    pub id: u8,
+    /// CPUID configuration of this vCPU.
+    pub cpuid: CpuId,
+    /// Model specific registers, chunked by `KVM_MAX_MSR_ENTRIES`.
+    pub msrs: Vec<Msrs>,
+    /// General purpose registers.
+    pub regs: kvm_regs,
+    /// Special registers.
+    pub sregs: kvm_sregs,
+    /// XSAVE area (contains FPU/SSE/AVX state, superset of `kvm_fpu`).
+    pub xsave: kvm_xsave,
+    /// Extended control registers.
+    pub xcrs: kvm_xcrs,
+    /// Debug registers.
+    pub debug_regs: kvm_debugregs,
+    /// Local APIC state.
+    pub lapic: kvm_lapic_state,
+    /// Multiprocessing state.
+    pub mp_state: kvm_mp_state,
+    /// Pending vCPU events.
+    pub vcpu_events: kvm_vcpu_events,
+    /// Guest TSC frequency in kHz, if the host supports retrieving it.
+    #[serde(default)]
+    pub tsc_khz: Option<u32>,
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for Vcpu {
+    type State = VcpuState;
+    type SaveArgs = &'a [u32];
+    type RestoreArgs = ();
+    type Error = VcpuError;
+
+    /// Save the KVM state of this vCPU.
+    ///
+    /// The vCPU must be quiesced (not running) when this is called; use the
+    /// vCPU manager's pause machinery first.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    fn save_state(&mut self, msr_index_list: &'a [u32]) -> Result<VcpuState> {
+        // Ordering matters (mirrors Firecracker):
+        // - KVM_GET_MP_STATE calls kvm_apic_accept_events(), which might
+        //   modify vCPU/LAPIC state, so it must run before everything else.
+        // - KVM_GET_VCPU_EVENTS is read last as the other GET ioctls may
+        //   modify internal pending-event state.
+        let mp_state = self.fd.get_mp_state().map_err(VcpuError::Kvm)?;
+        let regs = self.fd.get_regs().map_err(VcpuError::Kvm)?;
+        let sregs = self.fd.get_sregs().map_err(VcpuError::Kvm)?;
+        let xsave = self.fd.get_xsave().map_err(VcpuError::Kvm)?;
+        let xcrs = self.fd.get_xcrs().map_err(VcpuError::Kvm)?;
+        let debug_regs = self.fd.get_debug_regs().map_err(VcpuError::Kvm)?;
+        let lapic = self.fd.get_lapic().map_err(VcpuError::Kvm)?;
+        let cpuid = self
+            .fd
+            .get_cpuid2(KVM_MAX_CPUID_ENTRIES)
+            .map_err(VcpuError::Kvm)?;
+        let tsc_khz = self.fd.get_tsc_khz().ok();
+
+        let mut msrs = Vec::new();
+        for chunk in msr_index_list.chunks(KVM_MAX_MSR_ENTRIES) {
+            let entries: Vec<kvm_msr_entry> = chunk
+                .iter()
+                .map(|index| kvm_msr_entry {
+                    index: *index,
+                    ..Default::default()
+                })
+                .collect();
+            let mut chunk_msrs = Msrs::from_entries(&entries).map_err(VcpuError::Msr)?;
+            let nmsrs = self.fd.get_msrs(&mut chunk_msrs).map_err(VcpuError::Kvm)?;
+            if nmsrs != entries.len() {
+                // KVM stops at the first unreadable MSR, leaving the rest of
+                // the chunk zeroed; persisting it would write those zeros
+                // into the restored guest. Refuse the save instead.
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: entries.len(),
+                });
+            }
+            msrs.push(chunk_msrs);
+        }
+
+        let vcpu_events = self.fd.get_vcpu_events().map_err(VcpuError::Kvm)?;
+
+        Ok(VcpuState {
+            id: self.id,
+            cpuid,
+            msrs,
+            regs,
+            sregs,
+            xsave,
+            xcrs,
+            debug_regs,
+            lapic,
+            mp_state,
+            vcpu_events,
+            tsc_khz,
+        })
+    }
+
+    /// Restore the KVM state of this vCPU from a previously saved state.
+    ///
+    /// Must be called on a freshly created, unconfigured vCPU before it runs.
+    fn restore_state(&mut self, state: &VcpuState, _args: ()) -> Result<()> {
+        // Ordering matters (mirrors Firecracker): CPUID first as it gates
+        // MSR/XSAVE validation, events last.
+        self.cpuid = state.cpuid.clone();
+        self.fd
+            .set_cpuid2(&state.cpuid)
+            .map_err(VcpuError::SetSupportedCpusFailed)?;
+        for chunk in &state.msrs {
+            let expected = chunk.as_fam_struct_ref().nmsrs as usize;
+            let nmsrs = self.fd.set_msrs(chunk).map_err(VcpuError::Kvm)?;
+            if nmsrs != expected {
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: expected,
+                });
+            }
+        }
+        self.fd.set_sregs(&state.sregs).map_err(VcpuError::Kvm)?;
+        // SAFETY: the xsave area was obtained from KVM_GET_XSAVE with the
+        // standard fixed-size `kvm_xsave` region, so it cannot exceed the
+        // buffer the kernel copies from.
+        unsafe {
+            self.fd.set_xsave(&state.xsave).map_err(VcpuError::Kvm)?;
+        }
+        self.fd.set_xcrs(&state.xcrs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_debug_regs(&state.debug_regs)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_lapic(&state.lapic).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_mp_state(state.mp_state)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_regs(&state.regs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_vcpu_events(&state.vcpu_events)
+            .map_err(VcpuError::Kvm)?;
+        if let Some(tsc_khz) = state.tsc_khz {
+            // Best effort: hosts without KVM_CAP_TSC_CONTROL cannot set it.
+            if let Err(e) = self.fd.set_tsc_khz(tsc_khz) {
+                warn!("vcpu {}: failed to restore TSC frequency: {}", self.id, e);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use arc_swap::ArcSwap;
+    use dbs_device::device_manager::IoManager;
+    use dbs_interrupt::KvmIrqManager;
+    use kvm_bindings::MsrList;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    use super::*;
+    use crate::kvm_context::KvmContext;
+
+    // A vCPU on its own VM with an in-kernel irqchip (required by
+    // KVM_GET/SET_LAPIC).
+    fn create_vcpu_with_irqchip() -> (Vcpu, MsrList) {
+        let kvm_context = KvmContext::new(None).unwrap();
+        let vm = kvm_context.create_vm().unwrap();
+        vm.create_irq_chip().unwrap();
+        let msr_list = kvm_context.supported_msrs(0).unwrap();
+        let supported_cpuid = kvm_context.supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
+        let vm = Arc::new(vm);
+        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let io_manager = IoManagerCached::new(Arc::new(ArcSwap::new(Arc::new(IoManager::new()))));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm)));
+        let (tx, _rx) = channel();
+
+        let vcpu = Vcpu::new_x86_64(
+            0,
+            vcpu_fd,
+            io_manager,
+            supported_cpuid,
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            tx,
+            TimestampUs::default(),
+            false,
+            irq_manager,
+        )
+        .unwrap();
+
+        (vcpu, msr_list)
+    }
+
+    #[test]
+    fn test_vcpu_save_restore_roundtrip() {
+        skip_if_kvm_unaccessable!();
+
+        let (mut src, msr_list) = create_vcpu_with_irqchip();
+
+        // Plant recognizable register values on the source vCPU.
+        let mut regs = src.fd.get_regs().unwrap();
+        regs.rbx = 0xdbdb;
+        regs.rip = 0x1000;
+        src.fd.set_regs(&regs).unwrap();
+
+        let state = dbs_snapshot::Persist::save_state(&mut src, msr_list.as_slice()).unwrap();
+        assert_eq!(state.id, 0);
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+        assert!(!state.msrs.is_empty());
+
+        // The state itself must survive a JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: VcpuState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+
+        // Restore into a fresh vCPU on a fresh VM and verify the KVM state.
+        let (mut dst, _) = create_vcpu_with_irqchip();
+        dbs_snapshot::Persist::restore_state(&mut dst, &state, ()).unwrap();
+
+        let dst_regs = dst.fd.get_regs().unwrap();
+        assert_eq!(dst_regs.rbx, 0xdbdb);
+        assert_eq!(dst_regs.rip, 0x1000);
+        let dst_sregs = dst.fd.get_sregs().unwrap();
+        assert_eq!(dst_sregs.cr0, state.sregs.cr0);
+        assert_eq!(dst_sregs.cs.base, state.sregs.cs.base);
+        assert_eq!(
+            dst.fd.get_mp_state().unwrap().mp_state,
+            state.mp_state.mp_state
+        );
     }
 }

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -15,9 +15,13 @@ use dbs_boot::FirmwareType;
 use dbs_interrupt::InterruptManager;
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
-use kvm_bindings::CpuId;
+use kvm_bindings::{
+    kvm_debugregs, kvm_lapic_state, kvm_mp_state, kvm_msr_entry, kvm_regs, kvm_sregs,
+    kvm_vcpu_events, kvm_xcrs, kvm_xsave, CpuId, Msrs, KVM_MAX_CPUID_ENTRIES, KVM_MAX_MSR_ENTRIES,
+};
 use kvm_ioctls::{VcpuFd, VmFd};
-use log::error;
+use log::{error, warn};
+use serde_derive::{Deserialize, Serialize};
 use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -167,5 +171,253 @@ impl Vcpu {
         self.fd
             .set_cpuid2(&self.cpuid)
             .map_err(VcpuError::SetSupportedCpusFailed)
+    }
+}
+
+/// Snapshot state of a x86_64 vCPU: guest-visible registers plus
+/// KVM-internal state needed to transparently resume execution.
+///
+/// Compatibility policy (see `crate::snapshot`): only append new fields, with
+/// `#[serde(default)]`; never remove or repurpose existing ones.
+// No `Clone`: `kvm_xsave` contains an incomplete array field.
+#[derive(Deserialize, Serialize)]
+pub struct VcpuState {
+    /// vCPU id.
+    pub id: u8,
+    /// CPUID configuration of this vCPU.
+    pub cpuid: CpuId,
+    /// Model specific registers, chunked by `KVM_MAX_MSR_ENTRIES`.
+    pub msrs: Vec<Msrs>,
+    /// General purpose registers.
+    pub regs: kvm_regs,
+    /// Special registers.
+    pub sregs: kvm_sregs,
+    /// XSAVE area (contains FPU/SSE/AVX state, superset of `kvm_fpu`).
+    pub xsave: kvm_xsave,
+    /// Extended control registers.
+    pub xcrs: kvm_xcrs,
+    /// Debug registers.
+    pub debug_regs: kvm_debugregs,
+    /// Local APIC state.
+    pub lapic: kvm_lapic_state,
+    /// Multiprocessing state.
+    pub mp_state: kvm_mp_state,
+    /// Pending vCPU events.
+    pub vcpu_events: kvm_vcpu_events,
+    /// Guest TSC frequency in kHz, if the host supports retrieving it.
+    #[serde(default)]
+    pub tsc_khz: Option<u32>,
+}
+
+impl<'a> dbs_snapshot::Persist<'a> for Vcpu {
+    type State = VcpuState;
+    type SaveArgs = &'a [u32];
+    type RestoreArgs = ();
+    type Error = VcpuError;
+
+    /// Save the KVM state of this vCPU.
+    ///
+    /// The vCPU must be quiesced (not running) when this is called; use the
+    /// vCPU manager's pause machinery first.
+    ///
+    /// # Arguments
+    ///
+    /// * `msr_index_list` - Indices of the MSRs to save, typically
+    ///   `KvmContext::supported_msrs()` (pre-filtered for serializability).
+    fn save_state(&mut self, msr_index_list: &'a [u32]) -> Result<VcpuState> {
+        // Ordering matters (mirrors Firecracker):
+        // - KVM_GET_MP_STATE calls kvm_apic_accept_events(), which might
+        //   modify vCPU/LAPIC state, so it must run before everything else.
+        // - KVM_GET_VCPU_EVENTS is read last as the other GET ioctls may
+        //   modify internal pending-event state.
+        let mp_state = self.fd.get_mp_state().map_err(VcpuError::Kvm)?;
+        let regs = self.fd.get_regs().map_err(VcpuError::Kvm)?;
+        let sregs = self.fd.get_sregs().map_err(VcpuError::Kvm)?;
+        let xsave = self.fd.get_xsave().map_err(VcpuError::Kvm)?;
+        let xcrs = self.fd.get_xcrs().map_err(VcpuError::Kvm)?;
+        let debug_regs = self.fd.get_debug_regs().map_err(VcpuError::Kvm)?;
+        let lapic = self.fd.get_lapic().map_err(VcpuError::Kvm)?;
+        let cpuid = self
+            .fd
+            .get_cpuid2(KVM_MAX_CPUID_ENTRIES)
+            .map_err(VcpuError::Kvm)?;
+        let tsc_khz = self.fd.get_tsc_khz().ok();
+
+        let mut msrs = Vec::new();
+        for chunk in msr_index_list.chunks(KVM_MAX_MSR_ENTRIES) {
+            let entries: Vec<kvm_msr_entry> = chunk
+                .iter()
+                .map(|index| kvm_msr_entry {
+                    index: *index,
+                    ..Default::default()
+                })
+                .collect();
+            let mut chunk_msrs = Msrs::from_entries(&entries).map_err(VcpuError::Msr)?;
+            let nmsrs = self.fd.get_msrs(&mut chunk_msrs).map_err(VcpuError::Kvm)?;
+            if nmsrs != entries.len() {
+                // KVM stops at the first unreadable MSR, leaving the rest of
+                // the chunk zeroed; persisting it would write those zeros
+                // into the restored guest. Refuse the save instead.
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: entries.len(),
+                });
+            }
+            msrs.push(chunk_msrs);
+        }
+
+        let vcpu_events = self.fd.get_vcpu_events().map_err(VcpuError::Kvm)?;
+
+        Ok(VcpuState {
+            id: self.id,
+            cpuid,
+            msrs,
+            regs,
+            sregs,
+            xsave,
+            xcrs,
+            debug_regs,
+            lapic,
+            mp_state,
+            vcpu_events,
+            tsc_khz,
+        })
+    }
+
+    /// Restore the KVM state of this vCPU from a previously saved state.
+    ///
+    /// Must be called on a freshly created, unconfigured vCPU before it runs.
+    fn restore_state(&mut self, state: &VcpuState, _args: ()) -> Result<()> {
+        // Ordering matters (mirrors Firecracker): CPUID first as it gates
+        // MSR/XSAVE validation, events last.
+        self.cpuid = state.cpuid.clone();
+        self.fd
+            .set_cpuid2(&state.cpuid)
+            .map_err(VcpuError::SetSupportedCpusFailed)?;
+        for chunk in &state.msrs {
+            let expected = chunk.as_fam_struct_ref().nmsrs as usize;
+            let nmsrs = self.fd.set_msrs(chunk).map_err(VcpuError::Kvm)?;
+            if nmsrs != expected {
+                return Err(VcpuError::MsrsIncomplete {
+                    id: self.id,
+                    processed: nmsrs,
+                    requested: expected,
+                });
+            }
+        }
+        self.fd.set_sregs(&state.sregs).map_err(VcpuError::Kvm)?;
+        // SAFETY: the xsave area was obtained from KVM_GET_XSAVE with the
+        // standard fixed-size `kvm_xsave` region, so it cannot exceed the
+        // buffer the kernel copies from.
+        unsafe {
+            self.fd.set_xsave(&state.xsave).map_err(VcpuError::Kvm)?;
+        }
+        self.fd.set_xcrs(&state.xcrs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_debug_regs(&state.debug_regs)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_lapic(&state.lapic).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_mp_state(state.mp_state)
+            .map_err(VcpuError::Kvm)?;
+        self.fd.set_regs(&state.regs).map_err(VcpuError::Kvm)?;
+        self.fd
+            .set_vcpu_events(&state.vcpu_events)
+            .map_err(VcpuError::Kvm)?;
+        if let Some(tsc_khz) = state.tsc_khz {
+            // Best effort: hosts without KVM_CAP_TSC_CONTROL cannot set it.
+            if let Err(e) = self.fd.set_tsc_khz(tsc_khz) {
+                warn!("vcpu {}: failed to restore TSC frequency: {}", self.id, e);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::channel;
+
+    use arc_swap::ArcSwap;
+    use dbs_device::device_manager::IoManager;
+    use dbs_interrupt::KvmIrqManager;
+    use kvm_bindings::MsrList;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    use super::*;
+    use crate::kvm_context::KvmContext;
+
+    // A vCPU on its own VM with an in-kernel irqchip (required by
+    // KVM_GET/SET_LAPIC).
+    fn create_vcpu_with_irqchip() -> (Vcpu, MsrList) {
+        let kvm_context = KvmContext::new(None).unwrap();
+        let vm = kvm_context.create_vm().unwrap();
+        vm.create_irq_chip().unwrap();
+        let msr_list = kvm_context.supported_msrs(0).unwrap();
+        let supported_cpuid = kvm_context.supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
+        let vm = Arc::new(vm);
+        let vcpu_fd = vm.create_vcpu(0).unwrap();
+        let io_manager = IoManagerCached::new(Arc::new(ArcSwap::new(Arc::new(IoManager::new()))));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm.clone())));
+        let (tx, _rx) = channel();
+
+        let vcpu = Vcpu::new_x86_64(
+            0,
+            vcpu_fd,
+            vm,
+            io_manager,
+            supported_cpuid,
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            tx,
+            TimestampUs::default(),
+            false,
+            irq_manager,
+        )
+        .unwrap();
+
+        (vcpu, msr_list)
+    }
+
+    #[test]
+    fn test_vcpu_save_restore_roundtrip() {
+        skip_if_kvm_unaccessable!();
+
+        let (mut src, msr_list) = create_vcpu_with_irqchip();
+
+        // Plant recognizable register values on the source vCPU.
+        let mut regs = src.fd.get_regs().unwrap();
+        regs.rbx = 0xdbdb;
+        regs.rip = 0x1000;
+        src.fd.set_regs(&regs).unwrap();
+
+        let state = dbs_snapshot::Persist::save_state(&mut src, msr_list.as_slice()).unwrap();
+        assert_eq!(state.id, 0);
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+        assert!(!state.msrs.is_empty());
+
+        // The state itself must survive a JSON round-trip.
+        let json = serde_json::to_string(&state).unwrap();
+        let state: VcpuState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state.regs.rbx, 0xdbdb);
+        assert_eq!(state.regs.rip, 0x1000);
+
+        // Restore into a fresh vCPU on a fresh VM and verify the KVM state.
+        let (mut dst, _) = create_vcpu_with_irqchip();
+        dbs_snapshot::Persist::restore_state(&mut dst, &state, ()).unwrap();
+
+        let dst_regs = dst.fd.get_regs().unwrap();
+        assert_eq!(dst_regs.rbx, 0xdbdb);
+        assert_eq!(dst_regs.rip, 0x1000);
+        let dst_sregs = dst.fd.get_sregs().unwrap();
+        assert_eq!(dst_sregs.cr0, state.sregs.cr0);
+        assert_eq!(dst_sregs.cs.base, state.sregs.cs.base);
+        assert_eq!(
+            dst.fd.get_mp_state().unwrap().mp_state,
+            state.mp_state.mp_state
+        );
     }
 }

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -392,13 +392,17 @@ impl Vm {
 
     /// Check whether the VM instance is running.
     pub fn is_vm_running(&self) -> bool {
-        let instance_state = {
-            // Use expect() to crash if the other thread poisoned this lock.
-            let shared_info = self.shared_info.read()
-                .expect("Failed to determine if instance is initialized because shared info couldn't be read due to poisoned lock");
-            shared_info.state
-        };
-        instance_state == InstanceState::Running
+        self.instance_state() == InstanceState::Running
+    }
+
+    /// Return the current VM instance state.
+    pub fn instance_state(&self) -> InstanceState {
+        self.shared_info
+            .read()
+            .expect(
+                "Failed to determine instance state because shared info couldn't be read due to poisoned lock",
+            )
+            .state
     }
 
     /// Save VM instance exit state
@@ -506,6 +510,10 @@ impl Vm {
         self.start_instance_downtime = ts.time_us;
 
         self.vcpu_manager()?.pause_all_vcpus()?;
+        self.shared_info
+            .write()
+            .expect("Failed to pause microVM because shared info couldn't be written")
+            .state = InstanceState::Paused;
 
         Ok(())
     }
@@ -513,6 +521,10 @@ impl Vm {
     /// Resume all vcpus and calc the intance downtime
     pub fn resume_all_vcpus_with_downtime(&mut self) -> std::result::Result<(), VcpuManagerError> {
         self.vcpu_manager()?.resume_all_vcpus()?;
+        self.shared_info
+            .write()
+            .expect("Failed to resume microVM because shared info couldn't be written")
+            .state = InstanceState::Running;
 
         if self.start_instance_downtime != 0 {
             let now = TimestampUs::default();
@@ -856,6 +868,101 @@ impl Vm {
         info!(self.logger, "VM started");
         Ok(())
     }
+
+    /// Start a microVM by restoring it from a snapshot (see
+    /// [`Vm::save_microvm`]) instead of cold booting.
+    ///
+    /// The VM must have been configured with the *same configuration*
+    /// (machine config, boot source, devices) the snapshot was taken with.
+    /// This mirrors [`Vm::start_microvm`] but skips the boot-time system
+    /// configuration and applies the snapshot before the vCPUs start:
+    /// guest memory contents, device runtime state (replaying virtio
+    /// activation) and vCPU register state.
+    #[cfg(target_arch = "x86_64")]
+    pub fn start_microvm_from_snapshot(
+        &mut self,
+        event_mgr: &mut EventManager,
+        seccomp_filters: HashMap<String, BpfProgram>,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), StartMicroVmError> {
+        info!(self.logger, "VM: received restore-from-snapshot command");
+
+        if let Some(process_seccomp_filter) = seccomp_filters.get(ALL_THREADS) {
+            if let Err(e) = apply_filter_all_threads(process_seccomp_filter) {
+                if !matches!(e, SecError::EmptyFilter) {
+                    error!(
+                        self.logger,
+                        "VM: failed to apply process-wide seccomp filters: {}", e
+                    );
+                    return Err(StartMicroVmError::SeccompFilters(e));
+                }
+            }
+        }
+
+        if self.is_vm_initialized() {
+            return Err(StartMicroVmError::MicroVMAlreadyRunning);
+        }
+
+        let request_ts = TimestampUs::default();
+        self.start_instance_request_ts = request_ts.time_us;
+        self.start_instance_request_cpu_ts = request_ts.cputime_us;
+
+        self.init_dmesg_logger();
+        self.check_health()?;
+
+        // Use expect() to crash if the other thread poisoned this lock.
+        self.shared_info
+            .write()
+            .expect("Failed to start microVM because shared info couldn't be written due to poisoned lock")
+            .state = InstanceState::Starting;
+
+        self.init_guest_memory()?;
+        let vm_as = self
+            .vm_as()
+            .cloned()
+            .ok_or(StartMicroVmError::AddressManagerError(
+                AddressManagerError::GuestMemoryNotInitialized,
+            ))?;
+
+        self.init_vcpu_manager(
+            vm_as.clone(),
+            seccomp_filters
+                .get(VCPU_THREAD)
+                .cloned()
+                .unwrap_or_default(),
+        )
+        .map_err(StartMicroVmError::Vcpu)?;
+        // Creates devices and boot vCPUs. The boot-time vCPU register setup
+        // performed here is overwritten by the snapshot state below; the
+        // boot-time system configuration (`init_configure_system`) is
+        // skipped entirely since guest memory is reloaded from the snapshot.
+        self.init_microvm(event_mgr.epoll_manager(), vm_as.clone(), request_ts)?;
+        #[cfg(feature = "dbs-upcall")]
+        self.init_upcall()?;
+
+        info!(self.logger, "VM: restoring snapshot state");
+        self.restore_microvm(state_path, mem_path)
+            .map_err(|e| StartMicroVmError::RestoreMicroVm(e.to_string()))?;
+
+        info!(self.logger, "VM: register events");
+        self.register_events(event_mgr)?;
+
+        info!(self.logger, "VM: start vcpus");
+        self.vcpu_manager()
+            .map_err(StartMicroVmError::Vcpu)?
+            .start_boot_vcpus(seccomp_filters.get(VMM_THREAD).cloned().unwrap_or_default())
+            .map_err(StartMicroVmError::Vcpu)?;
+
+        // Use expect() to crash if the other thread poisoned this lock.
+        self.shared_info
+            .write()
+            .expect("Failed to start microVM because shared info couldn't be written due to poisoned lock")
+            .state = InstanceState::Running;
+
+        info!(self.logger, "VM restored from snapshot");
+        Ok(())
+    }
 }
 
 #[cfg(feature = "hotplug")]
@@ -965,6 +1072,258 @@ impl Vm {
         _epoll_mgr: Option<EpollManager>,
     ) -> std::result::Result<DeviceOpContext, StartMicroVmError> {
         Err(StartMicroVmError::MicroVMAlreadyRunning)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Vm {
+    /// Save the state of the running microVM into a snapshot: a state file
+    /// at `state_path` (vCPU/device metadata state, JSON) plus a memory file
+    /// at `mem_path` (guest RAM contents).
+    ///
+    /// A running VM is paused while the state is captured and resumed
+    /// afterwards (branch semantics). An already-paused VM remains paused,
+    /// which lets the common VM factory preserve its pause-save contract.
+    /// Saving stops in-kernel vhost rings on the source (a
+    /// VHOST_GET_VRING_BASE side effect), so its vhost devices stay quiesced.
+    /// The boot-to-be-template flow tears the source VM down afterwards.
+    pub fn save_microvm(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), crate::snapshot::SnapshotError> {
+        use crate::snapshot::SnapshotError;
+
+        let msr_list = self.kvm.supported_msrs(0).map_err(SnapshotError::Kvm)?;
+
+        let initial_state = self.instance_state();
+        let resume_after_save = match initial_state {
+            InstanceState::Running => {
+                self.pause_all_vcpus_with_downtime()?;
+                true
+            }
+            InstanceState::Paused => false,
+            state => return Err(SnapshotError::InvalidState(format!("{state:?}"))),
+        };
+
+        let save_result = self.save_microvm_paused(state_path, mem_path, msr_list.as_slice());
+        let resume_result = if resume_after_save {
+            self.resume_all_vcpus_with_downtime()
+        } else {
+            Ok(())
+        };
+        match (save_result, resume_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(save_err), Ok(())) => Err(save_err),
+            (Ok(()), Err(resume_err)) => Err(SnapshotError::Vcpu(resume_err)),
+            (Err(save_err), Err(resume_err)) => {
+                // Both failed: the vCPUs may be left paused, which is the more
+                // urgent condition to surface, but don't silently lose the
+                // save error that is the actual root cause.
+                error!(
+                    self.logger,
+                    "snapshot save failed and vCPUs could not be resumed, \
+                     VM may be left paused: {}",
+                    save_err
+                );
+                Err(SnapshotError::Vcpu(resume_err))
+            }
+        }
+    }
+
+    /// Capture the microVM state while all vCPUs are paused.
+    ///
+    /// Device (queue) state is captured *before* guest memory: the vCPUs are
+    /// paused and userspace virtio backends run on the VMM event-loop thread
+    /// executing this action, so captured queue state cannot change
+    /// afterwards, and saving a vhost device stops its in-kernel rings (a
+    /// VHOST_GET_VRING_BASE side effect), so kernel backends stop writing
+    /// guest memory before the dump below. Backends processing queues on
+    /// other threads must be idle; the boot-to-be-template flow quiesces
+    /// guest I/O before saving.
+    fn save_microvm_paused(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+        msr_list: &[u32],
+    ) -> std::result::Result<(), crate::snapshot::SnapshotError> {
+        use crate::snapshot::{DeviceManagerState, MicrovmState, SnapshotError};
+        use dbs_snapshot::Persist;
+
+        let vcpu_states = self.vcpu_manager()?.save_state(msr_list)?;
+
+        // VM-scoped KVM state, captured while the vCPUs are paused.
+        let vm_kvm_state = {
+            let vm_fd = self.vm_fd();
+            let pit = vm_fd.get_pit2().map_err(SnapshotError::Kvm)?;
+            let mut clock = vm_fd.get_clock().map_err(SnapshotError::Kvm)?;
+            // Per the KVM API, the KVM_CLOCK_TSC_STABLE flag returned by
+            // KVM_GET_CLOCK must not be fed back into KVM_SET_CLOCK.
+            clock.flags = 0;
+            let mut pic_master = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_PIC_MASTER,
+                ..Default::default()
+            };
+            vm_fd
+                .get_irqchip(&mut pic_master)
+                .map_err(SnapshotError::Kvm)?;
+            let mut pic_slave = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_PIC_SLAVE,
+                ..Default::default()
+            };
+            vm_fd
+                .get_irqchip(&mut pic_slave)
+                .map_err(SnapshotError::Kvm)?;
+            let mut ioapic = kvm_bindings::kvm_irqchip {
+                chip_id: kvm_bindings::KVM_IRQCHIP_IOAPIC,
+                ..Default::default()
+            };
+            vm_fd.get_irqchip(&mut ioapic).map_err(SnapshotError::Kvm)?;
+            crate::snapshot::VmKvmState {
+                pit,
+                clock,
+                pic_master,
+                pic_slave,
+                ioapic,
+            }
+        };
+
+        #[allow(unused_mut)]
+        let mut device_states = DeviceManagerState::default();
+        #[cfg(feature = "virtio-blk")]
+        {
+            device_states.block = Some(self.device_manager.block_manager.save_state(())?);
+        }
+        // TODO: this is gated on `virtio-net`, but `net_manager` also holds
+        // vhost-net and vhost-user-net devices. With `virtio-net` enabled they
+        // are refused loudly by `save_state` (`UnsupportedBackend`); in a build
+        // with only the vhost backends this block is compiled out entirely, so
+        // such devices are silently omitted from the snapshot. Gate the net
+        // snapshot on `any(virtio-net, vhost-net, vhost-user-net)` and keep the
+        // per-backend refuse so the guard holds in every build configuration.
+        #[cfg(feature = "virtio-net")]
+        {
+            device_states.virtio_net = Some(self.device_manager.net_manager.save_state(())?);
+        }
+        #[cfg(feature = "virtio-vsock")]
+        {
+            device_states.vsock = Some(self.device_manager.vsock_manager.save_state(())?);
+        }
+        #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+        {
+            device_states.fs = Some(
+                self.device_manager
+                    .fs_manager
+                    .lock()
+                    .unwrap()
+                    .save_state(())?,
+            );
+        }
+        // TODO: balloon, virtio-mem, vhost-net and vhost-user-net are not yet
+        // snapshotted; kata-dragonball does not instantiate them.
+
+        let mut mem_file = std::fs::File::create(mem_path)?;
+        let memory_state = self.address_space.save_state(&mut mem_file)?;
+
+        let state = MicrovmState {
+            vm_kvm_state: Some(vm_kvm_state),
+            vcpu_states,
+            memory_state: Some(memory_state),
+            device_states,
+            ..Default::default()
+        };
+        state.save_to_file(state_path)?;
+        Ok(())
+    }
+
+    /// Restore the runtime state of a freshly built microVM from a snapshot.
+    ///
+    /// Expected calling sequence (mirroring the normal boot flow, driven by
+    /// the VMM/API layer):
+    /// 1. Create the VM from the *same configuration* the snapshot was taken
+    ///    with: address space, devices and vCPUs are created (but the vCPUs
+    ///    not yet started, and no boot code runs).
+    /// 2. Call this method: it loads guest RAM from `mem_path` and applies
+    ///    the vCPU and device states from `state_path`, replaying virtio
+    ///    device activation.
+    /// 3. Start the vCPU threads and resume execution.
+    pub fn restore_microvm(
+        &mut self,
+        state_path: &std::path::Path,
+        mem_path: &std::path::Path,
+    ) -> std::result::Result<(), crate::snapshot::SnapshotError> {
+        use crate::snapshot::MicrovmState;
+        use dbs_snapshot::Persist;
+
+        let state = MicrovmState::load_from_file(state_path)?;
+
+        // Restore the VM-scoped KVM state first: interrupt delivery for
+        // everything below depends on the IOAPIC/PIC redirection tables the
+        // guest had programmed.
+        if let Some(kvm_state) = &state.vm_kvm_state {
+            let vm_fd = self.vm_fd();
+            vm_fd
+                .set_pit2(&kvm_state.pit)
+                .map_err(crate::snapshot::SnapshotError::Kvm)?;
+            vm_fd
+                .set_clock(&kvm_state.clock)
+                .map_err(crate::snapshot::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.pic_master)
+                .map_err(crate::snapshot::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.pic_slave)
+                .map_err(crate::snapshot::SnapshotError::Kvm)?;
+            vm_fd
+                .set_irqchip(&kvm_state.ioapic)
+                .map_err(crate::snapshot::SnapshotError::Kvm)?;
+        }
+
+        if let Some(memory_state) = &state.memory_state {
+            let mut mem_file = std::fs::File::open(mem_path)?;
+            self.address_space
+                .restore_state(memory_state, &mut mem_file)?;
+        }
+
+        #[cfg(feature = "virtio-blk")]
+        if let Some(block_state) = &state.device_states.block {
+            self.device_manager
+                .block_manager
+                .restore_state(block_state, ())?;
+        }
+        #[cfg(feature = "virtio-net")]
+        if let Some(net_state) = &state.device_states.virtio_net {
+            self.device_manager
+                .net_manager
+                .restore_state(net_state, ())?;
+        }
+        #[cfg(feature = "virtio-vsock")]
+        if let Some(vsock_state) = &state.device_states.vsock {
+            self.device_manager
+                .vsock_manager
+                .restore_state(vsock_state, ())?;
+        }
+        #[cfg(any(feature = "virtio-fs", feature = "vhost-user-fs"))]
+        if let Some(fs_state) = &state.device_states.fs {
+            self.device_manager
+                .fs_manager
+                .lock()
+                .unwrap()
+                .restore_state(fs_state, ())?;
+        }
+        // TODO: balloon, virtio-mem, vhost-net and vhost-user-net are not yet
+        // snapshotted; kata-dragonball does not instantiate them.
+
+        dbs_snapshot::Persist::restore_state(&mut *self.vcpu_manager()?, &state.vcpu_states, ())?;
+
+        // TODO(security): the guest's RNG/entropy state lives in the restored
+        // memory, so every VM restored from the same template starts with
+        // identical randomness and can emit identical secrets (crypto keys,
+        // UUIDs, nonces) until its pool refreshes. Reseed after restore --
+        // e.g. inject fresh entropy through a virtio-rng device. vmgenid is
+        // not usable here: its Linux guest driver is ACPI-only and Dragonball
+        // exposes no ACPI (MP table on x86_64, FDT on aarch64).
+        Ok(())
     }
 }
 

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -79,6 +79,9 @@ impl ConfigPlugin for DragonballConfig {
             if db.memory_info.memory_slots == 0 {
                 db.memory_info.memory_slots = default::DEFAULT_DRAGONBALL_MEMORY_SLOTS;
             }
+            if db.factory.template_path.is_empty() {
+                db.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
+            }
         }
         Ok(())
     }
@@ -199,5 +202,32 @@ impl ConfigPlugin for DragonballConfig {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::hypervisor::Hypervisor;
+
+    #[test]
+    fn test_adjust_config_sets_factory_template_path() {
+        let mut config = TomlConfig::default();
+        config.hypervisor.insert(
+            HYPERVISOR_NAME_DRAGONBALL.to_string(),
+            Hypervisor::default(),
+        );
+
+        DragonballConfig::new().adjust_config(&mut config).unwrap();
+
+        assert_eq!(
+            config
+                .hypervisor
+                .get(HYPERVISOR_NAME_DRAGONBALL)
+                .unwrap()
+                .factory
+                .template_path,
+            default::DEFAULT_TEMPLATE_PATH
+        );
     }
 }

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -272,6 +272,18 @@ guest_swap_size_percent = 100
 # Default 60.
 guest_swap_create_threshold_secs = 60
 
+[hypervisor.dragonball.factory]
+# VM templating support. Once enabled, new VMs are restored from the template
+# initialized with `kata-ctl factory init`.
+#
+# Default false
+enable_template = false
+
+# Specifies the path of the template memory and device-state files.
+#
+# Default "/run/vc/vm/template"
+template_path = "/run/vc/vm/template"
+
 [agent.@PROJECT_TYPE@]
 container_pipe_size = @PIPESIZE@
 # If enabled, make the agent display debug-level messages.

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -319,6 +319,37 @@ impl DragonballInner {
 
     fn start_vmm_instance(&mut self) -> Result<()> {
         info!(sl!(), "Starting VM");
+        // Boot from a VM template snapshot instead of cold booting when
+        // configured (mirrors the QEMU boot_from_template flow).
+        #[cfg(target_arch = "x86_64")]
+        if self.config.vm_template.boot_from_template {
+            let template = &self.config.vm_template;
+            if template.device_state_path.is_empty() || template.memory_path.is_empty() {
+                return Err(anyhow!(
+                    "vm_template memory_path/device_state_path are not configured"
+                ));
+            }
+            info!(
+                sl!(),
+                "Starting VM from template snapshot";
+                "device_state_path" => &template.device_state_path,
+                "memory_path" => &template.memory_path,
+            );
+            self.vmm_instance
+                .instance_start_from_snapshot(
+                    template.device_state_path.clone(),
+                    template.memory_path.clone(),
+                )
+                .context("Failed to start vmm from template snapshot")?;
+            self.state = VmmState::VmRunning;
+            return Ok(());
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        if self.config.vm_template.boot_from_template {
+            return Err(anyhow!(
+                "boot_from_template is not supported on this architecture"
+            ));
+        }
         self.vmm_instance
             .instance_start()
             .context("Failed to start vmm")?;

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -82,8 +82,35 @@ impl DragonballInner {
         Ok(())
     }
 
+    /// Save the microVM state into the VM template files configured in
+    /// `[hypervisor].vm_template` (boot-to-be-template flow): guest memory
+    /// contents to `memory_path`, vCPU/device state to `device_state_path`.
+    /// A running VM is paused while the state is captured and resumed
+    /// afterwards; an already-paused VM remains paused.
     pub(crate) async fn save_vm(&self) -> Result<()> {
-        todo!()
+        #[cfg(target_arch = "x86_64")]
+        {
+            let template = &self.config.vm_template;
+            if template.device_state_path.is_empty() || template.memory_path.is_empty() {
+                return Err(anyhow!(
+                    "vm_template memory_path/device_state_path are not configured"
+                ));
+            }
+            info!(
+                sl!(),
+                "saving microVM snapshot to template";
+                "device_state_path" => &template.device_state_path,
+                "memory_path" => &template.memory_path,
+            );
+            self.vmm_instance
+                .save_microvm(
+                    template.device_state_path.clone(),
+                    template.memory_path.clone(),
+                )
+                .context("save microvm")
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        Err(anyhow!("save_vm is not supported on this architecture"))
     }
 
     pub(crate) async fn get_agent_socket(&self) -> Result<String> {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -184,6 +184,18 @@ impl VmmInstance {
         Ok(())
     }
 
+    /// Start the microVM by restoring it from a snapshot (VM template)
+    /// instead of cold booting.
+    #[cfg(target_arch = "x86_64")]
+    pub fn instance_start_from_snapshot(&self, state_path: String, mem_path: String) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::StartMicroVmFromSnapshot {
+            state_path,
+            mem_path,
+        }))
+        .context("Failed to start MicroVm from snapshot")?;
+        Ok(())
+    }
+
     pub fn is_uninitialized(&self) -> bool {
         let share_info = self
             .vmm_shared_info
@@ -345,11 +357,28 @@ impl VmmInstance {
     }
 
     pub fn pause(&self) -> Result<()> {
-        todo!()
+        self.handle_request(Request::Sync(VmmAction::PauseMicroVm))
+            .context("Failed to pause MicroVm")?;
+        Ok(())
     }
 
     pub fn resume(&self) -> Result<()> {
-        todo!()
+        self.handle_request(Request::Sync(VmmAction::ResumeMicroVm))
+            .context("Failed to resume MicroVm")?;
+        Ok(())
+    }
+
+    /// Save the microVM state into a snapshot: a state file (vCPU/device
+    /// metadata, JSON) plus a guest memory contents file. Preserves whether
+    /// the VM was running or already paused.
+    #[cfg(target_arch = "x86_64")]
+    pub fn save_microvm(&self, state_path: String, mem_path: String) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::SaveMicrovm {
+            state_path,
+            mem_path,
+        }))
+        .context("Failed to save microvm")?;
+        Ok(())
     }
 
     pub fn pid(&self) -> u32 {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
@@ -198,17 +198,12 @@ impl Template {
         }
         .await;
 
-        let teardown_result: Result<()> = async {
-            vm.stop().await.context("stop template vm")?;
-            vm.cleanup().await.context("cleanup template vm")
-        }
-        .await;
+        let teardown_result = vm.teardown().await;
 
         if let Err(teardown_error) = teardown_result {
             if result.is_ok() {
                 return Err(teardown_error);
             }
-
             warn!(
                 sl!(),
                 "failed to tear down template VM after template creation failed: {}",

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
@@ -152,22 +152,31 @@ impl Template {
             .await
             .context("new template vm")?;
 
-        vm.disconnect().await.context("disconnect template vm")?;
+        let result: Result<()> = async {
+            vm.disconnect().await.context("disconnect template vm")?;
 
-        // Sleep a bit to let the agent grpc server clean up
-        // See: src/runtime/virtcontainers/factory/template/template_linux.go#L139-L145
-        // When we close connection to the agent, it needs sometime to cleanup
-        // and restart listening on the communication( serial or vsock) port.
-        // That time can be saved if we sleep a bit to wait for the agent to
-        // come around and start listening again. The sleep is only done when
-        // creating new vm templates and saves time for every new vm that are
-        // created from template, so it worth the invest.
-        sleep(TEMPLATE_WAIT_FOR_AGENT);
+            // Give the guest agent time to close the old connection and return
+            // to listening before its state is captured.
+            sleep(TEMPLATE_WAIT_FOR_AGENT);
 
-        vm.pause().await.context("pause template vm")?;
+            vm.pause().await.context("pause template vm")?;
+            vm.save().await.context("save template vm")
+        }
+        .await;
 
-        vm.save().await.context("save template vm")?;
+        let teardown_result = vm.teardown().await;
 
-        Ok(())
+        if let Err(teardown_error) = teardown_result {
+            if result.is_ok() {
+                return Err(teardown_error);
+            }
+            warn!(
+                sl!(),
+                "failed to tear down template VM after template creation failed: {}",
+                teardown_error
+            );
+        }
+
+        result
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -9,6 +9,8 @@ use agent::{kata::KataAgent, Agent, AGENT_KATA};
 use anyhow::{anyhow, Context, Result};
 use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
 use hypervisor::device::driver::{VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_PCI};
+#[cfg(all(feature = "dragonball", target_arch = "x86_64"))]
+use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
 use kata_types::config::{
     default, Agent as AgentConfig, Hypervisor as HypervisorConfig, TomlConfig,
@@ -27,6 +29,9 @@ const MESSAGE_BUFFER_SIZE: usize = 8;
 /// VM is an abstraction of a virtual machine.
 #[derive(Clone)]
 pub struct TemplateVm {
+    /// Sandbox that owns the VM and its host-side resources.
+    sandbox: VirtSandbox,
+
     /// The hypervisor responsible for managing the virtual machine lifecycle.
     pub hypervisor: Arc<dyn Hypervisor>,
 
@@ -168,16 +173,13 @@ impl VmConfig {
 }
 
 impl TemplateVm {
-    /// Creates a new TemplateVm instance with the provided components and resources.
-    /// Currently, only QEMU is supported; other hypervisors are not yet implemented.
-    pub fn new(
-        id: String,
-        hypervisor: Arc<dyn Hypervisor>,
-        agent: Arc<dyn Agent>,
-        cpu: f32,
-        memory: u32,
-    ) -> Self {
+    /// Creates a new TemplateVm instance from its owning sandbox.
+    pub fn new(sandbox: VirtSandbox, cpu: f32, memory: u32) -> Self {
+        let id = sandbox.get_sid();
+        let hypervisor = sandbox.get_hypervisor();
+        let agent = sandbox.get_agent();
         Self {
+            sandbox,
             id,
             hypervisor,
             agent,
@@ -187,8 +189,11 @@ impl TemplateVm {
         }
     }
 
-    /// Initializes the QEMU hypervisor for Kata
-    async fn new_hypervisor(config: &VmConfig) -> Result<Arc<dyn Hypervisor>> {
+    /// Initializes the configured hypervisor for Kata.
+    async fn new_hypervisor(
+        config: &VmConfig,
+        _toml_config: &TomlConfig,
+    ) -> Result<Arc<dyn Hypervisor>> {
         let hypervisor: Arc<dyn Hypervisor> = match config.hypervisor_name.as_str() {
             HYPERVISOR_QEMU => {
                 let h = Qemu::new();
@@ -196,7 +201,17 @@ impl TemplateVm {
                     .await;
                 Arc::new(h)
             }
-            // TODO: Add support for additional hypervisors or proper error handling here.
+            #[cfg(all(feature = "dragonball", target_arch = "x86_64"))]
+            HYPERVISOR_DRAGONBALL => {
+                let h = Dragonball::new();
+                h.set_hypervisor_config(config.hypervisor_config.clone())
+                    .await;
+                if _toml_config.runtime.use_passfd_io {
+                    h.set_passfd_listener_port(_toml_config.runtime.passfd_listener_port)
+                        .await;
+                }
+                Arc::new(h)
+            }
             _ => return Err(anyhow!("Unsupported hypervisor {}", config.hypervisor_name)),
         };
         Ok(hypervisor)
@@ -243,7 +258,7 @@ impl TemplateVm {
 
         let (sender, _receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
 
-        let hypervisor = Self::new_hypervisor(&config)
+        let hypervisor = Self::new_hypervisor(&config, &toml_config)
             .await
             .context("new hypervisor")?;
 
@@ -288,14 +303,20 @@ impl TemplateVm {
         .await
         .context("build sandbox")?;
 
-        sandbox.start_template().await.context("start template")?;
-        info!(sl!(), "VM has been started from template");
+        if let Err(start_error) = sandbox.start_template().await {
+            if let Err(teardown_error) = Self::teardown_sandbox(&sandbox).await {
+                warn!(
+                    sl!(),
+                    "failed to tear down template VM after startup failed: {}", teardown_error
+                );
+            }
+            return Err(start_error).context("start template");
+        }
+        info!(sl!(), "template VM has been started");
 
         let hypervisor_config = sandbox.get_hypervisor().hypervisor_config().await;
         let vm = TemplateVm::new(
-            sandbox.get_sid(),
-            sandbox.get_hypervisor(),
-            sandbox.get_agent(),
+            sandbox,
             hypervisor_config.cpu_info.default_vcpus,
             hypervisor_config.memory_info.default_memory,
         );
@@ -304,10 +325,41 @@ impl TemplateVm {
 
     /// Stop a VM
     pub async fn stop(&self) -> Result<()> {
-        self.hypervisor
-            .stop_vm()
+        self.sandbox.stop().await.context("stop template sandbox")
+    }
+
+    /// Remove sandbox-owned and hypervisor resources after the VM has stopped.
+    pub async fn cleanup(&self) -> Result<()> {
+        self.sandbox
+            .cleanup()
             .await
-            .map_err(|e| anyhow::anyhow!("failed to stop vm: {}", e))
+            .context("cleanup template sandbox")
+    }
+
+    /// Stop the template VM and release all resources created for its sandbox.
+    pub async fn teardown(&self) -> Result<()> {
+        Self::teardown_sandbox(&self.sandbox).await
+    }
+
+    async fn teardown_sandbox(sandbox: &VirtSandbox) -> Result<()> {
+        sandbox.get_agent().stop().await;
+
+        let stop_result = sandbox.stop().await;
+        let cleanup_result = sandbox.cleanup().await;
+
+        match (stop_result, cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(stop_error), Ok(())) => {
+                Err(stop_error).context("stop template sandbox during teardown")
+            }
+            (Ok(()), Err(cleanup_error)) => {
+                Err(cleanup_error).context("cleanup template sandbox during teardown")
+            }
+            (Err(stop_error), Err(cleanup_error)) => Err(anyhow!(
+                "stop template sandbox during teardown: {stop_error:#}; \
+                 cleanup template sandbox during teardown: {cleanup_error:#}"
+            )),
+        }
     }
 
     /// Disconnect agent

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use agent::{kata::KataAgent, Agent, AGENT_KATA};
+use agent::{kata::KataAgent, Agent, AgentManager, AGENT_KATA};
 use anyhow::{anyhow, Context, Result};
 use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
 use hypervisor::device::driver::{VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_PCI};
@@ -320,6 +320,30 @@ impl TemplateVm {
             hypervisor_config.cpu_info.default_vcpus,
             hypervisor_config.memory_info.default_memory,
         );
+
+        let readiness_result: Result<()> = async {
+            let address = hypervisor
+                .get_agent_socket()
+                .await
+                .context("get template VM agent socket")?;
+            agent
+                .start(&address)
+                .await
+                .context("connect to template VM agent")
+        }
+        .await;
+
+        if let Err(readiness_error) = readiness_result {
+            if let Err(teardown_error) = vm.teardown().await {
+                warn!(
+                    sl!(),
+                    "failed to tear down template VM after agent readiness failed: {}",
+                    teardown_error
+                );
+            }
+            return Err(readiness_error);
+        }
+
         Ok(vm)
     }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -9,6 +9,8 @@ use agent::{kata::KataAgent, Agent, AGENT_KATA};
 use anyhow::{anyhow, Context, Result};
 use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
 use hypervisor::device::driver::{VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_PCI};
+#[cfg(all(feature = "dragonball", target_arch = "x86_64"))]
+use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
 use kata_types::config::{
     default, Agent as AgentConfig, Hypervisor as HypervisorConfig, TomlConfig,
@@ -27,6 +29,9 @@ const MESSAGE_BUFFER_SIZE: usize = 8;
 /// VM is an abstraction of a virtual machine.
 #[derive(Clone)]
 pub struct TemplateVm {
+    /// Sandbox that owns the VM and its host-side resources.
+    sandbox: VirtSandbox,
+
     /// The hypervisor responsible for managing the virtual machine lifecycle.
     pub hypervisor: Arc<dyn Hypervisor>,
 
@@ -168,15 +173,13 @@ impl VmConfig {
 }
 
 impl TemplateVm {
-    /// Creates a new TemplateVm instance with the provided components and resources.
-    pub fn new(
-        id: String,
-        hypervisor: Arc<dyn Hypervisor>,
-        agent: Arc<dyn Agent>,
-        cpu: f32,
-        memory: u32,
-    ) -> Self {
+    /// Creates a new TemplateVm instance from its owning sandbox.
+    pub fn new(sandbox: VirtSandbox, cpu: f32, memory: u32) -> Self {
+        let id = sandbox.get_sid();
+        let hypervisor = sandbox.get_hypervisor();
+        let agent = sandbox.get_agent();
         Self {
+            sandbox,
             id,
             hypervisor,
             agent,
@@ -187,7 +190,10 @@ impl TemplateVm {
     }
 
     /// Initializes the configured hypervisor for Kata.
-    async fn new_hypervisor(config: &VmConfig) -> Result<Arc<dyn Hypervisor>> {
+    async fn new_hypervisor(
+        config: &VmConfig,
+        _toml_config: &TomlConfig,
+    ) -> Result<Arc<dyn Hypervisor>> {
         let hypervisor: Arc<dyn Hypervisor> = match config.hypervisor_name.as_str() {
             HYPERVISOR_QEMU => {
                 let h = Qemu::new();
@@ -203,6 +209,17 @@ impl TemplateVm {
                 let h = hypervisor::ch::CloudHypervisor::new();
                 h.set_hypervisor_config(config.hypervisor_config.clone())
                     .await;
+                Arc::new(h)
+            }
+            #[cfg(all(feature = "dragonball", target_arch = "x86_64"))]
+            HYPERVISOR_DRAGONBALL => {
+                let h = Dragonball::new();
+                h.set_hypervisor_config(config.hypervisor_config.clone())
+                    .await;
+                if _toml_config.runtime.use_passfd_io {
+                    h.set_passfd_listener_port(_toml_config.runtime.passfd_listener_port)
+                        .await;
+                }
                 Arc::new(h)
             }
             _ => return Err(anyhow!("Unsupported hypervisor {}", config.hypervisor_name)),
@@ -251,7 +268,7 @@ impl TemplateVm {
 
         let (sender, _receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
 
-        let hypervisor = Self::new_hypervisor(&config)
+        let hypervisor = Self::new_hypervisor(&config, &toml_config)
             .await
             .context("new hypervisor")?;
 
@@ -296,14 +313,20 @@ impl TemplateVm {
         .await
         .context("build sandbox")?;
 
-        sandbox.start_template().await.context("start template")?;
-        info!(sl!(), "VM has been started from template");
+        if let Err(start_error) = sandbox.start_template().await {
+            if let Err(teardown_error) = Self::teardown_sandbox(&sandbox).await {
+                warn!(
+                    sl!(),
+                    "failed to tear down template VM after startup failed: {}", teardown_error
+                );
+            }
+            return Err(start_error).context("start template");
+        }
+        info!(sl!(), "template VM has been started");
 
         let hypervisor_config = sandbox.get_hypervisor().hypervisor_config().await;
         let vm = TemplateVm::new(
-            sandbox.get_sid(),
-            sandbox.get_hypervisor(),
-            sandbox.get_agent(),
+            sandbox,
             hypervisor_config.cpu_info.default_vcpus,
             hypervisor_config.memory_info.default_memory,
         );
@@ -312,15 +335,41 @@ impl TemplateVm {
 
     /// Stop a VM
     pub async fn stop(&self) -> Result<()> {
-        self.hypervisor
-            .stop_vm()
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to stop vm: {}", e))
+        self.sandbox.stop().await.context("stop template sandbox")
     }
 
-    /// Remove runtime resources after the VM has stopped.
+    /// Remove sandbox-owned and hypervisor resources after the VM has stopped.
     pub async fn cleanup(&self) -> Result<()> {
-        self.hypervisor.cleanup().await.context("cleanup vm")
+        self.sandbox
+            .cleanup()
+            .await
+            .context("cleanup template sandbox")
+    }
+
+    /// Stop the template VM and release all resources created for its sandbox.
+    pub async fn teardown(&self) -> Result<()> {
+        Self::teardown_sandbox(&self.sandbox).await
+    }
+
+    async fn teardown_sandbox(sandbox: &VirtSandbox) -> Result<()> {
+        sandbox.get_agent().stop().await;
+
+        let stop_result = sandbox.stop().await;
+        let cleanup_result = sandbox.cleanup().await;
+
+        match (stop_result, cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(stop_error), Ok(())) => {
+                Err(stop_error).context("stop template sandbox during teardown")
+            }
+            (Ok(()), Err(cleanup_error)) => {
+                Err(cleanup_error).context("cleanup template sandbox during teardown")
+            }
+            (Err(stop_error), Err(cleanup_error)) => Err(anyhow!(
+                "stop template sandbox during teardown: {stop_error:#}; \
+                 cleanup template sandbox during teardown: {cleanup_error:#}"
+            )),
+        }
     }
 
     /// Disconnect agent

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use agent::{kata::KataAgent, Agent, AGENT_KATA};
+use agent::{kata::KataAgent, Agent, AgentManager, AGENT_KATA};
 use anyhow::{anyhow, Context, Result};
 use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
 use hypervisor::device::driver::{VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_PCI};
@@ -330,6 +330,30 @@ impl TemplateVm {
             hypervisor_config.cpu_info.default_vcpus,
             hypervisor_config.memory_info.default_memory,
         );
+
+        let readiness_result: Result<()> = async {
+            let address = hypervisor
+                .get_agent_socket()
+                .await
+                .context("get template VM agent socket")?;
+            agent
+                .start(&address)
+                .await
+                .context("connect to template VM agent")
+        }
+        .await;
+
+        if let Err(readiness_error) = readiness_result {
+            if let Err(teardown_error) = vm.teardown().await {
+                warn!(
+                    sl!(),
+                    "failed to tear down template VM after agent readiness failed: {}",
+                    teardown_error
+                );
+            }
+            return Err(readiness_error);
+        }
+
         Ok(vm)
     }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -33,7 +33,6 @@ use hypervisor::ch::CloudHypervisor;
 use hypervisor::device::topology::PCIePort;
 use hypervisor::device::util::{get_host_path, DEVICE_TYPE_CHAR};
 use hypervisor::remote::Remote;
-use hypervisor::{BlockConfigModern, Hypervisor, VfioDeviceBase, is_vfio_ap_device};
 use hypervisor::VsockConfig;
 use hypervisor::HYPERVISOR_REMOTE;
 #[cfg(all(
@@ -43,6 +42,7 @@ use hypervisor::HYPERVISOR_REMOTE;
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
+use hypervisor::{is_vfio_ap_device, BlockConfigModern, Hypervisor, VfioDeviceBase};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
     utils::{get_hvsock_path, uses_native_ccw_bus},

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -30,6 +30,7 @@ shim-interface.workspace = true
 kata-types.workspace = true
 kata-sys-util.workspace = true
 agent.workspace = true
+common.workspace = true
 virt_container.workspace = true
 serial_test.workspace = true
 vmm-sys-util.workspace = true
@@ -80,6 +81,11 @@ tempfile.workspace = true
 nix = { workspace = true }
 test-utils.workspace = true
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "5c2254d6cf4f32a668d0d8e57ba20bebad9d4fba" }
+
+[features]
+default = ["cloud-hypervisor"]
+cloud-hypervisor = ["virt_container/cloud-hypervisor"]
+dragonball = ["virt_container/dragonball"]
 
 [package.metadata.cargo-machete]
 ignored = ["strum"]

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -82,5 +82,10 @@ nix = { workspace = true }
 test-utils.workspace = true
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", rev = "5c2254d6cf4f32a668d0d8e57ba20bebad9d4fba" }
 
+[features]
+default = ["cloud-hypervisor"]
+cloud-hypervisor = ["virt_container/cloud-hypervisor"]
+dragonball = ["virt_container/dragonball"]
+
 [package.metadata.cargo-machete]
 ignored = ["strum"]

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -69,7 +69,7 @@ test: $(GENERATED_CODE)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test -p kata-ctl --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 install:
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path . --root $(INSTALL_PATH)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path . --root $(INSTALL_PATH) $(EXTRA_RUSTFEATURES)
 
 check: $(GENERATED_CODE) standard_rust_check
 

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -30,6 +30,16 @@ GENERATED_REPLACEMENTS= \
 
 GENERATED_FILES := $(GENERATED_CODE)
 
+EXTRA_RUSTFEATURES :=
+
+ifeq ($(USE_BUILTIN_DB),true)
+    EXTRA_RUSTFEATURES += dragonball
+endif
+
+ifneq ($(EXTRA_RUSTFEATURES),)
+    override EXTRA_RUSTFEATURES := --features $(EXTRA_RUSTFEATURES)
+endif
+
 .DEFAULT_GOAL := default
 
 ifeq ($(ARCH), ppc64le)

--- a/src/tools/kata-ctl/src/ops/factory_ops.rs
+++ b/src/tools/kata-ctl/src/ops/factory_ops.rs
@@ -4,12 +4,15 @@
 //
 
 use anyhow::{Context, Result};
+use common::RuntimeHandler;
 use tokio::runtime::Runtime;
-use virt_container::factory;
+use virt_container::{factory, VirtContainer};
 
 use crate::args::{FactoryArgs, FactorySubCommand};
 
 pub fn handle_factory(factory_args: FactoryArgs) -> Result<()> {
+    VirtContainer::init().context("initialize virtual-container runtime")?;
+
     let rt = Runtime::new().context("failed to create Tokio runtime")?;
     rt.block_on(async {
         match &factory_args.command {


### PR DESCRIPTION
This series adds checkpoint/restore (snapshot) support to the dragonball
VMM and wires it into the runtime-rs dragonball backend, so a sandbox VM
can be dumped once as a template and subsequent pods can be restored
from it instead of cold booting. The template is captured at a clean
quiesce point — after the sandbox VM has booted and its agent has
answered, but before any guest sandbox is created — giving the snapshot
branch semantics: the source VM keeps running and the restored VM
receives its first create_sandbox from the consuming pod.

The elapsed times of template start and cold start are 0.25s and 1.16s
respectively (~4.64x faster). The script of e2e tests can be found at [here](https://github.com/justxuewei/devkit/blob/main/scripts/kata-template/main.sh).

```bash
$ bash main.sh run-cold
=== cold start (plain /etc/kata-containers/runtime-rs/configuration.db.toml, no template) ===
shim config -> /etc/kata-containers/runtime-rs/configuration.db.toml
>>> sandbox boot (crictl runp) took 1.16s <<<
b90d47d058c8c0ca1ce73dd2cb1c29617f03bed326375cbbebcb617d6848d9ee
POD ID              CREATED             STATE               NAME                       NAMESPACE           ATTEMPT             RUNTIME
46d432cf89b07       1 second ago        Ready               kata-cold-pod-1784027341   default             0                   kata
container output: crictl logs b90d47d058c8c0ca1ce73dd2cb1c29617f03bed326375cbbebcb617d6848d9ee
$ bash main.sh run
=== [1/3] BootFromTemplate config ===
213:boot_to_be_template = false
214:boot_from_template = true
215:memory_path = "/run/vc/vm/template/memory"
216:device_state_path = "/run/vc/vm/template/state"
shim config -> /etc/kata-containers/runtime-rs/configuration.db.template-run.toml
=== [2/3] starting pod from template via crictl ===
>>> sandbox boot (crictl runp) took 0.25s <<<
pod sandbox: 6178b07d168a73e373fd58c1716d7df5003838dcff27af0ddd4b328d5dbadc15
49dd8232ad94201156da2a3e720f4e87fef03edafe3d41bcce2402e2ca4984ed
=== [3/3] result ===
POD ID              CREATED                  STATE               NAME                           NAMESPACE           ATTEMPT             RUNTIME
6178b07d168a7       Less than a second ago   Ready               kata-template-pod-1784027347   default             0                   kata
CONTAINER           IMAGE                              CREATED                  STATE               NAME                ATTEMPT             POD ID              POD
49dd8232ad942       docker.io/library/busybox:latest   Less than a second ago   Running             kata-template-ctr   0                   6178b07d168a7       unknown
container output: crictl logs 49dd8232ad94201156da2a3e720f4e87fef03edafe3d41bcce2402e2ca4984ed
```