### PR TITLE
tests: Fix helm key names for IBM SEL and bump Trustee

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -528,14 +528,14 @@ function kbs_k8s_deploy() {
 
 	# Handle IBM SE (s390x): the SE verifier runs inside the gRPC Attestation
 	# Service, so the SE materials are mounted on the AS Pod (not KBS) via the
-	# chart's as.ibmse.* knobs, which create a node-local PV/PVC pointing at
+	# chart's as.verifier.se.* knobs, which create a node-local PV/PVC pointing at
 	# ${IBM_SE_CREDS_DIR} on the target node.
 	if [[ "${KATA_HYPERVISOR}" == qemu-se* ]]; then
 		local node_name
 		node_name=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 		prepare_credentials_for_qemu_se
-		helm_set_args+=(--set "as.ibmse.credsDir=${IBM_SE_CREDS_DIR:-}")
-		helm_set_args+=(--set "as.ibmse.nodeName=${node_name}")
+		helm_set_args+=(--set "as.verifier.se.credsDir=${IBM_SE_CREDS_DIR:-}")
+		helm_set_args+=(--set "as.verifier.se.nodeName=${node_name}")
 		# fsGroup must match the owning GID of the files under credsDir so the
 		# non-root AS container (CAP_DAC_OVERRIDE dropped) can read them.
 		helm_set_args+=(--set "as.podSecurityContext.fsGroup=1000")

--- a/versions.yaml
+++ b/versions.yaml
@@ -310,16 +310,16 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "80a3c55e68e7d81fd31730ce9d49031f989e6c72"
+    version: "b6c8dc2bbb9374e00cb15e51acd8ba99b4febd7a"
     # image and image_tag must be in sync
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "80a3c55e68e7d81fd31730ce9d49031f989e6c72"
+    image_tag: "b6c8dc2bbb9374e00cb15e51acd8ba99b4febd7a"
     toolchain: "1.90.0"
     # Helm chart deploys three separate images (kbs, as, rvps)
     # yamllint disable rule:line-length
-    image_kbs: "ghcr.io/confidential-containers/staged-images/kbs-grpc-as:80a3c55e68e7d81fd31730ce9d49031f989e6c72"
-    image_as: "ghcr.io/confidential-containers/staged-images/coco-as-grpc:80a3c55e68e7d81fd31730ce9d49031f989e6c72"
-    image_rvps: "ghcr.io/confidential-containers/staged-images/rvps:80a3c55e68e7d81fd31730ce9d49031f989e6c72"
+    image_kbs: "ghcr.io/confidential-containers/staged-images/kbs-grpc-as:b6c8dc2bbb9374e00cb15e51acd8ba99b4febd7a"
+    image_as: "ghcr.io/confidential-containers/staged-images/coco-as-grpc:b6c8dc2bbb9374e00cb15e51acd8ba99b4febd7a"
+    image_rvps: "ghcr.io/confidential-containers/staged-images/rvps:b6c8dc2bbb9374e00cb15e51acd8ba99b4febd7a"
     # yamllint enable rule:line-length
 
   containerd:


### PR DESCRIPTION
As https://github.com/confidential-containers/trustee/pull/1486 is merged, update confidential_kbs.sh to use the renamed Helm chart knobs for IBM SEL credentials: `as.ibmse.*` → `as.verifier.se.*`.

Bump coco-trustee version and all associated image tags from 80a3c55e to b6c8dc2b accordingly.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>