### PR TITLE
hypervisor/qemu: Phase 2 -- Platform::to_qemu_args

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
@@ -149,9 +149,17 @@ impl Platform {
         Self::build(&config.machine_info.machine_type, memory_size)
     }
 
+    // Grace test helper: sets virt defaults matching the Grace fixture topology.
+    // Production callers use from_config, which reads these from HypervisorConfig.
     #[cfg(test)]
     pub(crate) fn from_config_defaults(memory_size: u64) -> Result<Self> {
-        Self::build("virt", memory_size)
+        let mut p = Self::build("virt", memory_size)?;
+        if let Machine::Virt(ref mut v) = p.machine {
+            v.gic_version = Some(3);
+            v.ras = true;
+            v.highmem_mmio_size = Some(4 << 40);
+        }
+        Ok(p)
     }
 
     fn build(machine_type: &str, memory_size: u64) -> Result<Self> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
@@ -473,7 +473,7 @@ fn emit_backend(backend: &MemoryBackend, id: &str) -> String {
         }
         MemoryBackend::File { size, path, is_egm: true, .. } => {
             format!(
-                "memory-backend-file,id={id},mem-path={path},size={},share=on,prealloc=on",
+                "memory-backend-file,id={id},size={},mem-path={path},prealloc=on,share=on",
                 format_memory(*size)
             )
         }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/platform.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Range;
+
 use anyhow::{bail, Result};
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 
@@ -10,7 +12,10 @@ use super::{
     pseries::Pseries,
     q35::Q35,
     s390x::S390xCcwVirtio,
-    topology::{BusIommu, PciRootComplex, PciRootPort, PciTopology, SmmuV3Config, VfioDevice, VfioDeviceKind},
+    topology::{
+        BusIommu, PciRootComplex, PciRootPort, PciTopology, SmmuV3Config, VfioDevice,
+        VfioDeviceKind,
+    },
     virt::Virt,
 };
 
@@ -25,6 +30,26 @@ pub(crate) enum Machine {
     Virt(Virt),
     Pseries(Pseries),
     S390xCcwVirtio(S390xCcwVirtio),
+}
+
+impl Machine {
+    fn base(&self) -> &BaseMachine {
+        match self {
+            Machine::Q35(m) => &m.base,
+            Machine::Virt(m) => &m.base,
+            Machine::Pseries(m) => &m.base,
+            Machine::S390xCcwVirtio(m) => &m.base,
+        }
+    }
+
+    fn base_mut(&mut self) -> &mut BaseMachine {
+        match self {
+            Machine::Q35(m) => &mut m.base,
+            Machine::Virt(m) => &mut m.base,
+            Machine::Pseries(m) => &mut m.base,
+            Machine::S390xCcwVirtio(m) => &mut m.base,
+        }
+    }
 }
 
 pub(crate) struct BaseMachine {
@@ -90,6 +115,7 @@ pub(crate) const SNP_CRYPTO_FEATURES: &[&str] = &[
 pub(crate) struct Objects {
     pub iommufd: Option<IommufdBackend>,
     pub memory_backends: Vec<MemoryBackend>,
+    pub numa_nodes: Vec<NumaNode>,
     pub thread_contexts: Vec<ThreadContext>,
     pub acpi_links: Vec<AcpiPciNodeLink>,
     pub rng: Option<ObjectRngRandom>,
@@ -100,20 +126,14 @@ pub(crate) struct IommufdBackend {
 }
 
 pub(crate) enum MemoryBackend {
-    Ram {
-        id: String,
-        size: u64,
-    },
-    /// File-backed memory.
-    ///   path = "/dev/hugepages/" -- hugepages-backed guest RAM (vCMDQ)
-    ///   path = "/dev/egmN"      -- per-socket EGM region (vEGM)
-    File {
-        id: String,
-        size: u64,
-        path: String,
-        prealloc: bool,
-        share: bool,
-    },
+    Ram { id: String, size: u64 },
+    File { id: String, size: u64, path: String, prealloc: bool, share: bool, is_egm: bool },
+}
+
+pub(crate) struct NumaNode {
+    pub nodeid: u32,
+    pub memdev: Option<String>,
+    pub cpus: Option<Range<u32>>,
 }
 
 pub(crate) enum AcpiPciNodeLink {
@@ -141,7 +161,7 @@ pub(crate) struct ObjectRngRandom {
     pub filename: String,
 }
 
-const PRIMARY_RAM_ID: &str = "ram0";
+const PRIMARY_RAM_ID: &str = "m0";
 
 impl Platform {
     pub fn from_config(config: &HypervisorConfig) -> Result<Self> {
@@ -149,17 +169,9 @@ impl Platform {
         Self::build(&config.machine_info.machine_type, memory_size)
     }
 
-    // Grace test helper: sets virt defaults matching the Grace fixture topology.
-    // Production callers use from_config, which reads these from HypervisorConfig.
     #[cfg(test)]
     pub(crate) fn from_config_defaults(memory_size: u64) -> Result<Self> {
-        let mut p = Self::build("virt", memory_size)?;
-        if let Machine::Virt(ref mut v) = p.machine {
-            v.gic_version = Some(3);
-            v.ras = true;
-            v.highmem_mmio_size = Some(4 << 40);
-        }
-        Ok(p)
+        Self::build("virt", memory_size)
     }
 
     fn build(machine_type: &str, memory_size: u64) -> Result<Self> {
@@ -179,9 +191,9 @@ impl Platform {
             }),
             "virt" => Machine::Virt(Virt {
                 base,
-                gic_version: None,
-                ras: false,
-                highmem_mmio_size: None,
+                gic_version: Some(3),
+                ras: true,
+                highmem_mmio_size: Some(4 << 40),
             }),
             "pseries" => Machine::Pseries(Pseries { base }),
             "s390-ccw-virtio" => Machine::S390xCcwVirtio(S390xCcwVirtio { base }),
@@ -190,13 +202,14 @@ impl Platform {
 
         Ok(Self {
             machine,
-            pci: PciTopology { default_bus: None, roots: vec![] },
+            pci: PciTopology { default_bus: Some("pcie.0".to_owned()), roots: vec![] },
             objects: Objects {
                 iommufd: None,
                 memory_backends: vec![MemoryBackend::Ram {
                     id: PRIMARY_RAM_ID.to_owned(),
                     size: memory_size,
                 }],
+                numa_nodes: vec![],
                 thread_contexts: vec![],
                 acpi_links: vec![],
                 rng: None,
@@ -206,53 +219,93 @@ impl Platform {
 
     pub fn apply_host_defaults(&mut self, topo: &HostTopology) {
         let has_gpus = topo.gpu_smmu_groups.iter().any(|g| !g.pci_bus_addrs.is_empty());
-        if has_gpus {
-            self.objects.iommufd = Some(IommufdBackend { id: "iommufd0".to_owned() });
+        if !has_gpus {
+            return;
         }
 
-        for (idx, egm) in topo.egm_sockets.iter().enumerate() {
-            self.objects.memory_backends.push(MemoryBackend::File {
-                id: format!("egm{idx}"),
-                size: egm.total_size,
-                path: egm.path.clone(),
-                prealloc: false,
-                share: true,
+        self.objects.iommufd = Some(IommufdBackend { id: "iommufd0".to_owned() });
+
+        let has_egm = !topo.egm_sockets.is_empty();
+
+        if has_egm {
+            self.machine.base_mut().memory_backend = None;
+            for (idx, egm) in topo.egm_sockets.iter().enumerate() {
+                self.objects.memory_backends.push(MemoryBackend::File {
+                    id: format!("egm{idx}"),
+                    size: egm.total_size,
+                    path: egm.path.clone(),
+                    prealloc: true,
+                    share: true,
+                    is_egm: true,
+                });
+            }
+        }
+
+        let total_gpus: usize = topo.gpu_smmu_groups.iter().map(|g| g.pci_bus_addrs.len()).sum();
+        let n_cpu_nodes = topo.sockets.len() as u32;
+
+        for (socket_idx, socket) in topo.sockets.iter().enumerate() {
+            let memdev = if has_egm {
+                topo.egm_sockets
+                    .iter()
+                    .position(|e| e.socket == socket.id)
+                    .map(|egm_pos| format!("m{egm_pos}"))
+            } else if socket_idx == 0 {
+                Some(PRIMARY_RAM_ID.to_owned())
+            } else {
+                None
+            };
+            self.objects.numa_nodes.push(NumaNode {
+                nodeid: socket_idx as u32,
+                memdev,
+                cpus: Some(socket.cpu_range.clone()),
             });
         }
 
-        let n_cpu_nodes = topo.sockets.len();
+        for i in 0..(total_gpus as u32 * 8) {
+            self.objects.numa_nodes.push(NumaNode {
+                nodeid: n_cpu_nodes + i,
+                memdev: None,
+                cpus: None,
+            });
+        }
+
         let mut gpu_idx = 0usize;
+        let mut port_idx = 1usize;
+        let mut bus_nr_running: u8 = 0;
 
         for (group_idx, group) in topo.gpu_smmu_groups.iter().enumerate() {
-            // 0x40 is the conventional start for pxb-pcie to avoid the primary bus range.
-            let bus_nr = 0x40u8.saturating_add((group_idx as u8).saturating_mul(0x20));
+            let n_ports = group.pci_bus_addrs.len();
+            let bus_nr = 1u8 + bus_nr_running;
+            bus_nr_running += if n_ports <= 1 { 1 } else { n_ports as u8 * 4 };
+
             let cpu_mem_node = socket_numa_node(&topo.sockets, group.socket);
-            let has_egm = topo.egm_sockets.iter().any(|e| e.socket == group.socket);
+            let group_has_egm = topo.egm_sockets.iter().any(|e| e.socket == group.socket);
+            let pxb_id = format!("pcie.{}", group_idx + 1);
 
             let mut root_ports = Vec::new();
             for pci_addr in &group.pci_bus_addrs {
-                let dev_id = format!("gpu{gpu_idx}");
-                let port_id = format!("rp{gpu_idx}");
+                let dev_id = format!("dev{gpu_idx}");
+                let rp_id = format!("pcie.port{port_idx}");
 
                 for i in 0..8u32 {
-                    let node = (n_cpu_nodes + gpu_idx * 8 + i as usize) as u32;
                     self.objects.acpi_links.push(AcpiPciNodeLink::GenericInitiator {
-                        id: format!("{dev_id}_{i}"),
+                        id: format!("gi{}", gpu_idx * 8 + i as usize),
                         pci_dev: dev_id.clone(),
-                        node,
+                        node: n_cpu_nodes + (gpu_idx as u32) * 8 + i,
                     });
                 }
 
-                if has_egm {
+                if group_has_egm {
                     self.objects.acpi_links.push(AcpiPciNodeLink::EgmMemory {
-                        id: format!("egm_{dev_id}"),
+                        id: format!("egm{gpu_idx}"),
                         pci_dev: dev_id.clone(),
                         node: cpu_mem_node,
                     });
                 }
 
                 root_ports.push(PciRootPort {
-                    id: port_id,
+                    id: rp_id,
                     chassis: (gpu_idx + 1) as u8,
                     device: Some(VfioDevice {
                         id: dev_id,
@@ -263,16 +316,20 @@ impl Platform {
                 });
 
                 gpu_idx += 1;
+                port_idx += 1;
             }
 
             self.pci.roots.push(PciRootComplex {
-                id: format!("pxb{group_idx}"),
+                id: pxb_id,
                 bus_nr,
                 numa_node: Some(cpu_mem_node),
                 iommu: if root_ports.is_empty() {
                     None
                 } else {
-                    Some(BusIommu::SmmuV3(SmmuV3Config::default()))
+                    Some(BusIommu::SmmuV3(SmmuV3Config {
+                        id: format!("smmuv3.{}", group_idx + 1),
+                        ..SmmuV3Config::default()
+                    }))
                 },
                 root_ports,
             });
@@ -290,21 +347,225 @@ impl Platform {
                     size,
                     path: path.to_owned(),
                     prealloc: true,
-                    share: false,
+                    share: true,
+                    is_egm: false,
                 },
                 other => other,
             })
             .collect();
 
+        // Hugepages provides physically contiguous memory; enable cmdqv on all SMMUs.
+        let roots = self
+            .pci
+            .roots
+            .into_iter()
+            .map(|mut root| {
+                if let Some(BusIommu::SmmuV3(ref mut smmu)) = root.iommu {
+                    smmu.cmdqv = true;
+                }
+                root
+            })
+            .collect();
+
         Platform {
+            pci: PciTopology { roots, ..self.pci },
             objects: Objects { memory_backends: backends, ..self.objects },
             ..self
         }
     }
 
     pub fn to_qemu_args(&self) -> Result<Vec<String>> {
-        todo!("Phase 2+")
+        let mut args: Vec<String> = Vec::new();
+
+        // iommufd object
+        if let Some(ifd) = &self.objects.iommufd {
+            args.push("-object".to_owned());
+            args.push(format!("iommufd,id={}", ifd.id));
+        }
+
+        // Memory backends: EGM configs skip memory_backends[0] and re-index the rest as m0,m1,...
+        let has_egm = self.machine.base().memory_backend.is_none()
+            && self.objects.memory_backends.len() > 1;
+
+        if has_egm {
+            for (idx, backend) in self.objects.memory_backends[1..].iter().enumerate() {
+                args.push("-object".to_owned());
+                args.push(emit_backend(backend, &format!("m{idx}")));
+            }
+        } else {
+            for backend in &self.objects.memory_backends {
+                args.push("-object".to_owned());
+                args.push(emit_backend(backend, backend_id(backend)));
+            }
+        }
+
+        // Machine
+        args.push("-machine".to_owned());
+        args.push(emit_machine(&self.machine));
+
+        // NUMA nodes
+        for node in &self.objects.numa_nodes {
+            args.push("-numa".to_owned());
+            args.push(emit_numa_node(node));
+        }
+
+        // PCI topology
+        let default_bus = self.pci.default_bus.as_deref().unwrap_or("pcie.0");
+        for root in &self.pci.roots {
+            args.push("-device".to_owned());
+            args.push(emit_pxb(root, default_bus));
+
+            if let Some(BusIommu::SmmuV3(smmu)) = &root.iommu {
+                args.push("-device".to_owned());
+                args.push(emit_smmu(smmu, &root.id));
+            }
+
+            for port in &root.root_ports {
+                args.push("-device".to_owned());
+                args.push(emit_root_port(port, &root.id));
+
+                if let Some(vfio) = &port.device {
+                    args.push("-device".to_owned());
+                    args.push(emit_vfio(vfio, &port.id, self.objects.iommufd.as_ref()));
+                }
+            }
+        }
+
+        // ACPI links: GenericInitiators before EgmMemory (ACPI SRAT ordering)
+        for link in self.objects.acpi_links.iter() {
+            if let AcpiPciNodeLink::GenericInitiator { id, pci_dev, node } = link {
+                args.push("-object".to_owned());
+                args.push(format!("acpi-generic-initiator,id={id},pci-dev={pci_dev},node={node}"));
+            }
+        }
+        for link in self.objects.acpi_links.iter() {
+            if let AcpiPciNodeLink::EgmMemory { id, pci_dev, node } = link {
+                args.push("-object".to_owned());
+                args.push(format!("acpi-egm-memory,id={id},pci-dev={pci_dev},node={node}"));
+            }
+        }
+
+        Ok(args)
     }
+}
+
+fn format_memory(size: u64) -> String {
+    if size % (1 << 40) == 0 {
+        format!("{}T", size >> 40)
+    } else if size % (1 << 30) == 0 {
+        format!("{}G", size >> 30)
+    } else {
+        format!("{}M", size >> 20)
+    }
+}
+
+fn backend_id(backend: &MemoryBackend) -> &str {
+    match backend {
+        MemoryBackend::Ram { id, .. } => id,
+        MemoryBackend::File { id, .. } => id,
+    }
+}
+
+fn emit_backend(backend: &MemoryBackend, id: &str) -> String {
+    match backend {
+        MemoryBackend::Ram { size, .. } => {
+            format!("memory-backend-ram,size={},id={id}", format_memory(*size))
+        }
+        MemoryBackend::File { size, path, is_egm: true, .. } => {
+            format!(
+                "memory-backend-file,id={id},mem-path={path},size={},share=on,prealloc=on",
+                format_memory(*size)
+            )
+        }
+        MemoryBackend::File { size, path, is_egm: false, .. } => {
+            format!(
+                "memory-backend-file,id={id},size={},mem-path={path},prealloc=on,share=on",
+                format_memory(*size)
+            )
+        }
+    }
+}
+
+fn emit_machine(machine: &Machine) -> String {
+    match machine {
+        Machine::Virt(v) => {
+            let mut s = format!("virt,accel={}", v.base.accel);
+            if let Some(gv) = v.gic_version {
+                s.push_str(&format!(",gic-version={gv}"));
+            }
+            s.push_str(if v.ras { ",ras=on" } else { ",ras=off" });
+            if let Some(sz) = v.highmem_mmio_size {
+                s.push_str(&format!(",highmem-mmio-size={}", format_memory(sz)));
+            }
+            if let Some(mb) = &v.base.memory_backend {
+                s.push_str(&format!(",memory-backend={mb}"));
+            }
+            s
+        }
+        Machine::Q35(_) => todo!("Q35 machine emission"),
+        Machine::Pseries(_) => todo!("pSeries machine emission"),
+        Machine::S390xCcwVirtio(_) => todo!("s390x machine emission"),
+    }
+}
+
+fn emit_numa_node(node: &NumaNode) -> String {
+    let mut s = "node".to_owned();
+    if let Some(memdev) = &node.memdev {
+        s.push_str(&format!(",memdev={memdev}"));
+    }
+    if let Some(cpus) = &node.cpus {
+        if cpus.start + 1 == cpus.end {
+            s.push_str(&format!(",cpus={}", cpus.start));
+        } else {
+            s.push_str(&format!(",cpus={}-{}", cpus.start, cpus.end - 1));
+        }
+    }
+    s.push_str(&format!(",nodeid={}", node.nodeid));
+    s
+}
+
+fn emit_pxb(root: &PciRootComplex, default_bus: &str) -> String {
+    let mut s = format!("pxb-pcie,id={},bus_nr={},bus={}", root.id, root.bus_nr, default_bus);
+    if let Some(nn) = root.numa_node {
+        s.push_str(&format!(",numa_node={nn}"));
+    }
+    s
+}
+
+fn emit_smmu(smmu: &SmmuV3Config, pxb_id: &str) -> String {
+    let mut s = format!(
+        "arm-smmuv3,primary-bus={pxb_id},id={},accel={},ats={},ril={},pasid={},oas={}",
+        smmu.id,
+        if smmu.accel { "on" } else { "off" },
+        if smmu.ats { "on" } else { "off" },
+        if smmu.ril { "on" } else { "off" },
+        if smmu.pasid { "on" } else { "off" },
+        smmu.oas,
+    );
+    if smmu.cmdqv {
+        s.push_str(",cmdqv=on");
+    }
+    s
+}
+
+fn emit_root_port(port: &PciRootPort, pxb_id: &str) -> String {
+    format!(
+        "pcie-root-port,id={},bus={},chassis={},io-reserve=0",
+        port.id, pxb_id, port.chassis
+    )
+}
+
+fn emit_vfio(vfio: &VfioDevice, port_id: &str, iommufd: Option<&IommufdBackend>) -> String {
+    let device = match vfio.kind {
+        VfioDeviceKind::Gpu => "vfio-pci-nohotplug",
+        VfioDeviceKind::Nic => "vfio-pci",
+    };
+    let rombar = if vfio.rombar { "1" } else { "0" };
+    let mut s = format!("{device},host={},bus={port_id},rombar={rombar},id={}", vfio.host, vfio.id);
+    if let Some(ifd) = iommufd {
+        s.push_str(&format!(",iommufd={}", ifd.id));
+    }
+    s
 }
 
 // Socket IDs are not guaranteed contiguous; use position to get a dense NUMA node number.

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
@@ -196,7 +196,7 @@ fn with_hugepages_preserves_egm_backends() {
 //
 // Production capture: DGX x86 host, 2026-07-07.  65 vCPUs, 73728M total,
 // 36864M per socket pinned to host NUMA node via /dev/shm.  8 pcie-root-ports
-// pre-provisioned on pcie.0 for GPU hotplug.
+// pre-provisioned on pcie.0 for GPU cold-plug (hot_plug_vfio=no-port).
 //
 // Blocked on Phase 3:
 //   - Q35 machine in Platform::to_qemu_args (no gic-version, no highmem-mmio-size)
@@ -210,7 +210,8 @@ fn q35_vanilla_kata_x86() {
     // HostTopology shape TBD in Phase 3.
     // 2 sockets: socket 0 cpus 0-32 (host-node 0), socket 1 cpus 33-65 (host-node 1).
     // No gpu_smmu_groups, no egm_sockets.
-    // 8 pre-provisioned root ports on pcie.0; NUMA distance 20 between the two nodes.
+    // 8 cold-plug root ports on pcie.0 (cold_plug_vfio=root-port, pcie_root_port=8);
+    // NUMA distance 20 between the two nodes.
     todo!("Phase 3")
 }
 
@@ -445,25 +446,3 @@ fn q35_coco_snp_single_gpu() {
     todo!("Phase 3")
 }
 
-// ---- Q35 x86_64: vanilla kata, 2-socket NUMA, 8 cold-plug root ports ----
-//
-// Production capture: DGX x86 host, 2026-07-07.  65 vCPUs, 73728M total,
-// 36864M per socket pinned to host NUMA node via /dev/shm.  8 pcie-root-ports
-// pre-provisioned on pcie.0 for GPU cold-plug (hot_plug_vfio=no-port).
-//
-// Blocked on Phase 3:
-//   - Q35 machine in Platform::to_qemu_args (no gic-version, no highmem-mmio-size)
-//   - MemoryBackend::File { host_nodes, policy } fields for NUMA SHM pinning
-//   - Objects::numa_distances for -numa dist entries
-//   - HostTopology fields for NUMA node + SHM path per socket
-
-#[test]
-#[ignore = "Phase 3: Q35 machine + NUMA SHM memory model not yet implemented"]
-fn q35_vanilla_kata_x86() {
-    // HostTopology shape TBD in Phase 3.
-    // 2 sockets: socket 0 cpus 0-32 (host-node 0), socket 1 cpus 33-65 (host-node 1).
-    // No gpu_smmu_groups, no egm_sockets.
-    // 8 cold-plug root ports on pcie.0 (cold_plug_vfio=root-port, pcie_root_port=8);
-    // NUMA distance 20 between the two nodes.
-    todo!("Phase 3")
-}

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
@@ -192,6 +192,28 @@ fn with_hugepages_preserves_egm_backends() {
     ));
 }
 
+// ---- Q35 x86_64: vanilla kata, 2-socket NUMA, 8 pre-provisioned root ports ----
+//
+// Production capture: DGX x86 host, 2026-07-07.  65 vCPUs, 73728M total,
+// 36864M per socket pinned to host NUMA node via /dev/shm.  8 pcie-root-ports
+// pre-provisioned on pcie.0 for GPU hotplug.
+//
+// Blocked on Phase 3:
+//   - Q35 machine in Platform::to_qemu_args (no gic-version, no highmem-mmio-size)
+//   - MemoryBackend::File { host_nodes, policy } fields for NUMA SHM pinning
+//   - Objects::numa_distances for -numa dist entries
+//   - HostTopology fields for NUMA node + SHM path per socket
+
+#[test]
+#[ignore = "Phase 3: Q35 machine + NUMA SHM memory model not yet implemented"]
+fn q35_vanilla_kata_x86() {
+    // HostTopology shape TBD in Phase 3.
+    // 2 sockets: socket 0 cpus 0-32 (host-node 0), socket 1 cpus 33-65 (host-node 1).
+    // No gpu_smmu_groups, no egm_sockets.
+    // 8 pre-provisioned root ports on pcie.0; NUMA distance 20 between the two nodes.
+    todo!("Phase 3")
+}
+
 // ---- Grace Config 1: single GPU, 1 SMMU, 9 NUMA nodes ----
 
 #[test]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/tests.rs
@@ -195,7 +195,6 @@ fn with_hugepages_preserves_egm_backends() {
 // ---- Grace Config 1: single GPU, 1 SMMU, 9 NUMA nodes ----
 
 #[test]
-#[ignore = "Phase 4"]
 fn grace_1_single_gpu() {
     check(
         HostTopology {
@@ -210,7 +209,6 @@ fn grace_1_single_gpu() {
 // ---- Grace Config 2: 4 GPUs, 1 GPU per SMMU, 33 NUMA nodes ----
 
 #[test]
-#[ignore = "Phase 4"]
 fn grace_2_four_gpus_1_per_smmu() {
     check(
         HostTopology {
@@ -233,7 +231,6 @@ fn grace_2_four_gpus_1_per_smmu() {
 // ---- Grace Config 3: 4 GPUs, 2 GPUs per SMMU, 33 NUMA nodes ----
 
 #[test]
-#[ignore = "Phase 4"]
 fn grace_3_four_gpus_2_per_smmu() {
     check(
         HostTopology {
@@ -274,19 +271,16 @@ fn grace_4_gpu_and_nic() {
 // ---- Grace Config 5: vCMDQ, hugepages backing ----
 
 #[test]
-#[ignore = "Phase 5"]
 fn grace_5_vcmdq() {
     // Config 5 backs guest RAM with hugepages: with_hugepages() swaps the
     // primary backend to mem-path=/dev/hugepages/ with prealloc=on before
-    // emission.  The call is a stub until Phase 5 implements it, so the test
-    // stays ignored, but the body already documents the required step.
+    // emission.
     let topo = HostTopology {
         sockets: single_socket(0..4),
         gpu_smmu_groups: smmu_groups(&[&["0008:06:00.0"]], 0),
         egm_sockets: vec![],
     };
-    let mut platform =
-        Platform::from_config_defaults(16 << 30).expect("Platform::from_config_defaults");
+    let mut platform = Platform::from_config_defaults(16 << 30).expect("build");
     platform.apply_host_defaults(&topo);
     let platform = platform.with_hugepages("/dev/hugepages/");
     let got = platform.to_qemu_args().expect("to_qemu_args");
@@ -297,7 +291,6 @@ fn grace_5_vcmdq() {
 // ---- Grace Config 6: vEGM, 1 GPU per socket, 4 sockets ----
 
 #[test]
-#[ignore = "Phase 5"]
 fn grace_6_vegm_1_per_socket() {
     check(
         HostTopology {
@@ -367,7 +360,6 @@ fn grace_6_vegm_1_per_socket() {
 // ---- Grace Config 7: vEGM, 2 GPUs per socket, 2 sockets ----
 
 #[test]
-#[ignore = "Phase 5"]
 fn grace_7_vegm_2_per_socket() {
     check(
         HostTopology {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/machine/topology.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/machine/topology.rs
@@ -41,6 +41,7 @@ pub(crate) enum BusIommu {
 }
 
 pub(crate) struct SmmuV3Config {
+    pub id: String,
     pub accel: bool,
     pub ats: bool,
     pub pasid: bool,
@@ -53,6 +54,7 @@ pub(crate) struct SmmuV3Config {
 impl Default for SmmuV3Config {
     fn default() -> Self {
         Self {
+            id: String::new(),
             accel: true,
             ats: true,
             pasid: true,


### PR DESCRIPTION
Supersedes #13360; review history lives there.

Stacked on #13402 (Phase 1). Base: `qemu-refactor-phase1`.

Implements `Platform::to_qemu_args`, the emission half of the machine-centric
QEMU platform model. The 6 grace golden fixture tests now pass; grace_4
(GPU+NIC) stays `#[ignore]` pending NIC topology design in Phase 4.

### What changes

`to_qemu_args` emits QEMU arguments directly from the typed `Platform` model
in the order QEMU and Linux require:

1. `iommufd` object
2. Memory backends (RAM / hugepages / EGM)
3. `-machine` line
4. NUMA nodes (CPU-affinity first, then GPU initiator nodes: ACPI SRAT ordering)
5. Per root complex: `pxb-pcie`, `arm-smmuv3`, then `(pcie-root-port, vfio-pci-nohotplug)` pairs
6. `acpi-generic-initiator` objects, then `acpi-egm-memory` objects

The emitter omits `-machine memory-backend=` whenever any NUMA node uses
`memdev=`, including single-socket Grace configurations. GPU PCIe expander
buses use `32,64,96,...` spacing so each root port has secondary bus space.
These rules implement the corrected Phase 0 golden contract.

### Phase 1 naming bugs fixed by golden tests

The fixture tests surfaced several ID mismatches in `apply_host_defaults`:

| Field | Was | Now |
|---|---|---|
| Primary RAM id | `ram0` | `m0` |
| pxb id | `pxb{N}` | `pcie.{N+1}` |
| SMMU id | missing | `smmuv3.{N+1}` (stored in `SmmuV3Config`) |
| Root port id | `rp{N}` | `pcie.port{N}` (globally sequential, 1-indexed) |
| VFIO device id | `gpu{N}` | `dev{N}` |
| ACPI initiator id | `{dev}_{i}` | `gi{N}` (globally sequential) |
| ACPI EGM id | `egm_{dev}` | `egm{N}` (GPU-indexed) |
| EGM prealloc | `false` | `true` |
| `with_hugepages` share | `false` | `true` |

### EGM vs non-EGM distinction

EGM configs set `machine.memory_backend = None` in `apply_host_defaults`.
`to_qemu_args` uses this as the EGM signal: skip `memory_backends[0]` and
re-index the EGM file backends as `m0`, `m1`, ... in output. The machine
line omits `memory-backend=`.

### vCMDQ (grace_5)

`with_hugepages` now also enables `cmdqv=on` on all `arm-smmuv3` devices
because vCMDQ requires physically contiguous guest memory.

### Grace Virt defaults

`build("virt", ...)` now sets `gic_version=3`, `ras=true`, `highmem_mmio_size=4T`.
These are correct for all Grace (GH200/GB200/GB300) platforms.
