### PR TITLE
runtime-rs: cold plug: select PodResources device sources via config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-scope",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tonic 0.14.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,6 +5492,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-scope",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tonic 0.14.6",

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -31,8 +31,8 @@ pub use self::hypervisor::{
 
 mod runtime;
 pub use self::runtime::{
-    Runtime, RuntimeVendor, EMPTYDIR_MODE_BLOCK_ENCRYPTED, EMPTYDIR_MODE_BLOCK_PLAIN,
-    EMPTYDIR_MODE_SHARED_FS, RUNTIME_NAME_VIRTCONTAINER,
+    PodResourceDeviceSource, Runtime, RuntimeVendor, EMPTYDIR_MODE_BLOCK_ENCRYPTED,
+    EMPTYDIR_MODE_BLOCK_PLAIN, EMPTYDIR_MODE_SHARED_FS, RUNTIME_NAME_VIRTCONTAINER,
 };
 
 pub use self::agent::AGENT_NAME_KATA;

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -224,10 +224,27 @@ pub struct Runtime {
     ///              based cold plug.
     #[serde(default)]
     pub pod_resource_api_sock: String,
+
+    /// PodResources API sources feeding the cold-plug device list:
+    /// "device-plugin" and/or "dra". Defaults to ["device-plugin"],
+    /// preserving historical behavior. List both only for disjoint device
+    /// sets: kubelet double-counts a device advertised via both at scheduling.
+    #[serde(default = "default_pod_resource_device_sources")]
+    pub pod_resource_device_sources: Vec<String>,
 }
 
 fn default_passfd_listener_port() -> u32 {
     default::DEFAULT_PASSFD_LISTENER_PORT
+}
+
+/// Device source token for the legacy device-plugin API (container.Devices).
+pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+
+/// Device source token for Dynamic Resource Allocation (KEP-3695).
+pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+
+fn default_pod_resource_device_sources() -> Vec<String> {
+    vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
 }
 
 impl ConfigOps for Runtime {
@@ -288,6 +305,32 @@ impl ConfigOps for Runtime {
             return Err(std::io::Error::other(format!(
                 "Invalid emptydir_mode `{emptydir_mode}` in configuration file",
             )));
+        }
+
+        // pod_resource_device_sources: a missing key defaults via serde; an
+        // explicitly empty list, unknown token, or duplicate is a hard error
+        // at config load time.
+        let sources = &conf.runtime.pod_resource_device_sources;
+        if sources.is_empty() {
+            return Err(std::io::Error::other(format!(
+                "pod_resource_device_sources: must not be empty, allowed values: {:?}, {:?}",
+                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
+            )));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for s in sources {
+            if s != POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN && s != POD_RESOURCE_DEVICE_SOURCE_DRA
+            {
+                return Err(std::io::Error::other(format!(
+                    "pod_resource_device_sources: invalid source {:?}, allowed values: {:?}, {:?}",
+                    s, POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
+                )));
+            }
+            if !seen.insert(s.clone()) {
+                return Err(std::io::Error::other(format!(
+                    "pod_resource_device_sources: duplicate source {s:?}",
+                )));
+            }
         }
 
         for shared_mount in &conf.runtime.shared_mounts {
@@ -433,6 +476,77 @@ emptydir_mode = "block-plain"
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap();
         assert_eq!(&config.runtime.emptydir_mode, "shared-fs");
+    }
+
+    #[test]
+    fn test_default_pod_resource_device_sources() {
+        let content = r#"
+[runtime]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert_eq!(
+            config.runtime.pod_resource_device_sources,
+            vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_valid_pod_resource_device_sources() {
+        // single valid source
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+
+        // dra only
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+
+        // both sources
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin", "dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert_eq!(
+            config.runtime.pod_resource_device_sources,
+            vec!["device-plugin".to_string(), "dra".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_invalid_pod_resource_device_sources() {
+        // explicitly empty list is a hard error
+        let content = r#"
+[runtime]
+pod_resource_device_sources = []
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // unknown token
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin", "bogus"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // duplicate token
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["dra", "dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
     }
 
     #[test]

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -223,10 +223,27 @@ pub struct Runtime {
     ///              based cold plug.
     #[serde(default)]
     pub pod_resource_api_sock: String,
+
+    /// PodResources API sources feeding the cold-plug device list:
+    /// "device-plugin" and/or "dra". Defaults to ["device-plugin"],
+    /// preserving historical behavior. List both only for disjoint device
+    /// sets: kubelet double-counts a device advertised via both at scheduling.
+    #[serde(default = "default_pod_resource_device_sources")]
+    pub pod_resource_device_sources: Vec<String>,
 }
 
 fn default_passfd_listener_port() -> u32 {
     default::DEFAULT_PASSFD_LISTENER_PORT
+}
+
+/// Device source token for the legacy device-plugin API (container.Devices).
+pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+
+/// Device source token for Dynamic Resource Allocation (KEP-3695).
+pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+
+fn default_pod_resource_device_sources() -> Vec<String> {
+    vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
 }
 
 impl ConfigOps for Runtime {
@@ -286,6 +303,32 @@ impl ConfigOps for Runtime {
             return Err(std::io::Error::other(format!(
                 "Invalid emptydir_mode `{emptydir_mode}` in configuration file",
             )));
+        }
+
+        // pod_resource_device_sources: mirrors the Go katautils validation.
+        // A missing key defaults via serde; an explicitly empty list, unknown
+        // token, or duplicate is a hard error at config load time.
+        let sources = &conf.runtime.pod_resource_device_sources;
+        if sources.is_empty() {
+            return Err(std::io::Error::other(format!(
+                "pod_resource_device_sources: must not be empty, allowed values: {:?}, {:?}",
+                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
+            )));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for s in sources {
+            if s != POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN && s != POD_RESOURCE_DEVICE_SOURCE_DRA
+            {
+                return Err(std::io::Error::other(format!(
+                    "pod_resource_device_sources: invalid source {:?}, allowed values: {:?}, {:?}",
+                    s, POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
+                )));
+            }
+            if !seen.insert(s.clone()) {
+                return Err(std::io::Error::other(format!(
+                    "pod_resource_device_sources: duplicate source {s:?}",
+                )));
+            }
         }
 
         for shared_mount in &conf.runtime.shared_mounts {
@@ -431,6 +474,77 @@ emptydir_mode = "block-plain"
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap();
         assert_eq!(&config.runtime.emptydir_mode, "shared-fs");
+    }
+
+    #[test]
+    fn test_default_pod_resource_device_sources() {
+        let content = r#"
+[runtime]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert_eq!(
+            config.runtime.pod_resource_device_sources,
+            vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_valid_pod_resource_device_sources() {
+        // single valid source
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+
+        // dra only
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+
+        // both sources
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin", "dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert_eq!(
+            config.runtime.pod_resource_device_sources,
+            vec!["device-plugin".to_string(), "dra".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_invalid_pod_resource_device_sources() {
+        // explicitly empty list is a hard error
+        let content = r#"
+[runtime]
+pod_resource_device_sources = []
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // unknown token
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["device-plugin", "bogus"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        // duplicate token
+        let content = r#"
+[runtime]
+pod_resource_device_sources = ["dra", "dra"]
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
     }
 
     #[test]

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -27,6 +27,12 @@ pub const EMPTYDIR_MODE_BLOCK_ENCRYPTED: &str = "block-encrypted";
 /// EmptyDir mode: plug a block device to be mounted directly in the guest.
 pub const EMPTYDIR_MODE_BLOCK_PLAIN: &str = "block-plain";
 
+/// Device source token for the legacy device-plugin API (container.Devices).
+pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+
+/// Device source token for Dynamic Resource Allocation (KEP-3695).
+pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+
 /// Kata runtime configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Runtime {
@@ -236,12 +242,6 @@ pub struct Runtime {
 fn default_passfd_listener_port() -> u32 {
     default::DEFAULT_PASSFD_LISTENER_PORT
 }
-
-/// Device source token for the legacy device-plugin API (container.Devices).
-pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
-
-/// Device source token for Dynamic Resource Allocation (KEP-3695).
-pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
 
 fn default_pod_resource_device_sources() -> Vec<String> {
     vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -27,11 +27,28 @@ pub const EMPTYDIR_MODE_BLOCK_ENCRYPTED: &str = "block-encrypted";
 /// EmptyDir mode: plug a block device to be mounted directly in the guest.
 pub const EMPTYDIR_MODE_BLOCK_PLAIN: &str = "block-plain";
 
-/// Device source token for the legacy device-plugin API (container.Devices).
-pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+/// A kubelet PodResources source the cold-plug path may trust. Serialized
+/// as the tokens `"device-plugin"` / `"dra"`, so an unknown or misspelled
+/// token is rejected when the config is loaded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum PodResourceDeviceSource {
+    /// Legacy device-plugin allocations (container.Devices).
+    #[serde(rename = "device-plugin")]
+    DevicePlugin,
+    /// Dynamic Resource Allocation (KEP-3695).
+    #[serde(rename = "dra")]
+    Dra,
+}
 
-/// Device source token for Dynamic Resource Allocation (KEP-3695).
-pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+impl PodResourceDeviceSource {
+    /// The config token this variant serializes as.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PodResourceDeviceSource::DevicePlugin => "device-plugin",
+            PodResourceDeviceSource::Dra => "dra",
+        }
+    }
+}
 
 /// Kata runtime configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -232,19 +249,30 @@ pub struct Runtime {
     pub pod_resource_api_sock: String,
 
     /// PodResources API sources feeding the cold-plug device list:
-    /// "device-plugin" and/or "dra". Defaults to ["device-plugin"],
-    /// preserving historical behavior. List both only for disjoint device
-    /// sets: kubelet double-counts a device advertised via both at scheduling.
-    #[serde(default = "default_pod_resource_device_sources")]
-    pub pod_resource_device_sources: Vec<String>,
+    /// "device-plugin" and/or "dra". `None` (key absent) means the
+    /// historical default of ["device-plugin"]; an explicit empty list
+    /// trusts neither source: a pod without cold-pluggable data runs
+    /// normally, one that carries it fails closed. `Option` keeps the two
+    /// apart even when the whole `[runtime]` section is absent and this
+    /// struct comes from `Default`. List both only for disjoint device
+    /// sets: kubelet double-counts a device advertised via both at
+    /// scheduling. Read through `pod_resource_device_sources()`.
+    #[serde(default)]
+    pub pod_resource_device_sources: Option<Vec<PodResourceDeviceSource>>,
+}
+
+impl Runtime {
+    /// The PodResources sources to trust: the configured list, or
+    /// ["device-plugin"] when the key is absent.
+    pub fn pod_resource_device_sources(&self) -> Vec<PodResourceDeviceSource> {
+        self.pod_resource_device_sources
+            .clone()
+            .unwrap_or_else(|| vec![PodResourceDeviceSource::DevicePlugin])
+    }
 }
 
 fn default_passfd_listener_port() -> u32 {
     default::DEFAULT_PASSFD_LISTENER_PORT
-}
-
-fn default_pod_resource_device_sources() -> Vec<String> {
-    vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
 }
 
 impl ConfigOps for Runtime {
@@ -307,29 +335,19 @@ impl ConfigOps for Runtime {
             )));
         }
 
-        // pod_resource_device_sources: a missing key defaults via serde; an
-        // explicitly empty list, unknown token, or duplicate is a hard error
-        // at config load time.
-        let sources = &conf.runtime.pod_resource_device_sources;
-        if sources.is_empty() {
-            return Err(std::io::Error::other(format!(
-                "pod_resource_device_sources: must not be empty, allowed values: {:?}, {:?}",
-                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
-            )));
-        }
-        let mut seen = std::collections::HashSet::new();
-        for s in sources {
-            if s != POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN && s != POD_RESOURCE_DEVICE_SOURCE_DRA
-            {
-                return Err(std::io::Error::other(format!(
-                    "pod_resource_device_sources: invalid source {:?}, allowed values: {:?}, {:?}",
-                    s, POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA,
-                )));
-            }
-            if !seen.insert(s.clone()) {
-                return Err(std::io::Error::other(format!(
-                    "pod_resource_device_sources: duplicate source {s:?}",
-                )));
+        // pod_resource_device_sources: a missing key means the default, an
+        // unknown token is rejected by serde at load, and an explicit empty
+        // list means "trust neither source". Only duplicates are left to
+        // check.
+        if let Some(sources) = &conf.runtime.pod_resource_device_sources {
+            let mut seen = std::collections::HashSet::new();
+            for s in sources {
+                if !seen.insert(*s) {
+                    return Err(std::io::Error::other(format!(
+                        "pod_resource_device_sources: duplicate source {:?}",
+                        s.as_str(),
+                    )));
+                }
             }
         }
 
@@ -485,9 +503,17 @@ emptydir_mode = "block-plain"
 "#;
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap();
+        // Key absent: the raw field stays None and the accessor supplies the
+        // historical default, even when the whole [runtime] section is
+        // missing (Runtime::default() would bypass a serde field default).
+        assert_eq!(config.runtime.pod_resource_device_sources, None);
         assert_eq!(
-            config.runtime.pod_resource_device_sources,
-            vec![POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()]
+            config.runtime.pod_resource_device_sources(),
+            vec![PodResourceDeviceSource::DevicePlugin]
+        );
+        assert_eq!(
+            Runtime::default().pod_resource_device_sources(),
+            vec![PodResourceDeviceSource::DevicePlugin]
         );
     }
 
@@ -517,30 +543,39 @@ pod_resource_device_sources = ["device-plugin", "dra"]
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap();
         assert_eq!(
-            config.runtime.pod_resource_device_sources,
-            vec!["device-plugin".to_string(), "dra".to_string()]
+            config.runtime.pod_resource_device_sources(),
+            vec![
+                PodResourceDeviceSource::DevicePlugin,
+                PodResourceDeviceSource::Dra
+            ]
         );
-    }
 
-    #[test]
-    fn test_invalid_pod_resource_device_sources() {
-        // explicitly empty list is a hard error
+        // explicitly empty list is valid: trust neither source
         let content = r#"
 [runtime]
 pod_resource_device_sources = []
 "#;
         let config: TomlConfig = TomlConfig::load(content).unwrap();
-        config.validate().unwrap_err();
+        config.validate().unwrap();
+        assert_eq!(config.runtime.pod_resource_device_sources, Some(vec![]));
+        assert!(config.runtime.pod_resource_device_sources().is_empty());
+    }
 
-        // unknown token
+    #[test]
+    fn test_invalid_pod_resource_device_sources() {
+        // unknown token is rejected by serde at load time
         let content = r#"
 [runtime]
 pod_resource_device_sources = ["device-plugin", "bogus"]
 "#;
-        let config: TomlConfig = TomlConfig::load(content).unwrap();
-        config.validate().unwrap_err();
+        let err = TomlConfig::load(content).unwrap_err();
+        assert!(
+            err.to_string().contains("pod_resource_device_sources"),
+            "{}",
+            err
+        );
 
-        // duplicate token
+        // duplicate token is rejected by validate
         let content = r#"
 [runtime]
 pod_resource_device_sources = ["dra", "dra"]

--- a/src/libs/pod-resources-rs/Cargo.toml
+++ b/src/libs/pod-resources-rs/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
 slog-scope = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/src/libs/pod-resources-rs/src/lib.rs
+++ b/src/libs/pod-resources-rs/src/lib.rs
@@ -6,14 +6,15 @@
 pub mod pod_resources;
 
 use anyhow::{anyhow, Result};
-use cdi::cache::{new_cache, with_auto_refresh, CdiOption};
+use cdi::cache::{new_cache, with_auto_refresh, Cache, CdiOption};
 use cdi::spec_dirs::with_spec_dirs;
 use cdi::specs::config::DeviceNode;
 use container_device_interface as cdi;
 use serde::Deserialize;
 
 use slog::info;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 /// DEFAULT_DYNAMIC_CDI_SPEC_PATH is the default directory for dynamic CDI Specs,
 /// which can be overridden by specifying a different path when creating the cache.
@@ -21,6 +22,85 @@ const DEFAULT_DYNAMIC_CDI_SPEC_PATH: &str = "/var/run/cdi";
 /// DEFAULT_STATIC_CDI_SPEC_PATH is the default directory for static CDI Specs,
 /// which can be overridden by specifying a different path when creating the cache.
 const DEFAULT_STATIC_CDI_SPEC_PATH: &str = "/etc/cdi";
+
+/// Default CDI spec directories consulted when resolving devices for cold plug.
+pub const DEFAULT_CDI_SPEC_DIRS: [&str; 2] =
+    [DEFAULT_DYNAMIC_CDI_SPEC_PATH, DEFAULT_STATIC_CDI_SPEC_PATH];
+
+/// Device source token for the legacy device-plugin API (container.devices);
+/// must match kata-types' `pod_resource_device_sources` tokens.
+pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+
+/// Device source token for Dynamic Resource Allocation (KEP-3695); must match
+/// kata-types' `pod_resource_device_sources` tokens.
+pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+
+/// Build a CDI cache with auto-refresh disabled: callers refresh explicitly,
+/// and a racing background refresh makes device lookups flaky.
+fn new_cdi_cache(spec_dirs: &[&str]) -> Arc<Mutex<Cache>> {
+    let options: Vec<CdiOption> = vec![with_auto_refresh(false), with_spec_dirs(spec_dirs)];
+    new_cache(options)
+}
+
+/// Resolve CDI device names to their host device-node paths; names that do
+/// not resolve in the cache are omitted from the map. A cache build/refresh
+/// failure is a hard error so the fail-closed overlap guard can propagate it.
+pub fn cdi_device_node_host_paths(
+    spec_dirs: &[&str],
+    names: &[String],
+) -> Result<HashMap<String, Vec<String>>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    if names.is_empty() {
+        return Ok(out);
+    }
+
+    let cache = new_cdi_cache(spec_dirs);
+    let mut cache = cache.lock().unwrap();
+    cache
+        .refresh()
+        .map_err(|e| anyhow!("Refreshing cache failed: {:?}", e))?;
+
+    for name in names {
+        if out.contains_key(name) {
+            continue;
+        }
+        if let Some(device) = cache.get_device(name) {
+            let mut paths = Vec::new();
+            if let Some(devnodes) = device.edits().container_edits.device_nodes {
+                for node in devnodes.iter() {
+                    if let Some(p) = device_node_host_path(node) {
+                        if !p.is_empty() {
+                            paths.push(p);
+                        }
+                    }
+                }
+            }
+            out.insert(name.clone(), paths);
+        }
+    }
+
+    Ok(out)
+}
+
+/// Filter `devs` to the names that resolve to at least one device node in the
+/// CDI cache (order-preserving); only node-bearing devices are cold-plugged, so
+/// a device with only env/mount edits must not count (it would fail-close an
+/// unlisted source that injects nothing). Mirrors Go's `cdiResolvableDevices`:
+/// a cache failure means "none resolvable", never an error.
+pub fn resolvable_cdi_devices(spec_dirs: &[&str], devs: &[String]) -> Vec<String> {
+    if devs.is_empty() {
+        return Vec::new();
+    }
+    let map = match cdi_device_node_host_paths(spec_dirs, devs) {
+        Ok(m) => m,
+        Err(_) => return Vec::new(),
+    };
+    let mut seen = std::collections::HashSet::new();
+    devs.iter()
+        .filter(|d| map.get(*d).is_some_and(|v| !v.is_empty()) && seen.insert((*d).clone()))
+        .cloned()
+        .collect()
+}
 
 /// Typed projection of the upstream `DeviceNode` fields we need. The upstream
 /// struct keeps `path` / `host_path` as `pub(crate)`, so we round-trip through
@@ -52,13 +132,7 @@ pub async fn handle_cdi_devices(devices: &[String]) -> Result<Vec<DeviceNode>> {
         info!(sl!(), "no pod CDI devices requested.");
         return Ok(vec![]);
     }
-    // Explicitly set the cache options to disable auto-refresh and
-    // to use the default spec dirs for dynamic and static CDI Specs
-    let options: Vec<CdiOption> = vec![
-        with_auto_refresh(false),
-        with_spec_dirs(&[DEFAULT_DYNAMIC_CDI_SPEC_PATH, DEFAULT_STATIC_CDI_SPEC_PATH]),
-    ];
-    let cache: Arc<std::sync::Mutex<cdi::cache::Cache>> = new_cache(options);
+    let cache: Arc<Mutex<Cache>> = new_cdi_cache(&DEFAULT_CDI_SPEC_DIRS);
 
     let target_devices = {
         let mut target_devices = vec![];

--- a/src/libs/pod-resources-rs/src/lib.rs
+++ b/src/libs/pod-resources-rs/src/lib.rs
@@ -27,13 +27,23 @@ const DEFAULT_STATIC_CDI_SPEC_PATH: &str = "/etc/cdi";
 pub const DEFAULT_CDI_SPEC_DIRS: [&str; 2] =
     [DEFAULT_DYNAMIC_CDI_SPEC_PATH, DEFAULT_STATIC_CDI_SPEC_PATH];
 
-/// Device source token for the legacy device-plugin API (container.devices);
-/// must match kata-types' `pod_resource_device_sources` tokens.
-pub const POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN: &str = "device-plugin";
+/// A kubelet PodResources field the cold-plug path is allowed to trust.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DeviceSource {
+    /// Legacy device-plugin allocations (`container.devices`).
+    DevicePlugin,
+    /// Dynamic Resource Allocation allocations (KEP-3695, `dynamic_resources`).
+    Dra,
+}
 
-/// Device source token for Dynamic Resource Allocation (KEP-3695); must match
-/// kata-types' `pod_resource_device_sources` tokens.
-pub const POD_RESOURCE_DEVICE_SOURCE_DRA: &str = "dra";
+impl std::fmt::Display for DeviceSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeviceSource::DevicePlugin => write!(f, "device-plugin"),
+            DeviceSource::Dra => write!(f, "dra"),
+        }
+    }
+}
 
 /// Build a CDI cache with auto-refresh disabled: callers refresh explicitly,
 /// and a racing background refresh makes device lookups flaky.

--- a/src/libs/pod-resources-rs/src/pod_resources/mod.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/mod.rs
@@ -3,14 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod overlap;
 pub mod v1;
 
 use v1::pod_resources_lister_client::PodResourcesListerClient;
+use v1::{ContainerResources, PodResources};
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use anyhow::{anyhow, Context, Result};
+
+use crate::{
+    resolvable_cdi_devices, DEFAULT_CDI_SPEC_DIRS, POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+    POD_RESOURCE_DEVICE_SOURCE_DRA,
+};
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tokio::time::{timeout, Duration};
@@ -61,10 +68,142 @@ async fn create_grpc_channel(socket_path: &str) -> Result<Channel> {
     Ok(channel)
 }
 
+/// Collect the CDI device names in a container's DynamicResources (KEP-3695):
+/// DRA allocations are reported only there, never in the device-plugin
+/// `devices` field.
+fn collect_pod_resource_cdi_devices(container: &ContainerResources) -> Vec<String> {
+    let mut devices = Vec::new();
+    for dr in &container.dynamic_resources {
+        for cr in &dr.claim_resources {
+            for cdi_dev in &cr.cdi_devices {
+                if cdi_dev.name.is_empty() {
+                    continue;
+                }
+                devices.push(cdi_dev.name.clone());
+            }
+        }
+    }
+    devices
+}
+
+/// Deduplicate preserving order: a ResourceClaim shared by several containers
+/// reports the same CDI device once per container, and plugging it twice
+/// would duplicate its OCI edits.
+fn dedup_strings(input: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::with_capacity(input.len());
+    let mut out = Vec::with_capacity(input.len());
+    for s in input {
+        if seen.insert(s.clone()) {
+            out.push(s.clone());
+        }
+    }
+    out
+}
+
+/// Select the cold-plug device list from a PodResources response, reading the
+/// fields picked by `sources`: "device-plugin" (`container.devices`) and/or
+/// "dra" (`dynamic_resources` CDI devices). List both only for disjoint device
+/// sets: kubelet double-counts a device advertised via both at scheduling; a
+/// same-device collision here is caught by the overlap check. Fail closed: an
+/// unlisted source carrying CDI-resolvable data is an error, so misconfiguration
+/// cannot silently boot the guest without its devices; data that never resolves
+/// in the CDI cache is not cold-pluggable and is exempt.
+fn select_cold_plug_devices(
+    pod_resources: &PodResources,
+    sources: &[String],
+    spec_dirs: &[&str],
+) -> Result<Vec<String>> {
+    let want_device_plugin = sources
+        .iter()
+        .any(|s| s == POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN);
+    let want_dra = sources.iter().any(|s| s == POD_RESOURCE_DEVICE_SOURCE_DRA);
+
+    let format_cdi_device_ids = |resource_name: &str, device_ids: &[String]| -> Vec<String> {
+        device_ids
+            .iter()
+            .map(|id| format!("{}={}", resource_name, id))
+            .collect()
+    };
+
+    let mut devices: Vec<String> = Vec::new();
+    let mut all_device_plugin_devs: Vec<String> = Vec::new();
+    let mut all_dra_devs: Vec<String> = Vec::new();
+
+    for container in &pod_resources.containers {
+        let mut device_plugin_devs: Vec<String> = Vec::new();
+        for device in &container.devices {
+            device_plugin_devs.extend(format_cdi_device_ids(&device.resource_name, &device.device_ids));
+        }
+
+        let dra_devs = collect_pod_resource_cdi_devices(container);
+
+        if !want_device_plugin && !device_plugin_devs.is_empty() {
+            let resolvable = resolvable_cdi_devices(spec_dirs, &device_plugin_devs);
+            if !resolvable.is_empty() {
+                return Err(anyhow!(
+                    "cold plug: container {:?} has cold-pluggable (CDI-resolvable) device-plugin \
+                     PodResources data ({:?}) but {:?} is not in pod_resource_device_sources={:?}; \
+                     add {:?} to the config option or this data will be silently dropped",
+                    container.name,
+                    resolvable,
+                    POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                    sources,
+                    POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                ));
+            }
+        }
+        if !want_dra && !dra_devs.is_empty() {
+            let resolvable = resolvable_cdi_devices(spec_dirs, &dra_devs);
+            if !resolvable.is_empty() {
+                return Err(anyhow!(
+                    "cold plug: container {:?} has cold-pluggable (CDI-resolvable) DRA \
+                     PodResources data ({:?}) but {:?} is not in pod_resource_device_sources={:?}; \
+                     add {:?} to the config option or this data will be silently dropped",
+                    container.name,
+                    resolvable,
+                    POD_RESOURCE_DEVICE_SOURCE_DRA,
+                    sources,
+                    POD_RESOURCE_DEVICE_SOURCE_DRA,
+                ));
+            }
+        }
+
+        if want_device_plugin {
+            let deduped = dedup_strings(&device_plugin_devs);
+            devices.extend(deduped.iter().cloned());
+            all_device_plugin_devs.extend(deduped);
+        }
+        if want_dra {
+            let deduped = dedup_strings(&dra_devs);
+            devices.extend(deduped.iter().cloned());
+            all_dra_devs.extend(deduped);
+        }
+    }
+
+    if want_device_plugin && want_dra {
+        overlap::check_cross_source_physical_overlap(
+            &dedup_strings(&all_device_plugin_devs),
+            &dedup_strings(&all_dra_devs),
+            spec_dirs,
+        )?;
+    }
+
+    Ok(dedup_strings(&devices))
+}
+
 pub async fn get_pod_cdi_devices(
     socket: &str,
     annotations: &HashMap<String, String>,
+    sources: &[String],
 ) -> Result<Vec<String>> {
+    if sources.is_empty() {
+        // Config loading defaults this to ["device-plugin"]; if it is empty
+        // anyway, fail closed rather than guess a source.
+        return Err(anyhow!(
+            "cold plug: pod_resource_device_sources is empty, refusing to guess a device source"
+        ));
+    }
+
     let pod_name = annotations
         .get(SANDBOX_NAME_ANNOTATION)
         .or_else(|| annotations.get(CRIO_NAME_ANNOTATION))
@@ -115,22 +254,173 @@ pub async fn get_pod_cdi_devices(
         .pod_resources
         .ok_or_else(|| anyhow!("cold plug: PodResources is nil"))?;
 
-    // Format device specifications
-    let format_cdi_device_ids = |resource_name: &str, device_ids: &[String]| -> Vec<String> {
-        device_ids
-            .iter()
-            .map(|id| format!("{}={}", resource_name, id))
-            .collect()
+    select_cold_plug_devices(&pod_resources, sources, &DEFAULT_CDI_SPEC_DIRS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pod_resources::v1::{
+        CdiDevice, ClaimResource, ContainerDevices, ContainerResources, DynamicResource,
+        PodResources,
     };
 
-    // Collect all device specifications from all containers
-    let mut devices = Vec::new();
-    for container in &pod_resources.containers {
-        for device in &container.devices {
-            let cdi_devices = format_cdi_device_ids(&device.resource_name, &device.device_ids);
-            devices.extend(cdi_devices);
+    fn pod_with_both_sources() -> PodResources {
+        PodResources {
+            name: "pod-a".to_string(),
+            namespace: "ns-a".to_string(),
+            containers: vec![ContainerResources {
+                name: "ctr-a".to_string(),
+                devices: vec![ContainerDevices {
+                    resource_name: "vendor.com/gpu".to_string(),
+                    device_ids: vec!["gpu0".to_string()],
+                    ..Default::default()
+                }],
+                dynamic_resources: vec![DynamicResource {
+                    claim_name: "claim-a".to_string(),
+                    claim_resources: vec![ClaimResource {
+                        cdi_devices: vec![CdiDevice {
+                            name: "vendor.com/dra=gpu1".to_string(),
+                        }],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
         }
     }
 
-    Ok(devices)
+    #[test]
+    fn test_collect_pod_resource_cdi_devices() {
+        let pod = pod_with_both_sources();
+        let dra = collect_pod_resource_cdi_devices(&pod.containers[0]);
+        assert_eq!(dra, vec!["vendor.com/dra=gpu1".to_string()]);
+    }
+
+    #[test]
+    fn test_dedup_strings() {
+        let input = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "a".to_string(),
+            "c".to_string(),
+            "b".to_string(),
+        ];
+        assert_eq!(
+            dedup_strings(&input),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_select_device_plugin_only() {
+        // Empty spec dir: nothing resolves, so the unlisted DRA data is exempt.
+        let spec = tempfile::tempdir().unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let pod = pod_with_both_sources();
+        let devs = select_cold_plug_devices(
+            &pod,
+            &[POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()],
+            &spec_dirs,
+        )
+        .unwrap();
+        assert_eq!(devs, vec!["vendor.com/gpu=gpu0".to_string()]);
+    }
+
+    #[test]
+    fn test_select_dra_only() {
+        let spec = tempfile::tempdir().unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let pod = pod_with_both_sources();
+        let devs = select_cold_plug_devices(
+            &pod,
+            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
+            &spec_dirs,
+        )
+        .unwrap();
+        assert_eq!(devs, vec!["vendor.com/dra=gpu1".to_string()]);
+    }
+
+    #[test]
+    fn test_select_both_sources() {
+        let spec = tempfile::tempdir().unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let pod = pod_with_both_sources();
+        let devs = select_cold_plug_devices(
+            &pod,
+            &[
+                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string(),
+                POD_RESOURCE_DEVICE_SOURCE_DRA.to_string(),
+            ],
+            &spec_dirs,
+        )
+        .unwrap();
+        assert_eq!(
+            devs,
+            vec![
+                "vendor.com/gpu=gpu0".to_string(),
+                "vendor.com/dra=gpu1".to_string()
+            ]
+        );
+    }
+
+    fn write_cdi_spec(dir: &std::path::Path, name: &str, kind: &str, devices: &[(&str, &str)]) {
+        let mut content = format!("cdiVersion: \"0.5.0\"\nkind: \"{kind}\"\ndevices:\n");
+        for (dev_name, path) in devices {
+            content.push_str(&format!(
+                "  - name: \"{dev_name}\"\n    containerEdits:\n      deviceNodes:\n      - path: \"{path}\"\n"
+            ));
+        }
+        std::fs::write(dir.join(format!("{name}.yaml")), content).unwrap();
+    }
+
+    #[test]
+    fn test_select_unlisted_source_with_resolvable_device_errors() {
+        // gpu0 resolves but "device-plugin" is not listed: fail closed.
+        let spec = tempfile::tempdir().unwrap();
+        write_cdi_spec(
+            spec.path(),
+            "dp",
+            "vendor.com/gpu",
+            &[("gpu0", "/dev/null")],
+        );
+        let spec_dirs = [spec.path().to_str().unwrap()];
+
+        let pod = pod_with_both_sources();
+        let err = select_cold_plug_devices(
+            &pod,
+            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
+            &spec_dirs,
+        )
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("not in pod_resource_device_sources"), "{}", msg);
+        assert!(msg.contains(POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN), "{}", msg);
+        assert!(msg.contains("vendor.com/gpu=gpu0"), "{}", msg);
+    }
+
+    #[test]
+    fn test_select_unlisted_source_without_device_nodes_is_exempt() {
+        // gpu0 resolves in the cache but declares no device nodes (env-only
+        // CDI): nothing is cold-plugged for it, so an unlisted source must not
+        // fail closed on it.
+        let spec = tempfile::tempdir().unwrap();
+        std::fs::write(
+            spec.path().join("dp.yaml"),
+            "cdiVersion: \"0.5.0\"\nkind: \"vendor.com/gpu\"\ndevices:\n  - name: \"gpu0\"\n    containerEdits:\n      env:\n      - \"FOO=bar\"\n",
+        )
+        .unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+
+        let pod = pod_with_both_sources();
+        let devices = select_cold_plug_devices(
+            &pod,
+            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
+            &spec_dirs,
+        )
+        .expect("node-less unlisted device must not fail closed");
+        assert!(!devices.iter().any(|d| d.contains("gpu0")), "{:?}", devices);
+    }
 }

--- a/src/libs/pod-resources-rs/src/pod_resources/mod.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/mod.rs
@@ -14,10 +14,7 @@ use std::convert::TryFrom;
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::{
-    resolvable_cdi_devices, DEFAULT_CDI_SPEC_DIRS, POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
-    POD_RESOURCE_DEVICE_SOURCE_DRA,
-};
+use crate::{resolvable_cdi_devices, DeviceSource, DEFAULT_CDI_SPEC_DIRS};
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 use tokio::time::{timeout, Duration};
@@ -117,23 +114,50 @@ fn dedup_strings(input: &[String]) -> Vec<String> {
     out
 }
 
-/// Select the cold-plug device list from a PodResources response, reading the
-/// fields picked by `sources`: "device-plugin" (`container.devices`) and/or
-/// "dra" (`dynamic_resources` CDI devices). List both only for disjoint device
-/// sets: kubelet double-counts a device advertised via both at scheduling; a
-/// same-device collision here is caught by the overlap check. Fail closed: an
-/// unlisted source carrying CDI-resolvable data is an error, so misconfiguration
-/// cannot silently boot the guest without its devices; data that never resolves
-/// in the CDI cache is not cold-pluggable and is exempt.
+/// Cold-plug CDI device names selected from a PodResources response, kept per
+/// source so the caller can run cross-source enforcement (the physical overlap
+/// check) before flattening for attachment.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SelectedColdPlugDevices {
+    /// Devices from `container.devices` (device-plugin allocations).
+    pub device_plugin: Vec<String>,
+    /// Devices from `dynamic_resources` (DRA allocations).
+    pub dra: Vec<String>,
+}
+
+impl SelectedColdPlugDevices {
+    /// The final plug list: device-plugin devices first, then DRA devices,
+    /// deduplicated preserving order.
+    ///
+    /// Precondition when both lists are non-empty: run
+    /// `overlap::check_cross_source_physical_overlap` on the two lists
+    /// first. Flattening erases the source, and a same-physical-device
+    /// collision that was not rejected would be cold-plugged twice.
+    pub fn flattened(&self) -> Vec<String> {
+        let mut all = self.device_plugin.clone();
+        all.extend(self.dra.iter().cloned());
+        dedup_strings(&all)
+    }
+}
+
+/// Select the cold-plug devices from a PodResources response, reading the
+/// fields picked by `sources`: `DevicePlugin` (`container.devices`) and/or
+/// `Dra` (`dynamic_resources` CDI devices). An empty `sources` trusts neither
+/// field. Fail closed: an unlisted source carrying CDI-resolvable data is an
+/// error, so misconfiguration cannot silently boot the guest without its
+/// devices; data that never resolves in the CDI cache is not cold-pluggable
+/// and is exempt. No cross-source policy is applied here: the response is
+/// passed through per source, and the overlap check runs in the caller's
+/// device path.
 fn select_cold_plug_devices(
     pod_resources: &PodResources,
-    sources: &[String],
+    sources: &[DeviceSource],
     spec_dirs: &[&str],
-) -> Result<Vec<String>> {
-    let want_device_plugin = sources
-        .iter()
-        .any(|s| s == POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN);
-    let want_dra = sources.iter().any(|s| s == POD_RESOURCE_DEVICE_SOURCE_DRA);
+) -> Result<SelectedColdPlugDevices> {
+    let want_device_plugin = sources.contains(&DeviceSource::DevicePlugin);
+    let want_dra = sources.contains(&DeviceSource::Dra);
+    let sources_display =
+        |sources: &[DeviceSource]| sources.iter().map(|s| s.to_string()).collect::<Vec<_>>();
 
     let format_cdi_device_ids = |resource_name: &str, device_ids: &[String]| -> Vec<String> {
         device_ids
@@ -142,14 +166,15 @@ fn select_cold_plug_devices(
             .collect()
     };
 
-    let mut devices: Vec<String> = Vec::new();
-    let mut all_device_plugin_devs: Vec<String> = Vec::new();
-    let mut all_dra_devs: Vec<String> = Vec::new();
+    let mut selected = SelectedColdPlugDevices::default();
 
     for container in &pod_resources.containers {
         let mut device_plugin_devs: Vec<String> = Vec::new();
         for device in &container.devices {
-            device_plugin_devs.extend(format_cdi_device_ids(&device.resource_name, &device.device_ids));
+            device_plugin_devs.extend(format_cdi_device_ids(
+                &device.resource_name,
+                &device.device_ids,
+            ));
         }
 
         let dra_devs = collect_pod_resource_cdi_devices(container);
@@ -163,9 +188,9 @@ fn select_cold_plug_devices(
                      add {:?} to the config option or this data will be silently dropped",
                     container.name,
                     resolvable,
-                    POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
-                    sources,
-                    POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                    DeviceSource::DevicePlugin.to_string(),
+                    sources_display(sources),
+                    DeviceSource::DevicePlugin.to_string(),
                 ));
             }
         }
@@ -178,58 +203,46 @@ fn select_cold_plug_devices(
                      add {:?} to the config option or this data will be silently dropped",
                     container.name,
                     resolvable,
-                    POD_RESOURCE_DEVICE_SOURCE_DRA,
-                    sources,
-                    POD_RESOURCE_DEVICE_SOURCE_DRA,
+                    DeviceSource::Dra.to_string(),
+                    sources_display(sources),
+                    DeviceSource::Dra.to_string(),
                 ));
             }
         }
 
         if want_device_plugin {
-            let deduped = dedup_strings(&device_plugin_devs);
-            devices.extend(deduped.iter().cloned());
-            all_device_plugin_devs.extend(deduped);
+            selected
+                .device_plugin
+                .extend(dedup_strings(&device_plugin_devs));
         }
         if want_dra {
-            let deduped = dedup_strings(&dra_devs);
-            devices.extend(deduped.iter().cloned());
-            all_dra_devs.extend(deduped);
+            selected.dra.extend(dedup_strings(&dra_devs));
         }
     }
 
-    if want_device_plugin && want_dra {
-        overlap::check_cross_source_physical_overlap(
-            &dedup_strings(&all_device_plugin_devs),
-            &dedup_strings(&all_dra_devs),
-            spec_dirs,
-        )?;
-    }
-
-    Ok(dedup_strings(&devices))
+    selected.device_plugin = dedup_strings(&selected.device_plugin);
+    selected.dra = dedup_strings(&selected.dra);
+    Ok(selected)
 }
 
-/// Resolve the pod's cold-plug CDI device list from kubelet's PodResources
-/// API, trusting only the sources named in `sources`.
+/// Resolve the pod's cold-plug CDI devices from kubelet's PodResources API,
+/// trusting only the sources named in `sources`. An empty `sources` trusts
+/// neither: a pod without cold-pluggable data proceeds normally, one that
+/// carries it fails closed through the unlisted-source check.
 ///
-/// "device-plugin" and "dra" may be listed together: an operator can serve
+/// `DevicePlugin` and `Dra` may be listed together: an operator can serve
 /// different device classes through each API on the same node, and a node
 /// migrating between the two runs both for a while. The sets have to stay
 /// disjoint, because kubelet counts a device advertised via both APIs twice
-/// at scheduling; a same-device collision is rejected by the overlap check
-/// instead of being plugged twice.
+/// at scheduling. This function passes each source's devices through as-is;
+/// the caller runs `overlap::check_cross_source_physical_overlap` on the
+/// returned lists before attaching, where a same-device collision is
+/// rejected instead of being plugged twice.
 pub async fn get_pod_cdi_devices(
     socket: &str,
     annotations: &HashMap<String, String>,
-    sources: &[String],
-) -> Result<Vec<String>> {
-    if sources.is_empty() {
-        // Config loading defaults this to ["device-plugin"]; if it is empty
-        // anyway, fail closed rather than guess a source.
-        return Err(anyhow!(
-            "cold plug: pod_resource_device_sources is empty, refusing to guess a device source"
-        ));
-    }
-
+    sources: &[DeviceSource],
+) -> Result<SelectedColdPlugDevices> {
     let pod_name = annotations
         .get(SANDBOX_NAME_ANNOTATION)
         .or_else(|| annotations.get(CRIO_NAME_ANNOTATION))
@@ -345,13 +358,11 @@ mod tests {
         let spec = tempfile::tempdir().unwrap();
         let spec_dirs = [spec.path().to_str().unwrap()];
         let pod = pod_with_both_sources();
-        let devs = select_cold_plug_devices(
-            &pod,
-            &[POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string()],
-            &spec_dirs,
-        )
-        .unwrap();
-        assert_eq!(devs, vec!["vendor.com/gpu=gpu0".to_string()]);
+        let devs =
+            select_cold_plug_devices(&pod, &[DeviceSource::DevicePlugin], &spec_dirs).unwrap();
+        assert_eq!(devs.device_plugin, vec!["vendor.com/gpu=gpu0".to_string()]);
+        assert!(devs.dra.is_empty());
+        assert_eq!(devs.flattened(), vec!["vendor.com/gpu=gpu0".to_string()]);
     }
 
     #[test]
@@ -359,13 +370,9 @@ mod tests {
         let spec = tempfile::tempdir().unwrap();
         let spec_dirs = [spec.path().to_str().unwrap()];
         let pod = pod_with_both_sources();
-        let devs = select_cold_plug_devices(
-            &pod,
-            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
-            &spec_dirs,
-        )
-        .unwrap();
-        assert_eq!(devs, vec!["vendor.com/dra=gpu1".to_string()]);
+        let devs = select_cold_plug_devices(&pod, &[DeviceSource::Dra], &spec_dirs).unwrap();
+        assert!(devs.device_plugin.is_empty());
+        assert_eq!(devs.dra, vec!["vendor.com/dra=gpu1".to_string()]);
     }
 
     #[test]
@@ -375,19 +382,85 @@ mod tests {
         let pod = pod_with_both_sources();
         let devs = select_cold_plug_devices(
             &pod,
-            &[
-                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN.to_string(),
-                POD_RESOURCE_DEVICE_SOURCE_DRA.to_string(),
-            ],
+            &[DeviceSource::DevicePlugin, DeviceSource::Dra],
             &spec_dirs,
         )
         .unwrap();
+        assert_eq!(devs.device_plugin, vec!["vendor.com/gpu=gpu0".to_string()]);
+        assert_eq!(devs.dra, vec!["vendor.com/dra=gpu1".to_string()]);
         assert_eq!(
-            devs,
+            devs.flattened(),
             vec![
                 "vendor.com/gpu=gpu0".to_string(),
                 "vendor.com/dra=gpu1".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn test_select_both_sources_two_containers_groups_by_source() {
+        // The plug list groups by source (all device-plugin devices, then
+        // all DRA devices), not by container. This pins the order the
+        // flattened list feeds into VFIO attachment.
+        let spec = tempfile::tempdir().unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let mut pod = pod_with_both_sources();
+        let mut second = pod.containers[0].clone();
+        second.name = "ctr-b".to_string();
+        second.devices[0].device_ids = vec!["gpu2".to_string()];
+        second.dynamic_resources[0].claim_resources[0].cdi_devices[0].name =
+            "vendor.com/dra=gpu3".to_string();
+        pod.containers.push(second);
+
+        let devs = select_cold_plug_devices(
+            &pod,
+            &[DeviceSource::DevicePlugin, DeviceSource::Dra],
+            &spec_dirs,
+        )
+        .unwrap();
+        assert_eq!(
+            devs.flattened(),
+            vec![
+                "vendor.com/gpu=gpu0".to_string(),
+                "vendor.com/gpu=gpu2".to_string(),
+                "vendor.com/dra=gpu1".to_string(),
+                "vendor.com/dra=gpu3".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_select_no_sources_without_resolvable_data_is_ok() {
+        // Explicit "trust neither": nothing resolves in the empty spec dir,
+        // so the pod proceeds with no cold-plug devices.
+        let spec = tempfile::tempdir().unwrap();
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let pod = pod_with_both_sources();
+        let devs = select_cold_plug_devices(&pod, &[], &spec_dirs).unwrap();
+        assert!(devs.device_plugin.is_empty());
+        assert!(devs.dra.is_empty());
+        assert!(devs.flattened().is_empty());
+    }
+
+    #[test]
+    fn test_select_no_sources_with_resolvable_data_errors() {
+        // Explicit "trust neither" still fails closed when the pod carries
+        // cold-pluggable data that would be silently dropped.
+        let spec = tempfile::tempdir().unwrap();
+        write_cdi_spec(
+            spec.path(),
+            "dp",
+            "vendor.com/gpu",
+            &[("gpu0", "/dev/null")],
+        );
+        let spec_dirs = [spec.path().to_str().unwrap()];
+        let pod = pod_with_both_sources();
+        let err = select_cold_plug_devices(&pod, &[], &spec_dirs).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("not in pod_resource_device_sources"),
+            "{}",
+            err
         );
     }
 
@@ -414,16 +487,15 @@ mod tests {
         let spec_dirs = [spec.path().to_str().unwrap()];
 
         let pod = pod_with_both_sources();
-        let err = select_cold_plug_devices(
-            &pod,
-            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
-            &spec_dirs,
-        )
-        .unwrap_err();
+        let err = select_cold_plug_devices(&pod, &[DeviceSource::Dra], &spec_dirs).unwrap_err();
 
         let msg = err.to_string();
-        assert!(msg.contains("not in pod_resource_device_sources"), "{}", msg);
-        assert!(msg.contains(POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN), "{}", msg);
+        assert!(
+            msg.contains("not in pod_resource_device_sources"),
+            "{}",
+            msg
+        );
+        assert!(msg.contains("device-plugin"), "{}", msg);
         assert!(msg.contains("vendor.com/gpu=gpu0"), "{}", msg);
     }
 
@@ -441,12 +513,12 @@ mod tests {
         let spec_dirs = [spec.path().to_str().unwrap()];
 
         let pod = pod_with_both_sources();
-        let devices = select_cold_plug_devices(
-            &pod,
-            &[POD_RESOURCE_DEVICE_SOURCE_DRA.to_string()],
-            &spec_dirs,
-        )
-        .expect("node-less unlisted device must not fail closed");
-        assert!(!devices.iter().any(|d| d.contains("gpu0")), "{:?}", devices);
+        let devices = select_cold_plug_devices(&pod, &[DeviceSource::Dra], &spec_dirs)
+            .expect("node-less unlisted device must not fail closed");
+        assert!(
+            !devices.flattened().iter().any(|d| d.contains("gpu0")),
+            "{:?}",
+            devices
+        );
     }
 }

--- a/src/libs/pod-resources-rs/src/pod_resources/mod.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/mod.rs
@@ -68,9 +68,26 @@ async fn create_grpc_channel(socket_path: &str) -> Result<Channel> {
     Ok(channel)
 }
 
-/// Collect the CDI device names in a container's DynamicResources (KEP-3695):
-/// DRA allocations are reported only there, never in the device-plugin
-/// `devices` field.
+/// Collect the CDI device names in a container's DynamicResources (KEP-3695).
+///
+/// A PodResources response carries device data in two places that never
+/// shadow each other, which is why each source gets its own collector:
+///
+/// ```text
+/// containers:
+/// - name: workload
+///   devices:                              # device-plugin allocations
+///   - resource_name: "nvidia.com/pgpu"
+///     device_ids: ["GPU-8c25ea9f"]
+///   dynamic_resources:                    # DRA allocations (read here)
+///   - claim_resources:
+///     - cdi_devices:
+///       - name: "gpu.example.com/gpu=gpu0"
+/// ```
+///
+/// DRA allocations appear only under `dynamic_resources`; the legacy
+/// `devices` field is read by `select_cold_plug_devices` when
+/// "device-plugin" is a trusted source.
 fn collect_pod_resource_cdi_devices(container: &ContainerResources) -> Vec<String> {
     let mut devices = Vec::new();
     for dr in &container.dynamic_resources {
@@ -191,6 +208,15 @@ fn select_cold_plug_devices(
     Ok(dedup_strings(&devices))
 }
 
+/// Resolve the pod's cold-plug CDI device list from kubelet's PodResources
+/// API, trusting only the sources named in `sources`.
+///
+/// "device-plugin" and "dra" may be listed together: an operator can serve
+/// different device classes through each API on the same node, and a node
+/// migrating between the two runs both for a while. The sets have to stay
+/// disjoint, because kubelet counts a device advertised via both APIs twice
+/// at scheduling; a same-device collision is rejected by the overlap check
+/// instead of being plugged twice.
 pub async fn get_pod_cdi_devices(
     socket: &str,
     annotations: &HashMap<String, String>,

--- a/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
@@ -1,0 +1,529 @@
+// Copyright (c) 2026 NAVER Cloud Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Cross-source physical-device overlap guard for cold plug.
+//!
+//! The same physical device can be reachable via a legacy iommu-group cdev
+//! from one source and a per-device vfio cdev from the other, so comparing
+//! CDI name lists as strings misses a double plug; compare by physical
+//! coordinate (PCI BDF or mdev instance UUID) instead.
+//!
+//! Mirrors the Go runtime's `device_cold_plug_overlap.go`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::sl;
+use crate::{POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA};
+use slog::debug;
+
+/// Roots for device-node resolution; parameterized so tests can use fixtures.
+const DEFAULT_SYS_ROOT: &str = "/sys";
+const DEFAULT_DEV_ROOT: &str = "/dev";
+
+/// Error when a device-plugin CDI device and a DRA CDI device resolve to the
+/// same underlying physical device (see the module doc for why names are not
+/// compared as strings).
+pub(crate) fn check_cross_source_physical_overlap(
+    device_plugin_devs: &[String],
+    dra_devs: &[String],
+    spec_dirs: &[&str],
+) -> Result<()> {
+    check_cross_source_physical_overlap_in(
+        device_plugin_devs,
+        dra_devs,
+        spec_dirs,
+        Path::new(DEFAULT_SYS_ROOT),
+        Path::new(DEFAULT_DEV_ROOT),
+    )
+}
+
+fn check_cross_source_physical_overlap_in(
+    device_plugin_devs: &[String],
+    dra_devs: &[String],
+    spec_dirs: &[&str],
+    sys_root: &Path,
+    dev_root: &Path,
+) -> Result<()> {
+    if device_plugin_devs.is_empty() || dra_devs.is_empty() {
+        return Ok(());
+    }
+
+    let dp_coords = resolve_physical_coords(device_plugin_devs, spec_dirs, sys_root, dev_root)?;
+    let dra_coords = resolve_physical_coords(dra_devs, spec_dirs, sys_root, dev_root)?;
+
+    for (coord, dp_name) in &dp_coords {
+        if let Some(dra_name) = dra_coords.get(coord) {
+            return Err(anyhow!(
+                "cold plug: physical device {:?} is reachable via both pod_resource_device_sources: \
+                 {:?} (device-plugin CDI device {:?}) and {:?} (dra CDI device {:?}); \
+                 this would double cold-plug the same underlying device",
+                coord,
+                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                dp_name,
+                POD_RESOURCE_DEVICE_SOURCE_DRA,
+                dra_name,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Map CDI devices to physical coordinates (BDF or mdev UUID). Unresolvable
+/// names are skipped (handle_cdi_devices already rejects them); a path that
+/// cannot be normalized is an error: the guard cannot prove it does not
+/// overlap.
+fn resolve_physical_coords(
+    cdi_devs: &[String],
+    spec_dirs: &[&str],
+    sys_root: &Path,
+    dev_root: &Path,
+) -> Result<HashMap<String, String>> {
+    let mut coords: HashMap<String, String> = HashMap::new();
+
+    // A cache build/refresh failure here is fail-closed for the overlap guard.
+    let name_to_paths = crate::cdi_device_node_host_paths(spec_dirs, cdi_devs)?;
+
+    for name in cdi_devs {
+        let paths = match name_to_paths.get(name) {
+            Some(paths) => paths,
+            None => continue,
+        };
+        for path in paths {
+            let keys = normalize_device_node_path(path, sys_root, dev_root).with_context(|| {
+                format!(
+                    "cold plug: failed to normalize device node path for overlap check (device {name:?})"
+                )
+            })?;
+            for k in keys {
+                coords.entry(k).or_insert_with(|| name.clone());
+            }
+        }
+    }
+
+    Ok(coords)
+}
+
+/// Map a device node path to physical coordinate keys. A legacy
+/// `<dev_root>/vfio/N` group cdev expands to every BDF in the group, since
+/// any member could alias a per-device cdev from the other source; non-vfio
+/// paths are their own key.
+fn normalize_device_node_path(path: &str, sys_root: &Path, dev_root: &Path) -> Result<Vec<String>> {
+    let p = Path::new(path);
+    let vfio_devices_dir = dev_root.join("vfio").join("devices");
+    let vfio_group_dir = dev_root.join("vfio");
+
+    if let Some(parent) = p.parent() {
+        if parent == vfio_devices_dir.as_path() {
+            return normalize_vfio_device_cdev(p, sys_root);
+        }
+        if parent == vfio_group_dir.as_path() {
+            if let Some(base) = p.file_name().and_then(|b| b.to_str()) {
+                if is_iommu_group(base) {
+                    return normalize_iommu_group_cdev(base, sys_root);
+                }
+            }
+        }
+    }
+
+    Ok(vec![path.to_string()])
+}
+
+/// Resolve `<dev_root>/vfio/devices/vfioN` via its sysfs device symlink; the
+/// target basename is the device's own identity (PCI BDF, or mdev instance
+/// UUID -- never the parent), so distinct mdev slices of one parent never
+/// collide.
+fn normalize_vfio_device_cdev(path: &Path, sys_root: &Path) -> Result<Vec<String>> {
+    let vfio_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("invalid vfio device node path {:?}", path))?;
+
+    let link = sys_root
+        .join("class")
+        .join("vfio-dev")
+        .join(vfio_name)
+        .join("device");
+    let target =
+        std::fs::read_link(&link).with_context(|| format!("failed to readlink {link:?}"))?;
+
+    let base = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("invalid symlink target {:?}", target))?;
+
+    Ok(vec![base.to_string()])
+}
+
+/// Return the BDFs of every device in the IOMMU group.
+fn normalize_iommu_group_cdev(group: &str, sys_root: &Path) -> Result<Vec<String>> {
+    let devices_dir = sys_root
+        .join("kernel")
+        .join("iommu_groups")
+        .join(group)
+        .join("devices");
+    let entries =
+        std::fs::read_dir(&devices_dir).with_context(|| format!("failed to list {devices_dir:?}"))?;
+
+    let mut bdfs = Vec::new();
+    for e in entries {
+        let e = e.with_context(|| format!("failed to read entry in {devices_dir:?}"))?;
+        bdfs.push(e.file_name().to_string_lossy().into_owned());
+    }
+
+    debug!(sl!(), "iommu group {} resolved to BDFs {:?}", group, bdfs);
+    Ok(bdfs)
+}
+
+fn is_iommu_group(base: &str) -> bool {
+    !base.is_empty() && base.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs as unix_fs;
+    use std::path::PathBuf;
+
+    fn write_cdi_spec(dir: &Path, name: &str, kind: &str, devices: &[(&str, &str)]) {
+        let mut content = format!("cdiVersion: \"0.5.0\"\nkind: \"{kind}\"\ndevices:\n");
+        for (dev_name, path) in devices {
+            content.push_str(&format!(
+                "  - name: \"{dev_name}\"\n    containerEdits:\n      deviceNodes:\n      - path: \"{path}\"\n"
+            ));
+        }
+        fs::write(dir.join(format!("{name}.yaml")), content).unwrap();
+    }
+
+    fn build_vfio_device_cdev(sys_dir: &Path, vfio_name: &str, bdf: &str) {
+        let link_dir = sys_dir.join("class").join("vfio-dev").join(vfio_name);
+        fs::create_dir_all(&link_dir).unwrap();
+        let target_dir = sys_dir.join("devices").join("pci0000:00").join(bdf);
+        fs::create_dir_all(&target_dir).unwrap();
+        let rel = pathdiff_rel(&target_dir, &link_dir);
+        unix_fs::symlink(rel, link_dir.join("device")).unwrap();
+    }
+
+    // Nests the mdev UUID under the parent BDF, mirroring real sysfs; the UUID basename is the device identity.
+    fn build_vfio_mdev_cdev(sys_dir: &Path, vfio_name: &str, parent_bdf: &str, mdev_uuid: &str) {
+        let link_dir = sys_dir.join("class").join("vfio-dev").join(vfio_name);
+        fs::create_dir_all(&link_dir).unwrap();
+        let target_dir = sys_dir
+            .join("devices")
+            .join("pci0000:00")
+            .join(parent_bdf)
+            .join(mdev_uuid);
+        fs::create_dir_all(&target_dir).unwrap();
+        let rel = pathdiff_rel(&target_dir, &link_dir);
+        unix_fs::symlink(rel, link_dir.join("device")).unwrap();
+    }
+
+    fn build_iommu_group(sys_dir: &Path, group: &str, bdfs: &[&str]) {
+        let devices_dir = sys_dir
+            .join("kernel")
+            .join("iommu_groups")
+            .join(group)
+            .join("devices");
+        fs::create_dir_all(&devices_dir).unwrap();
+        for bdf in bdfs {
+            fs::write(devices_dir.join(bdf), b"").unwrap();
+        }
+    }
+
+    // Hand-rolled to avoid a dev-dependency; fixtures share a common ancestor.
+    fn pathdiff_rel(target: &Path, base: &Path) -> PathBuf {
+        let t: Vec<_> = target.components().collect();
+        let b: Vec<_> = base.components().collect();
+        let mut i = 0;
+        while i < t.len() && i < b.len() && t[i] == b[i] {
+            i += 1;
+        }
+        let mut rel = PathBuf::new();
+        for _ in i..b.len() {
+            rel.push("..");
+        }
+        for comp in &t[i..] {
+            rel.push(comp.as_os_str());
+        }
+        rel
+    }
+
+    fn vfio_dev_path(dev_dir: &Path, name: &str) -> String {
+        dev_dir
+            .join("vfio")
+            .join("devices")
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn vfio_group_path(dev_dir: &Path, group: &str) -> String {
+        dev_dir
+            .join("vfio")
+            .join(group)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn test_normalize_device_node_path() {
+        let sys_dir = tempfile::tempdir().unwrap();
+        let dev_dir = tempfile::tempdir().unwrap();
+        let sys = sys_dir.path();
+        let dev = dev_dir.path();
+
+        // vfio device cdev resolves to BDF
+        build_vfio_device_cdev(sys, "vfio0", "0000:65:00.0");
+        let coords = normalize_device_node_path(&vfio_dev_path(dev, "vfio0"), sys, dev).unwrap();
+        assert_eq!(coords, vec!["0000:65:00.0".to_string()]);
+
+        // legacy iommu group cdev resolves to member BDFs
+        build_iommu_group(sys, "42", &["0000:65:00.0", "0000:65:00.1"]);
+        let mut coords = normalize_device_node_path(&vfio_group_path(dev, "42"), sys, dev).unwrap();
+        coords.sort();
+        assert_eq!(
+            coords,
+            vec!["0000:65:00.0".to_string(), "0000:65:00.1".to_string()]
+        );
+
+        // unrelated path falls back to the path itself
+        let coords = normalize_device_node_path("/dev/nvidia0", sys, dev).unwrap();
+        assert_eq!(coords, vec!["/dev/nvidia0".to_string()]);
+
+        // mdev cdev resolves to the mdev instance UUID, not the parent BDF
+        let mdev_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        build_vfio_mdev_cdev(sys, "vfio-mdev0", "0000:65:00.0", mdev_uuid);
+        let coords =
+            normalize_device_node_path(&vfio_dev_path(dev, "vfio-mdev0"), sys, dev).unwrap();
+        assert_eq!(coords, vec![mdev_uuid.to_string()]);
+
+        // vfio device cdev with unresolvable symlink errors
+        assert!(normalize_device_node_path(&vfio_dev_path(dev, "vfio-missing"), sys, dev).is_err());
+    }
+
+    #[test]
+    fn test_check_cross_source_physical_overlap() {
+        let sys_dir = tempfile::tempdir().unwrap();
+        let dev_dir = tempfile::tempdir().unwrap();
+        let sys = sys_dir.path();
+        let dev = dev_dir.path();
+
+        // no overlap when sets are disjoint
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            build_vfio_device_cdev(sys, "vfio0", "0000:65:00.0");
+            build_vfio_device_cdev(sys, "vfio1", "0000:66:00.0");
+            write_cdi_spec(
+                spec,
+                "dp",
+                "vendor.com/gpu",
+                &[("gpu0", &vfio_dev_path(dev, "vfio0"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra",
+                "vendor.com/dra",
+                &[("gpu1", &vfio_dev_path(dev, "vfio1"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu0".to_string()],
+                &["vendor.com/dra=gpu1".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // direct overlap: same BDF via vfio device cdev on both sides
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            build_vfio_device_cdev(sys, "vfio2", "0000:70:00.0");
+            write_cdi_spec(
+                spec,
+                "dp2",
+                "vendor.com/gpu",
+                &[("gpu2", &vfio_dev_path(dev, "vfio2"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra2",
+                "vendor.com/dra",
+                &[("gpu2", &vfio_dev_path(dev, "vfio2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu2".to_string()],
+                &["vendor.com/dra=gpu2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("0000:70:00.0"));
+        }
+
+        // aliased overlap: legacy group cdev vs vfio device cdev for the same BDF
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let bdf = "0000:99:00.0";
+            build_vfio_device_cdev(sys, "vfio9", bdf);
+            build_iommu_group(sys, "9", &[bdf]);
+            write_cdi_spec(
+                spec,
+                "dp3",
+                "vendor.com/gpu",
+                &[("gpu9", &vfio_group_path(dev, "9"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra3",
+                "vendor.com/dra",
+                &[("gpu9", &vfio_dev_path(dev, "vfio9"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu9".to_string()],
+                &["vendor.com/dra=gpu9".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains(bdf));
+        }
+
+        // distinct mdev slices of the same parent GPU never collide
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let parent_bdf = "0000:88:00.0";
+            build_vfio_mdev_cdev(sys, "vfio-mdev1", parent_bdf, "11111111-1111-1111-1111-111111111111");
+            build_vfio_mdev_cdev(sys, "vfio-mdev2", parent_bdf, "22222222-2222-2222-2222-222222222222");
+            write_cdi_spec(
+                spec,
+                "dp-mdev",
+                "vendor.com/gpu",
+                &[("slice1", &vfio_dev_path(dev, "vfio-mdev1"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-mdev",
+                "vendor.com/dra",
+                &[("slice2", &vfio_dev_path(dev, "vfio-mdev2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=slice1".to_string()],
+                &["vendor.com/dra=slice2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // same mdev instance UUID on both sides collides
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let uuid = "33333333-3333-3333-3333-333333333333";
+            build_vfio_mdev_cdev(sys, "vfio-mdev3", "0000:89:00.0", uuid);
+            write_cdi_spec(
+                spec,
+                "dp-mdev-same",
+                "vendor.com/gpu",
+                &[("slice3", &vfio_dev_path(dev, "vfio-mdev3"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-mdev-same",
+                "vendor.com/dra",
+                &[("slice3", &vfio_dev_path(dev, "vfio-mdev3"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=slice3".to_string()],
+                &["vendor.com/dra=slice3".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains(uuid));
+        }
+
+        // device node normalization failure fails closed instead of being skipped
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            write_cdi_spec(
+                spec,
+                "dp-broken",
+                "vendor.com/gpu",
+                &[("gpu-broken", &vfio_dev_path(dev, "vfio-broken-missing"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-broken",
+                "vendor.com/dra",
+                &[("gpu-broken-2", &vfio_dev_path(dev, "vfio-broken-missing-2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            assert!(check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu-broken".to_string()],
+                &["vendor.com/dra=gpu-broken-2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .is_err());
+        }
+
+        // empty inputs never error
+        {
+            let spec_dirs = [sys.to_str().unwrap()]; // any dir; not consulted
+            check_cross_source_physical_overlap_in(&[], &[], &spec_dirs, sys, dev).unwrap();
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu0".to_string()],
+                &[],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+            check_cross_source_physical_overlap_in(
+                &[],
+                &["vendor.com/dra=gpu0".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // unresolvable CDI device names are skipped silently
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec_dirs = [spec_dir.path().to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=does-not-exist".to_string()],
+                &["vendor.com/dra=also-does-not-exist".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+    }
+}

--- a/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use anyhow::{anyhow, Context, Result};
 
 use crate::sl;
-use crate::{POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA};
+use crate::DeviceSource;
 use slog::debug;
 
 /// Roots for device-node resolution; parameterized so tests can use fixtures.
@@ -27,7 +27,11 @@ const DEFAULT_DEV_ROOT: &str = "/dev";
 /// Error when a device-plugin CDI device and a DRA CDI device resolve to the
 /// same underlying physical device (see the module doc for why names are not
 /// compared as strings).
-pub(crate) fn check_cross_source_physical_overlap(
+///
+/// Exported for the runtime's device path: the parser hands the two source
+/// lists over as-is, and enforcement happens right before devices are
+/// attached, the last point where a device still carries its source.
+pub fn check_cross_source_physical_overlap(
     device_plugin_devs: &[String],
     dra_devs: &[String],
     spec_dirs: &[&str],
@@ -62,9 +66,9 @@ fn check_cross_source_physical_overlap_in(
                  {:?} (device-plugin CDI device {:?}) and {:?} (dra CDI device {:?}); \
                  this would double cold-plug the same underlying device",
                 coord,
-                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                DeviceSource::DevicePlugin.to_string(),
                 dp_name,
-                POD_RESOURCE_DEVICE_SOURCE_DRA,
+                DeviceSource::Dra.to_string(),
                 dra_name,
             ));
         }
@@ -166,8 +170,8 @@ fn normalize_iommu_group_cdev(group: &str, sys_root: &Path) -> Result<Vec<String
         .join("iommu_groups")
         .join(group)
         .join("devices");
-    let entries =
-        std::fs::read_dir(&devices_dir).with_context(|| format!("failed to list {devices_dir:?}"))?;
+    let entries = std::fs::read_dir(&devices_dir)
+        .with_context(|| format!("failed to list {devices_dir:?}"))?;
 
     let mut bdfs = Vec::new();
     for e in entries {
@@ -407,8 +411,18 @@ mod tests {
             let spec_dir = tempfile::tempdir().unwrap();
             let spec = spec_dir.path();
             let parent_bdf = "0000:88:00.0";
-            build_vfio_mdev_cdev(sys, "vfio-mdev1", parent_bdf, "11111111-1111-1111-1111-111111111111");
-            build_vfio_mdev_cdev(sys, "vfio-mdev2", parent_bdf, "22222222-2222-2222-2222-222222222222");
+            build_vfio_mdev_cdev(
+                sys,
+                "vfio-mdev1",
+                parent_bdf,
+                "11111111-1111-1111-1111-111111111111",
+            );
+            build_vfio_mdev_cdev(
+                sys,
+                "vfio-mdev2",
+                parent_bdf,
+                "22222222-2222-2222-2222-222222222222",
+            );
             write_cdi_spec(
                 spec,
                 "dp-mdev",

--- a/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
+++ b/src/libs/pod-resources-rs/src/pod_resources/overlap.rs
@@ -1,0 +1,528 @@
+// Copyright (c) 2026 NAVER Cloud Corp.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Cross-source physical-device overlap guard for cold plug.
+//!
+//! The same physical device can be reachable via a legacy iommu-group cdev
+//! from one source and a per-device vfio cdev from the other, so comparing
+//! CDI name lists as strings misses a double plug; compare by physical
+//! coordinate (PCI BDF or mdev instance UUID) instead.
+//!
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::sl;
+use crate::{POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN, POD_RESOURCE_DEVICE_SOURCE_DRA};
+use slog::debug;
+
+/// Roots for device-node resolution; parameterized so tests can use fixtures.
+const DEFAULT_SYS_ROOT: &str = "/sys";
+const DEFAULT_DEV_ROOT: &str = "/dev";
+
+/// Error when a device-plugin CDI device and a DRA CDI device resolve to the
+/// same underlying physical device (see the module doc for why names are not
+/// compared as strings).
+pub(crate) fn check_cross_source_physical_overlap(
+    device_plugin_devs: &[String],
+    dra_devs: &[String],
+    spec_dirs: &[&str],
+) -> Result<()> {
+    check_cross_source_physical_overlap_in(
+        device_plugin_devs,
+        dra_devs,
+        spec_dirs,
+        Path::new(DEFAULT_SYS_ROOT),
+        Path::new(DEFAULT_DEV_ROOT),
+    )
+}
+
+fn check_cross_source_physical_overlap_in(
+    device_plugin_devs: &[String],
+    dra_devs: &[String],
+    spec_dirs: &[&str],
+    sys_root: &Path,
+    dev_root: &Path,
+) -> Result<()> {
+    if device_plugin_devs.is_empty() || dra_devs.is_empty() {
+        return Ok(());
+    }
+
+    let dp_coords = resolve_physical_coords(device_plugin_devs, spec_dirs, sys_root, dev_root)?;
+    let dra_coords = resolve_physical_coords(dra_devs, spec_dirs, sys_root, dev_root)?;
+
+    for (coord, dp_name) in &dp_coords {
+        if let Some(dra_name) = dra_coords.get(coord) {
+            return Err(anyhow!(
+                "cold plug: physical device {:?} is reachable via both pod_resource_device_sources: \
+                 {:?} (device-plugin CDI device {:?}) and {:?} (dra CDI device {:?}); \
+                 this would double cold-plug the same underlying device",
+                coord,
+                POD_RESOURCE_DEVICE_SOURCE_DEVICE_PLUGIN,
+                dp_name,
+                POD_RESOURCE_DEVICE_SOURCE_DRA,
+                dra_name,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Map CDI devices to physical coordinates (BDF or mdev UUID). Unresolvable
+/// names are skipped (handle_cdi_devices already rejects them); a path that
+/// cannot be normalized is an error: the guard cannot prove it does not
+/// overlap.
+fn resolve_physical_coords(
+    cdi_devs: &[String],
+    spec_dirs: &[&str],
+    sys_root: &Path,
+    dev_root: &Path,
+) -> Result<HashMap<String, String>> {
+    let mut coords: HashMap<String, String> = HashMap::new();
+
+    // A cache build/refresh failure here is fail-closed for the overlap guard.
+    let name_to_paths = crate::cdi_device_node_host_paths(spec_dirs, cdi_devs)?;
+
+    for name in cdi_devs {
+        let paths = match name_to_paths.get(name) {
+            Some(paths) => paths,
+            None => continue,
+        };
+        for path in paths {
+            let keys = normalize_device_node_path(path, sys_root, dev_root).with_context(|| {
+                format!(
+                    "cold plug: failed to normalize device node path for overlap check (device {name:?})"
+                )
+            })?;
+            for k in keys {
+                coords.entry(k).or_insert_with(|| name.clone());
+            }
+        }
+    }
+
+    Ok(coords)
+}
+
+/// Map a device node path to physical coordinate keys. A legacy
+/// `<dev_root>/vfio/N` group cdev expands to every BDF in the group, since
+/// any member could alias a per-device cdev from the other source; non-vfio
+/// paths are their own key.
+fn normalize_device_node_path(path: &str, sys_root: &Path, dev_root: &Path) -> Result<Vec<String>> {
+    let p = Path::new(path);
+    let vfio_devices_dir = dev_root.join("vfio").join("devices");
+    let vfio_group_dir = dev_root.join("vfio");
+
+    if let Some(parent) = p.parent() {
+        if parent == vfio_devices_dir.as_path() {
+            return normalize_vfio_device_cdev(p, sys_root);
+        }
+        if parent == vfio_group_dir.as_path() {
+            if let Some(base) = p.file_name().and_then(|b| b.to_str()) {
+                if is_iommu_group(base) {
+                    return normalize_iommu_group_cdev(base, sys_root);
+                }
+            }
+        }
+    }
+
+    Ok(vec![path.to_string()])
+}
+
+/// Resolve `<dev_root>/vfio/devices/vfioN` via its sysfs device symlink; the
+/// target basename is the device's own identity (PCI BDF, or mdev instance
+/// UUID -- never the parent), so distinct mdev slices of one parent never
+/// collide.
+fn normalize_vfio_device_cdev(path: &Path, sys_root: &Path) -> Result<Vec<String>> {
+    let vfio_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("invalid vfio device node path {:?}", path))?;
+
+    let link = sys_root
+        .join("class")
+        .join("vfio-dev")
+        .join(vfio_name)
+        .join("device");
+    let target =
+        std::fs::read_link(&link).with_context(|| format!("failed to readlink {link:?}"))?;
+
+    let base = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| anyhow!("invalid symlink target {:?}", target))?;
+
+    Ok(vec![base.to_string()])
+}
+
+/// Return the BDFs of every device in the IOMMU group.
+fn normalize_iommu_group_cdev(group: &str, sys_root: &Path) -> Result<Vec<String>> {
+    let devices_dir = sys_root
+        .join("kernel")
+        .join("iommu_groups")
+        .join(group)
+        .join("devices");
+    let entries =
+        std::fs::read_dir(&devices_dir).with_context(|| format!("failed to list {devices_dir:?}"))?;
+
+    let mut bdfs = Vec::new();
+    for e in entries {
+        let e = e.with_context(|| format!("failed to read entry in {devices_dir:?}"))?;
+        bdfs.push(e.file_name().to_string_lossy().into_owned());
+    }
+
+    debug!(sl!(), "iommu group {} resolved to BDFs {:?}", group, bdfs);
+    Ok(bdfs)
+}
+
+fn is_iommu_group(base: &str) -> bool {
+    !base.is_empty() && base.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs as unix_fs;
+    use std::path::PathBuf;
+
+    fn write_cdi_spec(dir: &Path, name: &str, kind: &str, devices: &[(&str, &str)]) {
+        let mut content = format!("cdiVersion: \"0.5.0\"\nkind: \"{kind}\"\ndevices:\n");
+        for (dev_name, path) in devices {
+            content.push_str(&format!(
+                "  - name: \"{dev_name}\"\n    containerEdits:\n      deviceNodes:\n      - path: \"{path}\"\n"
+            ));
+        }
+        fs::write(dir.join(format!("{name}.yaml")), content).unwrap();
+    }
+
+    fn build_vfio_device_cdev(sys_dir: &Path, vfio_name: &str, bdf: &str) {
+        let link_dir = sys_dir.join("class").join("vfio-dev").join(vfio_name);
+        fs::create_dir_all(&link_dir).unwrap();
+        let target_dir = sys_dir.join("devices").join("pci0000:00").join(bdf);
+        fs::create_dir_all(&target_dir).unwrap();
+        let rel = pathdiff_rel(&target_dir, &link_dir);
+        unix_fs::symlink(rel, link_dir.join("device")).unwrap();
+    }
+
+    // Nests the mdev UUID under the parent BDF, mirroring real sysfs; the UUID basename is the device identity.
+    fn build_vfio_mdev_cdev(sys_dir: &Path, vfio_name: &str, parent_bdf: &str, mdev_uuid: &str) {
+        let link_dir = sys_dir.join("class").join("vfio-dev").join(vfio_name);
+        fs::create_dir_all(&link_dir).unwrap();
+        let target_dir = sys_dir
+            .join("devices")
+            .join("pci0000:00")
+            .join(parent_bdf)
+            .join(mdev_uuid);
+        fs::create_dir_all(&target_dir).unwrap();
+        let rel = pathdiff_rel(&target_dir, &link_dir);
+        unix_fs::symlink(rel, link_dir.join("device")).unwrap();
+    }
+
+    fn build_iommu_group(sys_dir: &Path, group: &str, bdfs: &[&str]) {
+        let devices_dir = sys_dir
+            .join("kernel")
+            .join("iommu_groups")
+            .join(group)
+            .join("devices");
+        fs::create_dir_all(&devices_dir).unwrap();
+        for bdf in bdfs {
+            fs::write(devices_dir.join(bdf), b"").unwrap();
+        }
+    }
+
+    // Hand-rolled to avoid a dev-dependency; fixtures share a common ancestor.
+    fn pathdiff_rel(target: &Path, base: &Path) -> PathBuf {
+        let t: Vec<_> = target.components().collect();
+        let b: Vec<_> = base.components().collect();
+        let mut i = 0;
+        while i < t.len() && i < b.len() && t[i] == b[i] {
+            i += 1;
+        }
+        let mut rel = PathBuf::new();
+        for _ in i..b.len() {
+            rel.push("..");
+        }
+        for comp in &t[i..] {
+            rel.push(comp.as_os_str());
+        }
+        rel
+    }
+
+    fn vfio_dev_path(dev_dir: &Path, name: &str) -> String {
+        dev_dir
+            .join("vfio")
+            .join("devices")
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn vfio_group_path(dev_dir: &Path, group: &str) -> String {
+        dev_dir
+            .join("vfio")
+            .join(group)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn test_normalize_device_node_path() {
+        let sys_dir = tempfile::tempdir().unwrap();
+        let dev_dir = tempfile::tempdir().unwrap();
+        let sys = sys_dir.path();
+        let dev = dev_dir.path();
+
+        // vfio device cdev resolves to BDF
+        build_vfio_device_cdev(sys, "vfio0", "0000:65:00.0");
+        let coords = normalize_device_node_path(&vfio_dev_path(dev, "vfio0"), sys, dev).unwrap();
+        assert_eq!(coords, vec!["0000:65:00.0".to_string()]);
+
+        // legacy iommu group cdev resolves to member BDFs
+        build_iommu_group(sys, "42", &["0000:65:00.0", "0000:65:00.1"]);
+        let mut coords = normalize_device_node_path(&vfio_group_path(dev, "42"), sys, dev).unwrap();
+        coords.sort();
+        assert_eq!(
+            coords,
+            vec!["0000:65:00.0".to_string(), "0000:65:00.1".to_string()]
+        );
+
+        // unrelated path falls back to the path itself
+        let coords = normalize_device_node_path("/dev/nvidia0", sys, dev).unwrap();
+        assert_eq!(coords, vec!["/dev/nvidia0".to_string()]);
+
+        // mdev cdev resolves to the mdev instance UUID, not the parent BDF
+        let mdev_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        build_vfio_mdev_cdev(sys, "vfio-mdev0", "0000:65:00.0", mdev_uuid);
+        let coords =
+            normalize_device_node_path(&vfio_dev_path(dev, "vfio-mdev0"), sys, dev).unwrap();
+        assert_eq!(coords, vec![mdev_uuid.to_string()]);
+
+        // vfio device cdev with unresolvable symlink errors
+        assert!(normalize_device_node_path(&vfio_dev_path(dev, "vfio-missing"), sys, dev).is_err());
+    }
+
+    #[test]
+    fn test_check_cross_source_physical_overlap() {
+        let sys_dir = tempfile::tempdir().unwrap();
+        let dev_dir = tempfile::tempdir().unwrap();
+        let sys = sys_dir.path();
+        let dev = dev_dir.path();
+
+        // no overlap when sets are disjoint
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            build_vfio_device_cdev(sys, "vfio0", "0000:65:00.0");
+            build_vfio_device_cdev(sys, "vfio1", "0000:66:00.0");
+            write_cdi_spec(
+                spec,
+                "dp",
+                "vendor.com/gpu",
+                &[("gpu0", &vfio_dev_path(dev, "vfio0"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra",
+                "vendor.com/dra",
+                &[("gpu1", &vfio_dev_path(dev, "vfio1"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu0".to_string()],
+                &["vendor.com/dra=gpu1".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // direct overlap: same BDF via vfio device cdev on both sides
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            build_vfio_device_cdev(sys, "vfio2", "0000:70:00.0");
+            write_cdi_spec(
+                spec,
+                "dp2",
+                "vendor.com/gpu",
+                &[("gpu2", &vfio_dev_path(dev, "vfio2"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra2",
+                "vendor.com/dra",
+                &[("gpu2", &vfio_dev_path(dev, "vfio2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu2".to_string()],
+                &["vendor.com/dra=gpu2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("0000:70:00.0"));
+        }
+
+        // aliased overlap: legacy group cdev vs vfio device cdev for the same BDF
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let bdf = "0000:99:00.0";
+            build_vfio_device_cdev(sys, "vfio9", bdf);
+            build_iommu_group(sys, "9", &[bdf]);
+            write_cdi_spec(
+                spec,
+                "dp3",
+                "vendor.com/gpu",
+                &[("gpu9", &vfio_group_path(dev, "9"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra3",
+                "vendor.com/dra",
+                &[("gpu9", &vfio_dev_path(dev, "vfio9"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu9".to_string()],
+                &["vendor.com/dra=gpu9".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains(bdf));
+        }
+
+        // distinct mdev slices of the same parent GPU never collide
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let parent_bdf = "0000:88:00.0";
+            build_vfio_mdev_cdev(sys, "vfio-mdev1", parent_bdf, "11111111-1111-1111-1111-111111111111");
+            build_vfio_mdev_cdev(sys, "vfio-mdev2", parent_bdf, "22222222-2222-2222-2222-222222222222");
+            write_cdi_spec(
+                spec,
+                "dp-mdev",
+                "vendor.com/gpu",
+                &[("slice1", &vfio_dev_path(dev, "vfio-mdev1"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-mdev",
+                "vendor.com/dra",
+                &[("slice2", &vfio_dev_path(dev, "vfio-mdev2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=slice1".to_string()],
+                &["vendor.com/dra=slice2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // same mdev instance UUID on both sides collides
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            let uuid = "33333333-3333-3333-3333-333333333333";
+            build_vfio_mdev_cdev(sys, "vfio-mdev3", "0000:89:00.0", uuid);
+            write_cdi_spec(
+                spec,
+                "dp-mdev-same",
+                "vendor.com/gpu",
+                &[("slice3", &vfio_dev_path(dev, "vfio-mdev3"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-mdev-same",
+                "vendor.com/dra",
+                &[("slice3", &vfio_dev_path(dev, "vfio-mdev3"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            let err = check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=slice3".to_string()],
+                &["vendor.com/dra=slice3".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains(uuid));
+        }
+
+        // device node normalization failure fails closed instead of being skipped
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec = spec_dir.path();
+            write_cdi_spec(
+                spec,
+                "dp-broken",
+                "vendor.com/gpu",
+                &[("gpu-broken", &vfio_dev_path(dev, "vfio-broken-missing"))],
+            );
+            write_cdi_spec(
+                spec,
+                "dra-broken",
+                "vendor.com/dra",
+                &[("gpu-broken-2", &vfio_dev_path(dev, "vfio-broken-missing-2"))],
+            );
+            let spec_dirs = [spec.to_str().unwrap()];
+            assert!(check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu-broken".to_string()],
+                &["vendor.com/dra=gpu-broken-2".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .is_err());
+        }
+
+        // empty inputs never error
+        {
+            let spec_dirs = [sys.to_str().unwrap()]; // any dir; not consulted
+            check_cross_source_physical_overlap_in(&[], &[], &spec_dirs, sys, dev).unwrap();
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=gpu0".to_string()],
+                &[],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+            check_cross_source_physical_overlap_in(
+                &[],
+                &["vendor.com/dra=gpu0".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+
+        // unresolvable CDI device names are skipped silently
+        {
+            let spec_dir = tempfile::tempdir().unwrap();
+            let spec_dirs = [spec_dir.path().to_str().unwrap()];
+            check_cross_source_physical_overlap_in(
+                &["vendor.com/gpu=does-not-exist".to_string()],
+                &["vendor.com/dra=also-does-not-exist".to_string()],
+                &spec_dirs,
+                sys,
+                dev,
+            )
+            .unwrap();
+        }
+    }
+}

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -516,6 +516,7 @@ endif
     DEFVFIOMODE_NV := guest-kernel
     DEFKUBELETROOTDIR := /var/lib/kubelet
     DEFPODRESOURCEAPISOCK_NV := "$(DEFKUBELETROOTDIR)/pod-resources/kubelet.sock"
+    DEFPODRESOURCEDEVICESOURCES_NV := ["device-plugin"]
     # NVIDIA profile: rootfs filesystem type (erofs for read-only, compressed images)
     DEFROOTFSTYPE_NV := $(ROOTFSTYPE_EROFS)
     # NVIDIA profile: rootfs block driver (avoid virtio-pmem/DAX for this stack)
@@ -848,6 +849,7 @@ USER_VARS += DEFSTATICRESOURCEMGMT_NV
 USER_VARS += DEFVFIOMODE_NV
 USER_VARS += DEFKUBELETROOTDIR
 USER_VARS += DEFPODRESOURCEAPISOCK_NV
+USER_VARS += DEFPODRESOURCEDEVICESOURCES_NV
 USER_VARS += DEFROOTFSTYPE_NV
 USER_VARS += VMROOTFSDRIVER_NV
 USER_VARS += DEFDIALTIMEOUTMS_NV

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -545,7 +545,11 @@ endif
     DEFSTATICRESOURCEMGMT_NV := true
     DEFVFIOMODE_NV := guest-kernel
     DEFKUBELETROOTDIR := /var/lib/kubelet
+    DEFPODRESOURCEAPISOCK := ""
     DEFPODRESOURCEAPISOCK_NV := "$(DEFKUBELETROOTDIR)/pod-resources/kubelet.sock"
+    # PodResources sources consulted for device cold plug. Same default for
+    # every flavor/hypervisor target (no _NV split).
+    DEFPODRESOURCEDEVICESOURCES := ["device-plugin"]
     # NVIDIA profile: rootfs filesystem type (erofs for read-only, compressed images)
     DEFROOTFSTYPE_NV := $(ROOTFSTYPE_EROFS)
     # NVIDIA profile: rootfs block driver (avoid virtio-pmem/DAX for this stack)
@@ -938,6 +942,8 @@ USER_VARS += DEFSTATICRESOURCEMGMT_NV
 USER_VARS += DEFVFIOMODE_NV
 USER_VARS += DEFKUBELETROOTDIR
 USER_VARS += DEFPODRESOURCEAPISOCK_NV
+USER_VARS += DEFPODRESOURCEAPISOCK
+USER_VARS += DEFPODRESOURCEDEVICESOURCES
 USER_VARS += DEFROOTFSTYPE_NV
 USER_VARS += VMROOTFSDRIVER_NV
 USER_VARS += DEFDIALTIMEOUTMS_NV

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -608,7 +608,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -600,3 +600,17 @@ sandbox_bind_mounts = @DEFBINDMOUNTS@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -608,7 +608,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -600,3 +600,17 @@ sandbox_bind_mounts = @DEFBINDMOUNTS@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -587,6 +587,20 @@ sandbox_bind_mounts = @DEFBINDMOUNTS@
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
 
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 # If enabled, the runtime will attempt to use fd passthrough feature for process io.
 # Note: this feature is only supported by the Dragonball hypervisor.
 use_passfd_io = true

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -594,7 +594,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
@@ -542,7 +542,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
@@ -534,3 +534,17 @@ sandbox_bind_mounts = @DEFBINDMOUNTS@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -733,6 +733,20 @@ enable_pprof = false
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
 
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 [[hypervisor.qemu.guest_extension_images]]
 name = "coco"
 path = "@COCOIMAGEPATH@"

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -740,7 +740,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -841,4 +841,13 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 # Empty here: qemu-nvidia-cpu does not cold-plug any VFIO device.
-pod_resource_api_sock = ""
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -845,7 +845,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -851,6 +851,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES_NV@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -859,7 +859,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -857,6 +857,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -783,6 +783,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES_NV@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -789,6 +789,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -791,7 +791,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -759,6 +759,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES_NV@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -767,7 +767,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -765,6 +765,15 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 # devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
 
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 # The GPU driver stack (userspace binaries, libraries, configs, firmware and the
 # NVIDIA kernel modules) ships in a separate, driver-versioned extension image that
 # is cold-plugged alongside the nvidia base boot image.  NVRC mounts it at

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -837,7 +837,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -829,3 +829,17 @@ enable_pprof = false
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -722,7 +722,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -715,6 +715,20 @@ enable_pprof = false
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
 
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 [[hypervisor.qemu.guest_extension_images]]
 name = "coco"
 path = "@COCOIMAGEPATH@"

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -762,6 +762,20 @@ enable_pprof = false
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
 
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 [[hypervisor.qemu.guest_extension_images]]
 name = "coco"
 path = "@COCOIMAGEPATH@"

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -769,7 +769,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -740,6 +740,20 @@ enable_pprof = false
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
 
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@
+
 [[hypervisor.qemu.guest_extension_images]]
 name = "coco"
 path = "@COCOIMAGEPATH@"

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -747,7 +747,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -320,7 +320,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -312,3 +312,17 @@ enable_pprof = false
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -440,3 +440,17 @@ enable_pprof = false
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# pod_resource_api_sock specifies the unix socket for the Kubelet's PodResource API endpoint.
+# When set (together with a non-"no-port" cold_plug_vfio), the runtime can cold-plug
+# devices discovered via the Pod Resources API. Path is typically under kubelet root-dir.
+pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# pod_resource_device_sources selects which kubelet PodResources sources feed
+# cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
+# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# DISJOINT device sets -- kubelet double-counts a device advertised via both at
+# scheduling (a same-device collision is caught at cold plug). Unlisted-source
+# cold-pluggable data fails sandbox creation rather than being silently dropped.
+# Requires cold_plug_vfio and pod_resource_api_sock.
+pod_resource_device_sources = @DEFPODRESOURCEDEVICESOURCES@

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -448,7 +448,8 @@ pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
 
 # pod_resource_device_sources selects which kubelet PodResources sources feed
 # cold plug: "device-plugin" and/or "dra" (KEP-3695). Default ["device-plugin"]
-# preserves historical behavior; ["dra"] for DRA-only nodes. List both only for
+# preserves historical behavior; ["dra"] for DRA-only nodes; [] trusts neither
+# (a pod carrying cold-pluggable data then fails closed). List both only for
 # DISJOINT device sets -- kubelet double-counts a device advertised via both at
 # scheduling (a same-device collision is caught at cold plug). Unlisted-source
 # cold-pluggable data fails sandbox creation rather than being silently dropped.

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -401,6 +401,7 @@ impl VirtSandbox {
             let cdi_devices = pod_resources_rs::pod_resources::get_pod_cdi_devices(
                 pod_resource_socket,
                 annotations,
+                &config.runtime.pod_resource_device_sources,
             )
             .await
             .context("failed to query Pod Resources CDI devices")?;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -404,6 +404,7 @@ impl VirtSandbox {
             let cdi_devices = pod_resources_rs::pod_resources::get_pod_cdi_devices(
                 pod_resource_socket,
                 annotations,
+                &config.runtime.pod_resource_device_sources,
             )
             .await
             .context("failed to query Pod Resources CDI devices")?;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -63,7 +63,7 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 ))]
 use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_BLK_PCI};
-use kata_types::config::{hypervisor::Factory, TomlConfig};
+use kata_types::config::{hypervisor::Factory, PodResourceDeviceSource, TomlConfig};
 use kata_types::initdata::{calculate_initdata_digest, ProtectedPlatform};
 use oci_spec::runtime as oci;
 use persist::{self, sandbox_persist::Persist};
@@ -401,13 +401,37 @@ impl VirtSandbox {
                 annotations.get("io.kubernetes.cri.sandbox-namespace")
             );
 
-            let cdi_devices = pod_resources_rs::pod_resources::get_pod_cdi_devices(
+            let sources: Vec<pod_resources_rs::DeviceSource> = config
+                .runtime
+                .pod_resource_device_sources()
+                .into_iter()
+                .map(|s| match s {
+                    PodResourceDeviceSource::DevicePlugin => {
+                        pod_resources_rs::DeviceSource::DevicePlugin
+                    }
+                    PodResourceDeviceSource::Dra => pod_resources_rs::DeviceSource::Dra,
+                })
+                .collect();
+
+            let selected = pod_resources_rs::pod_resources::get_pod_cdi_devices(
                 pod_resource_socket,
                 annotations,
-                &config.runtime.pod_resource_device_sources,
+                &sources,
             )
             .await
             .context("failed to query Pod Resources CDI devices")?;
+
+            // Cross-source enforcement belongs to the device path, not the
+            // PodResources parser: this is the last point where a device
+            // still carries its source, right before attachment.
+            pod_resources_rs::pod_resources::overlap::check_cross_source_physical_overlap(
+                &selected.device_plugin,
+                &selected.dra,
+                &pod_resources_rs::DEFAULT_CDI_SPEC_DIRS,
+            )
+            .context("cold plug: cross-source physical overlap")?;
+
+            let cdi_devices = selected.flattened();
             info!(sl!(), "pod cdi devices: {:?}", cdi_devices);
 
             let device_nodes = handle_cdi_devices(&cdi_devices).await?;


### PR DESCRIPTION
This is the runtime-rs side of #13323, same gap and same shape. runtime-rs cold plug only ever read the device-plugin devices from PodResources; the DRA path was never wired up. DRA allocations come in `dynamic_resources[].claim_resources[].cdi_devices[]`, and since nothing reads that field, a DRA-allocated VFIO device never made it into the guest and the VM came up without it. It's less a broken code path than one that was never implemented on this runtime.

What it does now, mirroring the Go change:

```toml
[runtime]
# allowed values: "device-plugin", "dra"
pod_resource_device_sources = ["device-plugin"]
```

The default (or an absent key) reproduces today's device-plugin-only behavior, so existing users see no change, and reading DRA is an explicit opt-in with `["dra"]`. Empty, unknown, or duplicate values fail once at config load. If a source is not listed but the pod carries cold-pluggable (CDI-resolvable) data from it, sandbox creation fails with an error naming the option instead of silently booting without the device; data that never resolves in the CDI cache (a fuse or NIC plugin) is left alone. With both sources listed I check the two groups for physical overlap before injection, keyed on what each CDI device resolves to (PCI BDF for vfio-pci in either the per-device cdev or legacy iommu-group shape, instance UUID for an mdev) rather than on names that never match across sources, and fail if the same device is reachable through both.

The semantics track the Go PR one to one. I kept the source-token strings (`"device-plugin"`/`"dra"`) as the shared contract rather than adding a dependency between `kata-types` and `pod-resources-rs`; the values match `oci.PodResourceDeviceSource*` on the Go side.

On testing: unit tests cover the config validation, the source selection, the fail-closed branch (an unlisted source with a CDI-resolvable device), and the overlap normalization (vfio cdev to BDF, legacy iommu-group to member BDFs, mdev UUID, fail-closed when a node path won't normalize). I also built the runtime-rs shim from this branch and ran it on my H100 HGX box (8 GPUs behind 4 NVSwitches) with the DRA driver serving partitions.

With `["dra"]`, a pod claiming one GPU partition, the guest sees it:

```
NVIDIA-SMI 595.58.03   Driver Version: 595.58.03   CUDA Version: 13.2
  0  NVIDIA H100 80GB HBM3   00000000:04:00.0   4MiB / 81559MiB
```

With `["device-plugin"]` (DRA unlisted), the same pod fails closed at sandbox creation:

```
cold plug: container "cuda" has cold-pluggable (CDI-resolvable) DRA PodResources data
([...gpu-partition=...]) but "dra" is not in pod_resource_device_sources=["device-plugin"];
add "dra" to the config option or this data will be silently dropped
  1: pod_resources_rs::pod_resources::select_cold_plug_devices
```

The cross-source overlap guard is only unit-tested: that cluster runs DRA-only (the kata sandbox device-plugin is disabled at the operator), so there's no second source to collide with live.
