### PR TITLE
tests: increase CPU hotplug retry timeout in k8s-cpu-ns

### DIFF
--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -56,7 +56,7 @@ setup() {
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
-	retries="10"
+	retries="6"
 
 	# Check the total of cpus
 	for _ in $(seq 1 "$retries"); do
@@ -76,7 +76,7 @@ setup() {
 		# Verify number of cpus
 		[ "$total_cpus_container" -le "$total_cpus" ]
 		[ "$total_cpus_container" -eq "$total_cpus" ] && break
-		sleep 1
+		sleep 5
 	done
 	[ "$total_cpus_container" -eq "$total_cpus" ]
 


### PR DESCRIPTION
The CPU namespace test polls for hotplugged vCPUs using a 10x1s retry loop (10s total). On systems under load or with slower ACPI hotplug negotiation, vCPU onlining can take longer than 10s, causing spurious test failures.

Increase the retry to 6x5s (30s total) to accommodate variable hotplug latency while keeping the test deterministic.

Fixes #13412