### PR TITLE
packaging: use Ubuntu noble for vanilla guest initrd

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -829,10 +829,8 @@ install_initrd() {
 			export PAUSE_IMAGE_TARBALL
 		fi
 	else
-		# No variant is passed, it means vanilla kata containers
-		if [[ "${os_name}" = "alpine" ]]; then
-			export AGENT_INIT=yes
-		fi
+		# Vanilla initrd uses kata-agent as /sbin/init (no systemd).
+		export AGENT_INIT=yes
 	fi
 
 	AGENT_TARBALL=$(get_agent_tarball_path)

--- a/versions.yaml
+++ b/versions.yaml
@@ -181,8 +181,8 @@ assets:
     url: "https://github.com/kata-containers/kata-containers/tools/osbuilder"
     architecture:
       aarch64:
-        name: "alpine"
-        version: "3.22"
+        name: "ubuntu"
+        version: "noble"  # 24.04 LTS
         confidential:
           name: "ubuntu"
           version: "noble"  # 24.04 LTS
@@ -204,8 +204,8 @@ assets:
           name: "ubuntu"
           version: "noble"  # 24.04 LTS
       x86_64:
-        name: "alpine"
-        version: "3.22"
+        name: "ubuntu"
+        version: "noble"  # 24.04 LTS
         confidential:
           name: "ubuntu"
           version: "noble"  # 24.04 LTS


### PR DESCRIPTION
The CI agent tarball is GNU-linked (USE_DEVMAPPER=yes) and does not run
reliably on Alpine/musl initrd.

Use Ubuntu noble for x86_64 and aarch64 vanilla initrd, matching the
other initrd variants, with kata-agent as /sbin/init.