### PR TITLE
helm: roll out kata-deploy when mounted ConfigMaps change

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -878,7 +878,7 @@ host. Emitted at column 0; indent with `nindent` at the call site.
   mountPath: /custom-containerd-config/
   readOnly: true
 {{- end }}
-{{- if or (and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes) (eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true") }}
+{{- if eq (include "kata-deploy.hasCustomConfigsConfigMap" . | trim) "true" }}
 - name: custom-configs
   mountPath: /custom-configs/
   readOnly: true
@@ -908,7 +908,7 @@ indent with `nindent` at the call site.
     name: {{ .Chart.Name }}-containerd-user-dropin
 {{- end }}
 {{- end }}
-{{- if or (and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes) (eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true") }}
+{{- if eq (include "kata-deploy.hasCustomConfigsConfigMap" . | trim) "true" }}
 - name: custom-configs
   configMap:
 {{- if .Values.env.multiInstallSuffix }}
@@ -991,6 +991,83 @@ Returns "true" when at least one default shim has a non-empty dropIn value.
 {{- end -}}
 {{- end -}}
 {{- if $has -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when the custom-configs ConfigMap is rendered and mounted.
+*/}}
+{{- define "kata-deploy.hasCustomConfigsConfigMap" -}}
+{{- $hasCustomRuntimes := and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes -}}
+{{- $hasDefaultRuntimeDropIns := eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true" -}}
+{{- if or $hasCustomRuntimes $hasDefaultRuntimeDropIns -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+ConfigMap containing custom runtime configuration and default shim drop-ins.
+Mounted into kata-deploy pods at /custom-configs/.
+*/}}
+{{- define "kata-deploy.customConfigsConfigMap" -}}
+{{- $hasCustomRuntimes := and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes -}}
+{{- $hasDefaultRuntimeDropIns := eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true" -}}
+{{- if or $hasCustomRuntimes $hasDefaultRuntimeDropIns }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-custom-configs-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
+  name: {{ .Chart.Name }}-custom-configs
+{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kata-deploy.labels" . | nindent 4 }}
+data:
+{{- if $hasCustomRuntimes }}
+  custom-runtimes.list: |
+{{- range $name := keys .Values.customRuntimes.runtimes | sortAlpha }}
+{{- $runtime := index $.Values.customRuntimes.runtimes $name }}
+{{- $handler := "" }}
+{{- if $runtime.runtimeClass }}
+{{- range (splitList "\n" $runtime.runtimeClass) }}
+{{- $line := trim . }}
+{{- if hasPrefix "handler:" $line }}
+{{- $handler = trim (trimPrefix "handler:" $line) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $handler }}
+    {{ $handler }}:{{ $runtime.baseConfig }}:{{ dig "containerd" "snapshotter" "" $runtime }}:{{ dig "crio" "pullType" "" $runtime }}
+{{- end }}
+{{- end }}
+{{- range $name := keys .Values.customRuntimes.runtimes | sortAlpha }}
+{{- $runtime := index $.Values.customRuntimes.runtimes $name }}
+{{- $handler := "" }}
+{{- if $runtime.runtimeClass }}
+{{- range (splitList "\n" $runtime.runtimeClass) }}
+{{- $line := trim . }}
+{{- if hasPrefix "handler:" $line }}
+{{- $handler = trim (trimPrefix "handler:" $line) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and $handler $runtime.dropIn }}
+  dropin-{{ $handler }}.toml: |
+{{ $runtime.dropIn | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $disableAll := .Values.shims.disableAll | default false -}}
+{{- range $shimName := keys .Values.shims | sortAlpha }}
+{{- if ne $shimName "disableAll" }}
+{{- $shimConfig := index $.Values.shims $shimName -}}
+{{- $shimEnabled := eq (include "kata-deploy.isShimEnabled" (dict "shimConfig" $shimConfig "disableAll" $disableAll) | trim) "true" -}}
+{{- if and $shimEnabled $shimConfig.dropIn (ne (trim $shimConfig.dropIn) "") }}
+  dropin-{{ $shimName }}.toml: |
+{{ $shimConfig.dropIn | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -776,6 +776,11 @@ spec:
         app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
         app.kubernetes.io/instance: {{ $root.Release.Name }}
         kata-deploy/stage: {{ $stage }}
+{{- $podAnnotations := include "kata-deploy.podTemplateAnnotations" $root | trim }}
+{{- if $podAnnotations }}
+      annotations:
+{{- $podAnnotations | nindent 8 }}
+{{- end }}
     spec:
 {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1071,6 +1071,43 @@ data:
 {{- end -}}
 
 {{/*
+Checksum annotations for ConfigMaps mounted into kata-deploy pods. Changing a
+mounted ConfigMap does not update the pod spec by itself; hashing the rendered
+ConfigMap into the pod template forces a rollout when the data changes.
+*/}}
+{{- define "kata-deploy.configMapChecksumAnnotations" -}}
+{{- $annotations := dict -}}
+{{- if .Values.containerd.userDropIn | trim }}
+{{- $_ := set $annotations "checksum/containerd-user-dropin" (include (print $.Template.BasePath "/containerd-user-dropin-config.yaml") . | sha256sum) -}}
+{{- end }}
+{{- if eq (include "kata-deploy.hasCustomConfigsConfigMap" . | trim) "true" }}
+{{- $_ := set $annotations "checksum/custom-configs" (include "kata-deploy.customConfigsConfigMap" . | sha256sum) -}}
+{{- end }}
+{{- toYaml $annotations -}}
+{{- end -}}
+
+{{/*
+Pod template annotations: user-provided podAnnotations plus ConfigMap checksums.
+Checksums are applied last so a user-supplied "checksum/*" key can never
+override a computed value and silently disable the rollout trigger.
+*/}}
+{{- define "kata-deploy.podTemplateAnnotations" -}}
+{{- $annotations := dict -}}
+{{- with .Values.podAnnotations }}
+{{- range $key, $value := . }}
+{{- $_ := set $annotations $key $value -}}
+{{- end }}
+{{- end }}
+{{- $checksums := fromYaml (include "kata-deploy.configMapChecksumAnnotations" .) | default dict -}}
+{{- range $key, $value := $checksums }}
+{{- $_ := set $annotations $key $value -}}
+{{- end }}
+{{- if $annotations }}
+{{- toYaml $annotations -}}
+{{- end }}
+{{- end -}}
+
+{{/*
 NFD virtualization nodeAffinity for the kata-deploy DaemonSet.
 Applied when node-feature-discovery is managed by this chart (enabled: true).
 Kata Containers requires hardware virtualization support to function.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
@@ -1,68 +1,9 @@
 {{- $hasCustomRuntimes := and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes -}}
-{{- $hasDefaultRuntimeDropIns := eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true" -}}
-{{- if or $hasCustomRuntimes $hasDefaultRuntimeDropIns }}
+{{- if eq (include "kata-deploy.hasCustomConfigsConfigMap" . | trim) "true" }}
 ---
 # ConfigMap containing custom runtime configuration and runtime drop-ins
 # This is mounted into the kata-deploy pod at /custom-configs/
-apiVersion: v1
-kind: ConfigMap
-metadata:
-{{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-custom-configs-{{ .Values.env.multiInstallSuffix }}
-{{- else }}
-  name: {{ .Chart.Name }}-custom-configs
-{{- end }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kata-deploy.labels" . | nindent 4 }}
-data:
-{{- if $hasCustomRuntimes }}
-  # Format: handler:baseConfig:containerd_snapshotter:crio_pulltype
-  custom-runtimes.list: |
-{{- range $name, $runtime := .Values.customRuntimes.runtimes }}
-{{- $handler := "" }}
-{{- /* Extract handler from runtimeClass YAML */ -}}
-{{- if $runtime.runtimeClass }}
-{{- range (splitList "\n" $runtime.runtimeClass) }}
-{{- $line := trim . }}
-{{- if hasPrefix "handler:" $line }}
-{{- $handler = trim (trimPrefix "handler:" $line) }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- if $handler }}
-    {{ $handler }}:{{ $runtime.baseConfig }}:{{ dig "containerd" "snapshotter" "" $runtime }}:{{ dig "crio" "pullType" "" $runtime }}
-{{- end }}
-{{- end }}
-{{- /* Generate drop-in files for each custom runtime */ -}}
-{{- range $name, $runtime := .Values.customRuntimes.runtimes }}
-{{- $handler := "" }}
-{{- if $runtime.runtimeClass }}
-{{- range (splitList "\n" $runtime.runtimeClass) }}
-{{- $line := trim . }}
-{{- if hasPrefix "handler:" $line }}
-{{- $handler = trim (trimPrefix "handler:" $line) }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- if and $handler $runtime.dropIn }}
-  dropin-{{ $handler }}.toml: |
-{{ $runtime.dropIn | indent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- /* Generate drop-in files for enabled default shims */ -}}
-{{- $disableAll := .Values.shims.disableAll | default false -}}
-{{- range $shimName := keys .Values.shims | sortAlpha }}
-{{- if ne $shimName "disableAll" }}
-{{- $shimConfig := index $.Values.shims $shimName -}}
-{{- $shimEnabled := eq (include "kata-deploy.isShimEnabled" (dict "shimConfig" $shimConfig "disableAll" $disableAll) | trim) "true" -}}
-{{- if and $shimEnabled $shimConfig.dropIn (ne (trim $shimConfig.dropIn) "") }}
-  dropin-{{ $shimName }}.toml: |
-{{ $shimConfig.dropIn | indent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{ include "kata-deploy.customConfigsConfigMap" . }}
 {{- if $hasCustomRuntimes }}
 ---
 # RuntimeClasses for custom runtimes

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -53,6 +53,10 @@ spec:
         app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
         app.kubernetes.io/instance: {{ $root.Release.Name }}
         kata-deploy/dispatcher: install
+{{- if eq ($root.Values.deploymentMode | default "daemonset") "job" }}
+      annotations:
+        checksum/job-templates: {{ include (print $root.Template.BasePath "/kata-deploy-job-templates.yaml") $root | sha256sum }}
+{{- end }}
     spec:
 {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -50,9 +50,10 @@ spec:
 {{- else }}
         name: {{ .Chart.Name }}
 {{- end }}
-{{- with .Values.podAnnotations }}
+{{- $podAnnotations := include "kata-deploy.podTemplateAnnotations" . | trim }}
+{{- if $podAnnotations }}
       annotations:
-{{- toYaml . | nindent 8 }}
+{{- $podAnnotations | nindent 8 }}
 {{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Changes to mounted ConfigMaps (`shims.*.dropIn`, `containerd.userDropIn`,
and custom-runtime drop-ins) update the ConfigMap data but leave the
kata-deploy pod template unchanged, so the DaemonSet does not roll out
and running pods keep stale configuration ([#13416]).

This series hashes each mounted ConfigMap into pod-template checksum
annotations so content changes update the pod spec and trigger the
existing `RollingUpdate` strategy. The custom-configs ConfigMap is
extracted into a shared helper so the rendered manifest and its checksum
stay in sync. The same annotations are applied to job-mode per-node
workloads, and the install dispatcher hashes `job-templates`.
Fixes #13416