### PR TITLE
kata-deploy: fix kata-monitor CRI socket mount for non-vanilla clusters

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -125,6 +125,24 @@ Used for kata-monitor volume hostPath and mountPath so the socket is reachable i
 {{- end -}}
 
 {{/*
+Resolve kata-monitor log level.
+Honors monitor.logLevel, then the chart-wide logLevel, then debug:true -> debug.
+*/}}
+{{- define "monitorLogLevel" -}}
+{{- $logLevel := .Values.monitor.logLevel | default "" | trim -}}
+{{- if not $logLevel -}}
+{{- $logLevel = .Values.logLevel | default "" | trim -}}
+{{- end -}}
+{{- if and (not $logLevel) .Values.debug -}}
+{{- $logLevel = "debug" -}}
+{{- end -}}
+{{- if not $logLevel -}}
+{{- $logLevel = "info" -}}
+{{- end -}}
+{{- $logLevel -}}
+{{- end -}}
+
+{{/*
 Check if node-feature-discovery is already installed by someone else
 Returns the namespace where node-feature-discovery is found, or empty string if not found
 */}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -72,6 +72,59 @@ If containerd.configDir is set explicitly, use that instead.
 {{- end -}}
 
 {{/*
+Set the CRI containerd socket URI depending on the k8s distribution.
+If containerd.runtimeSocket is set explicitly, use that instead.
+*/}}
+{{- define "containerdRuntimeSocket" -}}
+{{- if and .containerd .containerd.runtimeSocket -}}
+{{- .containerd.runtimeSocket -}}
+{{- else if or (eq .k8sDistribution "k3s") (eq .k8sDistribution "rke2") -}}
+unix:///run/k3s/containerd/containerd.sock
+{{- else if eq .k8sDistribution "k0s" -}}
+unix:///run/k0s/containerd.sock
+{{- else if eq .k8sDistribution "microk8s" -}}
+unix:///var/snap/microk8s/common/run/containerd.sock
+{{- else -}}
+unix:///run/containerd/containerd.sock
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the kata-monitor CRI runtime endpoint.
+When monitor.runtimeEndpoint is empty, inherit containerd.runtimeSocket or
+derive it from k8sDistribution.
+*/}}
+{{- define "monitorRuntimeEndpoint" -}}
+{{- if .Values.monitor.runtimeEndpoint -}}
+{{- .Values.monitor.runtimeEndpoint -}}
+{{- else -}}
+{{- include "containerdRuntimeSocket" .Values -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Filesystem path of the CRI runtime socket, derived from monitorRuntimeEndpoint.
+*/}}
+{{- define "monitorRuntimeSocketPath" -}}
+{{- $endpoint := include "monitorRuntimeEndpoint" . -}}
+{{- if hasPrefix "unix://" $endpoint -}}
+{{- trimPrefix "unix://" $endpoint -}}
+{{- else if hasPrefix "unix:" $endpoint -}}
+{{- trimPrefix "unix:" $endpoint -}}
+{{- else -}}
+{{- $endpoint -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Host directory containing the CRI runtime socket, derived from monitorRuntimeEndpoint.
+Used for kata-monitor volume hostPath and mountPath so the socket is reachable in-container.
+*/}}
+{{- define "monitorRuntimeSocketDir" -}}
+{{- include "monitorRuntimeSocketPath" . | dir -}}
+{{- end -}}
+
+{{/*
 Check if node-feature-discovery is already installed by someone else
 Returns the namespace where node-feature-discovery is found, or empty string if not found
 */}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -44,14 +44,14 @@ spec:
         args:
           - -listen-address={{ .Values.monitor.listenAddress }}
           - -log-level={{ .Values.monitor.logLevel }}
-          - -runtime-endpoint={{ .Values.monitor.runtimeEndpoint }}
+          - -runtime-endpoint={{ include "monitorRuntimeEndpoint" . }}
         ports:
           - containerPort: {{ .Values.monitor.port }}
         resources:
 {{- toYaml .Values.monitor.resources | nindent 10 }}
         volumeMounts:
         - name: containerd-sock
-          mountPath: /run/containerd
+          mountPath: {{ include "monitorRuntimeSocketDir" . }}
           readOnly: true
         - name: sbs
           mountPath: /run/vc/sbs/
@@ -60,7 +60,7 @@ spec:
       volumes:
       - name: containerd-sock
         hostPath:
-          path: /run/containerd
+          path: {{ include "monitorRuntimeSocketDir" . }}
           type: Directory
       - name: sbs
         hostPath:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -43,7 +43,7 @@ spec:
 {{- toYaml .Values.monitor.securityContext | nindent 10 }}
         args:
           - -listen-address={{ .Values.monitor.listenAddress }}
-          - -log-level={{ .Values.monitor.logLevel }}
+          - -log-level={{ include "monitorLogLevel" . }}
           - -runtime-endpoint={{ include "monitorRuntimeEndpoint" . }}
         ports:
           - containerPort: {{ .Values.monitor.port }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -122,7 +122,9 @@ monitor:
   # CRI runtime socket for kata-monitor. When empty, inherits containerd.runtimeSocket
   # or derives from k8sDistribution (e.g. k3s uses unix:///run/k3s/containerd/containerd.sock).
   runtimeEndpoint: ""
-  logLevel: "info"
+  # Log level for kata-monitor. When empty, inherits chart-wide logLevel and
+  # debug:true implies debug; otherwise defaults to info.
+  logLevel: ""
   port: 8090
   securityContext:
     privileged: false

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -119,7 +119,9 @@ monitor:
     reference: quay.io/kata-containers/kata-monitor
     tag: ""
   listenAddress: "0.0.0.0:8090"
-  runtimeEndpoint: "unix:///run/containerd/containerd.sock"
+  # CRI runtime socket for kata-monitor. When empty, inherits containerd.runtimeSocket
+  # or derives from k8sDistribution (e.g. k3s uses unix:///run/k3s/containerd/containerd.sock).
+  runtimeEndpoint: ""
   logLevel: "info"
   port: 8090
   securityContext:
@@ -144,6 +146,10 @@ containerd:
   # When empty, derived automatically from k8sDistribution.
   # Example: "/etc/my-containerd/"
   configDir: ""
+  # Override the CRI containerd socket URI.
+  # When empty, derived automatically from k8sDistribution.
+  # Example: "unix:///run/k3s/containerd/containerd.sock"
+  runtimeSocket: ""
   # Override the containerd config file name.
   # When empty, the kata-deploy binary uses its built-in default ("config.toml")
   # or auto-detects based on the runtime (k0s, microk8s, k3s/rke2).


### PR DESCRIPTION
Derive the runtime endpoint from k8sDistribution and mount the matching host socket directory so kata-monitor can reach containerd on non-vanilla k8s deployments.

Fixes #13378