### PR TITLE
runtime-rs: Add Cloud Hypervisor VM template support

### DIFF
--- a/.github/workflows/run-k8s-tests-on-free-runner.yaml
+++ b/.github/workflows/run-k8s-tests-on-free-runner.yaml
@@ -51,6 +51,8 @@ jobs:
           { vmm: qemu-runtime-rs, containerd_version: latest },
           { vmm: qemu-runtime-rs, containerd_version: minimum },
           { vmm: clh-runtime-rs, containerd_version: latest },
+          # TODO: Remove k8s_test_union once CLH supports multi-layer images with EROFS.
+          { vmm: clh-runtime-rs, containerd_version: latest, snapshotter: erofs, erofs_mode: disk, erofs_merge_mode: unmerged, k8s_test_union: k8s-vm-templating.bats },
           { vmm: clh-runtime-rs, containerd_version: minimum },
           { vmm: qemu-nvidia-cpu, containerd_version: latest },
           { vmm: qemu-nvidia-cpu-runtime-rs, containerd_version: latest, snapshotter: erofs, erofs_mode: memory, erofs_dmverity: dmverity },
@@ -70,6 +72,7 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.environment.vmm }}
       KUBERNETES: vanilla
       K8S_TEST_HOST_TYPE: baremetal-no-attestation
+      K8S_TEST_UNION: ${{ matrix.environment.k8s_test_union }}
       CONTAINER_ENGINE: containerd
       CONTAINER_ENGINE_VERSION: ${{ matrix.environment.containerd_version }}
       SNAPSHOTTER: ${{ matrix.environment.snapshotter }}

--- a/src/libs/kata-types/src/capabilities.rs
+++ b/src/libs/kata-types/src/capabilities.rs
@@ -23,6 +23,8 @@ pub enum CapabilityBits {
     GuestMemoryProbe,
     /// hypervisor supports exposing block discard/unmap to the guest
     BlockDeviceDiscardSupport,
+    /// hypervisor supports network device hotplug
+    NetworkDeviceHotplugSupport,
 }
 
 /// Capabilities describe a virtcontainers hypervisor capabilities through a bit mask.
@@ -91,6 +93,11 @@ impl Capabilities {
     pub fn is_block_device_discard_supported(&self) -> bool {
         self.flags.and(CapabilityBits::BlockDeviceDiscardSupport) != 0
     }
+
+    /// is_network_device_hotplug_supported tells if the hypervisor supports network hotplug.
+    pub fn is_network_device_hotplug_supported(&self) -> bool {
+        self.flags.and(CapabilityBits::NetworkDeviceHotplugSupport) != 0
+    }
 }
 
 #[cfg(test)]
@@ -103,6 +110,7 @@ mod tests {
     fn test_set_hypervisor_capabilities() {
         let mut cap = Capabilities::new();
         assert!(!cap.is_block_device_supported());
+        assert!(!cap.is_network_device_hotplug_supported());
 
         // test legacy vsock support
         assert!(!cap.is_hybrid_vsock_supported());
@@ -144,5 +152,8 @@ mod tests {
         // test block discard capability
         cap.add(CapabilityBits::BlockDeviceDiscardSupport);
         assert!(cap.is_block_device_discard_supported());
+        // test network device hotplug capability
+        cap.add(CapabilityBits::NetworkDeviceHotplugSupport);
+        assert!(cap.is_network_device_hotplug_supported());
     }
 }

--- a/src/libs/kata-types/src/config/hypervisor/ch.rs
+++ b/src/libs/kata-types/src/config/hypervisor/ch.rs
@@ -86,6 +86,9 @@ impl ConfigPlugin for CloudHypervisorConfig {
             if ch.memory_info.memory_slots == 0 {
                 ch.memory_info.memory_slots = default::DEFAULT_CH_MEMORY_SLOTS;
             }
+            if ch.factory.template_path.is_empty() {
+                ch.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
+            }
         }
 
         Ok(())

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -291,6 +291,18 @@ guest_swap_size_percent = 100
 # Default 60.
 guest_swap_create_threshold_secs = 60
 
+[hypervisor.clh.factory]
+# VM templating support. Once enabled, new VMs are created from template.
+# CLH templating requires no shared filesystem and a block-capable snapshotter.
+#
+# Default false
+enable_template = false
+
+# Specifies the path of template.
+#
+# Default "/run/vc/vm/template"
+template_path = "/run/vc/vm/template"
+
 [agent.@PROJECT_TYPE@]
 container_pipe_size = @PIPESIZE@
 # If enabled, make the agent display debug-level messages.

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -291,6 +291,18 @@ guest_swap_size_percent = 100
 # Default 60.
 guest_swap_create_threshold_secs = 60
 
+[hypervisor.clh.factory]
+# VM templating support. Once enabled, new VMs are created from template.
+# CLH templating requires no shared filesystem and a block-capable snapshotter.
+#
+# Default false
+enable_template = false
+
+# Specifies the path of template.
+#
+# Default "/run/vc/vm/template"
+template_path = "/run/vc/vm/template"
+
 [agent.@PROJECT_TYPE@]
 container_pipe_size = @PIPESIZE@
 # If enabled, make the agent display debug-level messages.

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
@@ -83,6 +83,40 @@ pub async fn cloud_hypervisor_vm_start(api_socket: &ApiSocket) -> Result<Option<
     api_command(api_socket, "PUT", "vm.boot", None, None).await
 }
 
+pub async fn cloud_hypervisor_vm_pause(api_socket: &ApiSocket) -> Result<Option<String>> {
+    api_command(api_socket, "PUT", "vm.pause", None, None).await
+}
+
+pub async fn cloud_hypervisor_vm_resume(api_socket: &ApiSocket) -> Result<Option<String>> {
+    api_command(api_socket, "PUT", "vm.resume", None, None).await
+}
+
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+pub struct VmSnapshotConfig {
+    pub destination_url: String,
+}
+
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+pub struct RestoreConfig {
+    pub source_url: String,
+}
+
+pub async fn cloud_hypervisor_vm_snapshot(
+    api_socket: &ApiSocket,
+    cfg: VmSnapshotConfig,
+) -> Result<Option<String>> {
+    let body = serde_json::to_string(&cfg)?;
+    api_command(api_socket, "PUT", "vm.snapshot", Some(body), None).await
+}
+
+pub async fn cloud_hypervisor_vm_restore(
+    api_socket: &ApiSocket,
+    cfg: RestoreConfig,
+) -> Result<Option<String>> {
+    let body = serde_json::to_string(&cfg)?;
+    api_command(api_socket, "PUT", "vm.restore", Some(body), None).await
+}
+
 #[allow(dead_code)]
 pub async fn cloud_hypervisor_vm_stop(api_socket: &ApiSocket) -> Result<Option<String>> {
     api_command(api_socket, "PUT", "vm.shutdown", None, None).await

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -7,8 +7,8 @@ use crate::ProtectionDevConfig;
 use crate::VmConfig;
 use crate::{
     guest_protection_is_tdx, ConsoleConfig, ConsoleOutputMode, CpuFeatures, CpuTopology,
-    CpusConfig, DiskConfig, MemoryConfig, PayloadConfig, PlatformConfig, PmemConfig, RngConfig,
-    VsockConfig,
+    CpusConfig, DiskConfig, MemoryConfig, MemoryZoneConfig, PayloadConfig, PlatformConfig,
+    PmemConfig, RngConfig, VsockConfig,
 };
 use anyhow::Result;
 use kata_sys_util::protection::GuestProtection;
@@ -19,6 +19,7 @@ use kata_types::config::hypervisor::{
 };
 use kata_types::config::BootInfo;
 use std::convert::TryFrom;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::errors::*;
@@ -124,6 +125,12 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
         let host_devices = n.host_devices;
         let protection_dev = n.protection_device;
 
+        let template_memory = if cfg.vm_template.boot_to_be_template {
+            Some(template_memory_config(&cfg).map_err(VmConfigError::MemoryError)?)
+        } else {
+            None
+        };
+
         let cpus = CpusConfig::try_from((cfg.cpu_info, guest_protection_to_use.clone()))
             .map_err(VmConfigError::CPUError)?;
 
@@ -174,8 +181,11 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
         let serial = get_serial_cfg(debug, guest_protection_to_use.clone());
         let console = get_console_cfg(debug, guest_protection_to_use.clone());
 
-        let memory = MemoryConfig::try_from((cfg.memory_info, guest_protection_to_use.clone()))
-            .map_err(VmConfigError::MemoryError)?;
+        let memory = match template_memory {
+            Some(memory) => memory,
+            None => MemoryConfig::try_from((cfg.memory_info, guest_protection_to_use.clone()))
+                .map_err(VmConfigError::MemoryError)?,
+        };
 
         std::fs::create_dir_all(sandbox_path.clone())
             .map_err(|e| VmConfigError::SandboxError(sandbox_path, e.to_string()))?;
@@ -297,6 +307,50 @@ impl TryFrom<(MemoryInfo, GuestProtection)> for MemoryConfig {
 
         Ok(cfg)
     }
+}
+
+/// Builds the file-backed memory configuration for creating a source template VM.
+fn template_memory_config(cfg: &HypervisorConfig) -> Result<MemoryConfig, MemoryConfigError> {
+    let mem = cfg.memory_info.clone();
+
+    if mem.default_memory == 0 {
+        return Err(MemoryConfigError::NoDefaultMemory);
+    }
+
+    if cfg.vm_template.memory_path.is_empty() {
+        return Err(MemoryConfigError::NoTemplateMemoryPath);
+    }
+
+    fs::metadata(&cfg.vm_template.memory_path).map_err(|e| {
+        MemoryConfigError::TemplateMemoryPathNotAccessible(format!(
+            "{}: {}",
+            cfg.vm_template.memory_path, e
+        ))
+    })?;
+
+    if cfg.shared_fs.shared_fs.is_some() {
+        return Err(MemoryConfigError::TemplateRequiresNoSharedFs);
+    }
+
+    let mem_bytes = MIB
+        .checked_mul(u64::from(mem.default_memory))
+        .ok_or(MemoryConfigError::BadDefaultMemSize(mem.default_memory))?;
+    let zone = MemoryZoneConfig {
+        id: "mem0".to_string(),
+        size: mem_bytes,
+        file: Some(PathBuf::from(&cfg.vm_template.memory_path)),
+        shared: true,
+        prefault: mem.enable_mem_prealloc,
+        ..Default::default()
+    };
+
+    Ok(MemoryConfig {
+        size: 0,
+        shared: true,
+        prefault: mem.enable_mem_prealloc,
+        zones: Some(vec![zone]),
+        ..Default::default()
+    })
 }
 
 // Return the next multiple of 'multiple' starting from the specified value
@@ -585,6 +639,8 @@ fn get_platform_cfg(guest_protection_to_use: GuestProtection) -> Option<Platform
 
 #[cfg(test)]
 mod tests {
+    use crate::HotplugMethod;
+
     use super::*;
     use kata_sys_util::protection::SevSnpDetails;
     use kata_types::config::hypervisor::{
@@ -1607,6 +1663,43 @@ mod tests {
             assert!(result.is_ok(), "{}", msg);
             assert_eq!(&result.unwrap(), d.result.as_ref().unwrap(), "{}", msg);
         }
+    }
+
+    #[test]
+    fn test_template_memory_config() {
+        let memory_path =
+            std::env::temp_dir().join(format!("kata-clh-template-memory-{}", std::process::id()));
+        fs::write(&memory_path, []).unwrap();
+
+        let mut cfg = HypervisorConfig {
+            memory_info: MemoryInfo {
+                default_memory: 512,
+                default_maxmemory: 0,
+                enable_hugepages: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        cfg.vm_template.boot_to_be_template = true;
+        cfg.vm_template.memory_path = memory_path.to_string_lossy().to_string();
+
+        let memory = template_memory_config(&cfg).unwrap();
+        let zones = memory.zones.as_ref().unwrap();
+
+        assert_eq!(memory.size, 0);
+        assert_eq!(memory.hotplug_method, HotplugMethod::Acpi);
+        assert!(memory.hotplug_size.is_none());
+        assert!(memory.shared);
+        assert!(!memory.hugepages);
+        assert_eq!(zones.len(), 1);
+        assert_eq!(zones[0].id, "mem0");
+        assert_eq!(zones[0].size, 512 * MIB);
+        assert_eq!(zones[0].file, Some(memory_path.clone()));
+        assert!(zones[0].shared);
+        assert!(!zones[0].hugepages);
+        assert!(zones[0].hotplug_size.is_none());
+
+        fs::remove_file(memory_path).unwrap();
     }
 
     #[test]

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -31,7 +31,7 @@ const PMEM_ALIGN_BYTES: u64 = 2 * MIB;
 
 const DEFAULT_CH_MAX_PHYS_BITS: u8 = 46;
 
-const DEFAULT_VSOCK_CID: u64 = 3;
+const DEFAULT_VSOCK_CID: u32 = 3;
 
 pub const DEFAULT_NUM_PCI_SEGMENTS: u16 = 1;
 
@@ -226,10 +226,10 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
     }
 }
 
-impl TryFrom<(String, u64)> for VsockConfig {
+impl TryFrom<(String, u32)> for VsockConfig {
     type Error = VsockConfigError;
 
-    fn try_from(args: (String, u64)) -> Result<Self, Self::Error> {
+    fn try_from(args: (String, u32)) -> Result<Self, Self::Error> {
         let vsock_socket_path = args.0;
         let cid = args.1;
 
@@ -380,16 +380,12 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
             return Err(CpusConfigError::BootVCPUsTooSmall);
         }
 
-        let default_vcpus = u8::try_from(cpu.default_vcpus.ceil() as u32)
-            .map_err(CpusConfigError::BootVCPUsTooBig)?;
+        let default_vcpus = cpu.default_vcpus.ceil() as u32;
 
         // This can only happen if runtime-rs fails to set default values.
         if cpu.default_maxvcpus == 0 {
             return Err(CpusConfigError::MaxVCPUsTooSmall);
         }
-
-        let default_max_vcpus =
-            u8::try_from(cpu.default_maxvcpus).map_err(CpusConfigError::MaxVCPUsTooBig)?;
 
         let boot_vcpus = default_vcpus;
 
@@ -398,15 +394,18 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
             // cpus.
             default_vcpus
         } else {
-            default_max_vcpus
+            cpu.default_maxvcpus
         };
 
         if boot_vcpus > max_vcpus {
             return Err(CpusConfigError::BootVPUsGtThanMaxVCPUs);
         }
 
+        let cores_per_die =
+            u16::try_from(max_vcpus).map_err(CpusConfigError::MaxVCPUsTooBigForTopology)?;
+
         let topology = CpuTopology {
-            cores_per_die: max_vcpus,
+            cores_per_die,
             threads_per_core: 1,
             dies_per_package: 1,
             packages: 1,
@@ -643,6 +642,7 @@ mod tests {
 
     use super::*;
     use kata_sys_util::protection::SevSnpDetails;
+    use kata_types::config::default::MAX_CH_VCPUS;
     use kata_types::config::hypervisor::{
         BlockDeviceInfo, Hypervisor as HypervisorConfig, SecurityInfo,
     };
@@ -692,12 +692,8 @@ mod tests {
         }
     }
 
-    fn make_cpu_objects(cpu_default: u8, cpu_max: u8, tdx: bool) -> (CpuInfo, CpusConfig) {
-        let default_maxvcpus = if tdx {
-            cpu_default as u32
-        } else {
-            cpu_max as u32
-        };
+    fn make_cpu_objects(cpu_default: u32, cpu_max: u32, tdx: bool) -> (CpuInfo, CpusConfig) {
+        let default_maxvcpus = if tdx { cpu_default } else { cpu_max };
 
         let cpu_info = CpuInfo {
             default_vcpus: cpu_default as f32,
@@ -706,18 +702,14 @@ mod tests {
             ..Default::default()
         };
 
-        let max_vcpus = if tdx {
-            cpu_default
-        } else {
-            default_maxvcpus as u8
-        };
+        let max_vcpus = if tdx { cpu_default } else { default_maxvcpus };
 
         let cpus_config = CpusConfig {
             boot_vcpus: cpu_default,
             max_vcpus,
             nested: cpu_nested_config(),
             topology: Some(CpuTopology {
-                cores_per_die: max_vcpus,
+                cores_per_die: u16::try_from(max_vcpus).unwrap(),
 
                 ..make_bare_topology()
             }),
@@ -1323,6 +1315,27 @@ mod tests {
             TestData {
                 cpu_info: CpuInfo {
                     default_vcpus: 1.0,
+                    default_maxvcpus: 256,
+                    ..Default::default()
+                },
+                guest_protection: GuestProtection::NoProtection,
+                result: Ok(CpusConfig {
+                    boot_vcpus: 1,
+                    max_vcpus: 256,
+                    nested: cpu_nested_config(),
+                    topology: Some(CpuTopology {
+                        cores_per_die: 256,
+
+                        ..topology
+                    }),
+                    max_phys_bits: DEFAULT_CH_MAX_PHYS_BITS,
+
+                    ..Default::default()
+                }),
+            },
+            TestData {
+                cpu_info: CpuInfo {
+                    default_vcpus: 1.0,
                     default_maxvcpus: 13,
                     ..Default::default()
                 },
@@ -1707,7 +1720,7 @@ mod tests {
         #[derive(Debug)]
         struct TestData<'a> {
             vsock_socket_path: &'a str,
-            cid: u64,
+            cid: u32,
             result: Result<VsockConfig, VsockConfigError>,
         }
 
@@ -1790,8 +1803,8 @@ mod tests {
         let valid_vsock =
             VsockConfig::try_from((vsock_socket_path.to_string(), DEFAULT_VSOCK_CID)).unwrap();
 
-        let (cpu_info, cpus_config) = make_cpu_objects(7, u8::MAX, false);
-        let (cpu_info_tdx, cpus_config_tdx) = make_cpu_objects(7, u8::MAX, true);
+        let (cpu_info, cpus_config) = make_cpu_objects(7, MAX_CH_VCPUS, false);
+        let (cpu_info_tdx, cpus_config_tdx) = make_cpu_objects(7, MAX_CH_VCPUS, true);
 
         let (memory_info_std, mem_config_std) =
             make_memory_objects(79, usable_max_mem_bytes, false);

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
@@ -114,6 +114,15 @@ pub enum MemoryConfigError {
 
     #[error("Failed to query system memory information: {0}")]
     SysInfoFail(#[source] nix::errno::Errno),
+
+    #[error("Template memory path is empty")]
+    NoTemplateMemoryPath,
+
+    #[error("Template memory path is not accessible: {0}")]
+    TemplateMemoryPathNotAccessible(String),
+
+    #[error("Template mode requires no shared filesystem")]
+    TemplateRequiresNoSharedFs,
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
@@ -70,14 +70,11 @@ pub enum CpusConfigError {
     #[error("Boot vCPUs cannot be zero or negative")]
     BootVCPUsTooSmall,
 
-    #[error("Too many boot vCPUs specified: {0}")]
-    BootVCPUsTooBig(<u8 as TryFrom<i32>>::Error),
-
     #[error("Max vCPUs cannot be zero or negative")]
     MaxVCPUsTooSmall,
 
-    #[error("Too many max vCPUs specified: {0}")]
-    MaxVCPUsTooBig(<u8 as TryFrom<u32>>::Error),
+    #[error("Max vCPUs cannot be represented in CPU topology: {0}")]
+    MaxVCPUsTooBigForTopology(<u16 as TryFrom<u32>>::Error),
 
     #[error("Boot vCPUs cannot be larger than max vCPUs")]
     BootVPUsGtThanMaxVCPUs,

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -15,8 +15,6 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 use kata_types::config::hypervisor::RateLimiterConfig;
 pub use net_util::MacAddr;
 
-pub const MAX_NUM_PCI_SEGMENTS: u16 = 16;
-
 mod errors;
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -62,14 +60,14 @@ pub enum ConsoleOutputMode {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpuAffinity {
-    pub vcpu: u8,
-    pub host_cpus: Vec<u8>,
+    pub vcpu: u32,
+    pub host_cpus: Vec<usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpusConfig {
-    pub boot_vcpus: u8,
-    pub max_vcpus: u8,
+    pub boot_vcpus: u32,
+    pub max_vcpus: u32,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topology: Option<CpuTopology>,
@@ -96,10 +94,10 @@ pub struct CpuFeatures {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpuTopology {
-    pub threads_per_core: u8,
-    pub cores_per_die: u8,
-    pub dies_per_package: u8,
-    pub packages: u8,
+    pub threads_per_core: u16,
+    pub cores_per_die: u16,
+    pub dies_per_package: u16,
+    pub packages: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -338,7 +336,7 @@ pub struct NumaConfig {
     #[serde(default)]
     pub guest_numa_id: u32,
     #[serde(default)]
-    pub cpus: Option<Vec<u8>>,
+    pub cpus: Option<Vec<u32>>,
     #[serde(default)]
     pub distances: Option<Vec<NumaDistance>>,
     #[serde(default)]
@@ -503,7 +501,7 @@ pub struct VmConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct VsockConfig {
-    pub cid: u64,
+    pub cid: u32,
     pub socket: PathBuf,
     #[serde(default)]
     pub iommu: bool,
@@ -555,7 +553,7 @@ pub struct NamedHypervisorConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct VmResize {
-    pub desired_vcpus: Option<u8>,
+    pub desired_vcpus: Option<u32>,
     pub desired_ram: Option<u64>,
     pub desired_balloon: Option<u64>,
 }
@@ -588,6 +586,23 @@ pub fn guest_protection_is_tdx(guest_protection_to_use: GuestProtection) -> bool
 mod tests {
     use super::*;
     use kata_sys_util::protection::SevSnpDetails;
+
+    #[test]
+    fn test_vm_resize_serialization_preserves_256_vcpus() {
+        let resize = VmResize {
+            desired_vcpus: Some(256),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(resize).unwrap(),
+            serde_json::json!({
+                "desired_vcpus": 256,
+                "desired_ram": null,
+                "desired_balloon": null,
+            })
+        );
+    }
 
     #[test]
     fn test_guest_protection_is_tdx() {

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -264,7 +264,7 @@ impl CloudHypervisorInner {
         let hvsock_config = device.config.clone();
 
         let vsock_config = VsockConfig {
-            cid: hvsock_config.guest_cid.into(),
+            cid: hvsock_config.guest_cid,
             socket: hvsock_config.uds_path.into(),
             ..Default::default()
         };

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -21,12 +21,14 @@ use anyhow::{anyhow, Context, Result};
 use ch_config::ch_api::cloud_hypervisor_vm_netdev_add_with_fds;
 use ch_config::{
     ch_api::{
-        cloud_hypervisor_vm_create, cloud_hypervisor_vm_info, cloud_hypervisor_vm_resize,
-        cloud_hypervisor_vm_start, cloud_hypervisor_vmm_ping, cloud_hypervisor_vmm_shutdown,
+        cloud_hypervisor_vm_create, cloud_hypervisor_vm_info, cloud_hypervisor_vm_pause,
+        cloud_hypervisor_vm_resize, cloud_hypervisor_vm_restore, cloud_hypervisor_vm_resume,
+        cloud_hypervisor_vm_snapshot, cloud_hypervisor_vm_start, cloud_hypervisor_vmm_ping,
+        cloud_hypervisor_vmm_shutdown, RestoreConfig, VmSnapshotConfig,
     },
     VmResize,
 };
-use ch_config::{guest_protection_is_tdx, NamedHypervisorConfig, VmConfig};
+use ch_config::{guest_protection_is_tdx, NamedHypervisorConfig, State, VmConfig};
 use core::future::poll_fn;
 use futures::future::join_all;
 use kata_sys_util::protection::{available_guest_protection, GuestProtection};
@@ -43,8 +45,10 @@ use nix::unistd::Uid;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, RwLock};
 use tokio::io::BufReader;
@@ -65,6 +69,9 @@ const CH_FEATURES_KEY: &str = "features";
 
 // The name of the CH build-time feature for Intel TDX.
 const CH_FEATURE_TDX: &str = "tdx";
+
+const CLH_TEMPLATE_STATE_FILE: &str = "state.json";
+const CLH_TEMPLATE_CONFIG_FILE: &str = "config.json";
 
 #[derive(Debug, PartialEq)]
 enum CloudHypervisorLogLevel {
@@ -254,6 +261,148 @@ impl CloudHypervisorInner {
         if let Some(detail) = response {
             debug!(sl!(), "vm start response: {:?}", detail);
         }
+
+        Ok(())
+    }
+
+    fn template_dir(&self) -> Option<PathBuf> {
+        let memory_path = Path::new(&self.config.vm_template.memory_path);
+
+        memory_path.parent().map(Path::to_path_buf)
+    }
+
+    fn should_restore_from_template(&self) -> bool {
+        let Some(template_dir) = self.template_dir() else {
+            debug!(sl!(), "template memory path has no parent directory"; "memory-path" => self.config.vm_template.memory_path.clone());
+            return false;
+        };
+
+        let required_files = [
+            PathBuf::from(&self.config.vm_template.memory_path),
+            template_dir.join(CLH_TEMPLATE_STATE_FILE),
+            template_dir.join(CLH_TEMPLATE_CONFIG_FILE),
+        ];
+
+        for path in required_files {
+            if let Err(err) = fs::metadata(&path) {
+                debug!(sl!(), "template artifact not accessible"; "path" => path.display().to_string(), "error" => err.to_string());
+                return false;
+            }
+        }
+
+        info!(sl!(), "Template files found, can restore VM from template");
+
+        true
+    }
+
+    /// Copy a CLH template artifact while preserving the source file permissions.
+    fn copy_template_artifact(src: &Path, dst: &Path) -> Result<()> {
+        let metadata = fs::metadata(src).with_context(|| format!("stat {}", src.display()))?;
+        fs::copy(src, dst)
+            .with_context(|| format!("copy {} to {}", src.display(), dst.display()))?;
+        fs::set_permissions(dst, metadata.permissions())
+            .with_context(|| format!("set permissions on {}", dst.display()))?;
+        Ok(())
+    }
+
+    fn write_json_file(path: &Path, value: &Value) -> Result<()> {
+        let data = serde_json::to_vec(value)?;
+        fs::write(path, data).with_context(|| format!("write {}", path.display()))?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("set permissions on {}", path.display()))?;
+        Ok(())
+    }
+
+    fn update_vsock_socket_path(config_path: &Path, sandbox_id: &str) -> Result<()> {
+        let data =
+            fs::read(config_path).with_context(|| format!("read {}", config_path.display()))?;
+        let mut config: Value = serde_json::from_slice(&data)
+            .with_context(|| format!("parse {}", config_path.display()))?;
+
+        if let Some(vsock) = config.get_mut("vsock").and_then(Value::as_object_mut) {
+            let vsock_socket_path = get_vsock_path(sandbox_id)?;
+            vsock.insert("socket".to_string(), Value::String(vsock_socket_path));
+        }
+
+        Self::write_json_file(config_path, &config)
+    }
+
+    fn patch_snapshot_memory_shared(config_path: &Path, shared: bool) -> Result<()> {
+        let data =
+            fs::read(config_path).with_context(|| format!("read {}", config_path.display()))?;
+        let mut config: Value = serde_json::from_slice(&data)
+            .with_context(|| format!("parse {}", config_path.display()))?;
+
+        let memory = config
+            .get_mut("memory")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| anyhow!("snapshot config missing memory section"))?;
+        memory.insert("shared".to_string(), Value::Bool(shared));
+
+        let zones = memory
+            .get_mut("zones")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| anyhow!("snapshot config missing memory zones"))?;
+        for zone in zones {
+            let zone = zone
+                .as_object_mut()
+                .ok_or_else(|| anyhow!("snapshot config has invalid memory zone"))?;
+            zone.insert("shared".to_string(), Value::Bool(shared));
+        }
+
+        Self::write_json_file(config_path, &config)
+    }
+
+    fn prepare_restore_files(&self) -> Result<()> {
+        let template_dir = self
+            .template_dir()
+            .ok_or_else(|| anyhow!("template memory path has no parent directory"))?;
+        let vm_path = PathBuf::from(&self.vm_path);
+
+        create_dir_all_with_inherit_owner(&vm_path, 0o750)
+            .with_context(|| format!("failed to create VM path {}", vm_path.display()))?;
+
+        let src_config = template_dir.join(CLH_TEMPLATE_CONFIG_FILE);
+        let src_state = template_dir.join(CLH_TEMPLATE_STATE_FILE);
+        let dst_config = vm_path.join(CLH_TEMPLATE_CONFIG_FILE);
+        let dst_state = vm_path.join(CLH_TEMPLATE_STATE_FILE);
+
+        Self::copy_template_artifact(&src_config, &dst_config).context("copy template config")?;
+        Self::copy_template_artifact(&src_state, &dst_state).context("copy template state")?;
+        Self::update_vsock_socket_path(&dst_config, &self.id)
+            .context("update restore vsock socket path")?;
+
+        Ok(())
+    }
+
+    async fn restore_vm(&self) -> Result<()> {
+        let vm_path = PathBuf::from(&self.vm_path);
+        let state_file = vm_path.join(CLH_TEMPLATE_STATE_FILE);
+        let config_file = vm_path.join(CLH_TEMPLATE_CONFIG_FILE);
+
+        fs::metadata(&state_file)
+            .with_context(|| format!("access state file {}", state_file.display()))?;
+        fs::metadata(&config_file)
+            .with_context(|| format!("access config file {}", config_file.display()))?;
+
+        let source_url = format!("file://{}", vm_path.display());
+        let response = cloud_hypervisor_vm_restore(
+            &self.api_socket,
+            RestoreConfig {
+                source_url: source_url.clone(),
+            },
+        )
+        .await?;
+        if let Some(detail) = response {
+            debug!(sl!(), "vm restore response: {:?}", detail);
+        }
+
+        let info = cloud_hypervisor_vm_info(&self.api_socket).await?;
+        if !matches!(info.state, State::Paused) {
+            warn!(sl!(), "restored VM is not paused"; "state" => format!("{:?}", info.state));
+        }
+
+        info!(sl!(), "Successfully restored VM from template");
 
         Ok(())
     }
@@ -654,7 +803,16 @@ impl CloudHypervisorInner {
 
         self.state = VmmState::VmmServerReady;
 
-        self.boot_vm().await?;
+        if self.config.vm_template.boot_from_template && self.should_restore_from_template() {
+            self.prepare_restore_files()?;
+            self.restore_vm().await?;
+            self.resume_vm().await?;
+        } else {
+            if self.config.vm_template.boot_from_template {
+                self.config.vm_template.boot_from_template = false;
+            }
+            self.boot_vm().await?;
+        }
 
         self.state = VmmState::VmRunning;
 
@@ -683,15 +841,39 @@ impl CloudHypervisorInner {
         Ok(0)
     }
 
-    pub(crate) fn pause_vm(&self) -> Result<()> {
+    pub(crate) async fn pause_vm(&self) -> Result<()> {
+        let response = cloud_hypervisor_vm_pause(&self.api_socket).await?;
+        if let Some(detail) = response {
+            debug!(sl!(), "vm pause response: {:?}", detail);
+        }
         Ok(())
     }
 
-    pub(crate) fn resume_vm(&self) -> Result<()> {
+    pub(crate) async fn resume_vm(&self) -> Result<()> {
+        let response = cloud_hypervisor_vm_resume(&self.api_socket).await?;
+        if let Some(detail) = response {
+            debug!(sl!(), "vm resume response: {:?}", detail);
+        }
         Ok(())
     }
 
     pub(crate) async fn save_vm(&self) -> Result<()> {
+        let snapshot_dir = self
+            .template_dir()
+            .ok_or_else(|| anyhow!("template memory path has no parent directory"))?;
+        let destination_url = format!("file://{}", snapshot_dir.display());
+        let response =
+            cloud_hypervisor_vm_snapshot(&self.api_socket, VmSnapshotConfig { destination_url })
+                .await?;
+        if let Some(detail) = response {
+            debug!(sl!(), "vm snapshot response: {:?}", detail);
+        }
+
+        if self.config.vm_template.boot_to_be_template {
+            Self::patch_snapshot_memory_shared(&snapshot_dir.join(CLH_TEMPLATE_CONFIG_FILE), false)
+                .context("patch snapshot memory sharing")?;
+        }
+
         Ok(())
     }
 
@@ -808,12 +990,14 @@ impl CloudHypervisorInner {
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
                 | CapabilityBits::HybridVsockSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         } else {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
                 | CapabilityBits::FsSharingSupport
                 | CapabilityBits::HybridVsockSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         };
 
         caps.set(flags);
@@ -1091,6 +1275,17 @@ mod tests {
 
         // Modify the lazy static global config structure
         *existing = protection;
+    }
+
+    #[actix_rt::test]
+    async fn test_network_device_hotplug_capability() {
+        let ch = CloudHypervisorInner::default();
+
+        assert!(ch
+            .capabilities()
+            .await
+            .unwrap()
+            .is_network_device_hotplug_supported());
     }
 
     #[serial]

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -935,7 +935,7 @@ impl CloudHypervisorInner {
         }
 
         let vmresize = VmResize {
-            desired_vcpus: Some(new_vcpus as u8),
+            desired_vcpus: Some(new_vcpus),
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -93,12 +93,12 @@ impl Hypervisor for CloudHypervisor {
 
     async fn pause_vm(&self) -> Result<()> {
         let inner = self.inner.write().await;
-        inner.pause_vm()
+        inner.pause_vm().await
     }
 
     async fn resume_vm(&self) -> Result<()> {
         let inner = self.inner.write().await;
-        inner.resume_vm()
+        inner.resume_vm().await
     }
 
     async fn save_vm(&self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -766,11 +766,13 @@ impl QemuInner {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         } else {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
                 | CapabilityBits::FsSharingSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         };
         caps.set(flags);
 
@@ -1297,6 +1299,23 @@ impl QemuInner {
             )
         })?;
         qmp.get_device_by_qdev_id(hostdev_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_network_device_hotplug_capability() {
+        let (exit_notify, _exit_waiter) = mpsc::channel(1);
+        let qemu = QemuInner::new(exit_notify);
+
+        assert!(qemu
+            .capabilities()
+            .await
+            .unwrap()
+            .is_network_device_hotplug_supported());
     }
 }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -769,11 +769,13 @@ impl QemuInner {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         } else {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport
                 | CapabilityBits::FsSharingSupport
+                | CapabilityBits::NetworkDeviceHotplugSupport
         };
         caps.set(flags);
 
@@ -1302,6 +1304,23 @@ impl QemuInner {
             )
         })?;
         qmp.get_device_by_qdev_id(hostdev_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_network_device_hotplug_capability() {
+        let (exit_notify, _exit_waiter) = mpsc::channel(1);
+        let qemu = QemuInner::new(exit_notify);
+
+        assert!(qemu
+            .capabilities()
+            .await
+            .unwrap()
+            .is_network_device_hotplug_supported());
     }
 }
 

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -580,6 +580,8 @@ impl ErofsMultiLayerRootfs {
                         format: BlockDeviceFormat::Raw, // rw layer should be raw format
                         path_on_host: mount.source.clone(),
                         blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
+                        num_queues: blkdev_info.num_queues,
+                        queue_size: blkdev_info.queue_size,
                         ..Default::default()
                     };
 
@@ -733,6 +735,8 @@ impl ErofsMultiLayerRootfs {
                             path_on_host: erofs_path,
                             is_readonly: true,
                             blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
+                            num_queues: blkdev_info.num_queues,
+                            queue_size: blkdev_info.queue_size,
                             ..Default::default()
                         };
 
@@ -888,6 +892,8 @@ impl ErofsMultiLayerRootfs {
                             path_on_host: erofs_path,
                             is_readonly: true, // EROFS layers are read-only, must set to avoid "resize" lock errors
                             blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
+                            num_queues: blkdev_info.num_queues,
+                            queue_size: blkdev_info.queue_size,
                             ..Default::default()
                         };
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
+use hypervisor::HYPERVISOR_NAME_CH;
 use kata_sys_util::mount::umount_all;
 use kata_types::config::TomlConfig;
 use serde::{Deserialize, Serialize};
@@ -16,6 +17,16 @@ use crate::factory::{template::Template, vm::VmConfig};
 
 pub mod template;
 pub mod vm;
+
+/// Returns the path to the hypervisor's device-state artifact in the template directory.
+pub(crate) fn template_device_state_path(hypervisor_name: &str, template_path: &Path) -> PathBuf {
+    let state_file = match hypervisor_name {
+        HYPERVISOR_NAME_CH => "state.json",
+        _ => "state",
+    };
+
+    template_path.join(state_file)
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FactoryConfig {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/template.rs
@@ -10,16 +10,22 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
+use hypervisor::HYPERVISOR_NAME_CH;
 use kata_types::config::TomlConfig;
 use nix::mount::{mount, MsFlags};
+use slog::warn;
 
-use crate::factory::vm::{TemplateVm, VmConfig};
+use crate::factory::{
+    template_device_state_path,
+    vm::{TemplateVm, VmConfig},
+};
 
 /// Maximum time to wait for the Kata Agent to become ready when initializing a template VM.
 const TEMPLATE_WAIT_FOR_AGENT: Duration = Duration::from_secs(2);
 
 /// Preallocated size (in MB) for saving the device state snapshot of the template VM.
 const TEMPLATE_DEVICE_STATE_SIZE_MB: u32 = 8;
+const MIB: u64 = 1024 * 1024;
 
 #[derive(Debug)]
 pub struct Template {
@@ -73,10 +79,26 @@ impl Template {
     }
 
     pub fn template_vm_exists(&self) -> bool {
-        let memory_path = self.state_path.join("memory");
-        let state_path = self.state_path.join("state");
+        if !self.memory_path().exists() || !self.device_state_path().exists() {
+            return false;
+        }
 
-        memory_path.exists() && state_path.exists()
+        self.config_path().is_none_or(|path| path.exists())
+    }
+
+    fn memory_path(&self) -> PathBuf {
+        self.state_path.join("memory")
+    }
+
+    fn device_state_path(&self) -> PathBuf {
+        template_device_state_path(&self.config.hypervisor_name, &self.state_path)
+    }
+
+    fn config_path(&self) -> Option<PathBuf> {
+        match self.config.hypervisor_name.as_str() {
+            HYPERVISOR_NAME_CH => Some(self.state_path.join("config.json")),
+            _ => None,
+        }
     }
 
     pub fn prepare_template_files(&self) -> Result<()> {
@@ -119,9 +141,14 @@ impl Template {
         }
 
         // Create memory file
-        let memory_file = self.state_path.join("memory");
-        File::create(&memory_file)
+        let memory_file = self.memory_path();
+        let file = File::create(&memory_file)
             .context(format!("failed to create memory file: {memory_file:?}"))?;
+        let memory_size_bytes = u64::from(self.config.hypervisor_config.memory_info.default_memory)
+            .checked_mul(MIB)
+            .ok_or_else(|| anyhow!("template memory size overflows u64"))?;
+        file.set_len(memory_size_bytes)
+            .context(format!("failed to size memory file: {memory_file:?}"))?;
 
         // Verify memory file was created successfully
         if !memory_file.exists() {
@@ -140,9 +167,9 @@ impl Template {
         config.hypervisor_config.vm_template.boot_to_be_template = boot_to_be_template;
         config.hypervisor_config.vm_template.boot_from_template = !boot_to_be_template;
         config.hypervisor_config.vm_template.memory_path =
-            self.state_path.join("memory").to_string_lossy().to_string();
+            self.memory_path().to_string_lossy().to_string();
         config.hypervisor_config.vm_template.device_state_path =
-            self.state_path.join("state").to_string_lossy().to_string();
+            self.device_state_path().to_string_lossy().to_string();
         config
     }
 
@@ -152,22 +179,43 @@ impl Template {
             .await
             .context("new template vm")?;
 
-        vm.disconnect().await.context("disconnect template vm")?;
+        // Save the result so teardown still runs if any creation step fails.
+        let result: Result<()> = async {
+            vm.disconnect().await.context("disconnect template vm")?;
 
-        // Sleep a bit to let the agent grpc server clean up
-        // See: src/runtime/virtcontainers/factory/template/template_linux.go#L139-L145
-        // When we close connection to the agent, it needs sometime to cleanup
-        // and restart listening on the communication( serial or vsock) port.
-        // That time can be saved if we sleep a bit to wait for the agent to
-        // come around and start listening again. The sleep is only done when
-        // creating new vm templates and saves time for every new vm that are
-        // created from template, so it worth the invest.
-        sleep(TEMPLATE_WAIT_FOR_AGENT);
+            // Sleep a bit to let the agent grpc server clean up
+            // See: src/runtime/virtcontainers/factory/template/template_linux.go#L139-L145
+            // When we close connection to the agent, it needs sometime to cleanup
+            // and restart listening on the communication( serial or vsock) port.
+            // That time can be saved if we sleep a bit to wait for the agent to
+            // come around and start listening again. The sleep is only done when
+            // creating new vm templates and saves time for every new vm that are
+            // created from template, so it worth the invest.
+            sleep(TEMPLATE_WAIT_FOR_AGENT);
 
-        vm.pause().await.context("pause template vm")?;
+            vm.pause().await.context("pause template vm")?;
+            vm.save().await.context("save template vm")
+        }
+        .await;
 
-        vm.save().await.context("save template vm")?;
+        let teardown_result: Result<()> = async {
+            vm.stop().await.context("stop template vm")?;
+            vm.cleanup().await.context("cleanup template vm")
+        }
+        .await;
 
-        Ok(())
+        if let Err(teardown_error) = teardown_result {
+            if result.is_ok() {
+                return Err(teardown_error);
+            }
+
+            warn!(
+                sl!(),
+                "failed to tear down template VM after template creation failed: {}",
+                teardown_error
+            );
+        }
+
+        result
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -169,7 +169,6 @@ impl VmConfig {
 
 impl TemplateVm {
     /// Creates a new TemplateVm instance with the provided components and resources.
-    /// Currently, only QEMU is supported; other hypervisors are not yet implemented.
     pub fn new(
         id: String,
         hypervisor: Arc<dyn Hypervisor>,
@@ -187,7 +186,7 @@ impl TemplateVm {
         }
     }
 
-    /// Initializes the QEMU hypervisor for Kata
+    /// Initializes the configured hypervisor for Kata.
     async fn new_hypervisor(config: &VmConfig) -> Result<Arc<dyn Hypervisor>> {
         let hypervisor: Arc<dyn Hypervisor> = match config.hypervisor_name.as_str() {
             HYPERVISOR_QEMU => {
@@ -196,7 +195,16 @@ impl TemplateVm {
                     .await;
                 Arc::new(h)
             }
-            // TODO: Add support for additional hypervisors or proper error handling here.
+            #[cfg(all(
+                feature = "cloud-hypervisor",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ))]
+            hypervisor::HYPERVISOR_NAME_CH => {
+                let h = hypervisor::ch::CloudHypervisor::new();
+                h.set_hypervisor_config(config.hypervisor_config.clone())
+                    .await;
+                Arc::new(h)
+            }
             _ => return Err(anyhow!("Unsupported hypervisor {}", config.hypervisor_name)),
         };
         Ok(hypervisor)
@@ -308,6 +316,11 @@ impl TemplateVm {
             .stop_vm()
             .await
             .map_err(|e| anyhow::anyhow!("failed to stop vm: {}", e))
+    }
+
+    /// Remove runtime resources after the VM has stopped.
+    pub async fn cleanup(&self) -> Result<()> {
+        self.hypervisor.cleanup().await.context("cleanup vm")
     }
 
     /// Disconnect agent

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -58,7 +58,7 @@ use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 use kata_types::config::OpenVmmConfig;
 
-use crate::factory::vm::VmConfig;
+use crate::factory::{template_device_state_path, vm::VmConfig};
 use resource::cpu_mem::initial_size::InitialSizeManager;
 use resource::ResourceManager;
 use sandbox::VIRTCONTAINER;
@@ -196,7 +196,9 @@ async fn build_vm_from_template() -> Result<(Arc<dyn Hypervisor>, Arc<dyn Agent>
         h.vm_template.boot_from_template = true;
         let path = Path::new(&h.factory.template_path);
         h.vm_template.memory_path = path.join("memory").to_string_lossy().to_string();
-        h.vm_template.device_state_path = path.join("state").to_string_lossy().to_string();
+        h.vm_template.device_state_path = template_device_state_path(&hypervisor_name, path)
+            .to_string_lossy()
+            .to_string();
         let _ = VmConfig::validate_hypervisor_config(h);
     } else {
         return Err(anyhow!("hypervisor '{}' not found", hypervisor_name));

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -33,7 +33,6 @@ use hypervisor::ch::CloudHypervisor;
 use hypervisor::device::topology::PCIePort;
 use hypervisor::device::util::{get_host_path, DEVICE_TYPE_CHAR};
 use hypervisor::remote::Remote;
-use hypervisor::{BlockConfigModern, Hypervisor, VfioDeviceBase, is_vfio_ap_device};
 use hypervisor::VsockConfig;
 use hypervisor::HYPERVISOR_REMOTE;
 #[cfg(all(
@@ -43,6 +42,7 @@ use hypervisor::HYPERVISOR_REMOTE;
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
+use hypervisor::{is_vfio_ap_device, BlockConfigModern, Hypervisor, VfioDeviceBase};
 #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
@@ -238,16 +238,17 @@ impl VirtSandbox {
 
         let network_env: SandboxNetworkEnv = sandbox_config.network_env.clone();
         // prepare network config
-        if !network_env.network_created {
+        if !network_env.network_created && !self.should_defer_network().await? {
             if let Some(network_resource) = self.prepare_network_resource(&network_env).await {
                 resource_configs.push(network_resource);
             }
         }
 
         // prepare sharefs device config
-        let virtio_fs_config =
-            ResourceConfig::ShareFs(self.hypervisor.hypervisor_config().await.shared_fs);
-        resource_configs.push(virtio_fs_config);
+        let shared_fs = self.hypervisor.hypervisor_config().await.shared_fs;
+        if shared_fs.shared_fs.is_some() {
+            resource_configs.push(ResourceConfig::ShareFs(shared_fs));
+        }
 
         // prepare VM rootfs device config
         if let Some(block_config) = self
@@ -881,6 +882,42 @@ impl VirtSandbox {
         !prestart_hooks.is_empty() || !create_runtime_hooks.is_empty()
     }
 
+    fn is_factory_enabled(&self) -> bool {
+        self.factory
+            .as_ref()
+            .map(|factory| factory.enable_template)
+            .unwrap_or(false)
+    }
+
+    async fn should_defer_network(&self) -> Result<bool> {
+        if !self.is_factory_enabled() {
+            return Ok(false);
+        }
+
+        Ok(self
+            .hypervisor
+            .capabilities()
+            .await?
+            .is_network_device_hotplug_supported())
+    }
+
+    async fn setup_deferred_network_after_start(
+        &self,
+        sandbox_config: &SandboxConfig,
+    ) -> Result<()> {
+        if let Some(ResourceConfig::Network(network_resource)) = self
+            .prepare_network_resource(&sandbox_config.network_env)
+            .await
+        {
+            self.resource_manager
+                .handle_network(network_resource)
+                .await
+                .context("set up factory network after start vm")?;
+        }
+
+        Ok(())
+    }
+
     /// Build a network rescan config targeting the hypervisor's network
     /// namespace.  Docker 26+ bind-mounts `/proc/<vmm_pid>/ns/net` and
     /// configures veth pairs there between Create and Start, so the
@@ -980,6 +1017,8 @@ impl Sandbox for VirtSandbox {
             .await
             .context("prepare vm")?;
 
+        let defer_network = self.should_defer_network().await?;
+
         // generate device and setup before start vm
         // should after hypervisor.prepare_vm
         let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
@@ -1030,9 +1069,12 @@ impl Sandbox for VirtSandbox {
         // 1. if there are pre-start hook functions, network config might have been changed.
         //    We need to rescan the netns to handle the change.
         // 2. Do not scan the netns if we want no network for the VM.
-        // TODO In case of vm factory, scan the netns to hotplug interfaces after the VM is started.
+        // QEMU and Cloud Hypervisor advertise network hotplug support, so
+        // factory VMs using them defer network setup until after VM startup.
+        // Backends without this capability retain pre-start setup.
         let config = self.resource_manager.config().await;
         if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
+            && !defer_network
             && !config.runtime.disable_new_netns
             && !dan_config_path(&config, &self.sid).exists()
         {
@@ -1053,6 +1095,11 @@ impl Sandbox for VirtSandbox {
                     .await
                     .context("set up device after start vm")?;
             }
+        }
+
+        if defer_network {
+            self.setup_deferred_network_after_start(sandbox_config)
+                .await?;
         }
 
         // connect agent

--- a/tests/integration/kubernetes/k8s-vm-templating.bats
+++ b/tests/integration/kubernetes/k8s-vm-templating.bats
@@ -13,18 +13,63 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 # Returns 0 if the current environment supports VM templating, non-zero
 # otherwise. VM templating is only supported on non-confidential clh/qemu
-# hypervisors, and because it uses shared_fs="none" it also requires a
-# block-device-based snapshotter (blockfile or erofs).
+# hypervisors (including runtime-rs CLH), and because it disables shared
+# filesystem support it also requires a block-device-based snapshotter.
 vm_templating_supported() {
-	[[ "${KATA_HYPERVISOR}" == "clh" || "${KATA_HYPERVISOR}" == "qemu" ]] || return 1
+	[[ "${KATA_HYPERVISOR}" == "clh" || "${KATA_HYPERVISOR}" == "clh-runtime-rs" || "${KATA_HYPERVISOR}" == "qemu" ]] || return 1
 	is_confidential_runtime_class && return 1
 	[[ "${SNAPSHOTTER:-}" =~ ^(blockfile|erofs)$ ]] || return 1
 	return 0
 }
 
+factory_command() {
+	local command="$1"
+
+	case "${KATA_HYPERVISOR}" in
+		clh-runtime-rs)
+			exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-ctl factory ${command}"
+			;;
+		*)
+			exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-runtime --config ${kata_config_path} factory ${command}"
+			;;
+	esac
+}
+
+configure_runtime_rs_factory() {
+	[[ "${KATA_HYPERVISOR}" == "clh-runtime-rs" ]] || return 0
+
+	local backup_id
+	backup_id="$(printf '%s' "${BATS_TEST_TMPDIR}" | sha256sum | cut -c1-12)"
+	kata_ctl_config_path="/etc/kata-containers/runtime-rs/configuration.toml"
+	kata_ctl_config_backup_path="${kata_ctl_config_path}.k8s-vm-templating.${backup_id}.bak"
+
+	# Comment out shared_fs because drop-ins cannot remove an existing key.
+	# Point kata-ctl at that same per-shim config because it has no --config flag.
+	exec_host "$node" "set -e; \
+		mkdir -p /etc/kata-containers/runtime-rs; \
+		sed -i '/^[[:space:]]*shared_fs[[:space:]]*=/s/^/# k8s-vm-templating: /' ${kata_config_path}; \
+		grep -q '^# k8s-vm-templating: [[:space:]]*shared_fs[[:space:]]*=' ${kata_config_path}; \
+		if [ -e ${kata_ctl_config_path} ] || [ -L ${kata_ctl_config_path} ]; then \
+			mv ${kata_ctl_config_path} ${kata_ctl_config_backup_path}; \
+		fi; \
+		ln -s ${kata_config_path} ${kata_ctl_config_path}"
+}
+
+restore_runtime_rs_factory() {
+	[[ "${KATA_HYPERVISOR}" == "clh-runtime-rs" ]] || return 0
+	[[ -n "${kata_ctl_config_path:-}" ]] || return 0
+
+	exec_host "$node" "set -e; \
+		sed -i 's/^# k8s-vm-templating: //' ${kata_config_path}; \
+		rm -f ${kata_ctl_config_path}; \
+		if [ -e ${kata_ctl_config_backup_path} ] || [ -L ${kata_ctl_config_backup_path} ]; then \
+			mv ${kata_ctl_config_backup_path} ${kata_ctl_config_path}; \
+		fi"
+}
+
 setup() {
 	if ! vm_templating_supported; then
-		skip "VM templating requires a non-confidential clh/qemu hypervisor and a blockfile/erofs snapshotter (KATA_HYPERVISOR=${KATA_HYPERVISOR}, SNAPSHOTTER=${SNAPSHOTTER:-unset})"
+		skip "VM templating requires a non-confidential clh/qemu hypervisor (including runtime-rs CLH) and a blockfile/erofs snapshotter (KATA_HYPERVISOR=${KATA_HYPERVISOR}, SNAPSHOTTER=${SNAPSHOTTER:-unset})"
 	fi
 
 	setup_common || die "setup_common failed"
@@ -32,20 +77,28 @@ setup() {
 	# Build a Kata runtime config drop-in that enables VM templating and
 	# disables shared_fs (incompatible with templating).
 	# QEMU VM templating requires an initrd, CLH does not.
+	local factory_section="factory"
+	local hypervisor_name="${KATA_HYPERVISOR}"
 	local rootfs_override=""
+	local shared_fs_override='shared_fs = "none"'
 	if [[ "${KATA_HYPERVISOR}" == "qemu" ]]; then
 		rootfs_override=$'image = ""\ninitrd = "/opt/kata/share/kata-containers/kata-containers-initrd.img"'
+	fi
+	if [[ "${KATA_HYPERVISOR}" == "clh-runtime-rs" ]]; then
+		factory_section="hypervisor.clh.factory"
+		hypervisor_name="clh"
+		shared_fs_override=""
 	fi
 
 	local runtime_config_dropin_file="${BATS_TEST_TMPDIR}/99-k8s-vm-templating.toml"
 	cat > "${runtime_config_dropin_file}" <<DROPIN
-[hypervisor.${KATA_HYPERVISOR}]
-shared_fs = "none"
+[hypervisor.${hypervisor_name}]
+${shared_fs_override}
 default_vcpus = 1
 default_memory = 512
 ${rootfs_override}
 
-[factory]
+[${factory_section}]
 enable_template = true
 template_path = "/run/vc/vm/template"
 DROPIN
@@ -60,11 +113,18 @@ DROPIN
 	# same settings, and the same config.d drop-in installed above, as the pod.
 	kata_config_path="$(get_kata_runtime_config_file "$node")" \
 		|| die "Failed to resolve the Kata runtime config file on node $node"
+	if [[ "${KATA_HYPERVISOR}" == "clh-runtime-rs" ]]; then
+		configure_runtime_rs_factory \
+			|| die "Failed to configure kata-ctl for ${KATA_HYPERVISOR}"
+	fi
+
+	# Tests reuse workers, so clear factory state left by an interrupted run.
+	factory_command destroy || true
 }
 
 @test "Pod can be created with a templated VM" {
 	# Initialize the VM template on the target node.
-	exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-runtime --config ${kata_config_path} factory init"
+	factory_command init
 
 	# The factory init above must have created the template directory. exec_host
 	# pipes the remote output through `tr`, so the pipeline's exit status is not
@@ -76,7 +136,9 @@ DROPIN
 	ctr_name="test-container"
 
 	pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
-	cp "$pod_config_dir/busybox-template.yaml" "$pod_config"
+	# TODO: Use the shared template once CLH supports multi-layer images with EROFS.
+	cp "$pod_config_dir/busybox-vm-templating.yaml" "$pod_config"
+	yq -i ".spec.nodeName = \"${node}\"" "$pod_config"
 
 	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
 	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
@@ -86,16 +148,18 @@ DROPIN
 
 	grep_pod_exec_output "${pod_name}" "Hello from templated VM" sh -c "echo 'Hello from templated VM'"
 
-	# Confirm at least one VM sandbox under /run/vc/vm/ is a symlink, which
-	# proves the factory/template path was used. A non-templated VM creates a
-	# real directory at /run/vc/vm/<sandbox-id>/, whereas a factory-spawned VM
-	# stores its state under a generated UUID and /run/vc/vm/<sandbox-id> is a
-	# symlink pointing at it (see assignSandbox() in
-	# src/runtime/virtcontainers/vm.go). Inspect PID 1's mount namespace, where
-	# the shim creates these entries alongside the template tmpfs.
-	exec_host "$node" \
-		"nsenter --mount=/proc/1/ns/mnt find /run/vc/vm -maxdepth 1 -mindepth 1 -type l ! -name template | grep -q . && echo symlink" \
-		| grep -q symlink
+	if [[ "${KATA_HYPERVISOR}" != "clh-runtime-rs" ]]; then
+		# Confirm at least one VM sandbox under /run/vc/vm/ is a symlink, which
+		# proves the factory/template path was used. A non-templated VM creates a
+		# real directory at /run/vc/vm/<sandbox-id>/, whereas a factory-spawned VM
+		# stores its state under a generated UUID and /run/vc/vm/<sandbox-id> is a
+		# symlink pointing at it (see assignSandbox() in
+		# src/runtime/virtcontainers/vm.go). Inspect PID 1's mount namespace, where
+		# the shim creates these entries alongside the template tmpfs.
+		exec_host "$node" \
+			"nsenter --mount=/proc/1/ns/mnt find /run/vc/vm -maxdepth 1 -mindepth 1 -type l ! -name template | grep -q . && echo symlink" \
+			| grep -q symlink
+	fi
 }
 
 teardown() {
@@ -107,9 +171,11 @@ teardown() {
 	# factory destroy must run in PID 1's mount namespace to unmount the template
 	# tmpfs that factory init created there (see the @test for details).
 	if [[ -n "${kata_config_path:-}" ]]; then
-		exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-runtime --config ${kata_config_path} factory destroy" \
+		factory_command destroy \
 			|| echo "Warning: Failed to destroy VM template on node $node"
 	fi
+	restore_runtime_rs_factory \
+		|| echo "Warning: Failed to restore kata-ctl configuration on node $node"
 
 	remove_kata_runtime_config_dropin_file "$node" "${dropin_path:-}" \
 		|| echo "Warning: Failed to remove Kata runtime config drop-in on node $node"

--- a/tests/integration/kubernetes/runtimeclass_workloads/busybox-vm-templating.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/busybox-vm-templating.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: POD_NAME
+spec:
+  runtimeClassName: kata
+  shareProcessNamespace: true
+  securityContext:
+    supplementalGroups: [10]
+  containers:
+  - name: CTR_NAME
+    # TODO: Use the shared template once CLH supports multi-layer images with EROFS.
+    image: docker.io/library/busybox:latest@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+    command:
+      - sleep
+      - "120"

--- a/tools/packaging/scripts/download-with-oras-cache.sh
+++ b/tools/packaging/scripts/download-with-oras-cache.sh
@@ -58,7 +58,7 @@ ensure_oras_installed() {
 
 	if [[ -f "${install_oras_script}" ]]; then
 		info "Installing ORAS using existing script"
-		if "${install_oras_script}"; then
+		if "${install_oras_script}" >&2; then
 			# Verify installation succeeded
 			if command -v oras &>/dev/null; then
 				info "ORAS installed successfully"


### PR DESCRIPTION
This PR adds VM template factory support for Cloud Hypervisor in runtime-rs,
providing parity with the runtime-go implementation introduced in #13196 .


The main changes include:

- Cloud Hypervisor API support for pausing, resuming, saving, and restoring VMs.
- Memory zones and backing files required for template creation and restore.
- Restore support in the Cloud Hypervisor VM startup path.
- Block queue configuration for EROFS devices used by templated VMs.
- Kubernetes integration coverage for runtime-rs templating with Cloud
  Hypervisor and EROFS. Currently, VM templating with EROFS supports only
  single-layer container images, multi-layer images are not yet supported.
-  Align the runtime-rs Cloud Hypervisor API models with CLH v51.1, including CPU, NUMA, VM resize, and vsock fields; this also fixes VM creation and resize at the supported 256-vCPU limit.


The runtime-rs VM template lifecycle was tested with Cloud Hypervisor and the
EROFS snapshotter, covering factory initialization, booting a pod from the
template, and factory cleanup.

During testing, we found that runtime-rs did not clean up the source VM after
creating a template. The runtime-go path does not have this issue. This PR fixes
runtime-rs to stop the source VM and remove its resources after template
creation.

Fixes: https://github.com/kata-containers/kata-containers/issues/13394 , #13449 


