### PR TITLE
runtime(-rs)/QEMU: enable rootless and seccomp sandbox with shared_fs=none

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -110,6 +110,12 @@ impl QemuInner {
         info!(sl!(), "Starting QEMU VM");
         let netns = self.netns.clone().unwrap_or_default();
 
+        // Create the runtime directory (side-effect of get_jailer_root) before
+        // QemuCmdLine::new() binds qmp.sock inside it. With shared_fs=none,
+        // prepare_before_start_vm() never calls get_jailer_root(), so it must
+        // be done here explicitly. In rootless mode the path is under XDG_RUNTIME_DIR.
+        let jailer_root = self.get_jailer_root().await?;
+
         check_bpf_enabled(self.config.security_info.seccomp_sandbox.as_deref());
 
         // CAUTION: since 'cmdline' contains file descriptors that have to stay
@@ -366,7 +372,7 @@ impl QemuInner {
         //cmdline.add_serial_console("/dev/pts/23");
 
         // Add a console to the devices of the cmdline
-        let console_socket_path = Path::new(&self.get_jailer_root().await?).join("console.sock");
+        let console_socket_path = Path::new(&jailer_root).join("console.sock");
         cmdline.add_console(console_socket_path.to_str().unwrap());
 
         info!(sl!(), "qemu args: {}", cmdline.build().await?.join(" "));

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -46,7 +46,7 @@ const INLINE_VIRTIO_FS: &str = "inline-virtio-fs";
 const DEFAULT_KATA_HOST_SHARED_DIR: &str = "/run/kata-containers/shared/sandboxes/";
 
 /// default share fs (for example virtio-fs) mount path in the guest
-const DEFAULT_KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
+pub(crate) const DEFAULT_KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
 
 /// The virtiofs mount point in the guest for nydusd mode.
 /// In nydusd mode, virtiofs is mounted at `/run/kata-containers/shared/`

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -33,8 +33,7 @@ use tokio::{
 use walkdir::WalkDir;
 
 use super::Volume;
-use crate::share_fs::kata_guest_share_dir;
-use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig};
+use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig, DEFAULT_KATA_GUEST_SHARE_DIR};
 use kata_types::{
     k8s::{is_configmap, is_downward_api, is_projected, is_secret},
     mount,
@@ -334,8 +333,8 @@ impl VolumeManager {
         }
 
         // Create a new volume state
-        let guest_path =
-            generate_guest_path(container_id, mount_destination).context("generate path failed")?;
+        let guest_path = generate_copy_file_guest_path(container_id, mount_destination)
+            .context("generate path failed")?;
 
         let mut containers = HashSet::new();
         containers.insert(container_id.to_string());
@@ -459,7 +458,7 @@ impl ShareFsVolume {
                 // If the mount source is a file, we can copy it to the sandbox
                 if src.is_file() {
                     // Generate guest path
-                    let guest_path = generate_guest_path(cid, m.destination())
+                    let guest_path = generate_copy_file_guest_path(cid, m.destination())
                         .context("generate path failed")?;
                     // Copy a single file
                     Self::copy_file_to_guest(&src, &guest_path, &agent)
@@ -966,8 +965,12 @@ pub(crate) fn is_watchable_volume(source_path: &PathBuf) -> bool {
         || is_configmap(source_path)
 }
 
-/// Generates a guest path related to mount dest
-fn generate_guest_path(cid: &str, mount_destination: &Path) -> Result<String> {
+/// Generates a destination for an agent CopyFile request.
+///
+/// CopyFile writes into the guest filesystem and confines destinations to the
+/// fixed guest shared directory. Unlike filesystem-sharing paths, this guest
+/// path must not be adjusted when rootless mode is enabled.
+fn generate_copy_file_guest_path(cid: &str, mount_destination: &Path) -> Result<String> {
     let mut data = vec![0u8; 8];
     let mut rng = rng(); // Get a thread-local RNG
     rng.fill_bytes(&mut data);
@@ -980,10 +983,7 @@ fn generate_guest_path(cid: &str, mount_destination: &Path) -> Result<String> {
 
     Ok(format!(
         "{}{}-{}-{}",
-        kata_guest_share_dir(),
-        cid,
-        hex_str,
-        dest_base
+        DEFAULT_KATA_GUEST_SHARE_DIR, cid, hex_str, dest_base
     ))
 }
 
@@ -1034,5 +1034,14 @@ mod test {
         assert!(is_watchable_volume(&secret_path));
         assert!(is_watchable_volume(&projected_path));
         assert!(is_watchable_volume(&downward_api_path));
+    }
+
+    #[test]
+    fn test_generate_copy_file_guest_path() {
+        let path =
+            generate_copy_file_guest_path("sandbox-id", Path::new("/etc/resolv.conf")).unwrap();
+
+        assert!(path.starts_with(&format!("{DEFAULT_KATA_GUEST_SHARE_DIR}sandbox-id-")));
+        assert!(path.ends_with("-resolv.conf"));
     }
 }

--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -325,11 +325,16 @@ func (f *FilesystemShare) ShareFile(ctx context.Context, c *Container, m *Mount)
 	mustCopyEmptyDir := !caps.IsFsSharingSupported() && IsDiskEmptyDir(m.Source)
 
 	filename := shareFileName(c.id, m.Source, m.Destination, randHex, mustCopyEmptyDir)
-	guestPath := filepath.Join(kataGuestSharedDir(), filename)
+	var guestPath string
 
 	// copy file to container's rootfs if filesystem sharing is not supported, otherwise
 	// bind mount it in the shared directory.
 	if !caps.IsFsSharingSupported() {
+		// CopyFile writes into the guest filesystem and the agent confines its
+		// destinations to this fixed directory. Unlike filesystem-sharing paths,
+		// this guest path must not be adjusted when rootless mode is enabled.
+		guestPath = filepath.Join(defaultKataGuestSharedDir, filename)
+
 		if mustCopyEmptyDir {
 			f.srcGuestMapLock.Lock()
 			defer f.srcGuestMapLock.Unlock()
@@ -422,6 +427,11 @@ func (f *FilesystemShare) ShareFile(ctx context.Context, c *Container, m *Mount)
 			f.srcGuestMap[m.Source] = guestPath
 		}
 	} else {
+		// Filesystem sharing must use this mount path. It is the standard guest
+		// shared directory normally and the required rootless-adjusted path when
+		// rootless mode is enabled.
+		guestPath = filepath.Join(kataGuestSharedDir(), filename)
+
 		// These mounts are created in the shared dir
 		mountDest := filepath.Join(getMountPath(f.sandbox.ID()), filename)
 		if !m.ReadOnly {

--- a/src/runtime/virtcontainers/fs_share_linux_test.go
+++ b/src/runtime/virtcontainers/fs_share_linux_test.go
@@ -11,13 +11,24 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"syscall"
 	"testing"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type noFSSharingHypervisor struct {
+	mockHypervisor
+}
+
+func (*noFSSharingHypervisor) Capabilities(context.Context) types.Capabilities {
+	return types.Capabilities{}
+}
 
 func TestSandboxSharedFilesystem(t *testing.T) {
 	if os.Getuid() != 0 {
@@ -214,4 +225,40 @@ func TestShareFileName(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, shareFileName(tc.containerID, tc.source, tc.destination, tc.randHex, tc.sandboxScoped))
 		})
 	}
+}
+
+func TestShareFileCopyGuestPath(t *testing.T) {
+	originalKataGuestSharedDir := kataGuestSharedDir
+	kataGuestSharedDir = func() string {
+		return "/run/user/1002" + defaultKataGuestSharedDir
+	}
+	t.Cleanup(func() {
+		kataGuestSharedDir = originalKataGuestSharedDir
+	})
+
+	sandbox := &Sandbox{
+		ctx:        context.Background(),
+		id:         "sandbox-id",
+		agent:      newMockAgent(),
+		hypervisor: &noFSSharingHypervisor{},
+	}
+	fsShare, err := NewFilesystemShare(sandbox)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		fsShare.watcher.Close()
+	})
+
+	source := filepath.Join(t.TempDir(), "resolv.conf")
+	require.NoError(t, os.WriteFile(source, []byte("nameserver 192.0.2.1\n"), 0o644))
+
+	sharedFile, err := fsShare.ShareFile(context.Background(), &Container{id: "container-id"}, &Mount{
+		Source:      source,
+		Destination: "/etc/resolv.conf",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sharedFile)
+
+	expected := "^" + regexp.QuoteMeta(defaultKataGuestSharedDir) +
+		`container-id-[0-9a-f]{16}-resolv\.conf$`
+	assert.Regexp(t, expected, sharedFile.guestPath)
 }

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -47,11 +47,23 @@ qemu_rootless_sandbox_supported() {
 
 	# Additional QEMU configurations are tracked in:
 	# https://github.com/kata-containers/kata-containers/issues/13424
-	is_shared_fs_none_runtime_class "${KATA_HYPERVISOR}" && return 1
 	# Rootless QEMU cannot access EROFS layers below root-owned
 	# snapshot directories.
 	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && return 1
-	is_confidential_runtime_class "${KATA_HYPERVISOR}" && return 1
+
+	# CoCo-dev does not enable a TEE or require TEE host resources. Keep
+	# actual confidential handlers excluded until rootless QEMU can access
+	# resources such as /dev/sev and the configured TDX QGS endpoint.
+	if is_confidential_runtime_class "${KATA_HYPERVISOR}" &&
+		[[ "${KATA_HYPERVISOR}" != qemu-coco-dev* ]]; then
+		return 1
+	fi
+	# Generated CoCo policies add an init-data disk below a root-owned host
+	# path. Neither runtime passes that disk to rootless QEMU yet.
+	if [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] &&
+		[[ "${AUTO_GENERATE_POLICY:-}" == "yes" ]]; then
+		return 1
+	fi
 	return 0
 }
 


### PR DESCRIPTION
The scope of this PR is to support rootless QEMU with `shared_fs=none` and extend the combined rootless and seccomp-sandbox BATS test to eligible configurations without filesystem sharing. This includes the `kata-qemu-coco-dev` and `kata-qemu-coco-dev-runtime-rs` handlers, which use nydus guest pull but do not enable a TEE and work under this setting.

EROFS snapshotter support, actual confidential RuntimeClasses, and device-passthrough scenarios such as VFIO/IOMMUFD are intentionally outside the scope of this PR. They require additional rootless host-resource access and will be addressed through subsequent work tracked in #13424.

For the current scope to work, we address two problems:

#### Problem 1 (runtime-rs): create the runtime directory before QMP

In rootless mode, runtime-rs places the QMP socket below the per-sandbox jailer root in the temporary VMM user’s runtime directory. `QemuCmdLine::new()` binds the QMP listener before QEMU starts, while the current code creates the jailer root only later when constructing the console socket path. With `shared_fs=none`, the QMP bind can therefore run before its parent directory exists, preventing VM startup.
With this PR, we create the jailer root before constructing the QEMU command line and reuse that path for the console socket. This allows the shim to bind the QMP listener and pass its file descriptor to rootless QEMU.

This does not normally surface with virtio-fs enabled, because its pre-start setup already calls `get_jailer_root()` while preparing virtiofsd, creating the directory before QEMU command-line construction.

#### Problem 2 (runtime-go and runtime-rs): use valid CopyFile guest paths

Without filesystem sharing, files such as `/etc/resolv.conf` are transferred through the agent's CopyFile ttRPC requests. CopyFile destinations must remain below the fixed guest directory `/run/kata-containers/shared/containers` as these are *guest-only* paths.

Both runtime-go and runtime-rs reused shared-directory helpers that include the host VMM user's `XDG_RUNTIME_DIR` when rootless mode is enabled. This adjustment is required for actual filesystem-sharing paths, but it produces an invalid CopyFile destination inside the guest.

With this PR, we construct the fixed guest path specifically for CopyFile while preserving the existing conditional rootless adjustment for actual filesystem-sharing paths. And, we add regression coverage for both runtime-go and runtime-rs. See some more context on this in #13518.