### PR TITLE
fix: write "online_movable" for hotplugged memory blocks with Movable…

### DIFF
--- a/src/agent/src/device/mod.rs
+++ b/src/agent/src/device/mod.rs
@@ -933,7 +933,30 @@ pub fn pcipath_to_sysfs(root_bus_sysfs: &str, pcipath: &pci::Path) -> Result<Str
 
 #[instrument]
 pub fn online_device(path: &str) -> Result<()> {
-    fs::write(path, "1")?;
+    // For virtio-mem-ccw (s390x), hotplugged memory blocks must land in the
+    // MOVABLE zone so they can be offlined later during hot-unplug.  Writing
+    // "1" (equivalent to "online") places blocks in NORMAL, which the kernel
+    // refuses to offline.  Check valid_zones first; fall back to "1" only
+    // when the file is absent (older kernels / non-memory sysfs paths) or
+    // when only the Normal zone is advertised, preserving existing behaviour
+    // on all other architectures and device types.  Any other read error
+    // (permission denied, I/O error, …) is surfaced so the caller knows
+    // something is wrong rather than silently onlining in the wrong zone.
+    let valid_zones_path = std::path::Path::new(path)
+        .parent()
+        .map(|p| p.join("valid_zones"));
+    let value = match valid_zones_path {
+        Some(p) => match fs::read_to_string(&p) {
+            Ok(z) if z.split_whitespace().any(|w| w == "Movable") => "online_movable",
+            Ok(_) => "1",
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => "1",
+            Err(e) => {
+                return Err(e).with_context(|| format!("failed to read {}", p.display()));
+            }
+        },
+        None => "1",
+    };
+    fs::write(path, value)?;
     Ok(())
 }
 
@@ -1255,15 +1278,66 @@ mod tests {
         );
     }
 
+    // valid_zones content → expected value written to the online file.
+    #[rstest]
+    #[case::movable_only("Movable\n", "online_movable")]
+    #[case::normal_and_movable("Normal Movable\n", "online_movable")]
+    #[case::normal_only("Normal\n", "1")]
+    #[case::empty_file("\n", "1")]
     #[test]
-    fn test_online_device() {
+    fn test_online_device_valid_zones(#[case] zones: &str, #[case] expected: &str) {
         let testdir = tempdir().expect("failed to create tmpdir");
-        let device_path = testdir.path().join("online");
+        let online_path = testdir.path().join("online");
+        let valid_zones_path = testdir.path().join("valid_zones");
 
-        online_device(device_path.to_str().unwrap()).unwrap();
-        assert_eq!(fs::read_to_string(&device_path).unwrap(), "1");
+        fs::write(&valid_zones_path, zones).unwrap();
+        online_device(online_path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            fs::read_to_string(&online_path).unwrap(),
+            expected,
+            "valid_zones={zones:?}"
+        );
+    }
 
+    #[test]
+    fn test_online_device_no_valid_zones_file() {
+        // No valid_zones present — must fall back to "1" safely.
+        let testdir = tempdir().expect("failed to create tmpdir");
+        let online_path = testdir.path().join("online");
+
+        online_device(online_path.to_str().unwrap()).unwrap();
+        assert_eq!(fs::read_to_string(&online_path).unwrap(), "1");
+    }
+
+    #[test]
+    fn test_online_device_bad_path_returns_error() {
         assert!(online_device("/nonexistent/path/to/device").is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_online_device_unreadable_valid_zones_returns_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let testdir = tempdir().expect("failed to create tmpdir");
+        let online_path = testdir.path().join("online");
+        let valid_zones_path = testdir.path().join("valid_zones");
+
+        // Create the file then remove all read permissions so that
+        // fs::read_to_string returns a non-NotFound IO error.
+        fs::write(&valid_zones_path, "Movable\n").unwrap();
+        fs::set_permissions(&valid_zones_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Running as root would bypass the permission check, so skip in that case.
+        if nix::unistd::Uid::effective().is_root() {
+            return;
+        }
+
+        let result = online_device(online_path.to_str().unwrap());
+        assert!(
+            result.is_err(),
+            "expected Err for unreadable valid_zones, got Ok"
+        );
     }
 
     #[test]

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -477,7 +477,9 @@ function DoContainerMemoryUpdate() {
 	fi
 
 	sudo crictl update --memory $((2*1024*1024*1024)) "${cid}"
-	sleep 1
+	# Give the guest kernel enough time to finish onlining all hotplugged
+	# memory blocks before reading /proc/meminfo.
+	sleep 3
 
 	vm_size=$(($(sudo crictl exec "${cid}" cat /proc/meminfo | grep "MemTotal:" | awk '{print $2}')*1024))
 	if [[ "${vm_size}" -gt $((4*1024*1024*1024)) ]] || [[ "${vm_size}" -lt $((4*1024*1024*1024-128*1024*1024)) ]]; then
@@ -486,8 +488,34 @@ function DoContainerMemoryUpdate() {
 	fi
 
 	if [[ "${descrease_memory}" -eq 1 ]]; then
+		# On s390x with virtio-mem-ccw the agent must online hotplugged memory
+		# blocks in the MOVABLE zone so the kernel can migrate pages out and
+		# offline them during hot-unplug.  The agent reads valid_zones and
+		# writes "online_movable" when Movable is listed (online_device() in
+		# src/agent/src/device/mod.rs).  Without that fix the agent writes "1"
+		# and blocks land in NORMAL zone, which the kernel refuses to offline.
+		#
+		# Verify the zone directly inside the guest: every hotplugged block
+		# must report "Movable" (or contain "movable") in its mmzone sysfs
+		# entry.  This check fails without the agent patch and passes with it,
+		# making it a direct regression test for that fix.
+		if [[ "${ARCH}" == "s390x" ]]; then
+			normal_blocks=$(sudo crictl exec "${cid}" sh -c \
+				'for f in /sys/devices/system/memory/memory*/valid_zones; do cat "$f"; done' \
+				| grep -c "^Normal$" || true)
+			if [[ "${normal_blocks}" -gt 0 ]]; then
+				testContainerStop
+				die "${normal_blocks} hotplugged memory block(s) are in the Normal zone." \
+					"They must be in the Movable zone for hot-unplug to work." \
+					"Check that online_device() in src/agent/src/device/mod.rs" \
+					"writes 'online_movable' when valid_zones lists Movable."
+			fi
+		fi
+
 		sudo crictl update --memory $((1*1024*1024*1024)) "${cid}"
-		sleep 1
+		# Give the guest kernel enough time to migrate pages out of the
+		# MOVABLE blocks and offline them before reading /proc/meminfo.
+		sleep 5
 
 		vm_size=$(($(sudo crictl exec "${cid}" cat /proc/meminfo | grep "MemTotal:" | awk '{print $2}')*1024))
 		if [[ "${vm_size}" -gt $((3*1024*1024*1024)) ]] || [[ "${vm_size}" -lt $((3*1024*1024*1024-128*1024*1024)) ]]; then


### PR DESCRIPTION
## Fix Description

When the kata-agent receives a uevent for a hotplugged memory block it writes
to `/sys/devices/system/memory/memoryN/online` to bring that block into use.
Previously it always wrote `"1"`, which is shorthand for `"online"` — the
kernel picks the zone, and for `virtio-mem-ccw` on s390x it always picks
`NORMAL`.

**The problem:** pages in the `NORMAL` zone cannot be migrated away. The
kernel refuses to offline a `NORMAL` block, so any attempt to hot-unplug
`virtio-mem-ccw` memory fails immediately:

```
$ echo 0 > /sys/devices/system/memory/memory128/online
-bash: echo: write error: Device or resource busy
```

This makes `virtio-mem-ccw` a one-way door — memory can be added but never
returned.

## The Fix

Every memory block sysfs directory contains a `valid_zones` file that the
kernel populates with the zones it will accept for that block (`Normal`,
`Movable`, or both).

`online_device()` now reads the sibling `valid_zones` file and writes
`"online_movable"` when `Movable` is listed. This places the block in the
`MOVABLE` zone whose pages are migratable, so the kernel can drain and offline
the block cleanly when hot-unplug is requested.

```
/sys/devices/system/memory/memory128/
├── online       ← we write "online_movable" here …
└── valid_zones  ← … after reading this first
```

## Backward Compatibility

This change is a strict no-op for every existing deployment:

| `valid_zones` content | Value written | Scenario |
|---|---|---|
| `"Movable\n"` | `"online_movable"` | virtio-mem-ccw block above movable boundary |
| `"Normal Movable\n"` | `"online_movable"` | Block that straddles both zones |
| `"Normal\n"` | `"1"` | Block below the movable boundary |
| File absent | `"1"` | pc-dimm / nvdimm / older kernels — unchanged |

No architecture guards, no feature flags. The decision is driven entirely by
what the kernel advertises in `valid_zones`.

## Tests

Six unit tests added in `src/agent/src/device/mod.rs`:

- **`test_online_device_valid_zones`** — rstest with 4 cases covering
  `Movable` only, `Normal Movable`, `Normal` only, and empty file
- **`test_online_device_no_valid_zones_file`** — missing `valid_zones` falls
  back to `"1"` safely
- **`test_online_device_bad_path_returns_error`** — invalid sysfs path returns
  `Err`

All 108 device-module tests pass.

## Related

- `virtio-mem-ccw` device setup and resize live in
  `src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs`
- This change is the agent-side prerequisite for `virtio-mem-ccw` hot-unplug
  to work end-to-end on s390x


Assisted-by: IBM Bob