### PR TITLE
kata-types: disallow sandbox bind mounts from annotations

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -1154,14 +1154,12 @@ impl Annotation {
                         config.runtime.shared_mounts = serde_json::from_str(value.as_str())?;
                     }
                     KATA_ANNO_CFG_SANDBOX_BIND_MOUNTS => {
-                        let args: Vec<String> = value
-                            .to_string()
-                            .split_ascii_whitespace()
-                            .map(str::to_string)
-                            .collect();
-                        for arg in args {
-                            config.runtime.sandbox_bind_mounts.push(arg.to_string());
-                        }
+                        // Host bind-mount paths are operator-controlled configuration only.
+                        // Never honor them from untrusted workload annotations.
+                        warn!(
+                            sl!(),
+                            "Annotation {} is not permitted from workload annotations", key
+                        );
                     }
                     _ => {
                         warn!(sl!(), "Annotation {} not enabled", key);


### PR DESCRIPTION
The sandbox_bind_mounts option accepts host paths that runtime-rs exposes to the guest shared filesystem. Runtime annotations are not gated by the hypervisor annotation allowlist, allowing an untrusted workload annotation to add arbitrary host paths to the sandbox bind mount configuration.

Ignore KATA_ANNO_CFG_SANDBOX_BIND_MOUNTS when processing workload annotations. Sandbox bind mounts remain available through the operator-controlled TOML configuration, preserving the sandbox-level host/guest sharing feature while removing the untrusted annotation path.

Really appreciate it that Anthropic and Ada Logics report this issue.

Reported-by: Anthropic and Ada Logics