### PR TITLE
runtime-rs: avoid container start hang on binary loggers

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/binary_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/binary_io.rs
@@ -176,9 +176,9 @@ pub(crate) async fn open(uri: &Url, container_id: &str, namespace: &str) -> Resu
     // the Go runtime, logger startup waits for that handshake.
     let mut ready = File::from_std(std::fs::File::from(ready_read));
     let mut byte = [0_u8; 1];
-    ready
-        .read(&mut byte)
+    tokio::time::timeout(Duration::from_secs(10), ready.read(&mut byte))
         .await
+        .map_err(|_| anyhow!("timed out waiting for binary logger readiness"))?
         .context("wait for binary logger readiness")?;
 
     Ok(BinaryIo {


### PR DESCRIPTION
open() waits for the binary logger readiness handshake with an unbounded async read(). If the logger never writes to fd 5 (or inherits a bad fd), container start can hang indefinitely.

Let's add a timeout around the readiness read and fail the start path if it expires (the child will be killed on drop due to kill_on_drop(true)).


Suggested-by: CoPilot