### PR TITLE
runtime-rs: fix "container process not found" error handling

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -193,11 +193,34 @@ trait ResultToTtrpcResult<T, E: Debug>: Sized {
     }
 }
 
-impl<T, E: Debug> ResultToTtrpcResult<T, E> for Result<T, E> {
-    fn map_ttrpc_err<R: Debug>(self, msg_builder: impl FnOnce(E) -> R) -> ttrpc::Result<T> {
-        self.map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)))
+impl<T> ResultToTtrpcResult<T, anyhow::Error> for anyhow::Result<T> {
+    fn map_ttrpc_err<R: Debug>(self, msg_builder: impl FnOnce(anyhow::Error) -> R) -> ttrpc::Result<T> {
+        self.map_err(|e| match e.downcast::<ttrpc::error::Error>() {
+            Ok(ttrpc_err) => ttrpc_err,
+            Err(e) => ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)),
+        })
     }
 }
+
+macro_rules! impl_ttrpc_result_simple {
+  ($($err_ty:ty),* $(,)?) => {
+      $(
+          impl<T> ResultToTtrpcResult<T, $err_ty> for Result<T, $err_ty> {
+              fn map_ttrpc_err<R: Debug>(self, msg_builder: impl FnOnce($err_ty) -> R) -> ttrpc::Result<T> {
+                  self.map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)))
+              }
+          }
+      )*
+  };
+}
+
+impl_ttrpc_result_simple!(
+  nix::errno::Errno,
+  tokio::time::error::Elapsed,
+  tokio::task::JoinError,
+  i32,
+  std::io::Error,
+);
 
 trait OptionToTtrpcResult<T>: Sized {
     fn map_ttrpc_err(self, code: ttrpc::Code, msg: &str) -> ttrpc::Result<T>;

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -193,11 +193,37 @@ trait ResultToTtrpcResult<T, E: Debug>: Sized {
     }
 }
 
-impl<T, E: Debug> ResultToTtrpcResult<T, E> for Result<T, E> {
-    fn map_ttrpc_err<R: Debug>(self, msg_builder: impl FnOnce(E) -> R) -> ttrpc::Result<T> {
-        self.map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)))
+impl<T> ResultToTtrpcResult<T, anyhow::Error> for anyhow::Result<T> {
+    fn map_ttrpc_err<R: Debug>(
+        self,
+        msg_builder: impl FnOnce(anyhow::Error) -> R,
+    ) -> ttrpc::Result<T> {
+        self.map_err(|e| match e.downcast::<ttrpc::error::Error>() {
+            Ok(ttrpc_err) => ttrpc_err,
+            Err(e) => ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)),
+        })
     }
 }
+
+macro_rules! impl_ttrpc_result_simple {
+    ($($err_ty:ty),* $(,)?) => {
+        $(
+            impl<T> ResultToTtrpcResult<T, $err_ty> for Result<T, $err_ty> {
+                fn map_ttrpc_err<R: Debug>(self, msg_builder: impl FnOnce($err_ty) -> R) -> ttrpc::Result<T> {
+                    self.map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, msg_builder(e)))
+                }
+            }
+        )*
+    };
+}
+
+impl_ttrpc_result_simple!(
+    nix::errno::Errno,
+    tokio::time::error::Elapsed,
+    tokio::task::JoinError,
+    i32,
+    std::io::Error,
+);
 
 trait OptionToTtrpcResult<T>: Sized {
     fn map_ttrpc_err(self, code: ttrpc::Code, msg: &str) -> ttrpc::Result<T>;
@@ -4161,6 +4187,35 @@ COMMIT
                 panic!("{}: unexpected do_copy_file result: {:?}", tc.name, res)
             }
             (tc.assertions)(&base).context(tc.name).unwrap()
+        }
+    }
+
+    #[test]
+    fn test_map_ttrpc_err_preserves_not_found() {
+        let not_found_err = ttrpc_error(ttrpc::Code::NOT_FOUND, "process not found");
+        let anyhow_err: anyhow::Result<()> = Err(not_found_err.into());
+
+        let result = anyhow_err.map_ttrpc_err(same);
+
+        match &result.unwrap_err() {
+            ttrpc::Error::RpcStatus(status) => {
+                assert_eq!(status.code(), ttrpc::Code::NOT_FOUND);
+            }
+            other => panic!("expected RpcStatus, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_map_ttrpc_err_wraps_non_ttrpc_as_internal() {
+        let plain_err: anyhow::Result<()> = Err(anyhow!("something went wrong"));
+
+        let result = plain_err.map_ttrpc_err(same);
+
+        match &result.unwrap_err() {
+            ttrpc::Error::RpcStatus(status) => {
+                assert_eq!(status.code(), ttrpc::Code::INTERNAL);
+            }
+            other => panic!("expected RpcStatus, got: {:?}", other),
         }
     }
 }

--- a/src/runtime-rs/crates/runtimes/common/src/error.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/error.rs
@@ -67,6 +67,12 @@ const NO_SUCH_PROCESS_MESSAGES: &[&str] = &[
 /// target is no longer available.
 /// The function checks for standard OS error codes (`ESRCH`, `ENOENT`) and common error message patterns.
 pub fn is_no_such_process_error(err: &anyhow::Error) -> bool {
+    if let Some(Error::ProcessAlreadyTerminated | Error::ProcessNotFound(_)) =
+        err.downcast_ref::<Error>()
+    {
+        return true;
+    }
+
     // Check for standard OS error codes.
     if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
         if let Some(raw_os_error) = io_err.raw_os_error() {


### PR DESCRIPTION
It can happen for several reasons that during an attempt to stop a container process it might turn out that the process has exited already.  In that case, at the agent level a request to stop a non-existent process can reasonably be treated as an error, however at the runtime level it makes more sense to treat it as success (the logic being, the runtime has been asked to stop a process and the process is indeed stopped).

That's the idea at least, as apparent from the agent and runtime code bases, however it hasn't worked that way so far.  While runtime-rs was checking for ttrpc NOT_FOUND whenever it received an error from agent while stopping a container process, a shortcoming in agent which turned all errors into ttrpc INTERNAL errors made sure that the runtime never actually received NOT_FOUND (or basically any other ttrpc error type apart from INTERNAL I guess).  This should be fixed by this PR's first commit.

With that fixed, it turned out that while runtime-rs did make effort to recognise errors with the "process not found" semantics, its own code implementing this was buggy, too.  This should be fixed by the second commit.