### PR TITLE
docs: bump pillow to 12.3.0 to remediate CVEs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ mkdocs-awesome-nav==3.3.0
 mkdocs-open-in-new-tab==1.0.8
 mkdocs-redirects==1.2.2
 CairoSVG==2.9.0
-pillow==12.2.0
+pillow==12.3.0
 click==8.3.3
 idna==3.15
 pymdown-extensions==10.21.3


### PR DESCRIPTION
Pin pillow to 12.3.0 to address security vulnerabilities:

- PYSEC-2026-2253
- PYSEC-2026-2254
- PYSEC-2026-2255
- PYSEC-2026-2256
- PYSEC-2026-2257
- PYSEC-2026-3451
- PYSEC-2026-3452
- PYSEC-2026-3453

Generated-By: IBM Bob