### PR TITLE
kata-deploy/nvidia: add NVIDIA CPU values file

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -297,6 +297,24 @@ Includes:
 - `qemu-coco-dev` - Confidential Containers development (amd64, s390x)
 - `qemu-coco-dev-runtime-rs` - Confidential Containers development Rust runtime (amd64, arm64, s390x)
 
+### [`try-kata-nvidia-cpu.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml)
+
+This file enables only the NVIDIA CPU-only shims and installs them using the
+[`job` deployment mode](#deployment-modes-daemonset-vs-job) (no always-on
+DaemonSet on the node):
+
+```sh
+helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
+  --version VERSION \
+  -f try-kata-nvidia-cpu.values.yaml
+```
+
+Includes:
+
+- `qemu-nvidia-cpu` - NVIDIA base image without GPU passthrough (amd64, arm64)
+- `qemu-nvidia-cpu-runtime-rs` - NVIDIA base image without GPU passthrough,
+  using the Rust runtime (amd64, arm64)
+
 ### [`try-kata-nvidia-gpu.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml)
 
 This file enables only the NVIDIA GPU-enabled shims and installs them using the
@@ -504,4 +522,3 @@ no manual `runtimeClass.nodeSelector` is set for that shim.
 **Note**: NFD detection requires cluster access. During `helm template` (dry-run without a
 cluster), external NFD is not seen, so auto-injected labels are not added. Manual
 `runtimeClass.nodeSelector` values are still applied in all cases.
-

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -701,6 +701,12 @@ function helm_helper() {
 	local base_values_file="${helm_chart_dir}/values.yaml"
 	if [[ -n "${KATA_HYPERVISOR}" ]]; then
 		case "${KATA_HYPERVISOR}" in
+			*nvidia-cpu*)
+				# Use NVIDIA CPU example file
+				if [[ -f "${helm_chart_dir}/try-kata-nvidia-cpu.values.yaml" ]]; then
+					base_values_file="${helm_chart_dir}/try-kata-nvidia-cpu.values.yaml"
+				fi
+				;;
 			*nvidia-gpu*)
 				# Use NVIDIA GPU example file
 				if [[ -f "${helm_chart_dir}/try-kata-nvidia-gpu.values.yaml" ]]; then

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -78,7 +78,7 @@ else
 		"k8s-nvidia-nim-service.bats")
 fi
 
-SUPPORTED_HYPERVISORS=("qemu-nvidia-cpu" "qemu-nvidia-cpu-runtime-rs" "qemu-nvidia-gpu" "qemu-nvidia-gpu-snp" "qemu-nvidia-gpu-tdx" "qemu-nvidia-gpu-runtime-rs" "qemu-nvidia-gpu-snp-runtime-rs" "qemu-nvidia-gpu-tdx-runtime-rs")
+SUPPORTED_HYPERVISORS=("qemu-nvidia-gpu" "qemu-nvidia-gpu-snp" "qemu-nvidia-gpu-tdx" "qemu-nvidia-gpu-runtime-rs" "qemu-nvidia-gpu-snp-runtime-rs" "qemu-nvidia-gpu-tdx-runtime-rs")
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu-nvidia-gpu}"
 # shellcheck disable=SC2076 # intentionally use literal string matching
 if [[ ! " ${SUPPORTED_HYPERVISORS[*]} " =~ " ${KATA_HYPERVISOR} " ]]; then

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -1,0 +1,51 @@
+# Example values file to enable NVIDIA CPU shims
+# This includes all NVIDIA CPU-only shims: qemu-nvidia-cpu,
+# qemu-nvidia-cpu-runtime-rs.
+#
+# Usage:
+#   helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
+#     --version VERSION \
+#     -f try-kata-nvidia-cpu.values.yaml
+
+debug: false
+
+# Install Kata via short-lived per-node Jobs instead of an always-on DaemonSet.
+# A tiny dispatcher Job fans out one install Job per selected node and exits, so
+# nothing keeps running on the node once the install completes.
+deploymentMode: job
+
+snapshotter:
+  setup: []
+
+# Enable NVIDIA CPU shims
+# Disable all shims at once, then enable only the ones we need.
+shims:
+  disableAll: true
+
+  qemu-nvidia-cpu:
+    enabled: true
+    supportedArches:
+      - amd64
+      - arm64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: ""
+
+  qemu-nvidia-cpu-runtime-rs:
+    enabled: true
+    supportedArches:
+      - amd64
+      - arm64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: ""
+
+# Default shim per architecture.
+defaultShim:
+  amd64: qemu-nvidia-cpu
+  arm64: qemu-nvidia-cpu
+
+runtimeClasses:
+  enabled: true
+  createDefault: false
+  defaultName: "kata"


### PR DESCRIPTION
This is some touch-up work based on #13349:
- remove the CPU-only NVIDIA runtime classes from `run_kubernetes_nv_tests.sh`. The base CPU runtime classes may be able to run parts of the NUMA tests, but if we aim to run (part of) the (current) NUMA tests we should not need to hook non-GPU handlers into the `run_kubernetes_nv_tests.sh`.
- add a dedicated `try-kata-nvidia-cpu.values.yaml` example file for the CPU-only NVIDIA runtime classes and use it in the  Kubernetes CI Helm helper. This gives the CPU-only handlers their own example deployment configuration.
