### PR TITLE
runtime-rs: enable NVSwitch (PCI class 0x0680) passthrough for HGX/DGX CC guests

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -387,6 +387,17 @@ fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
         Some(cid_u32) => {
             // PCI class code is 24 bits, shift right 8 to get base+sub class
             let class_code = u64::from(cid_u32) >> 8;
+            // NVSwitches (PCI class 0x0680, "Bridge: Other") are passthrough-capable
+            // and required for NVLink in HGX/DGX confidential guests. They must
+            // NOT be filtered out: the 0x0600 bridge bitmask is a *subset* match
+            // (class_code & 0x0600 == 0x0600) that catches the whole 0x06 bridge
+            // base class — including 0x0680 — not just Host Bridges (0x0600) as
+            // the IOMMU_IGNORE comment implies. Without this exception, each
+            // NVSwitch (which sits in a singleton IOMMU group) is stripped, leaving
+            // an empty group -> "IOMMU group N has no passthrough-capable devices".
+            if class_code == 0x0680 {
+                return None;
+            }
             for &bitmask in bitmasks {
                 if class_code & bitmask == bitmask {
                     return Some(class_code);

--- a/src/runtime-rs/crates/resource/src/cdi_devices/mod.rs
+++ b/src/runtime-rs/crates/resource/src/cdi_devices/mod.rs
@@ -33,6 +33,12 @@ lazy_static! {
     pub static ref CDI_DEVICE_KIND_TABLE: HashMap<&'static str, &'static str> = {
         let mut m = HashMap::new();
         m.insert("0x10de-0x030", "nvidia.com/gpu");
+        // NVIDIA NVSwitch (PCI class 0x068000 -> "Bridge: Other"). Required for
+        // NVLink in HGX/DGX confidential guests. The kata-sandbox-device-plugin
+        // advertises it as nvidia.com/nvswitch; without this entry
+        // resolve_cdi_device_kind returns None and annotate_container_devices
+        // silently drops the NVSwitch (no CDI annotation -> not injected into guest).
+        m.insert("0x10de-0x068", "nvidia.com/nvswitch");
         m.insert("0x8086-0x030", "intel.com/gpu");
         m.insert("0x1002-0x030", "amd.com/gpu");
         m.insert("0x15b3-0x020", "nvidia.com/nic");


### PR DESCRIPTION
# runtime-rs: enable NVSwitch (PCI class 0x0680) passthrough for HGX/DGX CC guests

## Summary

NVIDIA NVSwitches (PCI class `0x0680`, "Bridge: Other") are required for NVLink in HGX/DGX confidential-computing guests, but the **runtime-rs** shim never passed them through to the guest. This PR fixes the two bugs that blocked it.

This is the runtime-rs counterpart of the bridge-ignore problem already reported for the Go shim in #11912 (`runtime/pkg/device/drivers/utils.go#checkIgnorePCIClass`). A dedicated issue for the runtime-rs path is tracked in #13430.

## Problem — two bugs

### Bug 1: `filter_bridge_device()` strips NVSwitches from their IOMMU group

`crates/hypervisor/src/device/driver/vfio_device/core.rs` defines:

```rust
const IOMMU_IGNORE: &[u64] = &[0x0600, 0x403];
```

The comment implies `0x0600` targets Host Bridges, but the check is a **subset** match:

```rust
if class_code & bitmask == bitmask { return Some(class_code); }
```

`class_code & 0x0600 == 0x0600` is true for the **whole `0x06` bridge base class**, including `0x0680` (NVSwitch, "Bridge: Other"). Each NVSwitch sits in a **singleton IOMMU group**, so stripping it leaves an empty group and sandbox creation fails:

```
Failed to create sandbox for pod ... IOMMU group 62 has no passthrough-capable devices
```

### Bug 2: `CDI_DEVICE_KIND_TABLE` has no NVSwitch entry

`crates/resource/src/cdi_devices/mod.rs` maps PCI vendor-class to a CDI kind. There is no entry for `0x10de-0x068` (NVIDIA NVSwitch), so `resolve_cdi_device_kind()` returns `None` and `annotate_container_devices` **silently drops** the NVSwitch — no CDI annotation, so the device is never injected into the guest even when its IOMMU group is intact.

## Fix

1. Add an explicit `0x0680` exception in `filter_bridge_device()` (return `None` = do not filter), so NVSwitches stay in their IOMMU group.
2. Add `m.insert("0x10de-0x068", "nvidia.com/nvswitch")` to `CDI_DEVICE_KIND_TABLE`, so NVSwitches are annotated and injected.

## Validation

On an **HGX Hopper** node (8x H200 + 4x NVSwitch `10de:22a3`) with **Intel TDX**, gpu-operator with `BIND_NVSWITCHES=true` and the `nvidia-kata-sandbox-device-plugin` advertising `nvidia.com/nvswitch: 4`:

| | Before | After |
|---|---|---|
| Sandbox creation | ❌ `IOMMU group 62 has no passthrough-capable devices` | ✅ creates |
| QEMU vfio-pci devices | 8 GPUs only | ✅ 4 NVSwitches (`0000:83/84/85/86:00.0`) + 8 GPUs |
| Guest kernel | no nvswitch | ✅ `nvidia-nvswitch0..3: open (major=240)` |

The patched `containerd-shim-kata-v2` (static musl amd64) was cross-compiled and deployed to the node; the test pod requested `nvidia.com/pgpu: 8` + `nvidia.com/nvswitch: 4` with `runtimeClassName: kata-qemu-nvidia-gpu-tdx-runtime-rs`.

## Out of scope (tracked separately)

A separate, **deeper guest-side** issue remains: `NVRC panic: timeout waiting for: FM starting NvLink Inband` — the NvLink in-band fabric-manager channel doesn't come up in the passthrough guest even though the NVSwitches are present. That is beyond this Kata passthrough fix (likely needs the HGX fabric-manager in the guest rootfs, or a QEMU VFIO NVSwitch BAR/ATU quirk) and is tracked separately.

## Host prerequisites (not part of this PR)

For completeness, NVSwitch passthrough also requires the host to bind the NVSwitches to `vfio-pci`. With the NVIDIA gpu-operator this needs `vfioManager.env.BIND_NVSWITCHES=true` (opt-in flag from `k8s-driver-manager` PR #150, default `false`), and the `nvidia-kata-sandbox-device-plugin` must (re)start **after** the NVSwitches are bound so it advertises `nvidia.com/nvswitch`.

---
- [x] DCO sign-off included in commit
- [x] Validated on real HGX Hopper + TDX hardware
