### PR TITLE
kata-deploy: poll per-node Jobs by get (instead of list) & clean up dispatcher RBAC on uninstall

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-cleanup-rbac-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-cleanup-rbac-job.yaml
@@ -82,6 +82,19 @@ spec:
               delete_one clusterrolebinding "${CLUSTER_ROLE_BINDING_NAME}" ""
               delete_one clusterrole "${CLUSTER_ROLE_NAME}" ""
               delete_one serviceaccount "${SERVICE_ACCOUNT_NAME}" "${NAMESPACE}"
+{{- if eq (.Values.deploymentMode | default "daemonset") "job" }}
+              echo "Removing job-mode dispatcher RBAC (if present)..."
+              echo "  [RoleBinding] ${DISPATCHER_ROLE_BINDING_NAME} (namespace: ${NAMESPACE})"
+              echo "  [Role] ${DISPATCHER_ROLE_NAME} (namespace: ${NAMESPACE})"
+              echo "  [ClusterRoleBinding] ${DISPATCHER_NODE_ROLE_BINDING_NAME}"
+              echo "  [ClusterRole] ${DISPATCHER_NODE_ROLE_NAME}"
+              echo "  [ServiceAccount] ${DISPATCHER_SERVICE_ACCOUNT_NAME} (namespace: ${NAMESPACE})"
+              delete_one rolebinding "${DISPATCHER_ROLE_BINDING_NAME}" "${NAMESPACE}"
+              delete_one role "${DISPATCHER_ROLE_NAME}" "${NAMESPACE}"
+              delete_one clusterrolebinding "${DISPATCHER_NODE_ROLE_BINDING_NAME}" ""
+              delete_one clusterrole "${DISPATCHER_NODE_ROLE_NAME}" ""
+              delete_one serviceaccount "${DISPATCHER_SERVICE_ACCOUNT_NAME}" "${NAMESPACE}"
+{{- end }}
               echo "Kata-deploy RBAC cleanup completed."
           env:
             - name: NAMESPACE
@@ -109,4 +122,16 @@ spec:
               value: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
               value: {{ .Chart.Name }}-sa
+{{- end }}
+{{- if eq (.Values.deploymentMode | default "daemonset") "job" }}
+            - name: DISPATCHER_SERVICE_ACCOUNT_NAME
+              value: {{ include "kata-deploy.dispatcherServiceAccountName" . }}
+            - name: DISPATCHER_NODE_ROLE_NAME
+              value: {{ .Chart.Name }}-dispatcher-noderole{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+            - name: DISPATCHER_NODE_ROLE_BINDING_NAME
+              value: {{ .Chart.Name }}-dispatcher-noderb{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+            - name: DISPATCHER_ROLE_NAME
+              value: {{ .Chart.Name }}-dispatcher-role{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+            - name: DISPATCHER_ROLE_BINDING_NAME
+              value: {{ .Chart.Name }}-dispatcher-rb{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -108,10 +108,10 @@ metadata:
   name: {{ .Chart.Name }}-dispatcher-role{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
   namespace: {{ .Release.Namespace }}
 rules:
-# The dispatcher only ever creates/watches/GCs per-node Jobs in its own namespace.
+# The dispatcher only ever creates, polls, and deletes per-node Jobs in its own namespace.
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["create", "get", "list", "watch", "delete"]
+  verbs: ["create", "get", "delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -158,7 +158,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "clusterrolebindings"]
+  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
   verbs: ["delete"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]

--- a/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
@@ -96,7 +96,7 @@ pub fn sanitize_label_value(value: &str) -> String {
 
 /// True if `job` carries [`OWNER_LABEL`] set to exactly `owner_value`. Used to
 /// decide whether a pre-existing (409) Job is safe to adopt: the dispatcher
-/// only ever LISTs Jobs by that label, so adopting one that lacks it would
+/// only ever GETs in-flight Jobs by name, so adopting one that lacks it would
 /// leave it stuck in-flight forever.
 pub fn job_owned_by(job: &Job, owner_value: &str) -> bool {
     job.metadata

--- a/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
@@ -14,7 +14,7 @@
 //! completed pods when balancing the spread).
 //!
 //! It has no host dependencies and only needs RBAC to list nodes and to
-//! manage Jobs in its namespace.
+//! create/get/delete Jobs in its namespace.
 
 mod job;
 
@@ -256,7 +256,6 @@ async fn run_fanout(
     // prefix; sanitize it once so it is a valid label value / DNS-1123 prefix
     // regardless of what the caller passed (e.g. a Helm release suffix).
     let owner_value = sanitize_label_value(&args.name_prefix);
-    let owner_selector = format!("{OWNER_LABEL}={owner_value}");
 
     while !queue.is_empty() || !in_flight.is_empty() {
         // Refill the in-flight set up to the parallelism cap.
@@ -270,10 +269,10 @@ async fn run_fanout(
                 Ok(_) => info!("created job {name} (node {node})"),
                 // A Job with this name already exists (e.g. left over from a
                 // previous, interrupted run). Only adopt it if it actually
-                // carries our owner label: status polling LISTs Jobs by that
-                // label, so adopting one that lacks it (or belongs to someone
-                // else) would leave it stuck in-flight forever. If it is not
-                // ours, fail the node instead of hanging.
+                // carries our owner label: status polling GETs each in-flight
+                // Job by name, so adopting one that lacks it (or belongs to
+                // someone else) would leave it stuck in-flight forever. If it
+                // is not ours, fail the node instead of hanging.
                 Err(kube::Error::Api(e)) if e.code == 409 => match jobs.get(&name).await {
                     Ok(existing) if job_owned_by(&existing, &owner_value) => {
                         info!("job {name} (node {node}) already exists and is ours, adopting it");
@@ -307,28 +306,18 @@ async fn run_fanout(
 
         tokio::time::sleep(poll).await;
 
-        // One LIST per poll returns the status of all our Jobs at once.
-        let lp = ListParams {
-            label_selector: Some(owner_selector.clone()),
-            ..Default::default()
-        };
-        let listed = jobs
-            .list(&lp)
-            .await
-            .context("failed to list per-node jobs")?;
-        let mut status_by_name: HashMap<&str, &Job> = HashMap::new();
-        for j in &listed.items {
-            if let Some(name) = j.metadata.name.as_deref() {
-                status_by_name.insert(name, j);
-            }
-        }
-
+        // Poll each in-flight Job via GET so we only need the `get` verb on
+        // batch/jobs (not `list`), matching the least-privilege Role.
         let mut finished: Vec<String> = Vec::new();
         for (name, node) in &in_flight {
-            let Some(j) = status_by_name.get(name.as_str()) else {
-                continue;
+            let j = match jobs.get(name).await {
+                Ok(j) => j,
+                Err(e) => {
+                    error!("failed to get job {name} (node {node}): {e}");
+                    continue;
+                }
             };
-            match interpret_status(j) {
+            match interpret_status(&j) {
                 JobOutcome::Succeeded => {
                     succeeded += 1;
                     finished.push(name.clone());


### PR DESCRIPTION
The job dispatcher now GETs each in-flight Job by name when tracking
progress, so it no longer needs the list verb on batch/jobs. Trim the
dispatcher Role to match.

---

Extend the post-delete RBAC cleanup Job to remove job-mode dispatcher
identities (ServiceAccount, Role, RoleBinding, ClusterRole, and
ClusterRoleBinding) so reinstalls are not blocked by leftovers.