### PR TITLE
runtime-rs: fix VM console logging

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -425,6 +425,18 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
+        // When hypervisor debug is enabled, output the kernel boot messages for debugging.
+        if self.config.debug_info.enable_debug {
+            tokio::spawn(async move {
+                let stream_result = try_open_qemu_console(&console_socket_path).await;
+                if let Ok(stream) = stream_result {
+                    if let Err(err) = log_qemu_console(stream).await {
+                        warn!(sl!(), "error logging qemu console: {:?}", err);
+                    }
+                }
+            });
+        }
+
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -475,12 +487,6 @@ impl QemuInner {
                 .await
                 .context("boot from template")?;
             self.resume_vm().context("resume vm")?;
-        }
-
-        // When hypervisor debug is enabled, output the kernel boot messages for debugging.
-        if self.config.debug_info.enable_debug {
-            let stream = UnixStream::connect(console_socket_path.as_os_str()).await?;
-            tokio::spawn(log_qemu_console(stream));
         }
 
         Ok(())
@@ -941,6 +947,30 @@ impl QemuInner {
 
         Ok((new_total_mem_mb, MemoryConfig::default()))
     }
+}
+
+async fn try_open_qemu_console(console_socket_path: &Path) -> Result<UnixStream> {
+    const DEADLINE_SECS: u64 = 5;
+    let deadline = Instant::now() + Duration::from_secs(DEADLINE_SECS);
+    let console_stream = loop {
+        match UnixStream::connect(console_socket_path.as_os_str()).await {
+            Ok(stream) => break stream,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    warn!(
+                        sl!(),
+                        "couldn't open qemu console at {:#?} in {} seconds: {}",
+                        console_socket_path,
+                        DEADLINE_SECS,
+                        err
+                    );
+                    return Err(anyhow!("couldn't open qemu console: {err}"));
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        };
+    };
+    Ok(console_stream)
 }
 
 async fn log_qemu_console(console: UnixStream) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -442,6 +442,18 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
+        // When hypervisor debug is enabled, output the kernel boot messages for debugging.
+        if self.config.debug_info.enable_debug {
+            tokio::spawn(async move {
+                let stream_result = try_open_qemu_console(&console_socket_path).await;
+                if let Ok(stream) = stream_result {
+                    if let Err(err) = log_qemu_console(stream).await {
+                        warn!(sl!(), "error logging qemu console: {:?}", err);
+                    }
+                }
+            });
+        }
+
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -493,12 +505,6 @@ impl QemuInner {
                 .await
                 .context("boot from template")?;
             self.resume_vm().context("resume vm")?;
-        }
-
-        // When hypervisor debug is enabled, output the kernel boot messages for debugging.
-        if self.config.debug_info.enable_debug {
-            let stream = UnixStream::connect(console_socket_path.as_os_str()).await?;
-            tokio::spawn(log_qemu_console(stream));
         }
 
         Ok(())
@@ -1039,6 +1045,32 @@ where
     set_gid_fn(user.gid).context("setgid failed")?;
     set_uid_fn(user.uid).context("setuid failed")?;
     Ok(())
+}
+
+async fn try_open_qemu_console(console_socket_path: &Path) -> Result<UnixStream> {
+    const DEADLINE_SECS: u64 = 5;
+    let deadline = Instant::now()
+        .checked_add(Duration::from_secs(DEADLINE_SECS))
+        .ok_or_else(|| anyhow!("timeout overflow"))?;
+    let console_stream = loop {
+        match UnixStream::connect(console_socket_path.as_os_str()).await {
+            Ok(stream) => break stream,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    warn!(
+                        sl!(),
+                        "couldn't open qemu console at {:#?} in {} seconds: {}",
+                        console_socket_path,
+                        DEADLINE_SECS,
+                        err
+                    );
+                    return Err(anyhow!("couldn't open qemu console: {err}"));
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        };
+    };
+    Ok(console_stream)
 }
 
 async fn log_qemu_console(console: UnixStream) -> Result<()> {


### PR DESCRIPTION
Logging console messages of a kata VM while it's booting has so far been troubled by several problems:

1) a race between qemu opening the console socket and runtime connecting to it.  If runtime is faster and tries to open a socket that doesn't yet exist the whole operation fails if connection is only attempted once as has been the case so far.

2) a failure to connect to the console socket was compounded by treating it with the '?' operator, effectively aborting the whole runtime launch if console socket connection failed.

3) before this change, console logging was launched only after QMP connection had succeeded.  This is fine if everything works however if QEMU or the VM fail to start for any reason, QMP connection will be failing as well and VM console logging will not be launched at all. Thus we lose the VM kernel log precisely in the situation when we need it most.

The first two problems are fixed by (asynchronously) attempting connecting to the console until it succeeds or times out, whatever happens first (try_open_qemu_console()).  The remaining problem is addressed simply by ordering the VM console logging launch before attempting QMP.