### PR TITLE
kata-deploy: Follow general debug variable log level logic on kata mo…

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -41,9 +41,15 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
 {{- toYaml .Values.monitor.securityContext | nindent 10 }}
+        {{- $monitorLogLevel := .Values.monitor.logLevel | default "" | trim -}}
+        {{- if and (not $monitorLogLevel) .Values.debug -}}
+        {{- $monitorLogLevel = "debug" -}}
+        {{- end }}
         args:
           - -listen-address={{ .Values.monitor.listenAddress }}
-          - -log-level={{ .Values.monitor.logLevel }}
+          {{- if $monitorLogLevel }}
+          - -log-level={{ $monitorLogLevel }}
+          {{- end }}
           - -runtime-endpoint={{ .Values.monitor.runtimeEndpoint }}
         ports:
           - containerPort: {{ .Values.monitor.port }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -120,7 +120,11 @@ monitor:
     tag: ""
   listenAddress: "0.0.0.0:8090"
   runtimeEndpoint: "unix:///run/containerd/containerd.sock"
-  logLevel: "info"
+  # Optional CLI log level override for kata-monitor.
+  # Supported values: trace, debug, info, warn, error, fatal, panic
+  # When empty, debug:true implies -log-level=debug; otherwise kata-monitor falls
+  # back to cli default.
+  logLevel: ""
   port: 8090
   securityContext:
     privileged: false


### PR DESCRIPTION
…nitor

When setting debug in the helm chart kata monitor should derive the log level from it. Otherwise default back to default or log level set in monitor settings.

Fixes kata-containers#13382