### PR TITLE
qemu: establish rootless and seccomp test baseline

### DIFF
--- a/docs/how-to/how-to-run-rootless-vmm.md
+++ b/docs/how-to/how-to-run-rootless-vmm.md
@@ -17,7 +17,11 @@ $ sudo chmod 660 /dev/kvm
 ## Configure rootless VMM
 By default, the VMM process still runs as the root user. There are two ways to enable rootless VMM:
 1. Set the `rootless` flag to `true` in the hypervisor section of `configuration.toml`.
-2. Set the Kubernetes annotation `io.katacontainers.hypervisor.rootless` to `true`.
+2. Set the Kubernetes annotation `io.katacontainers.config.hypervisor.rootless` to `true`.
+
+Shipped configurations do not enable the `rootless` annotation by default, so
+it must be included in the hypervisor's `enable_annotations` list before the
+annotation can be used.
 
 ## Implementation details
 When `rootless` flag is enabled, upon a request to create a Pod, Kata Containers runtime creates a random user and group (e.g. `kata-123`), and uses them to start the hypervisor process.

--- a/docs/how-to/how-to-use-seccomp-with-runtime-rs.md
+++ b/docs/how-to/how-to-use-seccomp-with-runtime-rs.md
@@ -18,11 +18,11 @@ As with runtime-go, you need to modify the following in your **configuration fil
 ``` toml
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
 # Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-seccompsandbox="on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
 ```
 ### Cloud Hypervisor, Firecracker and Dragonball
 

--- a/docs/how-to/how-to-use-seccomp-with-runtime-rs.md
+++ b/docs/how-to/how-to-use-seccomp-with-runtime-rs.md
@@ -18,11 +18,10 @@ As with runtime-go, you need to modify the following in your **configuration fil
 ``` toml
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 ```
 ### Cloud Hypervisor, Firecracker and Dragonball
 

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1411,8 +1411,7 @@ pub struct SecurityInfo {
 
     /// Qemu seccomp sandbox feature
     /// comma-separated list of seccomp sandbox features to control the syscall access.
-    /// For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-    /// Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+    /// For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
     /// Another note: enabling this feature may reduce performance, you may enable
     /// /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
     pub seccomp_sandbox: Option<String>,

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1411,7 +1411,7 @@ pub struct SecurityInfo {
 
     /// Qemu seccomp sandbox feature
     /// comma-separated list of seccomp sandbox features to control the syscall access.
-    /// For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+    /// For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
     /// Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
     /// Another note: enabling this feature may reduce performance, you may enable
     /// /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -605,8 +605,9 @@ endif
     DEFNETWORKMODEL_QEMU := tcfilter
     DEFDISABLEGUESTSELINUX := true
     # Default is empty string "" to match Rust default None (when commented out in config).
-    # Most users will want to set this to "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
-    # for better security. Note: "elevateprivileges=deny" doesn't work with daemonize option.
+    # Most users will want to set this to
+    # "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+    # for better security.
     DEFSECCOMPSANDBOXPARAM := ""
 endif
 

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -88,11 +88,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -80,7 +80,7 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
 # Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -80,11 +80,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -80,7 +80,7 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
 # Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -80,11 +80,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -121,11 +121,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -121,7 +121,7 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
 # Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -97,11 +97,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -97,7 +97,7 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
+# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
 # Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -67,11 +67,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -76,11 +76,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -114,11 +114,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -92,11 +92,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccomp_sandbox = "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccomp_sandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccomp_sandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -253,9 +253,9 @@ DEFGUESTSELINUXLABEL :=
 # More explanation on https://lists.gnu.org/archive/html/qemu-devel/2017-02/msg03348.html
 #
 # Default is empty string "" to match the default (when commented out in config).
-# Most users will want to set this to "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
-# for better security. Note: "elevateprivileges=deny" doesn't work with daemonize option.
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# Most users will want to set this to
+# "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+# for better security.
 DEFSECCOMPSANDBOXPARAM :=
 
 #Default entropy source

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -74,11 +74,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
@@ -77,11 +77,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -114,11 +114,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -91,11 +91,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -73,11 +73,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -77,11 +77,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -113,11 +113,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -90,11 +90,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -68,11 +68,10 @@ machine_accelerators = "@MACHINEACCELERATORS@"
 
 # Qemu seccomp sandbox feature
 # comma-separated list of seccomp sandbox features to control the syscall access.
-# For example, `seccompsandbox= "on,obsolete=deny,spawn=deny,resourcecontrol=deny"`
-# Note: "elevateprivileges=deny" doesn't work with daemonize option, so it's removed from the seccomp sandbox
+# For example, `seccompsandbox = "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"`
 # Another note: enabling this feature may reduce performance, you may enable
 # /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
-# Recommended value when enabling: "on,obsolete=deny,spawn=deny,resourcecontrol=deny"
+# Recommended value when enabling: "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
 seccompsandbox = "@DEFSECCOMPSANDBOXPARAM@"
 
 # CPU features

--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -426,7 +425,7 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID stri
 		"sandbox_id": sandboxID,
 	}).Debug("successfully created a non root user for the hypervisor")
 
-	userTmpDir := path.Join("/run/user/", fmt.Sprint(uid))
+	userTmpDir := rootless.VmmUserRuntimeDir(runtimeConfig.HypervisorConfig.Uid)
 	_, err = os.Stat(userTmpDir)
 	// Clean up the directory created by the previous run
 	if !os.IsNotExist(err) {

--- a/src/runtime/virtcontainers/pkg/rootless/rootless.go
+++ b/src/runtime/virtcontainers/pkg/rootless/rootless.go
@@ -22,11 +22,15 @@ package rootless
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/moby/sys/userns"
 	"github.com/sirupsen/logrus"
 )
+
+const vmmUserRuntimeBaseDir = "/run/user"
 
 var (
 	// isRootless states whether execution is rootless or not
@@ -90,4 +94,14 @@ func GetRootlessDir() string {
 		rootlessLog.WithField("rootlessDir", rootlessDir).Debug("initialized rootlessDir")
 	})
 	return rootlessDir
+}
+
+// VmmUserRuntimeDir returns the runtime directory for a temporary VMM user.
+func VmmUserRuntimeDir(uid uint32) string {
+	return filepath.Join(vmmUserRuntimeBaseDir, strconv.FormatUint(uint64(uid), 10))
+}
+
+// RemoveVmmUserRuntimeDir removes the runtime directory for a temporary VMM user.
+func RemoveVmmUserRuntimeDir(uid uint32) error {
+	return os.RemoveAll(VmmUserRuntimeDir(uid))
 }

--- a/src/runtime/virtcontainers/pkg/rootless/rootless_test.go
+++ b/src/runtime/virtcontainers/pkg/rootless/rootless_test.go
@@ -7,6 +7,7 @@ package rootless
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/moby/sys/userns"
@@ -33,4 +34,8 @@ func TestIsRootless(t *testing.T) {
 	assert.False(isRootlessFunc())
 
 	isRootless = nil
+}
+
+func TestVmmUserRuntimeDir(t *testing.T) {
+	assert.Equal(t, filepath.Join(vmmUserRuntimeBaseDir, "1000"), VmmUserRuntimeDir(1000))
 }

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1120,6 +1120,14 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 		s.Logger().WithError(err).Error("failed to cleanup ephemeral disks")
 	}
 
+	if rootless.IsRootless() {
+		uid := s.config.HypervisorConfig.Uid
+		userRuntimeDir := rootless.VmmUserRuntimeDir(uid)
+		if err := rootless.RemoveVmmUserRuntimeDir(uid); err != nil {
+			s.Logger().WithError(err).WithField("path", userRuntimeDir).Warn("failed to remove rootless runtime directory")
+		}
+	}
+
 	return s.store.Destroy(s.id)
 }
 

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -445,7 +445,7 @@ function do_deploy_k8s() {
 		EOF
 
 		sudo apt-get update
-		if sudo apt-get -y install --dry-run kubeadm kubelet kubectl \
+		if sudo apt-get -y install --dry-run kubeadm kubelet kubectl cri-tools \
 			--allow-downgrades >/dev/null 2>&1; then
 			version="${candidate}"
 			break
@@ -459,7 +459,7 @@ function do_deploy_k8s() {
 	fi
 
 	info "Installing Kubernetes ${version}"
-	sudo apt-get -y install kubeadm kubelet kubectl --allow-downgrades
+	sudo apt-get -y install kubeadm kubelet kubectl cri-tools --allow-downgrades
 	sudo apt-mark hold kubeadm kubelet kubectl
 
 	# Deploy k8s using kubeadm with CreateContainerRequest (CRI) timeout set to 600s,

--- a/tests/hypervisor_helpers.sh
+++ b/tests/hypervisor_helpers.sh
@@ -15,6 +15,13 @@ FIRECRACKER_HYPERVISORS=("firecracker" "fc")
 NVIDIA_CPU_HYPERVISORS=("qemu-nvidia-cpu" "qemu-nvidia-cpu-runtime-rs")
 # All non-confidential NVIDIA classes (CPU-only + plain GPU passthrough).
 NVIDIA_HYPERVISORS=("${NVIDIA_CPU_HYPERVISORS[@]}" "qemu-nvidia-gpu" "qemu-nvidia-gpu-runtime-rs")
+# Runtime classes configured with shared_fs=none.
+SHARED_FS_NONE_HYPERVISORS=(
+	"${TEE_HYPERVISORS[@]}"
+	"${NON_TEE_HYPERVISORS[@]}"
+	"qemu-nvidia-cpu-runtime-rs"
+	"qemu-nvidia-gpu-runtime-rs"
+)
 
 ALL_HYPERVISORS=(
 	"clh"
@@ -118,15 +125,10 @@ function is_confidential_runtime_class() {
 # Runtime classes that boot with shared_fs=none, where the host cannot read
 # guest files directly. Data such as a container's termination log must then be
 # retrieved over the agent GetDiagnosticData RPC instead of a shared filesystem.
-# This covers the confidential runtime classes and the non-confidential NVIDIA
-# CPU runtime-rs handler. The plain qemu-nvidia-cpu (Go) class still uses
-# virtio-fs, so it is intentionally excluded.
 function is_shared_fs_none_runtime_class() {
 	local hypervisor="${1:-${KATA_HYPERVISOR}}"
-	if is_confidential_runtime_class "${hypervisor}"; then
-		return 0
-	fi
-	[[ "${hypervisor}" == "qemu-nvidia-cpu-runtime-rs" ]] && return 0
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${SHARED_FS_NONE_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
 	return 1
 }
 

--- a/tests/integration/kubernetes/k8s-nvidia-numa.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-numa.bats
@@ -195,20 +195,6 @@ guest_per_node_values() {
 # Host-side pinning helpers
 # -----------------------------------------------------------------------------
 
-# get_qemu_pid_for_numa_pod resolves the running pod's sandbox via crictl
-# and returns the QEMU PID via pgrep.  Fails the test if either lookup
-# turns up empty.
-get_qemu_pid_for_numa_pod() {
-    local sandbox_id qemu_pid
-    sandbox_id=$(sudo crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pods --name "${POD_NAME_NUMA}" -q | head -1)
-    [[ -n "${sandbox_id}" ]] || die "no sandbox id found for pod ${POD_NAME_NUMA}"
-
-    qemu_pid=$(sudo pgrep -f "qemu.*${sandbox_id}" | head -1)
-    [[ -n "${qemu_pid}" ]] || die "no QEMU PID found for sandbox ${sandbox_id}"
-    echo "${qemu_pid}"
-}
-
 # pinning_thread_total sums the per-bucket counts in numa-pinning-check.sh
 # output ("nodeN: <count>" lines) and echoes the total.
 pinning_thread_total() {
@@ -399,7 +385,7 @@ host_gpu_numa() {
 
     # --- Host-side vCPU pinning balance ---
     local qemu_pid host_output
-    qemu_pid=$(get_qemu_pid_for_numa_pod)
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA}")
     echo "# QEMU PID: ${qemu_pid}"
     host_output=$(wait_for_host_pinning "${qemu_pid}" "${NUMA_TEST_VCPUS_LARGE}")
     echo "# Host pinning per NUMA node: ${host_output}"
@@ -455,7 +441,7 @@ host_gpu_numa() {
 
     # --- Host-side vCPU pinning collapsed to a single node ---
     local qemu_pid host_output
-    qemu_pid=$(get_qemu_pid_for_numa_pod)
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA}")
     echo "# QEMU PID: ${qemu_pid}"
     host_output=$(wait_for_host_pinning "${qemu_pid}" "${NUMA_TEST_VCPUS_SMALL}")
     echo "# Host pinning per NUMA node: ${host_output}"
@@ -516,13 +502,8 @@ host_gpu_numa() {
     [[ ${#guest_mem[@]} -ge 2 ]] || die "expected >= 2 guest memory nodes"
 
     # --- Host-side QEMU lookup (needed for the GPU NUMA assertion) ---
-    local sandbox_id qemu_pid qemu_cmd host_bdf host_node
-    sandbox_id=$(sudo crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pods --name "${POD_NAME_NUMA_GPU}" -q | head -1)
-    [[ -n "${sandbox_id}" ]] || die "no sandbox id found for GPU pod"
-
-    qemu_pid=$(sudo pgrep -f "qemu.*${sandbox_id}" | head -1)
-    [[ -n "${qemu_pid}" ]] || die "no QEMU PID found for GPU sandbox ${sandbox_id}"
+    local qemu_pid qemu_cmd host_bdf host_node
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA_GPU}")
     echo "# QEMU PID: ${qemu_pid}"
 
     qemu_cmd=$(get_qemu_cmdline "${qemu_pid}")
@@ -593,13 +574,8 @@ host_gpu_numa() {
     echo "# ${guest_logs}"
 
     # --- Host-side QEMU lookup ---
-    local sandbox_id qemu_pid qemu_cmd host_bdf host_node
-    sandbox_id=$(sudo crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pods --name "${POD_NAME_NUMA_GPU}" -q | head -1)
-    [[ -n "${sandbox_id}" ]] || die "no sandbox id found for GPU pod"
-
-    qemu_pid=$(sudo pgrep -f "qemu.*${sandbox_id}" | head -1)
-    [[ -n "${qemu_pid}" ]] || die "no QEMU PID found for GPU sandbox ${sandbox_id}"
+    local qemu_pid qemu_cmd host_bdf host_node
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA_GPU}")
 
     qemu_cmd=$(get_qemu_cmdline "${qemu_pid}")
     host_bdf=$(extract_vfio_host_bdf "${qemu_cmd}")
@@ -694,7 +670,7 @@ host_gpu_numa() {
 
     # --- QEMU memory backend bound to host node 1 ---
     local qemu_pid qemu_cmd
-    qemu_pid=$(get_qemu_pid_for_numa_pod)
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA}")
     qemu_cmd=$(get_qemu_cmdline "${qemu_pid}")
     echo "# Checking QEMU cmdline for memory binding on host node 1..."
     [[ "${qemu_cmd}" == *"host-nodes=1"* ]] \

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
+readonly QEMU_SANDBOX_PARAM="on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+
+qemu_rootless_sandbox_supported() {
+	[[ "${KATA_HYPERVISOR}" == qemu* ]] || return 1
+
+	# Additional QEMU configurations are tracked in:
+	# https://github.com/kata-containers/kata-containers/issues/13424
+	is_runtime_rs && return 1
+	is_shared_fs_none_runtime_class "${KATA_HYPERVISOR}" && return 1
+	# Rootless QEMU cannot access EROFS layers below root-owned
+	# snapshot directories.
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && return 1
+	is_confidential_runtime_class "${KATA_HYPERVISOR}" && return 1
+	return 0
+}
+
+setup() {
+	local runtime_config_dropin_file
+
+	if ! qemu_rootless_sandbox_supported; then
+		skip "QEMU rootless and seccomp sandbox smoke testing does not cover ${KATA_HYPERVISOR}"
+	fi
+
+	setup_common || die "setup_common failed"
+
+	pod_name="test-e2e"
+	pod_config="$(new_pod_config \
+		"quay.io/prometheus/busybox:latest" \
+		"$(get_test_runtime_class)")"
+	set_node "${pod_config}" "${node}"
+	set_container_command "${pod_config}" 0 sleep 30
+
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	auto_generate_policy "${policy_settings_dir}" "${pod_config}"
+
+	runtime_config_dropin_file="${BATS_FILE_TMPDIR}/99-k8s-qemu-sandbox.toml"
+	cat > "${runtime_config_dropin_file}" <<EOF
+[hypervisor.qemu]
+rootless = true
+seccompsandbox = "${QEMU_SANDBOX_PARAM}"
+EOF
+
+	runtime_config_dropin="$(set_kata_runtime_config_dropin_file \
+		"${node}" \
+		"${runtime_config_dropin_file}")" || \
+		die "Failed to install QEMU sandbox config drop-in on ${node}"
+}
+
+@test "QEMU runs rootless with its seccomp sandbox enabled" {
+	local cmdline
+	local qemu_pid
+	local qemu_status
+	local qemu_gid
+	local qemu_uid
+
+	retry_kubectl_apply "${pod_config}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" "pod/${pod_name}"
+
+	qemu_pid="$(get_qemu_pid_for_pod "${pod_name}")"
+
+	qemu_status="$(exec_host "${node}" "cat /proc/${qemu_pid}/status")"
+	qemu_uid="$(awk '/^Uid:/ {print $2}' <<< "${qemu_status}")"
+	qemu_gid="$(awk '/^Gid:/ {print $2}' <<< "${qemu_status}")"
+
+	[[ "${qemu_uid}" =~ ^[0-9]+$ ]]
+	[[ "${qemu_gid}" =~ ^[0-9]+$ ]]
+	(( qemu_uid != 0 ))
+	(( qemu_gid != 0 ))
+	[[ "$(awk '/^Seccomp:/ {print $2}' <<< "${qemu_status}")" == "2" ]]
+	[[ "$(awk '/^NoNewPrivs:/ {print $2}' <<< "${qemu_status}")" == "1" ]]
+
+	cmdline="$(exec_host "${node}" "tr '\\0' ' ' < /proc/${qemu_pid}/cmdline")"
+	[[ " ${cmdline} " == *" -sandbox ${QEMU_SANDBOX_PARAM} "* ]]
+}
+
+teardown() {
+	qemu_rootless_sandbox_supported || return 0
+
+	echo "=== QEMU rootless sandbox pod describe ==="
+	kubectl describe pod "${pod_name:-test-e2e}" || true
+
+	remove_kata_runtime_config_dropin_file \
+		"${node}" \
+		"${runtime_config_dropin:-}" || true
+
+	delete_tmp_policy_settings_dir "${policy_settings_dir:-}"
+
+	[ -f "${pod_config:-}" ] && kubectl delete -f "${pod_config}" --ignore-not-found=true
+
+	print_node_journal_since_test_start \
+		"${node}" \
+		"${node_start_time:-}" \
+		"${BATS_TEST_COMPLETED:-}"
+}

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -168,6 +168,33 @@ exec_host() {
 	kubectl exec -qi -n kube-system "${pod_name}" -- chroot /host bash -c "${command}" | tr -d '\r'
 }
 
+# Return the QEMU PID for a running pod.
+#
+# Parameters:
+#	$1 - pod name in the current Kubernetes namespace
+get_qemu_pid_for_pod() {
+	local pod_name="$1"
+	local node
+	local qemu_pid
+	local sandbox_id
+
+	node="$(kubectl get pod "${pod_name}" -o jsonpath='{.spec.nodeName}')"
+	[[ -n "${node}" ]] || die "No node found for pod ${pod_name}"
+	exec_host "${node}" "command -v crictl >/dev/null" || \
+		die "crictl is required on Kubernetes node ${node}"
+
+	sandbox_id="$(exec_host "${node}" \
+		"crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
+		pods --name \"${pod_name}\" -q | head -1")"
+	[[ -n "${sandbox_id}" ]] || die "No sandbox ID found for pod ${pod_name}"
+
+	qemu_pid="$(exec_host "${node}" \
+		"pgrep -f \"qemu.*${sandbox_id}\" | head -1")"
+	[[ -n "${qemu_pid}" ]] || die "No QEMU PID found for sandbox ${sandbox_id}"
+
+	echo "${qemu_pid}"
+}
+
 # Check the logged messages on host have a given message.
 #
 # Parameters:

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -135,7 +135,8 @@ else
 	K8S_TEST_NV=("k8s-confidential-attestation.bats" \
 		"k8s-nvidia-numa.bats" \
 		"k8s-nvidia-cuda.bats" \
-		"k8s-nvidia-nim.bats")
+		"k8s-nvidia-nim.bats" \
+		"k8s-qemu-rootless-sandbox.bats")
 fi
 
 SUPPORTED_HYPERVISORS=("qemu-nvidia-gpu" "qemu-nvidia-gpu-snp" "qemu-nvidia-gpu-tdx" "qemu-nvidia-gpu-runtime-rs" "qemu-nvidia-gpu-snp-runtime-rs" "qemu-nvidia-gpu-tdx-runtime-rs")

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -105,6 +105,7 @@ else
 		"k8s-port-forward.bats" \
 		"k8s-privileged.bats" \
 		"k8s-projected-volume.bats" \
+		"k8s-qemu-rootless-sandbox.bats" \
 		"k8s-replication.bats" \
 		"k8s-sandbox-cgroup.bats" \
 		"k8s-sandbox-cgroup-placement.bats" \


### PR DESCRIPTION
Establish an initial validation baseline for QEMU's rootless and seccomp sandbox controls, update related documentation and code comments, see #13424.

### Changes for docs/configs:

- Correct the rootless annotation name and document its required `enable_annotations` entry.
- Correct the runtime-rs `seccomp_sandbox` examples.
- Recommend QEMU's complete built-in sandbox, including `elevateprivileges=deny`, now that Kata does not daemonize QEMU.

### Minor fixes and refactoring:

- Correct `shared_fs=none` detection for the non-confidential NVIDIA runtime-rs handlers.
- Move the QEMU PID lookup used by the NVIDIA NUMA tests into a shared Kubernetes helper.
- Clean up runtime-go's temporary rootless QEMU runtime directory after normal sandbox teardown, using a shared helper for setup and cleanup.

### Add a new BATS test

The test enables both controls and verifies that:

- QEMU runs with a non-root effective UID and GID.
- seccomp filtering and `NoNewPrivs` are active.
- QEMU receives the expected complete `-sandbox` argument.
- The test is included in both the general Kubernetes and NVIDIA test
  runners. Initial coverage is deliberately limited to non-confidential
  Go QEMU RuntimeClasses with filesystem sharing, see #13424.
