### PR TITLE
runtime(-rs): enable NVSwitch (PCI class 0x0680) passthrough for HGX/DGX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,6 +3014,7 @@ dependencies = [
  "qapi-spec",
  "rand 0.10.1",
  "regex",
+ "rstest",
  "rust-ini",
  "safe-path",
  "seccompiler",

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -90,6 +90,7 @@ dragonball = ["dep:dragonball"]
 cloud-hypervisor = ["ch-config"]
 
 [dev-dependencies]
+rstest = { workspace = true }
 serial_test = "2.0.0"
 tempfile = { workspace = true }
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -8,6 +8,14 @@ mod port_device;
 mod protection_device;
 mod vfio;
 pub mod vfio_device;
+
+/// Host Bridge (0x0600), PCI-to-PCI Bridge (0x0604) and Audio (0x0403) classes
+/// cannot be passed through when sharing an IOMMU group. Matched exactly rather
+/// than by base class so passthrough-capable bridges like NVSwitches (0x0680)
+/// are not filtered out.
+pub(crate) fn is_iommu_ignored_pci_class(class_code: u64) -> bool {
+    matches!(class_code, 0x0600 | 0x0604 | 0x0403)
+}
 mod vhost_user;
 pub mod vhost_user_blk;
 mod vhost_user_net;

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -17,6 +17,7 @@ use path_clean::PathClean;
 
 use kata_sys_util::fs::get_base_name;
 
+use super::is_iommu_ignored_pci_class;
 use crate::{
     device::{
         pci_path::PciPath,
@@ -35,10 +36,6 @@ pub const DRIVER_MMIO_BLK_TYPE: &str = "mmioblk";
 pub const DRIVER_VFIO_PCI_TYPE: &str = "vfio-pci";
 pub const DRIVER_VFIO_AP_TYPE: &str = "vfio-ap";
 pub const MAX_DEV_ID_SIZE: usize = 31;
-
-/// PCI class bitmasks for devices that must be ignored when enumerating an IOMMU group.
-/// Host Bridge: 0x0600, Audio device: 0x0403.
-const IOMMU_IGNORE: &[u64] = &[0x0600, 0x403];
 
 const VFIO_PCI_DRIVER_NEW_ID: &str = "/sys/bus/pci/drivers/vfio-pci/new_id";
 const VFIO_PCI_DRIVER_UNBIND: &str = "/sys/bus/pci/drivers/vfio-pci/unbind";
@@ -443,7 +440,7 @@ impl VfioDevice {
 
     // filter Host or PCI Bridges and audio devices that are in the same IOMMU
     // group as the passed-through devices.
-    fn filter_bridge_device(&self, bdf: &str, bitmasks: &[u64]) -> Option<u64> {
+    fn filter_bridge_device(&self, bdf: &str) -> Option<u64> {
         let device_class = match get_device_property(bdf, "class") {
             Ok(dev_class) => dev_class,
             Err(_) => "".to_string(),
@@ -453,19 +450,8 @@ impl VfioDevice {
             return None;
         }
 
-        match device_class.parse::<u32>() {
-            Ok(cid_u32) => {
-                // class code is 16 bits, remove the two trailing zeros
-                let class_code = u64::from(cid_u32) >> 8;
-                for &bitmask in bitmasks {
-                    if class_code & bitmask == bitmask {
-                        return Some(class_code);
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
+        let class_code = parse_pci_class_code(&device_class)?;
+        is_iommu_ignored_pci_class(class_code).then_some(class_code)
     }
 
     fn initialize_vfio_device(&mut self) -> Result<()> {
@@ -496,7 +482,7 @@ impl VfioDevice {
         // pass all devices in iommu group, and use index to identify device.
         for (index, device) in iommu_devices.iter().enumerate() {
             // filter host/PCI bridge, audio, etc.
-            if self.filter_bridge_device(device, IOMMU_IGNORE).is_some() {
+            if self.filter_bridge_device(device).is_some() {
                 continue;
             }
 
@@ -818,6 +804,13 @@ fn get_mediated_device_bdf(dev_sys_str: String) -> Option<String> {
 
 // dev_sys_path: /sys/bus/pci/devices/DDDD:BB:DD.F
 // cfg_path: : /sys/bus/pci/devices/DDDD:BB:DD.F/xxx
+fn parse_pci_class_code(device_class: &str) -> Option<u64> {
+    let trimmed = device_class.trim().strip_prefix("0x").unwrap_or(device_class.trim());
+    u32::from_str_radix(trimmed, 16)
+        .ok()
+        .map(|cid_u32| u64::from(cid_u32) >> 8)
+}
+
 fn get_device_property(device_name: &str, property: &str) -> Result<String> {
     let dev_sys_path = Path::new(SYS_BUS_PCI_DEVICES).join(device_name);
     let cfg_path = fs::read_to_string(dev_sys_path.join(property)).with_context(|| {
@@ -890,4 +883,32 @@ pub fn get_vfio_device(device: String) -> Result<String> {
     }
 
     Ok(vfio_device)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_iommu_ignored_pci_class, parse_pci_class_code};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("0x030200", Some(0x0302))]
+    #[case("030200", Some(0x0302))]
+    #[case(" 0x068000\n", Some(0x0680))]
+    #[case("not-a-number", None)]
+    fn test_parse_pci_class_code(#[case] sysfs_class: &str, #[case] expected: Option<u64>) {
+        assert_eq!(parse_pci_class_code(sysfs_class), expected);
+    }
+
+    #[rstest]
+    #[case::host_bridge("0x060000", true)]
+    #[case::pci_bridge("0x060400", true)]
+    #[case::audio_device("0x040300", true)]
+    #[case::nvswitch("0x068000", false)]
+    #[case::gpu("0x030200", false)]
+    fn test_is_iommu_ignored_pci_class(#[case] sysfs_class: &str, #[case] ignored: bool) {
+        let is_ignored = parse_pci_class_code(sysfs_class)
+            .map(is_iommu_ignored_pci_class)
+            .unwrap_or(false);
+        assert_eq!(is_ignored, ignored);
+    }
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -12,6 +12,8 @@ use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 
+use crate::device::driver::is_iommu_ignored_pci_class;
+
 /// Path constants for VFIO and IOMMU sysfs/dev interfaces
 const DEV_VFIO: &str = "/dev/vfio";
 const SYS_IOMMU_GROUPS: &str = "/sys/kernel/iommu_groups";
@@ -346,7 +348,7 @@ fn validate_group_basic(devices: &[DeviceInfo]) -> bool {
             // filter host or PCI bridge
             let bdf_str = bdf.to_string();
             // Filter out devices that cannot be passed through (bridges, audio, etc.)
-            if filter_bridge_device(&bdf_str, IOMMU_IGNORE).is_some() {
+            if filter_bridge_device(&bdf_str).is_some() {
                 continue;
             }
         }
@@ -367,13 +369,9 @@ fn get_device_property(device_bdf: &str, property: &str) -> Result<String> {
     Ok(cfg_path.trim().to_string())
 }
 
-/// PCI class bitmasks for devices that must be ignored when enumerating an IOMMU group.
-/// Host Bridge: 0x0600, Audio device: 0x0403.
-const IOMMU_IGNORE: &[u64] = &[0x0600, 0x403];
-
 /// Filters for devices that cannot or should not be passed through within an IOMMU group
 /// (Host/PCI bridges, audio controllers that share the GPU's IOMMU group, etc.).
-fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
+fn filter_bridge_device(bdf: &str) -> Option<u64> {
     let device_class = get_device_property(bdf, "class").unwrap_or_default();
 
     if device_class.is_empty() {
@@ -387,12 +385,7 @@ fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
         Some(cid_u32) => {
             // PCI class code is 24 bits, shift right 8 to get base+sub class
             let class_code = u64::from(cid_u32) >> 8;
-            for &bitmask in bitmasks {
-                if class_code & bitmask == bitmask {
-                    return Some(class_code);
-                }
-            }
-            None
+            is_iommu_ignored_pci_class(class_code).then_some(class_code)
         }
         None => None,
     }
@@ -610,13 +603,13 @@ fn discover_vfio_device_for_iommu_group(gid: u32, group_devnode: PathBuf) -> Res
 
     // Drop functions that only share the GPU's IOMMU group but must not be
     // passed through (audio controllers, bridges), reusing the same
-    // IOMMU_IGNORE classification as validate_group_basic. Everything derived
+    // IOMMU ignored-class classification as validate_group_basic. Everything derived
     // below (vfio_cdevs, the IOMMUFD backend cdevs and the primary device) is
     // built from this filtered list. Passing such a function would otherwise
     // emit an extra vfio-pci entry reusing the GPU's cold-plug root-port and
     // IOMMUFD object ids, making QEMU abort with a duplicate-id error.
     devices.retain(|d| match &d.addr {
-        DeviceAddress::Pci(bdf) => filter_bridge_device(&bdf.to_string(), IOMMU_IGNORE).is_none(),
+        DeviceAddress::Pci(bdf) => filter_bridge_device(&bdf.to_string()).is_none(),
         _ => true,
     });
     if devices.is_empty() {
@@ -889,4 +882,27 @@ pub fn discover_vfio_ap_device(group_devnode: &Path) -> Result<VfioDevice> {
         health: Health::Healthy,
         ap_devices,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_iommu_ignored_pci_class, parse_class_code_u32};
+    use rstest::rstest;
+
+    fn is_ignored_sysfs_class(class: &str) -> bool {
+        parse_class_code_u32(class)
+            .map(|cid_u32| u64::from(cid_u32) >> 8)
+            .map(is_iommu_ignored_pci_class)
+            .unwrap_or(false)
+    }
+
+    #[rstest]
+    #[case::host_bridge("0x060000", true)]
+    #[case::pci_bridge("0x060400", true)]
+    #[case::audio_device("0x040300", true)]
+    #[case::nvswitch("0x068000", false)]
+    #[case::gpu("0x030200", false)]
+    fn test_is_iommu_ignored_pci_class(#[case] sysfs_class: &str, #[case] ignored: bool) {
+        assert_eq!(is_ignored_sysfs_class(sysfs_class), ignored);
+    }
 }

--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -239,6 +239,8 @@ fn get_sizing_info(annotation: Annotation) -> Result<(u64, i64, i64)> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::too_many_arguments)]
+
     use super::*;
     use kata_types::annotations::cri_containerd;
     use oci_spec::runtime::{LinuxBuilder, LinuxMemory, LinuxMemoryBuilder, LinuxResourcesBuilder};

--- a/src/runtime/pkg/device/drivers/utils.go
+++ b/src/runtime/pkg/device/drivers/utils.go
@@ -156,9 +156,22 @@ func GetAPVFIODevices(sysfsdev string) ([]string, error) {
 	return strings.Split(string(data[:len(data)-1]), "\n"), nil
 }
 
-// Ignore specific PCI devices, supply the pciClass and the bitmask to check
-// against the device class, deviceBDF for meaningfull info message
-func checkIgnorePCIClass(pciClass string, deviceBDF string, bitmask uint64) (bool, error) {
+// pciClassesIgnoredForPassthrough lists the PCI class codes (base+subclass, i.e.
+// the sysfs `class` value with the trailing programming-interface byte removed)
+// that cannot be passed through when they merely share an IOMMU group with a
+// passthrough-capable device: 0x0600 Host Bridge and 0x0604 PCI-to-PCI Bridge.
+// Matched exactly rather than against the PCI base class 0x06 (Bridge) so
+// passthrough-capable bridges like NVSwitches (0x0680, "Bridge: Other") are not
+// filtered out.
+var pciClassesIgnoredForPassthrough = map[uint64]struct{}{
+	0x0600: {},
+	0x0604: {},
+}
+
+// checkIgnorePCIClass reports whether the device with the given sysfs pciClass
+// must be ignored (not passed through) because it is a Host or PCI-to-PCI bridge
+// sharing the IOMMU group. deviceBDF is only used for the info message.
+func checkIgnorePCIClass(pciClass string, deviceBDF string) (bool, error) {
 	if pciClass == "" {
 		return false, nil
 	}
@@ -168,8 +181,8 @@ func checkIgnorePCIClass(pciClass string, deviceBDF string, bitmask uint64) (boo
 	}
 	// ClassID is 16 bits, remove the two trailing zeros
 	pciClassID = pciClassID >> 8
-	if pciClassID&bitmask == bitmask {
-		deviceLogger().Infof("Ignoring PCI (Host) Bridge deviceBDF %v Class %x", deviceBDF, pciClassID)
+	if _, ok := pciClassesIgnoredForPassthrough[pciClassID]; ok {
+		deviceLogger().Infof("Ignoring PCI Host/PCI Bridge deviceBDF %v Class %x", deviceBDF, pciClassID)
 		return true, nil
 	}
 	return false, nil
@@ -296,7 +309,7 @@ func GetAllVFIODevicesFromIOMMUGroup(device config.DeviceInfo) ([]*config.VFIODe
 			// We need to ignore Host or PCI Bridges that are in the same IOMMU group as the
 			// passed-through devices. One CANNOT pass-through a PCI bridge or Host bridge.
 			// Class 0x0604 is PCI bridge, 0x0600 is Host bridge
-			ignorePCIDevice, err := checkIgnorePCIClass(pciClass, deviceBDF, 0x0600)
+			ignorePCIDevice, err := checkIgnorePCIClass(pciClass, deviceBDF)
 			if err != nil {
 				return nil, err
 			}

--- a/src/runtime/pkg/device/drivers/utils_test.go
+++ b/src/runtime/pkg/device/drivers/utils_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIgnorePCIClass(t *testing.T) {
+	type testData struct {
+		pciClass string
+		ignored  bool
+	}
+
+	data := []testData{
+		{"0x060000", true},  // Host Bridge
+		{"0x060400", true},  // PCI-to-PCI Bridge
+		{"0x068000", false}, // NVSwitch ("Bridge: Other"), must be passed through
+		{"0x030200", false}, // 3D controller (GPU)
+		{"0x040300", false}, // Audio device
+		{"", false},
+	}
+
+	for _, d := range data {
+		ignored, err := checkIgnorePCIClass(d.pciClass, "0000:00:00.0")
+		assert.NoError(t, err, "pciClass %q", d.pciClass)
+		assert.Equal(t, d.ignored, ignored, "pciClass %q", d.pciClass)
+	}
+}


### PR DESCRIPTION
NVSwitches are stripped from IOMMU groups and never passed through to the
guest, breaking NVLink on HGX/DGX systems: `nvidia-smi topo -m` shows `PHB`
instead of `NV`, and multi-GPU confidential workloads requesting
`nvidia.com/nvswitch` fail during guest init.