### PR TITLE
agent: move kbs:// scheme out of get_cdh_resource() helper

### DIFF
--- a/src/agent/src/confidential_data_hub/mod.rs
+++ b/src/agent/src/confidential_data_hub/mod.rs
@@ -110,7 +110,7 @@ impl CDHClient {
 
     pub async fn get_resource(&self, resource_path: &str) -> Result<Vec<u8>> {
         let req = GetResourceRequest {
-            ResourcePath: format!("kbs://{resource_path}"),
+            ResourcePath: resource_path.to_string(),
             ..Default::default()
         };
         let res = self

--- a/src/agent/src/device/vfio_device_handler.rs
+++ b/src/agent/src/device/vfio_device_handler.rs
@@ -277,7 +277,7 @@ async fn check_ap_device(address: ap::Address) -> Result<()> {
 
 #[cfg(target_arch = "s390x")]
 async fn associate_ap_device(apqn: &Apqn, mkvp: &str) -> Result<()> {
-    let resource_path = format!("/vfio_ap/{mkvp}");
+    let resource_path = format!("kbs:///vfio_ap/{mkvp}");
     let secret_resource_path = format!("{resource_path}/secret");
     let secret_id_resource_path = format!("{resource_path}/secret_id");
 


### PR DESCRIPTION
With the plugins support added to CoCo Resource URI scheme, users may want to use get_cdh_resource() to pull resources from Trustee plugins.

Currently, get_cdh_resource() unconditionally uses kbs:// scheme which prevents callers to specify plugin paths as kbs+<plugin>://.

Move kbs:// scheme out of get_cdh_resource() helper and update call sites accordingly. Currently, only s390x path uses this so only one caller needs to be updated.

Fixes: #13393