### PR TITLE
packaging: increase default zstd level for kata tarballs

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1786,7 +1786,7 @@ handle_build() {
 	virtiofsd) install_virtiofsd ;;
 
 	dummy)
-		tar --zstd -cvf "${final_tarball_path}" --files-from /dev/null
+		kata_tar_zstd -cvf "${final_tarball_path}" --files-from /dev/null
 	       	;;
 
 	*)
@@ -1796,7 +1796,7 @@ handle_build() {
 
 	if [[ ! -f "${final_tarball_path}" ]]; then
 		cd "${destdir}"
-		tar --zstd -cvf "${final_tarball_path}" "."
+		kata_tar_zstd -cvf "${final_tarball_path}" "."
 	fi
 	tar --zstd -tvf "${final_tarball_path}"
 
@@ -1812,7 +1812,7 @@ handle_build() {
 
 				pushd "${parent_dir}"
 				rm -f "${parent_dir_basename}"/build
-				tar --zstd -cvf "${modules_final_tarball_path}" "."
+				kata_tar_zstd -cvf "${modules_final_tarball_path}" "."
 				popd
 			fi
 			tar --zstd -tvf "${modules_final_tarball_path}"
@@ -1825,7 +1825,7 @@ handle_build() {
 
 				pushd "${modules_dir}"
 				rm -f build
-				tar --zstd -cvf "${modules_final_tarball_path}" "."
+				kata_tar_zstd -cvf "${modules_final_tarball_path}" "."
 				popd
 			fi
 			tar --zstd -tvf "${modules_final_tarball_path}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
@@ -11,6 +11,9 @@ set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+
+# shellcheck source=tools/packaging/scripts/lib.sh
+source "${script_dir}/../../scripts/lib.sh"
 build_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
 component="${1:-all}"
 versions_yaml="${repo_root_dir}/versions.yaml"
@@ -66,7 +69,7 @@ build_kata_deploy_binary() {
 	mkdir -p "${build_dir}/kata-deploy-binary/usr/bin"
 	tar -xf "${rust_builder_tar}" -C "${build_dir}/kata-deploy-binary/usr/bin" \
 		--strip-components=2 kata-deploy/bin/kata-deploy
-	tar --zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-binary.tar.zst" \
+	kata_tar_zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-binary.tar.zst" \
 		-C "${build_dir}/kata-deploy-binary" .
 }
 
@@ -76,7 +79,7 @@ build_kata_deploy_job_dispatcher() {
 	mkdir -p "${build_dir}/kata-deploy-job-dispatcher/usr/bin"
 	tar -xf "${rust_builder_tar}" -C "${build_dir}/kata-deploy-job-dispatcher/usr/bin" \
 		--strip-components=2 kata-deploy/bin/kata-deploy-job-dispatcher
-	tar --zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-job-dispatcher.tar.zst" \
+	kata_tar_zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-job-dispatcher.tar.zst" \
 		-C "${build_dir}/kata-deploy-job-dispatcher" .
 }
 
@@ -99,7 +102,7 @@ build_nydus_snapshotter_for_coco_guest_pull() {
 		"${build_dir}/nydus-snapshotter/opt/kata-artifacts/nydus-snapshotter/"
 	cp "${build_dir}/nydus-snapshotter-out/opt/nydus-snapshotter/bin/nydus-overlayfs" \
 		"${build_dir}/nydus-snapshotter/opt/kata-artifacts/nydus-snapshotter/"
-	tar --zstd -cf "${build_dir}/kata-deploy-static-nydus-snapshotter-for-coco-guest-pull.tar.zst" \
+	kata_tar_zstd -cf "${build_dir}/kata-deploy-static-nydus-snapshotter-for-coco-guest-pull.tar.zst" \
 		-C "${build_dir}/nydus-snapshotter" .
 }
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -13,6 +13,9 @@ set -o errtrace
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root_dir="$(cd "${this_script_dir}/../../../../" && pwd)"
 
+# shellcheck source=tools/packaging/scripts/lib.sh
+source "${this_script_dir}/../../scripts/lib.sh"
+
 kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 output_tarball_name=${3:-kata-static.tar.zst}
@@ -78,5 +81,5 @@ pushd "${tarball_content_dir}"
 popd
 
 echo "create ${tar_path}"
-(cd "${tarball_content_dir}"; tar --zstd -cvf "${tar_path}" --owner=0 --group=0 .)
+(cd "${tarball_content_dir}"; kata_tar_zstd -cvf "${tar_path}" --owner=0 --group=0 .)
 popd

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -60,6 +60,14 @@ warn() {
 	echo >&2 "WARN: $*"
 }
 
+# ZSTD compression level (1-19) for kata tarball creation.
+# Override with KATA_TARBALL_ZSTD_LEVEL to tune size vs build time.
+KATA_TARBALL_ZSTD_LEVEL="${KATA_TARBALL_ZSTD_LEVEL:-10}"
+
+kata_tar_zstd() {
+	tar --use-compress-program="zstd -${KATA_TARBALL_ZSTD_LEVEL}" "$@"
+}
+
 get_repo_hash() {
 	local repo_dir=${1:-}
 	[[ -d "${repo_dir}" ]] || die "${repo_dir} is not a directory"


### PR DESCRIPTION
Use zstd level 10 (via kata_tar_zstd) when creating static build tarballs so CI artifacts stay under GitHub's 2GB limit without paying the build-time cost of maximum compression.


Assisted-by: Cursor <cursoragent@cursor.com>