### PR TITLE
runtime-rs: enable QEMU rootless seccomp BATS test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "qapi-spec",
  "rand 0.10.1",
  "regex",
+ "rstest",
  "rust-ini",
  "safe-path",
  "seccompiler",

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -93,6 +93,7 @@ cloud-hypervisor = ["ch-config"]
 openvmm = ["dep:protobuf"]
 
 [dev-dependencies]
+rstest = { workspace = true }
 serial_test = "2.0.0"
 tempfile = { workspace = true }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -3908,4 +3908,25 @@ mod tests {
         drop(cmdline);
         let _ = std::fs::remove_file(QMP_SOCKET_FILE);
     }
+
+    #[rstest]
+    #[case::sandbox_unset(None, vec![])]
+    #[case::sandbox_enabled(Some("on"), vec!["on"])]
+    #[actix_rt::test]
+    #[serial]
+    async fn test_qemu_seccomp_sandbox_params(
+        #[case] seccomp_sandbox: Option<&str>,
+        #[case] expected_values: Vec<&str>,
+    ) {
+        let mut config = test_qemu_config(None, false);
+        config.security_info.seccomp_sandbox = seccomp_sandbox.map(str::to_owned);
+        let params = build_test_cmdline("seccomp-sandbox", &config).await;
+
+        let values: Vec<&str> = params
+            .windows(2)
+            .filter_map(|args| (args[0] == "-sandbox").then_some(args[1].as_str()))
+            .collect();
+
+        assert_eq!(values, expected_values);
+    }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1089,11 +1089,10 @@ impl ToQemuParams for BlockBackend {
         } else {
             params.push("cache.no-flush=off".to_owned());
         }
-        if self.read_only {
-            params.push("auto-read-only=on".to_owned());
-        } else {
-            params.push("auto-read-only=off".to_owned());
-        }
+        params.push(format!(
+            "read-only={}",
+            if self.read_only { "on" } else { "off" }
+        ));
         if self.discard_unmap {
             params.push("discard=unmap".to_owned());
         }
@@ -3140,16 +3139,19 @@ impl<'a> QemuCmdLine<'a> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_block_device(
         &mut self,
         device_id: &str,
         path: &str,
         is_direct: bool,
+        is_readonly: bool,
         is_scsi: bool,
         discard_unmap: bool,
         serial_override: Option<&str>,
     ) -> Result<()> {
         let mut backend = BlockBackend::new(device_id, path, is_direct);
+        backend.set_read_only(is_readonly);
         backend.set_discard_unmap(discard_unmap);
         self.devices.push(Box::new(backend));
         let devno = get_devno_ccw(&mut self.ccw_subchannel, device_id);
@@ -3779,6 +3781,7 @@ impl ToQemuParams for SeccompSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use serial_test::serial;
 
     fn contains_param(params: &[String], expected: &str) -> bool {
@@ -3868,5 +3871,41 @@ mod tests {
         let scsi_hd = DeviceScsiHd::new("blk0", "scsi0.0", None);
         let scsi_hd_params = scsi_hd.qemu_params().await.unwrap();
         assert!(!contains_param(&scsi_hd_params, "discard=on"));
+    }
+
+    #[rstest]
+    #[case::read_only(true, "read-only=on")]
+    #[case::writable(false, "read-only=off")]
+    #[actix_rt::test]
+    #[serial]
+    async fn test_qemu_block_backend_read_only_params(
+        #[case] is_readonly: bool,
+        #[case] expected_param: &str,
+    ) {
+        let config = test_qemu_config(Some("none"), false);
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+        let mut cmdline = QemuCmdLine::new("block-read-only", &config).unwrap();
+        cmdline
+            .add_block_device(
+                "blk0",
+                "/tmp/disk.img",
+                true,
+                is_readonly,
+                false,
+                false,
+                None,
+            )
+            .unwrap();
+
+        let params = cmdline.build().await.unwrap();
+        assert!(params.windows(2).any(|args| {
+            args[0] == "-blockdev"
+                && args[1].contains("node-name=image-blk0")
+                && contains_param(&args[1..2], expected_param)
+        }));
+        assert!(!params.iter().any(|arg| arg.contains("auto-read-only=")));
+
+        drop(cmdline);
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -177,6 +177,7 @@ impl QemuInner {
                                 device_id.as_str(),
                                 &path_on_host,
                                 is_direct,
+                                is_readonly,
                                 driver_option.as_str() == KATA_SCSI_DEV_TYPE,
                                 discard_unmap,
                                 serial,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -407,13 +407,8 @@ impl QemuInner {
                     }
                 }
                 if let Some(user) = &user {
-                    let groups = user.groups.clone();
-                    let gid = Gid::from_raw(user.gid);
-                    let uid = Uid::from_raw(user.uid);
-
-                    let _ = set_groups(&groups);
-                    let _ = setgid(gid).context("setgid failed");
-                    let _ = setuid(uid).context("setuid failed");
+                    set_process_credentials(user)
+                        .map_err(|err| io::Error::other(format!("{err:#}")))?;
                 }
 
                 Ok(())
@@ -1001,6 +996,32 @@ fn check_bpf_enabled_with<ReadStatus, LogWarning>(
     }
 }
 
+fn set_process_credentials(user: &RootlessUser) -> Result<()> {
+    set_process_credentials_with(
+        user,
+        set_groups,
+        |gid| setgid(Gid::from_raw(gid)).map_err(anyhow::Error::from),
+        |uid| setuid(Uid::from_raw(uid)).map_err(anyhow::Error::from),
+    )
+}
+
+fn set_process_credentials_with<SetGroups, SetGid, SetUid>(
+    user: &RootlessUser,
+    set_groups_fn: SetGroups,
+    set_gid_fn: SetGid,
+    set_uid_fn: SetUid,
+) -> Result<()>
+where
+    SetGroups: Fn(&[u32]) -> Result<()>,
+    SetGid: Fn(u32) -> Result<()>,
+    SetUid: Fn(u32) -> Result<()>,
+{
+    set_groups_fn(&user.groups).context("setgroups failed")?;
+    set_gid_fn(user.gid).context("setgid failed")?;
+    set_uid_fn(user.uid).context("setuid failed")?;
+    Ok(())
+}
+
 async fn log_qemu_console(console: UnixStream) -> Result<()> {
     info!(sl!(), "starting reading qemu console");
 
@@ -1360,23 +1381,6 @@ impl QemuInner {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_network_device_hotplug_capability() {
-        let (exit_notify, _exit_waiter) = mpsc::channel(1);
-        let qemu = QemuInner::new(exit_notify);
-
-        assert!(qemu
-            .capabilities()
-            .await
-            .unwrap()
-            .is_network_device_hotplug_supported());
-    }
-}
-
 #[async_trait]
 impl Persist for QemuInner {
     type State = HypervisorState;
@@ -1413,6 +1417,18 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+
+    #[tokio::test]
+    async fn test_network_device_hotplug_capability() {
+        let (exit_notify, _exit_waiter) = mpsc::channel(1);
+        let qemu = QemuInner::new(exit_notify);
+
+        assert!(qemu
+            .capabilities()
+            .await
+            .unwrap()
+            .is_network_device_hotplug_supported());
+    }
 
     #[rstest]
     #[case::seccomp_sandbox_unset(None, Err(io::ErrorKind::NotFound), false, None)]
@@ -1465,5 +1481,114 @@ mod tests {
             }
             None => assert!(warnings.is_empty()),
         }
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum CredentialOperation {
+        SetGroups(Vec<u32>),
+        SetGid(u32),
+        SetUid(u32),
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum CredentialStep {
+        SetGroups,
+        SetGid,
+        SetUid,
+    }
+
+    fn rootless_user() -> RootlessUser {
+        RootlessUser {
+            uid: 1001,
+            gid: 1002,
+            groups: vec![1003, 1004],
+            user_name: "kata-test".to_string(),
+        }
+    }
+
+    #[rstest]
+    #[case::with_supplementary_groups(vec![1003, 1004])]
+    #[case::without_supplementary_groups(Vec::new())]
+    fn test_set_process_credentials_order(#[case] groups: Vec<u32>) {
+        let operations = RefCell::new(Vec::new());
+        let mut user = rootless_user();
+        user.groups = groups.clone();
+
+        set_process_credentials_with(
+            &user,
+            |groups| {
+                operations
+                    .borrow_mut()
+                    .push(CredentialOperation::SetGroups(groups.to_vec()));
+                Ok(())
+            },
+            |gid| {
+                operations
+                    .borrow_mut()
+                    .push(CredentialOperation::SetGid(gid));
+                Ok(())
+            },
+            |uid| {
+                operations
+                    .borrow_mut()
+                    .push(CredentialOperation::SetUid(uid));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            *operations.borrow(),
+            vec![
+                // Calling setgroups with an empty list clears any inherited
+                // supplementary groups and must not be skipped.
+                CredentialOperation::SetGroups(groups),
+                CredentialOperation::SetGid(1002),
+                CredentialOperation::SetUid(1001),
+            ]
+        );
+    }
+
+    #[rstest]
+    #[case::setgroups(CredentialStep::SetGroups, "setgroups failed", 1)]
+    #[case::setgid(CredentialStep::SetGid, "setgid failed", 2)]
+    #[case::setuid(CredentialStep::SetUid, "setuid failed", 3)]
+    fn test_set_process_credentials_stops_on_error(
+        #[case] failed_step: CredentialStep,
+        #[case] expected_error: &str,
+        #[case] expected_calls: usize,
+    ) {
+        let calls = Cell::new(0);
+        let result = set_process_credentials_with(
+            &rootless_user(),
+            |_| {
+                calls.set(calls.get() + 1);
+                if failed_step == CredentialStep::SetGroups {
+                    Err(anyhow!("injected setgroups failure"))
+                } else {
+                    Ok(())
+                }
+            },
+            |_| {
+                calls.set(calls.get() + 1);
+                if failed_step == CredentialStep::SetGid {
+                    Err(anyhow!("injected setgid failure"))
+                } else {
+                    Ok(())
+                }
+            },
+            |_| {
+                calls.set(calls.get() + 1);
+                if failed_step == CredentialStep::SetUid {
+                    Err(anyhow!("injected setuid failure"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+
+        let error = result.expect_err("credential failure must abort setup");
+        assert!(format!("{error:#}").contains(expected_error));
+        assert_eq!(calls.get(), expected_calls);
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -35,6 +35,8 @@ use persist::sandbox_persist::Persist;
 use qapi_qmp::MigrationStatus;
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
+use std::fs;
+use std::io;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
@@ -107,6 +109,8 @@ impl QemuInner {
     pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
         info!(sl!(), "Starting QEMU VM");
         let netns = self.netns.clone().unwrap_or_default();
+
+        check_bpf_enabled(self.config.security_info.seccomp_sandbox.as_deref());
 
         // CAUTION: since 'cmdline' contains file descriptors that have to stay
         // open until spawn() is called to launch qemu later in this function,
@@ -949,6 +953,54 @@ impl QemuInner {
     }
 }
 
+const BPF_JIT_ENABLE_PATH: &str = "/proc/sys/net/core/bpf_jit_enable";
+
+fn check_bpf_enabled(seccomp_sandbox: Option<&str>) {
+    check_bpf_enabled_with(
+        seccomp_sandbox,
+        || fs::read_to_string(BPF_JIT_ENABLE_PATH),
+        |message| warn!(sl!(), "{}", message),
+    );
+}
+
+fn check_bpf_enabled_with<ReadStatus, LogWarning>(
+    seccomp_sandbox: Option<&str>,
+    read_status: ReadStatus,
+    mut log_warning: LogWarning,
+) where
+    ReadStatus: FnOnce() -> io::Result<String>,
+    LogWarning: FnMut(String),
+{
+    if seccomp_sandbox.unwrap_or_default().is_empty() {
+        return;
+    }
+
+    let status = match read_status() {
+        Ok(status) => status,
+        Err(err) => {
+            log_warning(format!("failed to get bpf_jit_enable status: {err}"));
+            return;
+        }
+    };
+
+    let enabled = match status.trim().parse::<i32>() {
+        Ok(enabled) => enabled,
+        Err(err) => {
+            log_warning(format!(
+                "failed to convert bpf_jit_enable status to integer: {err}"
+            ));
+            return;
+        }
+    };
+
+    if enabled == 0 {
+        log_warning(
+            "bpf_jit_enable is disabled. It's recommended to turn on bpf_jit_enable to reduce the performance impact of QEMU seccomp sandbox."
+                .to_string(),
+        );
+    }
+}
+
 async fn log_qemu_console(console: UnixStream) -> Result<()> {
     info!(sl!(), "starting reading qemu console");
 
@@ -1352,5 +1404,66 @@ impl Persist for QemuInner {
 
             exit_notify: Some(exit_notify),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::seccomp_sandbox_unset(None, Err(io::ErrorKind::NotFound), false, None)]
+    #[case::seccomp_sandbox_empty(Some(""), Err(io::ErrorKind::NotFound), false, None)]
+    #[case::read_failure(
+        Some("on"),
+        Err(io::ErrorKind::NotFound),
+        true,
+        Some("failed to get bpf_jit_enable status")
+    )]
+    #[case::parse_failure(
+        Some("on"),
+        Ok("invalid"),
+        true,
+        Some("failed to convert bpf_jit_enable status to integer")
+    )]
+    #[case::disabled(
+        Some("on"),
+        Ok("0\n"),
+        true,
+        Some("bpf_jit_enable is disabled")
+    )]
+    #[case::enabled(Some("on"), Ok("1\n"), true, None)]
+    fn test_bpf_jit_check_warnings(
+        #[case] seccomp_sandbox: Option<&str>,
+        #[case] read_result: Result<&str, io::ErrorKind>,
+        #[case] expect_read: bool,
+        #[case] expected_warning: Option<&str>,
+    ) {
+        let read_called = Cell::new(false);
+        let warnings = RefCell::new(Vec::new());
+        check_bpf_enabled_with(
+            seccomp_sandbox,
+            || {
+                read_called.set(true);
+                read_result
+                    .map(str::to_owned)
+                    .map_err(|kind| io::Error::new(kind, "injected"))
+            },
+            |warning| warnings.borrow_mut().push(warning),
+        );
+
+        assert_eq!(read_called.get(), expect_read);
+
+        let warnings = warnings.borrow();
+        match expected_warning {
+            Some(expected) => {
+                assert_eq!(warnings.len(), 1);
+                assert!(warnings[0].contains(expected));
+            }
+            None => assert!(warnings.is_empty()),
+        }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -119,13 +119,12 @@ pub fn enter_netns(netns_path: &str) -> Result<()> {
 }
 
 pub fn set_groups(groups: &[u32]) -> Result<()> {
-    if !groups.is_empty() {
-        let group = groups
-            .iter()
-            .map(|gid| Gid::from_raw(*gid))
-            .collect::<Vec<_>>();
-        setgroups(&group).context("set groups failed")?;
-    }
+    let group = groups
+        .iter()
+        .map(|gid| Gid::from_raw(*gid))
+        .collect::<Vec<_>>();
+    // An empty list intentionally clears inherited supplementary groups.
+    setgroups(&group).context("set groups failed")?;
 
     Ok(())
 }

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -39,7 +39,7 @@ use crate::device::Tap;
 
 use crate::{DEFAULT_HYBRID_VSOCK_NAME, JAILER_ROOT};
 
-pub fn remove_dir_all_if_exists(path: &str) -> Result<()> {
+pub fn remove_dir_all_if_exists(path: impl AsRef<Path>) -> Result<()> {
     match std::fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -253,6 +253,16 @@ fn first_valid_executable_path(paths: &[&str]) -> Result<String> {
         }
     }
     Err(anyhow!("No valid executable found in paths: {:?}", paths))
+}
+
+const VMM_USER_RUNTIME_BASE_DIR: &str = "/run/user";
+
+pub fn vmm_user_runtime_dir(uid: u32) -> PathBuf {
+    Path::new(VMM_USER_RUNTIME_BASE_DIR).join(uid.to_string())
+}
+
+pub fn remove_vmm_user_runtime_dir(uid: u32) -> Result<()> {
+    remove_dir_all_if_exists(vmm_user_runtime_dir(uid))
 }
 
 pub fn create_vmm_user() -> Result<String> {
@@ -527,6 +537,8 @@ mod tests {
     use crate::utils::first_valid_executable_path;
 
     use super::create_fds;
+    use super::remove_dir_all_if_exists;
+    use super::vmm_user_runtime_dir;
     use super::SocketAddress;
 
     #[test]
@@ -536,6 +548,23 @@ mod tests {
         let fds = create_fds(device, num_fds);
         assert!(fds.is_ok());
         assert_eq!(fds.unwrap().len(), num_fds);
+    }
+
+    #[test]
+    fn test_vmm_user_runtime_dir() {
+        assert_eq!(vmm_user_runtime_dir(1000), PathBuf::from("/run/user/1000"));
+    }
+
+    #[test]
+    fn test_remove_dir_all_if_exists_is_idempotent() {
+        let parent = TempDir::new().unwrap();
+        let runtime_dir = parent.path().join("runtime");
+        fs::create_dir_all(&runtime_dir).unwrap();
+
+        remove_dir_all_if_exists(&runtime_dir).unwrap();
+        assert!(!runtime_dir.exists());
+
+        remove_dir_all_if_exists(&runtime_dir).unwrap();
     }
 
     #[test]

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -17,7 +17,9 @@ use common::{
 
 use containerd_shim_protos::events::task::{TaskCreate, TaskDelete, TaskStart};
 use hypervisor::{
-    utils::{create_dir_all_with_inherit_owner, create_vmm_user, remove_vmm_user},
+    utils::{
+        create_dir_all_with_inherit_owner, create_vmm_user, remove_vmm_user, vmm_user_runtime_dir,
+    },
     Param,
 };
 use kata_sys_util::{mount::get_mount_path, spec::load_oci_spec};
@@ -48,7 +50,6 @@ use std::{
     ops::Deref,
     os::unix::fs::{chown, MetadataExt},
     path::{Path, PathBuf},
-    str::FromStr,
     sync::Arc,
     time::SystemTime,
 };
@@ -969,7 +970,7 @@ fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<()> {
     let uid = user.uid.as_raw();
     let gid = user.gid.as_raw();
 
-    let user_tmp_dir = PathBuf::from_str(&format!("/run/user/{uid}"))?;
+    let user_tmp_dir = vmm_user_runtime_dir(uid);
 
     match std::fs::create_dir_all(&user_tmp_dir) {
         Ok(_) => match chown(&user_tmp_dir, Some(uid), Some(gid)) {

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -18,7 +18,8 @@ use common::{
 use containerd_shim_protos::events::task::{TaskCreate, TaskDelete, TaskStart};
 use hypervisor::{
     utils::{
-        create_dir_all_with_inherit_owner, create_vmm_user, remove_vmm_user, vmm_user_runtime_dir,
+        create_dir_all_with_inherit_owner, create_vmm_user, remove_dir_all_if_exists,
+        remove_vmm_user, vmm_user_runtime_dir,
     },
     Param,
 };
@@ -190,9 +191,16 @@ impl RuntimeHandlerManagerInner {
             .ok_or_else(|| anyhow!("hypervisor {} not found in config", hypervisor_name))?;
 
         set_rootless(hypervisor.security_info.rootless);
-        if is_rootless() {
-            configure_non_root_hypervisor(hypervisor).context("configure non-root hypervisor")?;
+        let mut rootless_setup_guard = if is_rootless() {
+            Some(
+                configure_non_root_hypervisor(hypervisor)
+                    .context("configure non-root hypervisor")?,
+            )
+        } else {
+            None
+        };
 
+        if is_rootless() {
             // When kata-runtime is invoked as rootless by podman with net=none,
             // the initially created netns (bind-mounted under /var/run/netns) requires root privileges.
             // This makes it inaccessible to non-root users. We need to create a non-root accessible
@@ -247,6 +255,12 @@ impl RuntimeHandlerManagerInner {
         self.init_runtime_handler(sandbox_config, Arc::new(config), initial_size_manager)
             .await
             .context("init runtime handler")?;
+
+        // Rootless resource ownership now passes to the runtime instance and
+        // its normal teardown paths.
+        if let Some(guard) = rootless_setup_guard.as_mut() {
+            guard.disarm();
+        }
 
         // the sandbox creation can reach here only once and the sandbox is created
         // so we can safely create the shim management socket right now
@@ -962,8 +976,58 @@ fn get_shm_size(spec: &oci::Spec) -> Result<u64> {
     Ok(shm_size)
 }
 
-fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<()> {
+struct RootlessSetupGuard {
+    user_name: Option<String>,
+    user_tmp_dir: Option<PathBuf>,
+    armed: bool,
+}
+
+impl RootlessSetupGuard {
+    fn new(user_name: String) -> Self {
+        Self {
+            user_name: Some(user_name),
+            user_tmp_dir: None,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RootlessSetupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        if let Some(path) = self.user_tmp_dir.as_ref() {
+            if let Err(err) = remove_dir_all_if_exists(path) {
+                warn!(
+                    sl!(),
+                    "failed to remove rootless runtime directory {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+
+        if let Some(user_name) = self.user_name.as_ref() {
+            if let Err(err) = remove_vmm_user(user_name) {
+                warn!(
+                    sl!(),
+                    "failed to remove rootless user {}: {}", user_name, err
+                );
+            }
+        }
+    }
+}
+
+fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<RootlessSetupGuard> {
     let user_name = create_vmm_user().context("failed to create vmm user")?;
+    let mut guard = RootlessSetupGuard::new(user_name.clone());
+
     let user = User::from_name(&user_name)?
         .ok_or_else(|| anyhow!("failed to get user by name {}, user not found", user_name))?;
 
@@ -971,34 +1035,19 @@ fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<()> {
     let gid = user.gid.as_raw();
 
     let user_tmp_dir = vmm_user_runtime_dir(uid);
+    guard.user_tmp_dir = Some(user_tmp_dir.clone());
 
-    match std::fs::create_dir_all(&user_tmp_dir) {
-        Ok(_) => match chown(&user_tmp_dir, Some(uid), Some(gid)) {
-            Ok(_) => info!(
-                sl!(),
-                "chown user tmp dir {} to uid {}, gid {}",
-                user_tmp_dir.display(),
-                uid,
-                gid
-            ),
-            Err(e) => {
-                remove_vmm_user(&user_name)?;
-                return Err(anyhow!(
-                    "failed to chown user tmp dir {}: {}",
-                    user_tmp_dir.display(),
-                    e
-                ));
-            }
-        },
-        Err(e) => {
-            remove_vmm_user(&user_name)?;
-            return Err(anyhow!(
-                "failed to create user tmp dir {}: {}",
-                user_tmp_dir.display(),
-                e
-            ));
-        }
-    }
+    std::fs::create_dir_all(&user_tmp_dir)
+        .with_context(|| format!("create user tmp dir {}", user_tmp_dir.display()))?;
+    chown(&user_tmp_dir, Some(uid), Some(gid))
+        .with_context(|| format!("chown user tmp dir {}", user_tmp_dir.display()))?;
+    info!(
+        sl!(),
+        "chown user tmp dir {} to uid {}, gid {}",
+        user_tmp_dir.display(),
+        uid,
+        gid
+    );
 
     env::set_var("XDG_RUNTIME_DIR", user_tmp_dir);
 
@@ -1016,7 +1065,7 @@ fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<()> {
         user_name,
     });
 
-    Ok(())
+    Ok(guard)
 }
 
 #[cfg(test)]
@@ -1025,6 +1074,30 @@ mod tests {
     use common::types::ShutdownRequest;
     use rstest::rstest;
     use tokio::sync::mpsc::channel;
+
+    #[rstest]
+    #[case::armed_guard_removes_runtime_dir(false, false)]
+    #[case::disarmed_guard_keeps_runtime_dir(true, true)]
+    fn test_rootless_setup_guard_runtime_dir(
+        #[case] disarm_guard: bool,
+        #[case] runtime_dir_survives: bool,
+    ) {
+        let parent = tempfile::tempdir().unwrap();
+        let runtime_dir = parent.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+
+        let mut guard = RootlessSetupGuard {
+            user_name: None,
+            user_tmp_dir: Some(runtime_dir.clone()),
+            armed: true,
+        };
+        if disarm_guard {
+            guard.disarm();
+        }
+        drop(guard);
+
+        assert_eq!(runtime_dir.exists(), runtime_dir_survives);
+    }
 
     // A ShutdownContainer RPC that arrives before any runtime instance was
     // created (e.g. after a failed CreateContainer) must still drive the shim

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -47,7 +47,9 @@ use hypervisor::{is_vfio_ap_device, BlockConfigModern, Hypervisor, VfioDeviceBas
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
-    utils::{get_hvsock_path, uses_native_ccw_bus},
+    utils::{
+        get_hvsock_path, remove_vmm_user_runtime_dir, uses_native_ccw_bus, vmm_user_runtime_dir,
+    },
     HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID,
 };
 use hypervisor::{BlockDeviceAio, PortDeviceConfig};
@@ -1372,6 +1374,14 @@ impl Sandbox for VirtSandbox {
             inner.cleaned = true;
         }
 
+        let rootless_uid = self
+            .hypervisor
+            .hypervisor_config()
+            .await
+            .security_info
+            .rootless_user
+            .map(|user| user.uid);
+
         info!(sl!(), "delete hypervisor");
         self.hypervisor
             .cleanup()
@@ -1383,6 +1393,18 @@ impl Sandbox for VirtSandbox {
             .cleanup()
             .await
             .context("resource clean up")?;
+
+        if let Some(uid) = rootless_uid {
+            let path = vmm_user_runtime_dir(uid);
+            if let Err(err) = remove_vmm_user_runtime_dir(uid) {
+                warn!(
+                    sl!(),
+                    "failed to remove rootless runtime directory {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
 
         // TODO: cleanup other sandbox resource
         Ok(())

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -47,7 +47,6 @@ qemu_rootless_sandbox_supported() {
 
 	# Additional QEMU configurations are tracked in:
 	# https://github.com/kata-containers/kata-containers/issues/13424
-	is_runtime_rs && return 1
 	is_shared_fs_none_runtime_class "${KATA_HYPERVISOR}" && return 1
 	# Rootless QEMU cannot access EROFS layers below root-owned
 	# snapshot directories.
@@ -58,6 +57,7 @@ qemu_rootless_sandbox_supported() {
 
 setup() {
 	local runtime_config_dropin_file
+	local seccomp_key
 
 	if ! qemu_rootless_sandbox_supported; then
 		skip "QEMU rootless and seccomp sandbox smoke testing does not cover ${KATA_HYPERVISOR}"
@@ -75,11 +75,17 @@ setup() {
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 	auto_generate_policy "${policy_settings_dir}" "${pod_config}"
 
+	if is_runtime_rs; then
+		seccomp_key="seccomp_sandbox"
+	else
+		seccomp_key="seccompsandbox"
+	fi
+
 	runtime_config_dropin_file="${BATS_FILE_TMPDIR}/99-k8s-qemu-sandbox.toml"
 	cat > "${runtime_config_dropin_file}" <<EOF
 [hypervisor.qemu]
 rootless = true
-seccompsandbox = "${QEMU_SANDBOX_PARAM}"
+${seccomp_key} = "${QEMU_SANDBOX_PARAM}"
 EOF
 
 	runtime_config_dropin="$(set_kata_runtime_config_dropin_file \


### PR DESCRIPTION
This fixes the runtime-rs gaps encountered when enabling the QEMU rootless and seccomp-sandbox BATS test for configurations with filesystem sharing. It also brings rootless cleanup, partial-setup rollback, credential handling, and seccomp diagnostics closer to runtime-go parity.

**Problems addressed:**

#### Problem 1 (runtime-rs): read-only access the block backend

Runtime-rs previously translated a configured read-only block backend into:

```text
-blockdev ...,auto-read-only=on
```

Unlike `read-only=on`, `auto-read-only=on` does not require QEMU to open the backend read-only from the start. QEMU therefore attempted to open the guest image read-write. This is hidden when QEMU runs as root.

With `rootless=true`, QEMU runs as a temporary unprivileged user and cannot open a root-owned, mode-0644 image read-write, such as:

```text
-rw-r--r-- root root /opt/kata/share/kata-containers/*.image
```

The attempted read-write open consequently failed with `Permission denied`, preventing QEMU startup.

Runtime-rs now emits:

```text
-blockdev ...,read-only=on
```

This makes QEMU open the image read-only from the beginning and matches runtime-go's `-drive ...,readonly=on` semantics.

#### Problem 2 (runtime-rs): rootless lifecycle and credential handling.

Exercising invocations for the failure and success paths, various lifecycle problems surfaced which this PR aims to address:

- remove the temporary VMM user's runtime directory after normal teardown;
- roll back the temporary user and runtime directory when rootless setup fails before ownership reaches the runtime instance;
- apply supplementary groups, GID, and UID in fail-closed order,   including clearing inherited supplementary groups when the configured list is empty.

Note, for seccomp sandboxing, this PR also:

- adds unit coverage proving the configured value is passed exactly once through QEMU's `-sandbox` argument;
- matches runtime-go's non-fatal BPF-JIT diagnostics by warning when the setting is unreadable, invalid, or disabled.

Support for `shared_fs=none` is added by the follow-up #13429. Remaining rootless and seccomp-sandbox work is tracked in #13424.
