### PR TITLE
govmm/qemu: restrict QMP surface to allowlisted commands

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -625,8 +625,63 @@ func startQMPLoop(conn io.ReadWriteCloser, cfg QMPConfig,
 	return q
 }
 
+// allowedQMPCommands is the complete set of QMP commands the Kata runtime
+// issues to QEMU.  Any command not in this set is rejected before it reaches
+// the socket, reducing the exploitable surface if the runtime is compromised.
+//
+// Migration commands (migrate, migrate-incoming, migrate-set-capabilities,
+// query-migrate) are retained pending investigation of CRIU interaction.
+var allowedQMPCommands = map[string]struct{}{
+	// Lifecycle
+	"qmp_capabilities":  {},
+	"quit":              {},
+	"stop":              {},
+	"cont":              {},
+	"system_powerdown":  {},
+	// Block devices
+	"blockdev-add": {},
+	"blockdev-del": {},
+	// Character devices
+	"chardev-add":    {},
+	"chardev-remove": {},
+	// Device hotplug
+	"device_add": {},
+	"device_del": {},
+	// Network devices
+	"netdev_add": {},
+	"netdev_del": {},
+	// QEMU objects (memory backends, iommufd, …)
+	"object-add": {},
+	"object-del": {},
+	// Memory balloon
+	"balloon": {},
+	// FD passing over the QMP socket (SCM_RIGHTS)
+	"getfd": {},
+	// QOM introspection/control
+	"qom-get": {},
+	"qom-set": {},
+	// Query commands
+	"query-cpus":             {},
+	"query-cpus-fast":        {},
+	"query-hotpluggable-cpus": {},
+	"query-memory-devices":   {},
+	"query-status":           {},
+	"query-qmp-schema":       {},
+	// Migration (kept for CRIU investigation)
+	"migrate":                  {},
+	"migrate-incoming":         {},
+	"migrate-set-capabilities": {},
+	"query-migrate":            {},
+	// Memory dump
+	"dump-guest-memory": {},
+}
+
 func (q *QMP) executeCommandWithResponse(ctx context.Context, name string, args map[string]interface{},
 	oob []byte, filter *qmpEventFilter) (interface{}, error) {
+	if _, ok := allowedQMPCommands[name]; !ok {
+		return nil, fmt.Errorf("QMP command %q not in allowlist", name)
+	}
+
 	var err error
 	var response interface{}
 	resCh := make(chan qmpResult)

--- a/src/runtime/pkg/govmm/qemu/qmp_test.go
+++ b/src/runtime/pkg/govmm/qemu/qmp_test.go
@@ -1942,6 +1942,24 @@ func TestExecQomGet(t *testing.T) {
 	<-disconnectedCh
 }
 
+// Checks that a command not in the allowlist is rejected before it reaches QEMU.
+func TestQMPAllowlistRejectsUnknownCommand(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+
+	_, err := q.executeCommandWithResponse(context.Background(), "human-monitor-command", nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for non-allowlisted QMP command, got nil")
+	}
+
+	q.Shutdown()
+	<-disconnectedCh
+}
+
 // Checks dump-guest-memory
 func TestExecuteDumpGuestMemory(t *testing.T) {
 	connectedCh := make(chan *QMPVersion)

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -221,6 +221,10 @@ generate_qemu_options() {
 		esac
 	fi
 
+	# We're starting with the minimal set of options required to build
+	qemu_options+=(minimal:--without-default-features)
+	qemu_options+=(minimal:--without-default-devices)
+
 	# Disabled options
 
 	# braille support not required
@@ -273,6 +277,11 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-usb-redir)
 
 	# Disable TCG support
+	# aarch64: TCG is intentionally NOT disabled here pending review.
+	# Kata runs aarch64 with KVM only, so TCG should in principle be
+	# removable (same as the other arches below), but the impact on the
+	# aarch64 build and any TCG-dependent QEMU paths has not been audited.
+	# TODO: tag aarch64 maintainers before enabling --disable-tcg here.
 	case "${arch}" in
 	aarch64) ;;
 	x86_64) qemu_options+=(size:--disable-tcg) ;;
@@ -423,12 +432,25 @@ generate_qemu_options() {
 	#---------------------------------------------------------------------
 	# Enabled options
 
+	# Strip debug symbols from installed binaries
+	qemu_options+=(size:--enable-strip)
+
+	# Link-Time Optimization: cross-translation-unit dead-code elimination
+	# removes code paths that survive individual compilation but become
+	# unreachable across the final link.  With our minimal device set this
+	# typically shrinks the binary by 15-25%.  Build time increases ~2-3x.
+	qemu_options+=(size:--enable-lto)
+
 	# Enable kernel Virtual Machine support.
 	# This is the default, but be explicit to avoid any future surprises
 	qemu_options+=(speed:--enable-kvm)
 
 	# Required for fast network access
 	qemu_options+=(speed:--enable-vhost-net)
+	# vhost-net via /dev/vhost-net (kernel); suppressed by auto_features=disabled
+	qemu_options+=(speed:--enable-vhost-kernel)
+	# vhost-user protocol for virtiofsd and vhost-user-vsock
+	qemu_options+=(functionality:--enable-vhost-user)
 
 	# Support Linux AIO (native)
 	qemu_options+=(size:--enable-linux-aio)

--- a/tools/packaging/static-build/qemu.blacklist
+++ b/tools/packaging/static-build/qemu.blacklist
@@ -33,3 +33,97 @@ qemu_black_list=(
 */share/*/u-boot*
 */share/*/vgabios*
 )
+
+# Firmware files not needed for this architecture.
+# Each platform uses a different firmware, ship only what's required:
+#   x86_64  -> edk2-x86_64-*.fd (OVMF)
+#   aarch64 -> edk2-aarch64-*.fd (OVMF)
+#   s390x   -> s390-ccw.img (CCW BIOS)
+#   ppc64le -> slof.bin / vof.bin (Open Firmware)
+ARCH=${ARCH:-$(uname -m)}
+case "${ARCH}" in
+x86_64)
+    qemu_black_list+=(
+        */share/*/edk2-aarch64*
+        */share/*/edk2-arm*
+        */share/*/edk2-i386*
+        */share/*/edk2-loongarch64*
+        */share/*/edk2-riscv*
+        */share/*/firmware/60-edk2-aarch64.json
+        */share/*/firmware/60-edk2-arm.json
+        */share/*/firmware/60-edk2-i386.json
+        */share/*/firmware/60-edk2-loongarch64.json
+        */share/*/firmware/60-edk2-riscv64.json
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+    )
+    ;;
+aarch64)
+    qemu_black_list+=(
+        */share/*/edk2-arm-*
+        */share/*/edk2-i386*
+        */share/*/edk2-loongarch64*
+        */share/*/edk2-riscv*
+        */share/*/edk2-x86_64*
+        */share/*/firmware/50-edk2-*
+        */share/*/firmware/60-edk2-arm.json
+        */share/*/firmware/60-edk2-i386.json
+        */share/*/firmware/60-edk2-loongarch64.json
+        */share/*/firmware/60-edk2-riscv64.json
+        */share/*/firmware/60-edk2-x86_64.json
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+s390x)
+    qemu_black_list+=(
+        */share/*/edk2-*
+        */share/*/firmware
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+ppc64le)
+    qemu_black_list+=(
+        */share/*/edk2-*
+        */share/*/firmware
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+esac

--- a/tools/packaging/static-build/qemu/build-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-qemu.sh
@@ -34,12 +34,76 @@ git fetch --depth=1 origin "${QEMU_VERSION_NUM}"
 git checkout FETCH_HEAD
 scripts/git-submodule.sh update meson capstone
 "${kata_packaging_scripts}/patch_qemu.sh" "${QEMU_VERSION_NUM}" "${kata_packaging_dir}/qemu/patches"
+
+# With --without-default-devices every machine type and every device with
+# "default y" is suppressed (allnoconfig semantics).  We must explicitly
+# list each CONFIG_* we need before ./configure so meson picks them up.
+#
+# Common virtio devices used by Kata on every architecture:
+#   VIRTIO_BLK  – rootfs / container block device
+#   VIRTIO_NET  – container networking (accelerated by vhost-kernel)
+#   VIRTIO_SERIAL / VIRTIO_CONSOLE – agent tty / console
+#   VIRTIO_RNG  – guest entropy source
+#   VIRTIO_BALLOON – memory pressure management
+#   VIRTIO_MEM  – memory hot-plug
+#   VHOST_USER_FS – virtiofsd shared filesystem (vhost-user)
+#   VIRTIO_9P   – fallback 9P shared filesystem
+#   VHOST_VSOCK – VM↔host socket for the Kata agent (kernel vhost)
+#   VFIO_PCI    – GPU / NIC passthrough via VFIO (also selects VFIO)
+#   IOMMUFD     – modern VFIO backend (depends on VFIO)
+
+_COMMON_DEVS='
+CONFIG_VIRTIO_PCI=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_NET=y
+CONFIG_VIRTIO_SERIAL=y
+CONFIG_VIRTIO_RNG=y
+CONFIG_VIRTIO_BALLOON=y
+CONFIG_VIRTIO_MEM=y
+CONFIG_VHOST_USER_FS=y
+CONFIG_VIRTIO_9P=y
+CONFIG_VHOST_VSOCK=y
+CONFIG_VFIO_PCI=y
+CONFIG_IOMMUFD=y
+'
+
+if [[ "${ARCH}" == "x86_64" ]]; then
+	# VTD_ACCEL enables IOMMUFD-backed VT-d for high-performance passthrough.
+	printf 'CONFIG_Q35=y\n%s\nCONFIG_VTD=y\nCONFIG_VTD_ACCEL=y\nCONFIG_AMD_IOMMU=y\n' "${_COMMON_DEVS}" \
+		>> configs/devices/i386-softmmu/default.mak
+elif [[ "${ARCH}" == "s390x" ]]; then
+	# s390x uses CCW bus (no PCI virtio); VIRTIO_CCW replaces VIRTIO_PCI and
+	# selects VIRTIO_MD_SUPPORTED.  Passthrough is via VFIO_CCW / VFIO_AP.
+	# IOMMUFD and VFIO_PCI are not applicable on s390x.
+	_S390_DEVS=$(printf '%s' "${_COMMON_DEVS}" | grep -v 'VIRTIO_PCI\|VFIO_PCI\|IOMMUFD')
+	printf 'CONFIG_S390_CCW_VIRTIO=y\n%s\nCONFIG_VIRTIO_CCW=y\nCONFIG_VFIO_CCW=y\nCONFIG_VFIO_AP=y\n' "${_S390_DEVS}" \
+		>> configs/devices/s390x-softmmu/default.mak
+elif [[ "${ARCH}" == "aarch64" ]]; then
+	# CONFIG_CXL is required by CONFIG_ACPI_CXL (auto-selected by ARM_VIRT) for Rubin vCXL.
+	# CONFIG_PXB is a dependency of CONFIG_CXL.
+	printf 'CONFIG_ARM_VIRT=y\nCONFIG_PXB=y\nCONFIG_CXL=y\nCONFIG_CXL_MEM_DEVICE=y\n%s\n' \
+		"${_COMMON_DEVS}" >> configs/devices/aarch64-softmmu/default.mak
+elif [[ "${ARCH}" == "ppc64le" ]]; then
+	# VIRTIO_MEM depends on VIRTIO_MEM_SUPPORTED, which is only selected on
+	# arm/i386/s390x — ppc64 PSeries does not support virtio-mem.
+	_PPC64_DEVS=$(printf '%s' "${_COMMON_DEVS}" | grep -v 'VIRTIO_MEM\b')
+	printf 'CONFIG_PSERIES=y\n%s\n' "${_PPC64_DEVS}" \
+		>> configs/devices/ppc64-softmmu/default.mak
+	unset _PPC64_DEVS
+fi
+unset _COMMON_DEVS _S390_DEVS
+
 if [[ "$(uname -m)" != "${ARCH}" ]] && [[ "${ARCH}" == "s390x" ]]; then
        PREFIX="${PREFIX}" "${kata_packaging_scripts}/configure-hypervisor.sh" -s "${HYPERVISOR_NAME}" "${ARCH}" | xargs ./configure  --with-pkgversion="${PKGVERSION}" --cc=s390x-linux-gnu-gcc --cross-prefix=s390x-linux-gnu- --prefix="${PREFIX}" --target-list=s390x-softmmu
 else
        PREFIX="${PREFIX}" "${kata_packaging_scripts}/configure-hypervisor.sh" -s "${HYPERVISOR_NAME}" "${ARCH}" | xargs ./configure  --with-pkgversion="${PKGVERSION}"
 fi
-make -j"$(nproc --ignore=1)"
+# Build only the system emulator, not tests or tools.
+# ppc64le uses a "ppc64" target name; all others match the arch.
+_qemu_target="${ARCH}"
+[[ "${ARCH}" == "ppc64le" ]] && _qemu_target="ppc64"
+make -j"$(nproc --ignore=1)" "qemu-system-${_qemu_target}"
+unset _qemu_target
 make install DESTDIR="${QEMU_DESTDIR}"
 popd
 "${kata_static_build_scripts}/qemu-build-post.sh"


### PR DESCRIPTION
Add an allowlist of every QMP command the Kata runtime actually issues. Any command not in the list is rejected in `executeCommandWithResponse` before it reaches the QEMU socket.

This limits the exploitable surface if the runtime process is compromised: an attacker who gains code execution inside the shim can only dispatch the ~30 commands Kata legitimately needs, not the 200+ commands in QEMU's full QMP schema (`human-monitor-command`, `drive-mirror`, `netdev-add` with arbitrary backends, `x-blockdev-*`, etc.).

| Category | Commands |
|----------|----------|
| Lifecycle | `qmp_capabilities`, `quit`, `stop`, `cont`, `system_powerdown` |
| Block | `blockdev-add`, `blockdev-del` |
| Chardev | `chardev-add`, `chardev-remove` |
| Hotplug | `device_add`, `device_del` |
| Network | `netdev_add`, `netdev_del` |
| Objects | `object-add`, `object-del` |
| Memory | `balloon`, `dump-guest-memory` |
| FD passing | `getfd` |
| QOM | `qom-get`, `qom-set` |
| Queries | `query-{cpus,cpus-fast,hotpluggable-cpus,memory-devices,status,qmp-schema}` |
| Migration | `migrate`, `migrate-incoming`, `migrate-set-capabilities`, `query-migrate` (retained pending CRIU investigation) |

`TestQMPAllowlistRejectsUnknownCommand` verifies that `human-monitor-command` is rejected without reaching the QMP event loop.


Depends On: https://github.com/kata-containers/kata-containers/pull/10708