### PR TITLE
dragonball: Add virtio-rng entropy device

### DIFF
--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -80,6 +80,7 @@ virtio-mem = [
   "atomic-guest-memory",
 ]
 virtio-balloon = ["dbs-virtio-devices/virtio-balloon", "virtio-queue"]
+virtio-rng = ["dbs-virtio-devices/virtio-rng", "virtio-queue"]
 vhost-net = ["dbs-virtio-devices/vhost-net"]
 vhost-user-fs = ["dbs-virtio-devices/vhost-user-fs"]
 vhost-user-net = ["dbs-virtio-devices/vhost-user-net"]

--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -82,6 +82,7 @@ virtio-mem = [
   "atomic-guest-memory",
 ]
 virtio-balloon = ["dbs-virtio-devices/virtio-balloon", "virtio-queue"]
+virtio-rng = ["dbs-virtio-devices/virtio-rng", "virtio-queue"]
 vhost-net = ["dbs-virtio-devices/vhost-net"]
 vhost-user-fs = ["dbs-virtio-devices/vhost-user-fs"]
 vhost-user-net = ["dbs-virtio-devices/vhost-user-net"]

--- a/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
@@ -65,6 +65,7 @@ virtio-fs-pro = [
 ]
 virtio-mem = ["virtio-mmio"]
 virtio-balloon = ["virtio-mmio"]
+virtio-rng = ["virtio-mmio"]
 vhost = ["virtio-mmio", "vhost-rs/vhost-user-frontend", "vhost-rs/vhost-kern"]
 vhost-net = ["vhost", "vhost-rs/vhost-net"]
 vhost-user = ["vhost"]

--- a/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
@@ -66,6 +66,7 @@ virtio-fs-pro = [
 ]
 virtio-mem = ["virtio-mmio"]
 virtio-balloon = ["virtio-mmio"]
+virtio-rng = ["virtio-mmio"]
 vhost = ["virtio-mmio", "vhost-rs/vhost-user-frontend", "vhost-rs/vhost-kern"]
 vhost-net = ["vhost", "vhost-rs/vhost-net"]
 vhost-user = ["vhost"]

--- a/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
@@ -53,6 +53,9 @@ pub mod mem;
 #[cfg(feature = "virtio-balloon")]
 pub mod balloon;
 
+#[cfg(feature = "virtio-rng")]
+pub mod rng;
+
 #[cfg(feature = "vhost")]
 pub mod vhost;
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/lib.rs
@@ -55,6 +55,9 @@ pub mod mem;
 #[cfg(feature = "virtio-balloon")]
 pub mod balloon;
 
+#[cfg(feature = "virtio-rng")]
+pub mod rng;
+
 #[cfg(feature = "vhost")]
 pub mod vhost;
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
@@ -1,0 +1,475 @@
+// Copyright 2026 Ant Group. All rights reserved.
+// Copyright (C) 2021 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::any::Any;
+use std::fs::File;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use dbs_device::resources::ResourceConstraint;
+use dbs_utils::epoll_manager::{
+    EpollManager, EventOps, EventSet, Events, MutEventSubscriber, SubscriberId,
+};
+use log::{debug, error, trace};
+use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryRegion, GuestRegionMmap};
+
+use crate::device::{VirtioDevice, VirtioDeviceConfig, VirtioDeviceInfo};
+use crate::{ActivateError, ActivateResult, ConfigResult, DbsGuestAddressSpace, Result, TYPE_RNG};
+
+const RNG_DRIVER_NAME: &str = "virtio-rng";
+
+const QUEUE_SIZE: u16 = 256;
+const NUM_QUEUES: usize = 1;
+const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
+
+pub(crate) struct RngEpollHandler<
+    AS: GuestAddressSpace,
+    Q: QueueT + Send = QueueSync,
+    R: GuestMemoryRegion = GuestRegionMmap,
+> {
+    pub(crate) config: VirtioDeviceConfig<AS, Q, R>,
+    pub(crate) random_file: File,
+    id: String,
+}
+
+impl<AS: DbsGuestAddressSpace, Q: QueueT + Send, R: GuestMemoryRegion> RngEpollHandler<AS, Q, R> {
+    fn process_queue(&mut self, queue_index: usize) -> bool {
+        let guard = self.config.lock_guest_memory();
+        let mem = guard.deref().memory();
+        let queue = &mut self.config.queues[queue_index];
+        let mut used_desc_heads = Vec::with_capacity(QUEUE_SIZE as usize);
+        let mut queue_guard = queue.queue_mut().lock();
+
+        let mut iter = match queue_guard.iter(mem) {
+            Err(e) => {
+                error!("{}: failed to process queue. {}", self.id, e);
+                return false;
+            }
+            Ok(iter) => iter,
+        };
+
+        for mut desc_chain in &mut iter {
+            let mut len = 0;
+
+            if let Some(avail_desc) = desc_chain.next() {
+                // Drivers can only read from the random device.
+                if avail_desc.is_write_only() {
+                    // Fill the read with data from the random device on the host.
+                    if let Ok(count) = mem.read_volatile_from(
+                        avail_desc.addr(),
+                        &mut self.random_file,
+                        avail_desc.len() as usize,
+                    ) {
+                        len = count as u32;
+                    }
+                }
+            }
+
+            used_desc_heads.push((desc_chain.head_index(), len));
+        }
+
+        drop(queue_guard);
+
+        for &(desc_index, len) in &used_desc_heads {
+            queue.add_used(mem, desc_index, len);
+        }
+
+        !used_desc_heads.is_empty()
+    }
+}
+
+impl<AS: DbsGuestAddressSpace, Q: QueueT + Send, R: GuestMemoryRegion> MutEventSubscriber
+    for RngEpollHandler<AS, Q, R>
+where
+    AS: 'static + GuestAddressSpace + Send + Sync,
+{
+    fn init(&mut self, ops: &mut EventOps) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: RngEpollHandler::init()",
+            self.id
+        );
+
+        for (idx, queue) in self.config.queues.iter().enumerate() {
+            let events = Events::with_data(queue.eventfd.as_ref(), idx as u32, EventSet::IN);
+            if let Err(e) = ops.add(events) {
+                error!("{}: failed to register queue event, {:?}", self.id, e);
+            }
+        }
+    }
+
+    fn process(&mut self, events: Events, _ops: &mut EventOps) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: RngEpollHandler::process()",
+            self.id
+        );
+
+        let idx = events.data() as usize;
+        if idx >= self.config.queues.len() {
+            error!("{}: invalid queue index {}", self.id, idx);
+            return;
+        }
+
+        if let Err(e) = self.config.queues[idx].consume_event() {
+            error!("{}: failed to get queue event: {:?}", self.id, e);
+        } else if self.process_queue(idx) {
+            if let Err(e) = self.config.queues[idx].notify() {
+                error!("{}: failed to signal used queue: {}", self.id, e);
+            }
+        } else {
+            debug!("{}: no request processed", self.id);
+        }
+    }
+}
+
+/// Virtio device for exposing entropy to the guest OS through virtio.
+pub struct Rng<AS: GuestAddressSpace> {
+    pub(crate) device_info: VirtioDeviceInfo,
+    pub(crate) random_file: Option<File>,
+    pub(crate) subscriber_id: Option<SubscriberId>,
+    pub(crate) id: String,
+    pub(crate) phantom: PhantomData<AS>,
+}
+
+impl<AS: GuestAddressSpace> Rng<AS> {
+    /// Create a new virtio-rng device that gets random data from the host.
+    pub fn new(path: String, epoll_mgr: EpollManager) -> Result<Self> {
+        trace!(target: RNG_DRIVER_NAME, "{}: Rng::new({})", RNG_DRIVER_NAME, path);
+
+        let avail_features = 1u64 << VIRTIO_F_VERSION_1;
+        let random_file = File::open(path)?;
+
+        // The virtio-rng device has no device configuration space.
+        let device_info = VirtioDeviceInfo::new(
+            RNG_DRIVER_NAME.to_string(),
+            avail_features,
+            Arc::new(vec![QUEUE_SIZE; NUM_QUEUES]),
+            Vec::new(),
+            epoll_mgr,
+        );
+        let id = device_info.driver_name.clone();
+
+        Ok(Rng {
+            device_info,
+            random_file: Some(random_file),
+            subscriber_id: None,
+            id,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<AS, Q, R> VirtioDevice<AS, Q, R> for Rng<AS>
+where
+    AS: DbsGuestAddressSpace,
+    Q: QueueT + Send + 'static,
+    R: GuestMemoryRegion + Sync + Send + 'static,
+{
+    fn device_type(&self) -> u32 {
+        TYPE_RNG
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        QUEUE_SIZES
+    }
+
+    fn get_avail_features(&self, page: u32) -> u32 {
+        self.device_info.get_avail_features(page)
+    }
+
+    fn set_acked_features(&mut self, page: u32, value: u32) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: VirtioDevice::set_acked_features({}, 0x{:x})",
+            self.id,
+            page,
+            value
+        );
+        self.device_info.set_acked_features(page, value)
+    }
+
+    fn read_config(&mut self, _offset: u64, _data: &mut [u8]) -> ConfigResult {
+        trace!("{RNG_DRIVER_NAME}: has no device configuration");
+        Ok(())
+    }
+
+    fn write_config(&mut self, _offset: u64, _data: &[u8]) -> ConfigResult {
+        trace!("{RNG_DRIVER_NAME}: has no device configuration");
+        Ok(())
+    }
+
+    fn activate(&mut self, config: VirtioDeviceConfig<AS, Q, R>) -> ActivateResult {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: VirtioDevice::activate()",
+            self.id
+        );
+
+        self.device_info.check_queue_sizes(&config.queues)?;
+
+        match self.random_file.as_ref() {
+            Some(file) => {
+                let random_file = file.try_clone().map_err(|e| {
+                    error!("{}: failed to clone rng source, {}", self.id, e);
+                    ActivateError::InternalError
+                })?;
+                let handler = Box::new(RngEpollHandler {
+                    config,
+                    random_file,
+                    id: self.id.clone(),
+                });
+
+                self.subscriber_id = Some(self.device_info.register_event_handler(handler));
+
+                Ok(())
+            }
+            None => Err(ActivateError::InternalError),
+        }
+    }
+
+    fn get_resource_requirements(
+        &self,
+        requests: &mut Vec<ResourceConstraint>,
+        use_generic_irq: bool,
+    ) {
+        requests.push(ResourceConstraint::LegacyIrq { irq: None });
+        if use_generic_irq {
+            requests.push(ResourceConstraint::GenericIrq {
+                size: (self.device_info.queue_sizes.len() + 1) as u32,
+            });
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use dbs_device::resources::DeviceResources;
+    use dbs_interrupt::NoopNotifier;
+    use dbs_utils::epoll_manager::SubscriberOps;
+    use kvm_ioctls::Kvm;
+    use test_utils::skip_if_kvm_unaccessable;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vmm_sys_util::eventfd::EventFd;
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::device::VirtioQueueConfig;
+    use crate::tests::{create_address_space, VirtQueue, VIRTQ_DESC_F_WRITE};
+
+    fn dummy_path(file: &TempFile) -> String {
+        file.as_path()
+            .to_owned()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
+    fn create_rng_epoll_handler() -> RngEpollHandler<Arc<GuestMemoryMmap>> {
+        let mem = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 0x10000)]).unwrap());
+        let queues = vec![VirtioQueueConfig::create(QUEUE_SIZE, 0).unwrap()];
+        let resources = DeviceResources::new();
+        let kvm = Kvm::new().unwrap();
+        let vm_fd = Arc::new(kvm.create_vm().unwrap());
+        let address_space = create_address_space();
+
+        let config = VirtioDeviceConfig::new(
+            mem,
+            address_space,
+            vm_fd,
+            resources,
+            queues,
+            None,
+            Arc::new(NoopNotifier::new()),
+        );
+
+        // Populate the entropy source with deterministic data so the device
+        // has something to copy into the guest's write-only buffers.
+        let random_file = TempFile::new().unwrap();
+        std::fs::write(random_file.as_path(), vec![0xa5u8; 0x1000]).unwrap();
+        let random_file = random_file.into_file();
+        RngEpollHandler {
+            config,
+            random_file,
+            id: RNG_DRIVER_NAME.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_rng_virtio_device_normal() {
+        let epoll_mgr = EpollManager::default();
+        let dummy_file = TempFile::new().unwrap();
+
+        let mut dev = Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr).unwrap();
+
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(&dev),
+            TYPE_RNG
+        );
+        let queue_size = [QUEUE_SIZE];
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::queue_max_sizes(
+                &dev
+            ),
+            &queue_size[..]
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 0),
+            dev.device_info.get_avail_features(0)
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 1),
+            dev.device_info.get_avail_features(1)
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 2),
+            dev.device_info.get_avail_features(2)
+        );
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::set_acked_features(
+            &mut dev, 2, 0,
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 2),
+            0
+        );
+
+        // The device has no configuration space: writes are ignored and reads
+        // leave the buffer untouched.
+        let config: [u8; 8] = [0; 8];
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
+            &mut dev, 0, &config,
+        )
+        .unwrap();
+        let mut data: [u8; 8] = [1; 8];
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
+            &mut dev, 0, &mut data,
+        )
+        .unwrap();
+        assert_eq!(data, [1; 8]);
+    }
+
+    #[test]
+    fn test_rng_virtio_device_activate() {
+        skip_if_kvm_unaccessable!();
+        let epoll_mgr = EpollManager::default();
+        let dummy_file = TempFile::new().unwrap();
+
+        // check queue sizes error
+        {
+            let mut dev =
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr.clone())
+                    .unwrap();
+            let queues = vec![
+                VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
+                VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
+            ];
+
+            let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let kvm = Kvm::new().unwrap();
+            let vm_fd = Arc::new(kvm.create_vm().unwrap());
+            let resources = DeviceResources::new();
+            let address_space = create_address_space();
+            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>>::new(
+                Arc::new(mem),
+                address_space,
+                vm_fd,
+                resources,
+                queues,
+                None,
+                Arc::new(NoopNotifier::new()),
+            );
+            assert!(matches!(
+                dev.activate(config),
+                Err(ActivateError::InvalidParam)
+            ));
+        }
+        // success
+        {
+            let mut dev =
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr).unwrap();
+            let queues = vec![VirtioQueueConfig::<QueueSync>::create(QUEUE_SIZE, 0).unwrap()];
+
+            let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let kvm = Kvm::new().unwrap();
+            let vm_fd = Arc::new(kvm.create_vm().unwrap());
+            let resources = DeviceResources::new();
+            let address_space = create_address_space();
+            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>>::new(
+                Arc::new(mem),
+                address_space,
+                vm_fd,
+                resources,
+                queues,
+                None,
+                Arc::new(NoopNotifier::new()),
+            );
+            assert!(dev.activate(config).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_rng_epoll_handler_handle_event() {
+        skip_if_kvm_unaccessable!();
+        let handler = create_rng_epoll_handler();
+        let event_fd = EventFd::new(0).unwrap();
+        let mgr = EpollManager::default();
+        let id = mgr.add_subscriber(Box::new(handler));
+        let mut inner_mgr = mgr.mgr.lock().unwrap();
+        let mut event_op = inner_mgr.event_ops(id).unwrap();
+        let event_set = EventSet::EDGE_TRIGGERED;
+        let mut handler = create_rng_epoll_handler();
+
+        // invalid queue index
+        let events = Events::with_data(&event_fd, 1024, event_set);
+        handler.process(events, &mut event_op);
+
+        // valid queue index
+        let events = Events::with_data(&event_fd, 0, event_set);
+        handler.config.queues[0].generate_event().unwrap();
+        handler.process(events, &mut event_op);
+    }
+
+    #[test]
+    fn test_rng_epoll_handler_process_queue() {
+        skip_if_kvm_unaccessable!();
+        let mut handler = create_rng_epoll_handler();
+        let m = &handler.config.vm_as.clone();
+
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        vq.avail.ring(0).store(0);
+        vq.avail.idx().store(1);
+        let q = vq.create_queue();
+        // The virtio-rng driver hands the device a single write-only buffer to
+        // be filled with entropy from the host source.
+        vq.dtable(0).set(0x1000, 0x100, VIRTQ_DESC_F_WRITE, 0);
+        handler.config.queues = vec![VirtioQueueConfig::new(
+            q,
+            Arc::new(EventFd::new(0).unwrap()),
+            Arc::new(NoopNotifier::new()),
+            0,
+        )];
+        assert!(handler.process_queue(0));
+
+        // The device consumed the descriptor and reported the number of entropy
+        // bytes written into the buffer through the used ring.
+        let used_elem = vq.used.ring(0).load();
+        assert_eq!(used_elem.id, 0);
+        assert_eq!(used_elem.len, 0x100);
+    }
+}

--- a/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
@@ -1,0 +1,557 @@
+// Copyright 2026 Ant Group. All rights reserved.
+// Copyright (C) 2021 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+use std::any::Any;
+use std::fs::File;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use dbs_device::resources::ResourceConstraint;
+use dbs_utils::epoll_manager::{
+    EpollManager, EventOps, EventSet, Events, MutEventSubscriber, SubscriberId,
+};
+use log::{debug, error, trace};
+use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryRegion, GuestRegionMmap};
+
+use crate::device::{VirtioDevice, VirtioDeviceConfig, VirtioDeviceInfo};
+use crate::{ActivateError, ActivateResult, ConfigResult, DbsGuestAddressSpace, Result, TYPE_RNG};
+
+const RNG_DRIVER_NAME: &str = "virtio-rng";
+
+const QUEUE_SIZE: u16 = 256;
+const NUM_QUEUES: usize = 1;
+const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE];
+
+pub(crate) struct RngEpollHandler<
+    AS: GuestAddressSpace,
+    Q: QueueT + Send = QueueSync,
+    R: GuestMemoryRegion = GuestRegionMmap,
+> {
+    pub(crate) config: VirtioDeviceConfig<AS, Q, R>,
+    pub(crate) random_file: File,
+    id: String,
+}
+
+impl<AS: DbsGuestAddressSpace, Q: QueueT + Send, R: GuestMemoryRegion> RngEpollHandler<AS, Q, R> {
+    fn process_queue(&mut self, queue_index: usize) -> bool {
+        let guard = self.config.lock_guest_memory();
+        let mem = guard.deref().memory();
+        let queue = &mut self.config.queues[queue_index];
+        let mut queue_guard = queue.queue_mut().lock();
+        let queue_size = queue_guard.size();
+        let mut used_desc_heads = Vec::with_capacity(queue_size as usize);
+
+        let mut iter = match queue_guard.iter(mem) {
+            Err(e) => {
+                error!("{}: failed to process queue. {}", self.id, e);
+                return false;
+            }
+            Ok(iter) => iter,
+        };
+
+        // A malformed queue can fail on every chain in a row, so only report
+        // the first failure for each queue notification to keep a broken
+        // entropy source or a hostile guest from flooding the host log.
+        let mut first_error: Option<String> = None;
+
+        for mut desc_chain in &mut iter {
+            let head_index = desc_chain.head_index();
+
+            // The available ring is guest owned and is not validated by
+            // `AvailIter`. An out of range head index yields an empty chain
+            // and can not be put back into the used ring, so drop it here
+            // instead of failing later on.
+            if head_index >= queue_size {
+                if first_error.is_none() {
+                    first_error = Some(format!(
+                        "invalid descriptor chain head index {head_index}, queue size {queue_size}"
+                    ));
+                }
+                continue;
+            }
+
+            let mut len = 0;
+
+            for avail_desc in &mut desc_chain {
+                // Drivers can only read from the random device.
+                if !avail_desc.is_write_only() {
+                    if first_error.is_none() {
+                        first_error = Some("rng descriptor is not write-only".to_string());
+                    }
+                    break;
+                }
+
+                // Fill the buffer with data from the random device on the host.
+                match mem.read_volatile_from(
+                    avail_desc.addr(),
+                    &mut self.random_file,
+                    avail_desc.len() as usize,
+                ) {
+                    Ok(count) => {
+                        len += count as u32;
+                        if count < avail_desc.len() as usize {
+                            if count == 0 && first_error.is_none() {
+                                first_error = Some("rng source returned no data".to_string());
+                            }
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        if first_error.is_none() {
+                            first_error = Some(e.to_string());
+                        }
+                        break;
+                    }
+                }
+            }
+
+            used_desc_heads.push((head_index, len));
+        }
+
+        drop(queue_guard);
+
+        if let Some(e) = first_error {
+            error!("{}: failed to process rng queue: {}", self.id, e);
+        }
+
+        let mut nr_used = 0;
+        for &(desc_index, len) in &used_desc_heads {
+            // Do not use `VirtioQueueConfig::add_used()` here: it panics on
+            // failure, which would take down the event thread shared by every
+            // virtio device of the VM.
+            match queue.queue_mut().add_used(mem, desc_index, len) {
+                Ok(()) => nr_used += 1,
+                Err(e) => error!(
+                    "{}: failed to add used descriptor {}: {}",
+                    self.id, desc_index, e
+                ),
+            }
+        }
+
+        nr_used > 0
+    }
+}
+
+impl<AS: DbsGuestAddressSpace, Q: QueueT + Send, R: GuestMemoryRegion> MutEventSubscriber
+    for RngEpollHandler<AS, Q, R>
+where
+    AS: 'static + GuestAddressSpace + Send + Sync,
+{
+    fn init(&mut self, ops: &mut EventOps) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: RngEpollHandler::init()",
+            self.id
+        );
+
+        for (idx, queue) in self.config.queues.iter().enumerate() {
+            let events = Events::with_data(queue.eventfd.as_ref(), idx as u32, EventSet::IN);
+            if let Err(e) = ops.add(events) {
+                error!("{}: failed to register queue event, {:?}", self.id, e);
+            }
+        }
+    }
+
+    fn process(&mut self, events: Events, _ops: &mut EventOps) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: RngEpollHandler::process()",
+            self.id
+        );
+
+        let idx = events.data() as usize;
+        if idx >= self.config.queues.len() {
+            error!("{}: invalid queue index {}", self.id, idx);
+            return;
+        }
+
+        if let Err(e) = self.config.queues[idx].consume_event() {
+            error!("{}: failed to get queue event: {:?}", self.id, e);
+        } else if self.process_queue(idx) {
+            if let Err(e) = self.config.queues[idx].notify() {
+                error!("{}: failed to signal used queue: {}", self.id, e);
+            }
+        } else {
+            debug!("{}: no request processed", self.id);
+        }
+    }
+}
+
+/// Virtio device for exposing entropy to the guest OS through virtio.
+pub struct Rng<AS: GuestAddressSpace> {
+    pub(crate) device_info: VirtioDeviceInfo,
+    pub(crate) random_file: Option<File>,
+    pub(crate) subscriber_id: Option<SubscriberId>,
+    pub(crate) id: String,
+    pub(crate) phantom: PhantomData<AS>,
+}
+
+impl<AS: GuestAddressSpace> Rng<AS> {
+    /// Create a new virtio-rng device that gets random data from the host.
+    pub fn new(path: String, epoll_mgr: EpollManager) -> Result<Self> {
+        trace!(target: RNG_DRIVER_NAME, "{}: Rng::new({})", RNG_DRIVER_NAME, path);
+
+        let avail_features = 1u64 << VIRTIO_F_VERSION_1;
+        let random_file = File::open(&path)?;
+
+        // The virtio-rng device has no device configuration space.
+        let device_info = VirtioDeviceInfo::new(
+            RNG_DRIVER_NAME.to_string(),
+            avail_features,
+            Arc::new(vec![QUEUE_SIZE; NUM_QUEUES]),
+            Vec::new(),
+            epoll_mgr,
+        );
+
+        Ok(Rng {
+            device_info,
+            random_file: Some(random_file),
+            subscriber_id: None,
+            id: path,
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<AS, Q, R> VirtioDevice<AS, Q, R> for Rng<AS>
+where
+    AS: DbsGuestAddressSpace,
+    Q: QueueT + Send + 'static,
+    R: GuestMemoryRegion + Sync + Send + 'static,
+{
+    fn device_type(&self) -> u32 {
+        TYPE_RNG
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        QUEUE_SIZES
+    }
+
+    fn get_avail_features(&self, page: u32) -> u32 {
+        self.device_info.get_avail_features(page)
+    }
+
+    fn set_acked_features(&mut self, page: u32, value: u32) {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: VirtioDevice::set_acked_features({}, 0x{:x})",
+            self.id,
+            page,
+            value
+        );
+        self.device_info.set_acked_features(page, value)
+    }
+
+    fn read_config(&mut self, _offset: u64, _data: &mut [u8]) -> ConfigResult {
+        trace!("{RNG_DRIVER_NAME}: has no device configuration");
+        Ok(())
+    }
+
+    fn write_config(&mut self, _offset: u64, _data: &[u8]) -> ConfigResult {
+        trace!("{RNG_DRIVER_NAME}: has no device configuration");
+        Ok(())
+    }
+
+    fn activate(&mut self, config: VirtioDeviceConfig<AS, Q, R>) -> ActivateResult {
+        trace!(
+            target: RNG_DRIVER_NAME,
+            "{}: VirtioDevice::activate()",
+            self.id
+        );
+
+        self.device_info.check_queue_sizes(&config.queues)?;
+
+        match self.random_file.as_ref() {
+            Some(file) => {
+                let random_file = file.try_clone().map_err(|e| {
+                    error!("{}: failed to clone rng source, {}", self.id, e);
+                    ActivateError::InternalError
+                })?;
+                let handler = Box::new(RngEpollHandler {
+                    config,
+                    random_file,
+                    id: self.id.clone(),
+                });
+
+                self.subscriber_id = Some(self.device_info.register_event_handler(handler));
+
+                Ok(())
+            }
+            None => Err(ActivateError::InternalError),
+        }
+    }
+
+    fn get_resource_requirements(
+        &self,
+        requests: &mut Vec<ResourceConstraint>,
+        use_generic_irq: bool,
+    ) {
+        requests.push(ResourceConstraint::LegacyIrq { irq: None });
+        if use_generic_irq {
+            requests.push(ResourceConstraint::GenericIrq {
+                size: (self.device_info.queue_sizes.len() + 1) as u32,
+            });
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use dbs_device::resources::DeviceResources;
+    use dbs_interrupt::NoopNotifier;
+    use dbs_utils::epoll_manager::SubscriberOps;
+    use kvm_ioctls::Kvm;
+    use test_utils::skip_if_kvm_unaccessable;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+    use vmm_sys_util::eventfd::EventFd;
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::*;
+    use crate::device::VirtioQueueConfig;
+    use crate::tests::{create_address_space, VirtQueue, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+
+    fn dummy_path(file: &TempFile) -> String {
+        file.as_path()
+            .to_owned()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
+    fn create_rng_epoll_handler() -> RngEpollHandler<Arc<GuestMemoryMmap>> {
+        let mem = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 0x10000)]).unwrap());
+        let queues = vec![VirtioQueueConfig::create(QUEUE_SIZE, 0).unwrap()];
+        let resources = DeviceResources::new();
+        let kvm = Kvm::new().unwrap();
+        let vm_fd = Arc::new(kvm.create_vm().unwrap());
+        let address_space = create_address_space();
+
+        let config = VirtioDeviceConfig::new(
+            mem,
+            address_space,
+            vm_fd,
+            resources,
+            queues,
+            None,
+            Arc::new(NoopNotifier::new()),
+        );
+
+        // Populate the entropy source with deterministic data so the device
+        // has something to copy into the guest's write-only buffers.
+        let random_file = TempFile::new().unwrap();
+        std::fs::write(random_file.as_path(), vec![0xa5u8; 0x1000]).unwrap();
+        let random_file = random_file.into_file();
+        RngEpollHandler {
+            config,
+            random_file,
+            id: RNG_DRIVER_NAME.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_rng_virtio_device_normal() {
+        let epoll_mgr = EpollManager::default();
+        let dummy_file = TempFile::new().unwrap();
+
+        let path = dummy_path(&dummy_file);
+        let mut dev = Rng::<Arc<GuestMemoryMmap>>::new(path.clone(), epoll_mgr).unwrap();
+
+        assert_eq!(dev.id, path);
+
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(&dev),
+            TYPE_RNG
+        );
+        let queue_size = [QUEUE_SIZE];
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::queue_max_sizes(
+                &dev
+            ),
+            &queue_size[..]
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 0),
+            dev.device_info.get_avail_features(0)
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 1),
+            dev.device_info.get_avail_features(1)
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 2),
+            dev.device_info.get_avail_features(2)
+        );
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::set_acked_features(
+            &mut dev, 2, 0,
+        );
+        assert_eq!(
+            VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::get_avail_features(&dev, 2),
+            0
+        );
+
+        // The device has no configuration space: writes are ignored and reads
+        // leave the buffer untouched.
+        let config: [u8; 8] = [0; 8];
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::write_config(
+            &mut dev, 0, &config,
+        )
+        .unwrap();
+        let mut data: [u8; 8] = [1; 8];
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::read_config(
+            &mut dev, 0, &mut data,
+        )
+        .unwrap();
+        assert_eq!(data, [1; 8]);
+    }
+
+    #[test]
+    fn test_rng_virtio_device_activate() {
+        skip_if_kvm_unaccessable!();
+        let epoll_mgr = EpollManager::default();
+        let dummy_file = TempFile::new().unwrap();
+
+        // check queue sizes error
+        {
+            let mut dev =
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr.clone())
+                    .unwrap();
+            let queues = vec![
+                VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
+                VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
+            ];
+
+            let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let kvm = Kvm::new().unwrap();
+            let vm_fd = Arc::new(kvm.create_vm().unwrap());
+            let resources = DeviceResources::new();
+            let address_space = create_address_space();
+            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>>::new(
+                Arc::new(mem),
+                address_space,
+                vm_fd,
+                resources,
+                queues,
+                None,
+                Arc::new(NoopNotifier::new()),
+            );
+            assert!(matches!(
+                dev.activate(config),
+                Err(ActivateError::InvalidParam)
+            ));
+        }
+        // success
+        {
+            let mut dev =
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr).unwrap();
+            let queues = vec![VirtioQueueConfig::<QueueSync>::create(QUEUE_SIZE, 0).unwrap()];
+
+            let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+            let kvm = Kvm::new().unwrap();
+            let vm_fd = Arc::new(kvm.create_vm().unwrap());
+            let resources = DeviceResources::new();
+            let address_space = create_address_space();
+            let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>>::new(
+                Arc::new(mem),
+                address_space,
+                vm_fd,
+                resources,
+                queues,
+                None,
+                Arc::new(NoopNotifier::new()),
+            );
+            assert!(dev.activate(config).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_rng_epoll_handler_handle_event() {
+        skip_if_kvm_unaccessable!();
+        let handler = create_rng_epoll_handler();
+        let event_fd = EventFd::new(0).unwrap();
+        let mgr = EpollManager::default();
+        let id = mgr.add_subscriber(Box::new(handler));
+        let mut inner_mgr = mgr.mgr.lock().unwrap();
+        let mut event_op = inner_mgr.event_ops(id).unwrap();
+        let event_set = EventSet::EDGE_TRIGGERED;
+        let mut handler = create_rng_epoll_handler();
+
+        // invalid queue index
+        let events = Events::with_data(&event_fd, 1024, event_set);
+        handler.process(events, &mut event_op);
+
+        // valid queue index
+        let events = Events::with_data(&event_fd, 0, event_set);
+        handler.config.queues[0].generate_event().unwrap();
+        handler.process(events, &mut event_op);
+    }
+
+    #[test]
+    fn test_rng_epoll_handler_process_queue() {
+        skip_if_kvm_unaccessable!();
+        let mut handler = create_rng_epoll_handler();
+        let m = &handler.config.vm_as.clone();
+
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        vq.avail.ring(0).store(0);
+        vq.avail.idx().store(1);
+        let q = vq.create_queue();
+        // Virtio permits an entropy buffer to span multiple write-only
+        // descriptors, even though the Linux driver currently uses one.
+        vq.dtable(0)
+            .set(0x1000, 0x100, VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT, 1);
+        vq.dtable(1).set(0x2000, 0x80, VIRTQ_DESC_F_WRITE, 0);
+        handler.config.queues = vec![VirtioQueueConfig::new(
+            q,
+            Arc::new(EventFd::new(0).unwrap()),
+            Arc::new(NoopNotifier::new()),
+            0,
+        )];
+        assert!(handler.process_queue(0));
+
+        // The device consumed the descriptor and reported the number of entropy
+        // bytes written into the buffer through the used ring.
+        let used_elem = vq.used.ring(0).load();
+        assert_eq!(used_elem.id, 0);
+        assert_eq!(used_elem.len, 0x180);
+    }
+
+    #[test]
+    fn test_rng_epoll_handler_invalid_head_index() {
+        skip_if_kvm_unaccessable!();
+        let mut handler = create_rng_epoll_handler();
+        let m = &handler.config.vm_as.clone();
+
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+        // The available ring is guest owned: point it at a head index beyond
+        // the queue size. The chain must be dropped instead of ending up in
+        // the used ring, which would otherwise panic the event thread.
+        vq.avail.ring(0).store(16);
+        vq.avail.idx().store(1);
+        let q = vq.create_queue();
+        handler.config.queues = vec![VirtioQueueConfig::new(
+            q,
+            Arc::new(EventFd::new(0).unwrap()),
+            Arc::new(NoopNotifier::new()),
+            0,
+        )];
+
+        assert!(!handler.process_queue(0));
+        assert_eq!(vq.used.idx().load(), 0);
+    }
+}

--- a/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/rng.rs
@@ -17,7 +17,7 @@ use dbs_utils::epoll_manager::{
     EpollManager, EventOps, EventSet, Events, MutEventSubscriber, SubscriberId,
 };
 use log::{debug, error, trace};
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryRegion, GuestRegionMmap};
 
@@ -196,10 +196,13 @@ pub struct Rng<AS: GuestAddressSpace> {
 
 impl<AS: GuestAddressSpace> Rng<AS> {
     /// Create a new virtio-rng device that gets random data from the host.
-    pub fn new(path: String, epoll_mgr: EpollManager) -> Result<Self> {
+    pub fn new(path: String, epoll_mgr: EpollManager, f_access_platform: bool) -> Result<Self> {
         trace!(target: RNG_DRIVER_NAME, "{}: Rng::new({})", RNG_DRIVER_NAME, path);
 
-        let avail_features = 1u64 << VIRTIO_F_VERSION_1;
+        let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
         let random_file = File::open(&path)?;
 
         // The virtio-rng device has no device configuration space.
@@ -370,7 +373,7 @@ pub(crate) mod tests {
         let dummy_file = TempFile::new().unwrap();
 
         let path = dummy_path(&dummy_file);
-        let mut dev = Rng::<Arc<GuestMemoryMmap>>::new(path.clone(), epoll_mgr).unwrap();
+        let mut dev = Rng::<Arc<GuestMemoryMmap>>::new(path.clone(), epoll_mgr, false).unwrap();
 
         assert_eq!(dev.id, path);
 
@@ -421,6 +424,24 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_rng_access_platform_feature() {
+        let epoll_mgr = EpollManager::default();
+        let dummy_file = TempFile::new().unwrap();
+
+        let dev =
+            Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr.clone(), false)
+                .unwrap();
+        assert_eq!(dev.device_info.avail_features(), 1u64 << VIRTIO_F_VERSION_1);
+
+        let dev =
+            Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr, true).unwrap();
+        assert_eq!(
+            dev.device_info.avail_features(),
+            (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_F_ACCESS_PLATFORM)
+        );
+    }
+
+    #[test]
     fn test_rng_virtio_device_activate() {
         skip_if_kvm_unaccessable!();
         let epoll_mgr = EpollManager::default();
@@ -429,7 +450,7 @@ pub(crate) mod tests {
         // check queue sizes error
         {
             let mut dev =
-                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr.clone())
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr.clone(), false)
                     .unwrap();
             let queues = vec![
                 VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
@@ -458,7 +479,8 @@ pub(crate) mod tests {
         // success
         {
             let mut dev =
-                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr).unwrap();
+                Rng::<Arc<GuestMemoryMmap>>::new(dummy_path(&dummy_file), epoll_mgr, false)
+                    .unwrap();
             let queues = vec![VirtioQueueConfig::<QueueSync>::create(QUEUE_SIZE, 0).unwrap()];
 
             let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -37,6 +37,8 @@ pub use crate::device_manager::fs_dev_mgr::{
 };
 #[cfg(feature = "virtio-mem")]
 pub use crate::device_manager::mem_dev_mgr::{MemDeviceConfigInfo, MemDeviceError};
+#[cfg(feature = "virtio-rng")]
+pub use crate::device_manager::rng_dev_mgr::{RngDeviceConfigInfo, RngDeviceError};
 #[cfg(feature = "host-device")]
 use crate::device_manager::vfio_dev_mgr::{HostDeviceConfig, VfioDeviceError};
 #[cfg(feature = "vhost-net")]
@@ -147,6 +149,11 @@ pub enum VmmActionError {
     /// Balloon device related errors.
     #[error("virtio-balloon device error: {0}")]
     Balloon(#[source] BalloonDeviceError),
+
+    #[cfg(feature = "virtio-rng")]
+    /// Rng device related errors.
+    #[error("virtio-rng device error: {0}")]
+    Rng(#[source] RngDeviceError),
     /// Setup tracing Failed.
     #[error("Setup tracing failed: {0}")]
     SetupTracingFailed(#[source] TraceError),
@@ -263,6 +270,11 @@ pub enum VmmAction {
     /// Add a new balloon device or update one that already exists using the `BalloonDeviceConfig`
     /// as input.
     InsertBalloonDevice(BalloonDeviceConfigInfo),
+
+    #[cfg(feature = "virtio-rng")]
+    /// Add a new rng device or update one that already exists using the `RngDeviceConfigInfo`
+    /// as input. This action can only be called before the microVM has booted.
+    InsertRngDevice(RngDeviceConfigInfo),
 
     #[cfg(feature = "host-device")]
     /// Add a VFIO assignment host device or update that already exists
@@ -409,6 +421,8 @@ impl VmmService {
             VmmAction::InsertBalloonDevice(balloon_cfg) => {
                 self.add_balloon_device(vmm, event_mgr, balloon_cfg)
             }
+            #[cfg(feature = "virtio-rng")]
+            VmmAction::InsertRngDevice(rng_cfg) => self.add_rng_device(vmm, event_mgr, rng_cfg),
             #[cfg(feature = "host-device")]
             VmmAction::InsertHostDevice(mut hostdev_cfg) => {
                 self.add_vfio_device(vmm, &mut hostdev_cfg)
@@ -1091,6 +1105,33 @@ impl VmmService {
             .insert_or_update_device(ctx, config)
             .map(|_| VmmData::Empty)
             .map_err(VmmActionError::Balloon)
+    }
+
+    #[cfg(feature = "virtio-rng")]
+    #[instrument(skip(self, event_mgr))]
+    fn add_rng_device(
+        &mut self,
+        vmm: &mut Vmm,
+        event_mgr: &mut EventManager,
+        config: RngDeviceConfigInfo,
+    ) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+
+        let ctx = vm
+            .create_device_op_context(Some(event_mgr.epoll_manager()))
+            .map_err(|e| {
+                if let StartMicroVmError::UpcallServerNotReady = e {
+                    VmmActionError::UpcallServerNotReady
+                } else {
+                    VmmActionError::StartMicroVm(e)
+                }
+            })?;
+
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(ctx, config)
+            .map(|_| VmmData::Empty)
+            .map_err(VmmActionError::Rng)
     }
 }
 
@@ -1970,6 +2011,46 @@ mod tests {
             // success
             TestData::new(
                 VmmAction::InsertBalloonDevice(BalloonDeviceConfigInfo::default()),
+                InstanceState::Uninitialized,
+                &|result| {
+                    assert!(result.is_ok());
+                },
+            ),
+        ];
+
+        for t in tests.iter_mut() {
+            t.check_request();
+        }
+    }
+
+    #[cfg(feature = "virtio-rng")]
+    #[test]
+    fn test_vmm_action_insert_rng_device() {
+        skip_if_kvm_unaccessable!();
+
+        let tests = &mut [
+            // hotplug unready
+            TestData::new(
+                VmmAction::InsertRngDevice(RngDeviceConfigInfo::default()),
+                InstanceState::Running,
+                &|result| {
+                    assert!(matches!(
+                        result,
+                        Err(VmmActionError::StartMicroVm(
+                            StartMicroVmError::UpcallMissVsock
+                        ))
+                    ));
+                    let err_string = format!("{}", result.unwrap_err());
+                    let expected_err = String::from(
+                        "failed to boot the VM: \
+                        the upcall client needs a virtio-vsock device for communication",
+                    );
+                    assert_eq!(err_string, expected_err);
+                },
+            ),
+            // success
+            TestData::new(
+                VmmAction::InsertRngDevice(RngDeviceConfigInfo::default()),
                 InstanceState::Uninitialized,
                 &|result| {
                     assert!(result.is_ok());

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -45,6 +45,8 @@ pub use crate::device_manager::mem_dev_mgr::{MemDeviceConfigInfo, MemDeviceError
 pub use crate::device_manager::net_dev_mgr::{
     NetworkDeviceError, NetworkDeviceMgr, NetworkInterfaceConfig, NetworkInterfaceUpdateConfig,
 };
+#[cfg(feature = "virtio-rng")]
+pub use crate::device_manager::rng_dev_mgr::{RngDeviceConfigInfo, RngDeviceError};
 #[cfg(feature = "host-device")]
 use crate::device_manager::vfio_dev_mgr::{HostDeviceConfig, VfioDeviceError};
 #[cfg(feature = "virtio-vsock")]
@@ -148,6 +150,11 @@ pub enum VmmActionError {
     /// Balloon device related errors.
     #[error("virtio-balloon device error: {0}")]
     Balloon(#[source] BalloonDeviceError),
+
+    #[cfg(feature = "virtio-rng")]
+    /// Rng device related errors.
+    #[error("virtio-rng device error: {0}")]
+    Rng(#[source] RngDeviceError),
     /// Setup tracing Failed.
     #[error("Setup tracing failed: {0}")]
     SetupTracingFailed(#[source] TraceError),
@@ -295,6 +302,11 @@ pub enum VmmAction {
     /// Add a new balloon device or update one that already exists using the `BalloonDeviceConfig`
     /// as input.
     InsertBalloonDevice(BalloonDeviceConfigInfo),
+
+    #[cfg(feature = "virtio-rng")]
+    /// Add a new rng device or update one that already exists using the `RngDeviceConfigInfo`
+    /// as input. This action can only be called before the microVM has booted.
+    InsertRngDevice(RngDeviceConfigInfo),
 
     #[cfg(feature = "host-device")]
     /// Add a VFIO assignment host device or update that already exists
@@ -446,6 +458,8 @@ impl VmmService {
             VmmAction::InsertBalloonDevice(balloon_cfg) => {
                 self.add_balloon_device(vmm, event_mgr, balloon_cfg)
             }
+            #[cfg(feature = "virtio-rng")]
+            VmmAction::InsertRngDevice(rng_cfg) => self.add_rng_device(vmm, event_mgr, rng_cfg),
             #[cfg(feature = "host-device")]
             VmmAction::InsertHostDevice(mut hostdev_cfg) => {
                 self.add_vfio_device(vmm, &mut hostdev_cfg)
@@ -1147,6 +1161,39 @@ impl VmmService {
             .insert_or_update_device(ctx, config)
             .map(|_| VmmData::Empty)
             .map_err(VmmActionError::Balloon)
+    }
+
+    #[cfg(feature = "virtio-rng")]
+    #[instrument(skip(self, event_mgr))]
+    fn add_rng_device(
+        &mut self,
+        vmm: &mut Vmm,
+        event_mgr: &mut EventManager,
+        config: RngDeviceConfigInfo,
+    ) -> VmmRequestResult {
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::InvalidVMID)?;
+
+        if vm.is_vm_initialized() {
+            return Err(VmmActionError::Rng(
+                RngDeviceError::UpdateNotAllowedPostBoot,
+            ));
+        }
+
+        let ctx = vm
+            .create_device_op_context(Some(event_mgr.epoll_manager()))
+            .map_err(|e| {
+                if let StartMicroVmError::UpcallServerNotReady = e {
+                    VmmActionError::UpcallServerNotReady
+                } else {
+                    VmmActionError::StartMicroVm(e)
+                }
+            })?;
+
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(ctx, config)
+            .map(|_| VmmData::Empty)
+            .map_err(VmmActionError::Rng)
     }
 }
 
@@ -2037,6 +2084,46 @@ mod tests {
             // success
             TestData::new(
                 VmmAction::InsertBalloonDevice(BalloonDeviceConfigInfo::default()),
+                InstanceState::Uninitialized,
+                &|result| {
+                    assert!(result.is_ok());
+                },
+            ),
+        ];
+
+        for t in tests.iter_mut() {
+            t.check_request();
+        }
+    }
+
+    #[cfg(feature = "virtio-rng")]
+    #[test]
+    fn test_vmm_action_insert_rng_device() {
+        skip_if_kvm_unaccessable!();
+
+        let tests = &mut [
+            // invalid state
+            TestData::new(
+                VmmAction::InsertRngDevice(RngDeviceConfigInfo::default()),
+                InstanceState::Running,
+                &|result| {
+                    assert!(matches!(
+                        result,
+                        Err(VmmActionError::Rng(
+                            RngDeviceError::UpdateNotAllowedPostBoot
+                        ))
+                    ));
+                    let err_string = format!("{}", result.unwrap_err());
+                    let expected_err = String::from(
+                        "virtio-rng device error: \
+                        the update operation is not allowed after boot",
+                    );
+                    assert_eq!(err_string, expected_err);
+                },
+            ),
+            // success
+            TestData::new(
+                VmmAction::InsertRngDevice(RngDeviceConfigInfo::default()),
                 InstanceState::Uninitialized,
                 &|result| {
                     assert!(result.is_ok());

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -117,6 +117,12 @@ pub mod balloon_dev_mgr;
 #[cfg(feature = "virtio-balloon")]
 use self::balloon_dev_mgr::BalloonDeviceMgr;
 
+#[cfg(feature = "virtio-rng")]
+/// Device manager for virtio-rng devices.
+pub mod rng_dev_mgr;
+#[cfg(feature = "virtio-rng")]
+use self::rng_dev_mgr::RngDeviceMgr;
+
 #[cfg(feature = "vhost-net")]
 /// Device manager for vhost-net devices.
 pub mod vhost_net_dev_mgr;
@@ -668,6 +674,9 @@ pub struct DeviceManager {
     #[cfg(feature = "virtio-balloon")]
     pub(crate) balloon_manager: BalloonDeviceMgr,
 
+    #[cfg(feature = "virtio-rng")]
+    pub(crate) rng_manager: RngDeviceMgr,
+
     #[cfg(feature = "vhost-net")]
     vhost_net_manager: VhostNetDeviceMgr,
 
@@ -745,6 +754,8 @@ impl DeviceManager {
             mem_manager: MemDeviceMgr::default(),
             #[cfg(feature = "virtio-balloon")]
             balloon_manager: BalloonDeviceMgr::default(),
+            #[cfg(feature = "virtio-rng")]
+            rng_manager: RngDeviceMgr::default(),
             #[cfg(feature = "vhost-net")]
             vhost_net_manager: VhostNetDeviceMgr::default(),
             #[cfg(feature = "vhost-user-net")]
@@ -926,6 +937,11 @@ impl DeviceManager {
 
         #[cfg(feature = "virtio-vsock")]
         self.vsock_manager.attach_devices(&mut ctx)?;
+
+        #[cfg(feature = "virtio-rng")]
+        self.rng_manager
+            .attach_devices(&mut ctx)
+            .map_err(StartMicroVmError::RngDeviceError)?;
 
         #[cfg(any(feature = "virtio-blk", feature = "vhost-user-blk"))]
         self.block_manager
@@ -1671,6 +1687,8 @@ mod tests {
                 mem_manager: MemDeviceMgr::default(),
                 #[cfg(feature = "virtio-balloon")]
                 balloon_manager: BalloonDeviceMgr::default(),
+                #[cfg(feature = "virtio-rng")]
+                rng_manager: RngDeviceMgr::default(),
                 #[cfg(target_arch = "aarch64")]
                 mmio_device_info: HashMap::new(),
                 #[cfg(feature = "vhost-net")]

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -125,6 +125,11 @@ pub mod balloon_dev_mgr;
 #[cfg(feature = "virtio-balloon")]
 use self::balloon_dev_mgr::BalloonDeviceMgr;
 
+#[cfg(feature = "virtio-rng")]
+/// Device manager for virtio-rng devices.
+pub mod rng_dev_mgr;
+#[cfg(feature = "virtio-rng")]
+use self::rng_dev_mgr::RngDeviceMgr;
 #[cfg(feature = "host-device")]
 /// Device manager for PCI/MMIO VFIO devices.
 pub mod vfio_dev_mgr;
@@ -676,6 +681,9 @@ pub struct DeviceManager {
 
     #[cfg(feature = "virtio-balloon")]
     pub(crate) balloon_manager: BalloonDeviceMgr,
+
+    #[cfg(feature = "virtio-rng")]
+    pub(crate) rng_manager: RngDeviceMgr,
     #[cfg(feature = "host-device")]
     pub(crate) vfio_manager: Arc<Mutex<VfioDeviceMgr>>,
     #[cfg(feature = "host-device")]
@@ -752,6 +760,8 @@ impl DeviceManager {
             mem_manager: MemDeviceMgr::default(),
             #[cfg(feature = "virtio-balloon")]
             balloon_manager: BalloonDeviceMgr::default(),
+            #[cfg(feature = "virtio-rng")]
+            rng_manager: RngDeviceMgr::default(),
             #[cfg(feature = "host-device")]
             vfio_manager: Arc::new(Mutex::new(VfioDeviceMgr::new(
                 vm_fd,
@@ -970,6 +980,11 @@ impl DeviceManager {
 
         #[cfg(feature = "virtio-vsock")]
         self.vsock_manager.attach_devices(&mut ctx)?;
+
+        #[cfg(feature = "virtio-rng")]
+        self.rng_manager
+            .attach_devices(&mut ctx)
+            .map_err(StartMicroVmError::RngDeviceError)?;
 
         #[cfg(any(feature = "virtio-blk", feature = "vhost-user-blk"))]
         let kernel_config = {
@@ -1722,6 +1737,8 @@ mod tests {
                 mem_manager: MemDeviceMgr::default(),
                 #[cfg(feature = "virtio-balloon")]
                 balloon_manager: BalloonDeviceMgr::default(),
+                #[cfg(feature = "virtio-rng")]
+                rng_manager: RngDeviceMgr::default(),
                 #[cfg(target_arch = "aarch64")]
                 mmio_device_info: HashMap::new(),
                 #[cfg(feature = "host-device")]

--- a/src/dragonball/src/device_manager/rng_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/rng_dev_mgr.rs
@@ -1,0 +1,282 @@
+// Copyright 2026 Ant Group. All Rights Reserved.
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dbs_virtio_devices as virtio;
+use serde_derive::{Deserialize, Serialize};
+use slog::{error, info};
+use virtio::rng::Rng;
+
+use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
+use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
+
+// The flag of whether to use the shared irq.
+const USE_SHARED_IRQ: bool = true;
+// The flag of whether to use the generic irq. It is for the virtio-mmio MSI
+// extension, which is not supported by the guest kernels in use, so it is
+// disabled by default.
+const USE_GENERIC_IRQ: bool = false;
+
+/// Errors associated with `RngDeviceConfig`.
+#[derive(Debug, thiserror::Error)]
+pub enum RngDeviceError {
+    /// The rng device was already used.
+    #[error("the virtio-rng device was already added to a different device")]
+    RngDeviceAlreadyExists,
+
+    /// Cannot perform the requested operation after booting the microVM.
+    #[error("the update operation is not allowed after boot")]
+    UpdateNotAllowedPostBoot,
+
+    /// create rng device error
+    #[error("failed to create virtio-rng device, {0}")]
+    CreateRngDevice(#[source] virtio::Error),
+
+    /// Cannot initialize a rng device or add a device to the MMIO Bus.
+    #[error("failure while registering rng device: {0}")]
+    RegisterRngDevice(#[source] DeviceMgrError),
+
+    /// The device manager errors.
+    #[error("DeviceManager error: {0}")]
+    DeviceManager(#[source] DeviceMgrError),
+}
+
+/// Configuration information for a virtio-rng device.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct RngDeviceConfigInfo {
+    /// Path to the host entropy source, which doubles as the rng device id.
+    pub src: String,
+    /// Use shared irq
+    pub use_shared_irq: Option<bool>,
+    /// Use generic irq
+    pub use_generic_irq: Option<bool>,
+}
+
+impl ConfigItem for RngDeviceConfigInfo {
+    type Err = RngDeviceError;
+
+    fn id(&self) -> &str {
+        &self.src
+    }
+
+    fn check_conflicts(&self, other: &Self) -> Result<(), RngDeviceError> {
+        if self.src.as_str() == other.src.as_str() {
+            Err(RngDeviceError::RngDeviceAlreadyExists)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Rng Device Info
+pub type RngDeviceInfo = DeviceConfigInfo<RngDeviceConfigInfo>;
+
+impl ConfigItem for RngDeviceInfo {
+    type Err = RngDeviceError;
+
+    fn id(&self) -> &str {
+        &self.config.src
+    }
+
+    fn check_conflicts(&self, other: &Self) -> Result<(), RngDeviceError> {
+        if self.config.src.as_str() == other.config.src.as_str() {
+            Err(RngDeviceError::RngDeviceAlreadyExists)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Wrapper for the collection that holds all the Rng Devices Configs
+#[derive(Clone)]
+pub struct RngDeviceMgr {
+    /// A list of `RngDeviceConfig` objects.
+    info_list: DeviceConfigInfos<RngDeviceConfigInfo>,
+}
+
+impl RngDeviceMgr {
+    /// Inserts `rng_cfg` in the virtio-rng device configuration list.
+    /// The virtio-rng device is a cold-plug only device, so hotplug requests
+    /// are rejected.
+    pub fn insert_or_update_device(
+        &mut self,
+        ctx: DeviceOpContext,
+        rng_cfg: RngDeviceConfigInfo,
+    ) -> std::result::Result<(), RngDeviceError> {
+        if ctx.is_hotplug {
+            error!(ctx.logger(), "no support of virtio-rng device hotplug";
+                "subsystem" => "rng_dev_mgr",
+                "src" => &rng_cfg.src,
+            );
+            return Err(RngDeviceError::UpdateNotAllowedPostBoot);
+        }
+
+        info!(ctx.logger(), "add virtio-rng device configuration";
+            "subsystem" => "rng_dev_mgr",
+            "src" => &rng_cfg.src,
+        );
+        self.info_list.insert_or_update(&rng_cfg)?;
+
+        Ok(())
+    }
+
+    /// Attaches all virtio-rng devices from the RngDevicesConfig.
+    pub fn attach_devices(
+        &mut self,
+        ctx: &mut DeviceOpContext,
+    ) -> std::result::Result<(), RngDeviceError> {
+        let epoll_mgr = ctx.get_epoll_mgr().map_err(RngDeviceError::DeviceManager)?;
+
+        for info in self.info_list.iter_mut() {
+            info!(ctx.logger(), "attach virtio-rng device";
+                "subsystem" => "rng_dev_mgr",
+                "src" => &info.config.src,
+            );
+
+            let device = Rng::new(info.config.src.clone(), epoll_mgr.clone())
+                .map_err(RngDeviceError::CreateRngDevice)?;
+            let mmio_dev = DeviceManager::create_mmio_virtio_device(
+                Box::new(device),
+                ctx,
+                info.config.use_shared_irq.unwrap_or(USE_SHARED_IRQ),
+                info.config.use_generic_irq.unwrap_or(USE_GENERIC_IRQ),
+            )
+            .map_err(RngDeviceError::RegisterRngDevice)?;
+            info.set_device(mmio_dev);
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for RngDeviceMgr {
+    /// Create a new `RngDeviceMgr` object..
+    fn default() -> Self {
+        RngDeviceMgr {
+            info_list: DeviceConfigInfos::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device_manager::tests::create_address_space;
+    use crate::test_utils::tests::create_vm_for_test;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    impl Default for RngDeviceConfigInfo {
+        fn default() -> Self {
+            RngDeviceConfigInfo {
+                src: "".to_string(),
+                use_shared_irq: None,
+                use_generic_irq: None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_rng_config_check_conflicts() {
+        let config = RngDeviceConfigInfo::default();
+        let mut config2 = RngDeviceConfigInfo::default();
+        assert!(config.check_conflicts(&config2).is_err());
+        config2.src = "/dev/urandom".to_string();
+        assert!(config.check_conflicts(&config2).is_ok());
+    }
+
+    #[test]
+    fn test_rng_insert_or_update_device() {
+        skip_if_kvm_unaccessable!();
+        //Init vm for test.
+        let mut vm = create_vm_for_test();
+
+        // Test for standard config
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            None,
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/urandom".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(device_op_ctx, dummy_rng_device)
+            .unwrap();
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+
+        // Hotplug is rejected
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            None,
+            true,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/random".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        assert!(matches!(
+            vm.device_manager_mut()
+                .rng_manager
+                .insert_or_update_device(device_op_ctx, dummy_rng_device),
+            Err(RngDeviceError::UpdateNotAllowedPostBoot)
+        ));
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+    }
+
+    #[test]
+    fn test_rng_attach_device() {
+        skip_if_kvm_unaccessable!();
+        //Init vm and insert rng config for test.
+        let mut vm = create_vm_for_test();
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            Some(create_address_space()),
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/urandom".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(device_op_ctx, dummy_rng_device)
+            .unwrap();
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+
+        // Test for standard config
+        let mut device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            Some(create_address_space()),
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+        assert!(vm
+            .device_manager_mut()
+            .rng_manager
+            .attach_devices(&mut device_op_ctx)
+            .is_ok());
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+    }
+}

--- a/src/dragonball/src/device_manager/rng_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/rng_dev_mgr.rs
@@ -1,0 +1,282 @@
+// Copyright 2026 Ant Group. All Rights Reserved.
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dbs_virtio_devices as virtio;
+use serde_derive::{Deserialize, Serialize};
+use slog::{error, info};
+use virtio::rng::Rng;
+
+use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
+use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
+
+// The flag of whether to use the shared irq.
+const USE_SHARED_IRQ: bool = true;
+// The flag of whether to use the generic irq. It is for the virtio-mmio MSI
+// extension, which is not supported by the guest kernels in use, so it is
+// disabled by default.
+const USE_GENERIC_IRQ: bool = false;
+
+/// Errors associated with `RngDeviceConfig`.
+#[derive(Debug, thiserror::Error)]
+pub enum RngDeviceError {
+    /// The rng device was already used.
+    #[error("the virtio-rng device was already added to a different device")]
+    RngDeviceAlreadyExists,
+
+    /// Cannot perform the requested operation after booting the microVM.
+    #[error("the update operation is not allowed after boot")]
+    UpdateNotAllowedPostBoot,
+
+    /// Failed to create an rng device.
+    #[error("failed to create virtio-rng device, {0}")]
+    CreateRngDevice(#[source] virtio::Error),
+
+    /// Cannot initialize a rng device or add a device to the MMIO Bus.
+    #[error("failure while registering rng device: {0}")]
+    RegisterRngDevice(#[source] DeviceMgrError),
+
+    /// The device manager errors.
+    #[error("DeviceManager error: {0}")]
+    DeviceManager(#[source] DeviceMgrError),
+}
+
+/// Configuration information for a virtio-rng device.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct RngDeviceConfigInfo {
+    /// Path to the host entropy source, which doubles as the rng device id.
+    pub src: String,
+    /// Use shared irq
+    pub use_shared_irq: Option<bool>,
+    /// Use generic irq
+    pub use_generic_irq: Option<bool>,
+}
+
+impl ConfigItem for RngDeviceConfigInfo {
+    type Err = RngDeviceError;
+
+    fn id(&self) -> &str {
+        &self.src
+    }
+
+    fn check_conflicts(&self, other: &Self) -> Result<(), RngDeviceError> {
+        if self.src.as_str() == other.src.as_str() {
+            Err(RngDeviceError::RngDeviceAlreadyExists)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Rng Device Info
+pub type RngDeviceInfo = DeviceConfigInfo<RngDeviceConfigInfo>;
+
+impl ConfigItem for RngDeviceInfo {
+    type Err = RngDeviceError;
+
+    fn id(&self) -> &str {
+        &self.config.src
+    }
+
+    fn check_conflicts(&self, other: &Self) -> Result<(), RngDeviceError> {
+        if self.config.src.as_str() == other.config.src.as_str() {
+            Err(RngDeviceError::RngDeviceAlreadyExists)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Wrapper for the collection that holds all the Rng Devices Configs
+#[derive(Clone)]
+pub struct RngDeviceMgr {
+    /// A list of `RngDeviceConfig` objects.
+    info_list: DeviceConfigInfos<RngDeviceConfigInfo>,
+}
+
+impl RngDeviceMgr {
+    /// Inserts `rng_cfg` in the virtio-rng device configuration list.
+    /// The virtio-rng device is a cold-plug only device, so hotplug requests
+    /// are rejected.
+    pub fn insert_or_update_device(
+        &mut self,
+        ctx: DeviceOpContext,
+        rng_cfg: RngDeviceConfigInfo,
+    ) -> std::result::Result<(), RngDeviceError> {
+        if ctx.is_hotplug {
+            error!(ctx.logger(), "no support of virtio-rng device hotplug";
+                "subsystem" => "rng_dev_mgr",
+                "src" => &rng_cfg.src,
+            );
+            return Err(RngDeviceError::UpdateNotAllowedPostBoot);
+        }
+
+        info!(ctx.logger(), "add virtio-rng device configuration";
+            "subsystem" => "rng_dev_mgr",
+            "src" => &rng_cfg.src,
+        );
+        self.info_list.insert_or_update(&rng_cfg)?;
+
+        Ok(())
+    }
+
+    /// Attaches all virtio-rng devices from the RngDevicesConfig.
+    pub fn attach_devices(
+        &mut self,
+        ctx: &mut DeviceOpContext,
+    ) -> std::result::Result<(), RngDeviceError> {
+        let epoll_mgr = ctx.get_epoll_mgr().map_err(RngDeviceError::DeviceManager)?;
+
+        for info in self.info_list.iter_mut() {
+            info!(ctx.logger(), "attach virtio-rng device";
+                "subsystem" => "rng_dev_mgr",
+                "src" => &info.config.src,
+            );
+
+            let device = Rng::new(info.config.src.clone(), epoll_mgr.clone())
+                .map_err(RngDeviceError::CreateRngDevice)?;
+            let mmio_dev = DeviceManager::create_mmio_virtio_device(
+                Box::new(device),
+                ctx,
+                info.config.use_shared_irq.unwrap_or(USE_SHARED_IRQ),
+                info.config.use_generic_irq.unwrap_or(USE_GENERIC_IRQ),
+            )
+            .map_err(RngDeviceError::RegisterRngDevice)?;
+            info.set_device(mmio_dev);
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for RngDeviceMgr {
+    /// Create a new `RngDeviceMgr` object.
+    fn default() -> Self {
+        RngDeviceMgr {
+            info_list: DeviceConfigInfos::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device_manager::tests::create_address_space;
+    use crate::test_utils::tests::create_vm_for_test;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    impl Default for RngDeviceConfigInfo {
+        fn default() -> Self {
+            RngDeviceConfigInfo {
+                src: "/dev/urandom".to_string(),
+                use_shared_irq: None,
+                use_generic_irq: None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_rng_config_check_conflicts() {
+        let config = RngDeviceConfigInfo::default();
+        let mut config2 = RngDeviceConfigInfo::default();
+        assert!(config.check_conflicts(&config2).is_err());
+        config2.src = "/dev/random".to_string();
+        assert!(config.check_conflicts(&config2).is_ok());
+    }
+
+    #[test]
+    fn test_rng_insert_or_update_device() {
+        skip_if_kvm_unaccessable!();
+        //Init vm for test.
+        let mut vm = create_vm_for_test();
+
+        // Test for standard config
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            None,
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/urandom".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(device_op_ctx, dummy_rng_device)
+            .unwrap();
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+
+        // Hotplug is rejected
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            None,
+            true,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/random".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        assert!(matches!(
+            vm.device_manager_mut()
+                .rng_manager
+                .insert_or_update_device(device_op_ctx, dummy_rng_device),
+            Err(RngDeviceError::UpdateNotAllowedPostBoot)
+        ));
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+    }
+
+    #[test]
+    fn test_rng_attach_device() {
+        skip_if_kvm_unaccessable!();
+        //Init vm and insert rng config for test.
+        let mut vm = create_vm_for_test();
+        let device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            Some(create_address_space()),
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+
+        let dummy_rng_device = RngDeviceConfigInfo {
+            src: "/dev/urandom".to_string(),
+            use_shared_irq: None,
+            use_generic_irq: None,
+        };
+        vm.device_manager_mut()
+            .rng_manager
+            .insert_or_update_device(device_op_ctx, dummy_rng_device)
+            .unwrap();
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+
+        // Test for standard config
+        let mut device_op_ctx = DeviceOpContext::new(
+            Some(vm.epoll_manager().clone()),
+            vm.device_manager(),
+            Some(vm.vm_as().unwrap().clone()),
+            Some(create_address_space()),
+            false,
+            Some(vm.vm_config().clone()),
+            vm.shared_info().clone(),
+        );
+        assert!(vm
+            .device_manager_mut()
+            .rng_manager
+            .attach_devices(&mut device_op_ctx)
+            .is_ok());
+        assert_eq!(vm.device_manager().rng_manager.info_list.len(), 1);
+    }
+}

--- a/src/dragonball/src/device_manager/rng_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/rng_dev_mgr.rs
@@ -7,6 +7,8 @@ use serde_derive::{Deserialize, Serialize};
 use slog::{error, info};
 use virtio::rng::Rng;
 
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
 
@@ -127,14 +129,28 @@ impl RngDeviceMgr {
     ) -> std::result::Result<(), RngDeviceError> {
         let epoll_mgr = ctx.get_epoll_mgr().map_err(RngDeviceError::DeviceManager)?;
 
+        // A TDX guest can only DMA into shared memory, so the device has to
+        // advertise VIRTIO_F_ACCESS_PLATFORM for the guest to set up bounce
+        // buffers. Note that the kata runtime never inserts a host backed
+        // virtio-rng device into a confidential VM, this only applies to other
+        // users of the dragonball API.
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         for info in self.info_list.iter_mut() {
             info!(ctx.logger(), "attach virtio-rng device";
                 "subsystem" => "rng_dev_mgr",
                 "src" => &info.config.src,
             );
 
-            let device = Rng::new(info.config.src.clone(), epoll_mgr.clone())
-                .map_err(RngDeviceError::CreateRngDevice)?;
+            let device = Rng::new(
+                info.config.src.clone(),
+                epoll_mgr.clone(),
+                f_access_platform,
+            )
+            .map_err(RngDeviceError::CreateRngDevice)?;
             let mmio_dev = DeviceManager::create_mmio_virtio_device(
                 Box::new(device),
                 ctx,

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -210,6 +210,11 @@ pub enum StartMicroVmError {
     #[error("virtio-balloon errors: {0}")]
     BalloonDeviceError(#[source] device_manager::balloon_dev_mgr::BalloonDeviceError),
 
+    #[cfg(feature = "virtio-rng")]
+    /// Virtio-rng errors.
+    #[error("virtio-rng errors: {0}")]
+    RngDeviceError(#[source] device_manager::rng_dev_mgr::RngDeviceError),
+
     /// Vhost-net device errors.
     #[cfg(feature = "vhost-net")]
     #[error("vhost-net errors: {0:?}")]

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -217,6 +217,11 @@ pub enum StartMicroVmError {
     /// Virtio-balloon errors.
     #[error("virtio-balloon errors: {0}")]
     BalloonDeviceError(#[source] device_manager::balloon_dev_mgr::BalloonDeviceError),
+
+    #[cfg(feature = "virtio-rng")]
+    /// Virtio-rng errors.
+    #[error("virtio-rng errors: {0}")]
+    RngDeviceError(#[source] device_manager::rng_dev_mgr::RngDeviceError),
     #[cfg(feature = "host-device")]
     /// Failed to create VFIO device
     #[error("cannot create VFIO device {0:?}")]

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -170,6 +170,23 @@ disable_nesting_checks = false
 # Default false
 disable_vhost_net = false
 
+#
+# Default entropy source.
+# The path to a host source of entropy (including a real hardware RNG)
+# /dev/urandom and /dev/random are two main options.
+# Be aware that /dev/random is a blocking source of entropy.  If the host
+# runs out of entropy, the VMs boot time will increase leading to get startup
+# timeouts.
+# The source of entropy /dev/urandom is non-blocking and provides a
+# generally acceptable source of entropy. It should work well for pretty much
+# all practical purposes.
+entropy_source =  "@DEFENTROPYSOURCE@"
+
+# List of valid annotations values for entropy_source
+# The default if not set is empty (all annotations rejected.)
+# Your distribution recommends: @DEFVALIDENTROPYSOURCES@
+valid_entropy_sources = @DEFVALIDENTROPYSOURCES@
+
 # Path to OCI hook binaries in the *guest rootfs*.
 # This does not affect host-side hooks which must instead be added to
 # the OCI spec passed to the runtime.

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -79,6 +79,7 @@ dragonball = { workspace = true, features = [
     "dbs-upcall",
     "virtio-mem",
     "virtio-balloon",
+    "virtio-rng",
     "vhost-user-net",
     "host-device",
 ], optional = true }

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -82,6 +82,7 @@ dragonball = { workspace = true, features = [
     "dbs-upcall",
     "virtio-mem",
     "virtio-balloon",
+    "virtio-rng",
     "vhost-user-net",
     "host-device",
 ], optional = true }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -14,7 +14,10 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use dragonball::{
     api::v1::{BootSourceConfig, VcpuResizeInfo},
-    device_manager::{balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo},
+    device_manager::{
+        balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo,
+        rng_dev_mgr::RngDeviceConfigInfo,
+    },
     vm::VmConfigInfo,
 };
 
@@ -171,6 +174,19 @@ impl DragonballInner {
                 .context("kernel params to string")?,
         )
         .context("set_boot_source")?;
+
+        // insert the virtio-rng device before boot: it is cold-plug only
+        let entropy_source = &self.config.machine_info.entropy_source;
+        if !entropy_source.is_empty() {
+            let rng_config = RngDeviceConfigInfo {
+                src: entropy_source.clone(),
+                use_shared_irq: None,
+                use_generic_irq: None,
+            };
+            self.vmm_instance
+                .insert_rng_device(rng_config)
+                .context("insert rng device")?;
+        }
 
         // add pending devices
         while let Some(dev) = self.pending_devices.pop() {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -14,7 +14,10 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use dragonball::{
     api::v1::{BootSourceConfig, VcpuResizeInfo},
-    device_manager::{balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo},
+    device_manager::{
+        balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo,
+        rng_dev_mgr::RngDeviceConfigInfo,
+    },
     vm::VmConfigInfo,
 };
 
@@ -141,6 +144,19 @@ impl DragonballInner {
 
         self.set_vm_base_config().context("set vm base config")?;
         self.configure_boot_source()?;
+
+        // insert the virtio-rng device before boot: it is cold-plug only
+        let entropy_source = &self.config.machine_info.entropy_source;
+        if !entropy_source.is_empty() {
+            let rng_config = RngDeviceConfigInfo {
+                src: entropy_source.clone(),
+                use_shared_irq: None,
+                use_generic_irq: None,
+            };
+            self.vmm_instance
+                .insert_rng_device(rng_config)
+                .context("insert rng device")?;
+        }
 
         // add pending devices
         while let Some(dev) = self.pending_devices.pop() {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -42,6 +42,10 @@ const DRAGONBALL_ROOT_FS: &str = "rootfs";
 const BALLOON_DEVICE_ID: &str = "balloon0";
 const MEM_DEVICE_ID: &str = "memmr0";
 
+fn should_insert_host_rng(entropy_source: &str, confidential_guest: bool) -> bool {
+    !entropy_source.is_empty() && !confidential_guest
+}
+
 #[derive(Debug)]
 pub struct DragonballInner {
     /// sandbox id
@@ -147,15 +151,31 @@ impl DragonballInner {
 
         // insert the virtio-rng device before boot: it is cold-plug only
         let entropy_source = &self.config.machine_info.entropy_source;
-        if !entropy_source.is_empty() {
-            let rng_config = RngDeviceConfigInfo {
-                src: entropy_source.clone(),
-                use_shared_irq: None,
-                use_generic_irq: None,
-            };
-            self.vmm_instance
-                .insert_rng_device(rng_config)
-                .context("insert rng device")?;
+        let confidential_guest = self.config.security_info.confidential_guest;
+        if should_insert_host_rng(entropy_source, confidential_guest) {
+            // The VMM opens the entropy source while creating the devices and
+            // reports a failure there as a fatal boot error. Probe it first so
+            // that a source which is configured but not readable at runtime
+            // only costs the VM its virtio-rng device instead of preventing
+            // every container on the host from starting.
+            match std::fs::File::open(entropy_source) {
+                Ok(_) => {
+                    let rng_config = RngDeviceConfigInfo {
+                        src: entropy_source.clone(),
+                        use_shared_irq: None,
+                        use_generic_irq: None,
+                    };
+                    self.vmm_instance
+                        .insert_rng_device(rng_config)
+                        .context("insert rng device")?;
+                }
+                Err(e) => warn!(
+                    sl!(),
+                    "skip virtio-rng, entropy source {} is not readable: {}", entropy_source, e
+                ),
+            }
+        } else if confidential_guest && !entropy_source.is_empty() {
+            warn!(sl!(), "skip host-backed virtio-rng for confidential guest");
         }
 
         // add pending devices
@@ -627,5 +647,12 @@ mod tests {
         inner.config.boot_info.kernel = "/kernel-must-not-be-opened".to_string();
 
         inner.configure_boot_source().unwrap();
+    }
+
+    #[test]
+    fn test_should_insert_host_rng() {
+        assert!(should_insert_host_rng("/dev/urandom", false));
+        assert!(!should_insert_host_rng("", false));
+        assert!(!should_insert_host_rng("/dev/urandom", true));
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -23,7 +23,7 @@ use dragonball::{
     },
     device_manager::{
         balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo,
-        vfio_dev_mgr::HostDeviceConfig,
+        rng_dev_mgr::RngDeviceConfigInfo, vfio_dev_mgr::HostDeviceConfig,
     },
     vm::VmConfigInfo,
     Vmm,
@@ -341,6 +341,12 @@ impl VmmInstance {
     pub fn insert_balloon_device(&self, cfg: BalloonDeviceConfigInfo) -> Result<()> {
         self.handle_request(Request::Sync(VmmAction::InsertBalloonDevice(cfg.clone())))
             .with_context(|| format!("Failed to insert balloon device: {cfg:?}"))?;
+        Ok(())
+    }
+
+    pub fn insert_rng_device(&self, cfg: RngDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertRngDevice(cfg.clone())))
+            .with_context(|| format!("Failed to insert rng device: {cfg:?}"))?;
         Ok(())
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -23,7 +23,7 @@ use dragonball::{
     },
     device_manager::{
         balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo,
-        vfio_dev_mgr::HostDeviceConfig,
+        rng_dev_mgr::RngDeviceConfigInfo, vfio_dev_mgr::HostDeviceConfig,
     },
     vm::VmConfigInfo,
     Vmm,
@@ -353,6 +353,12 @@ impl VmmInstance {
     pub fn insert_balloon_device(&self, cfg: BalloonDeviceConfigInfo) -> Result<()> {
         self.handle_request(Request::Sync(VmmAction::InsertBalloonDevice(cfg.clone())))
             .with_context(|| format!("Failed to insert balloon device: {cfg:?}"))?;
+        Ok(())
+    }
+
+    pub fn insert_rng_device(&self, cfg: RngDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertRngDevice(cfg.clone())))
+            .with_context(|| format!("Failed to insert rng device: {cfg:?}"))?;
         Ok(())
     }
 


### PR DESCRIPTION
## What this PR does

Adds a virtio-rng (entropy) device to Dragonball and wires it to the
`machine_info.entropy_source` configuration that kata already exposes (default
`/dev/urandom`, annotation `io.katacontainers.config.hypervisor.entropy_source`)
but never used for the Dragonball backend.

Short-lived microVMs can stall on guest entropy during early boot (systemd, TLS,
`getrandom`); a paravirtual RNG seeds the guest cheaply.

### Implementation

Follows the existing Dragonball device pattern, mirroring virtio-balloon at each layer:

- **`dbs-virtio-devices/src/rng.rs`**: the device backend. `TYPE_RNG` (4) was already
  reserved. One virtqueue (size 256), no device config space, features =
  `VIRTIO_F_VERSION_1`. An epoll handler fills guest write-only descriptors from the
  host entropy `File` (`read_volatile_from`) and returns them via the used ring.
- **`src/device_manager/rng_dev_mgr.rs`**: `RngDeviceMgr` + `RngDeviceConfigInfo`
  (the entropy path doubles as the device id). Cold-plug only: hotplug requests are
  rejected with `UpdateNotAllowedPostBoot`. Devices are attached in
  `DeviceManager::create_devices` at boot.
- **`api/v1/vmm_action.rs`**: new `VmmAction::InsertRngDevice`, valid only before boot.
- **runtime-rs**: `VmmInstance::insert_rng_device` and a call in the Dragonball
  `cold_start_vm` path that inserts the device when `entropy_source` is non-empty.

Everything is gated behind a new `virtio-rng` cargo feature, enabled by the
runtime-rs hypervisor crate.

## Verification

Unit tests cover the device (type/queues/features, activate, queue processing), the
manager (conflict, insert, hotplug rejection, attach) and the vmm action.

Verified end-to-end by booting a container with the runtime-rs shim + built-in
Dragonball. Guest side:

```
/sys/bus/virtio/devices/virtio2: 0x0004     # TYPE_RNG on the virtio bus
# cat /sys/class/misc/hw_random/rng_current
virtio_rng.0
```

Host side (with temporary debug logs), showing the guest kernel negotiating features
and pulling entropy through the virtqueue (16-byte hwrng probe read at driver
registration, then 64-byte `khwrngd` reads feeding the guest CRNG):

```
virtio-rng: entropy_source from config: "/dev/urandom"
add virtio-rng device configuration
attach virtio-rng device
virtio-rng: activating with 1 queue(s), acked_features 0x100000000
virtio-rng: filled 1 used descriptor(s) with 16 random bytes in total
virtio-rng: filled 1 used descriptor(s) with 64 random bytes in total  (x6)
```

## Out of scope (follow-ups)

Hotplug/unplug, rate limiting, and snapshot/persistence support for the device.