### PR TITLE
runtime-rs: record sandbox id for direct volumes

### DIFF
--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -552,6 +552,43 @@ pub fn add_volume_mount_info(volume_path: &str, mount_info: &DirectVolumeMountIn
     Ok(())
 }
 
+/// Records the association between a sandbox and a direct volume by writing an
+/// empty file, named after the `sandbox_id`, into the direct-volume directory of
+/// `volume_path`.
+///
+/// This mirrors runtime-go's `RecordSandboxID` and is required for
+/// `kata-ctl direct-volume {stats,resize}` to work: those commands locate the
+/// owning sandbox by scanning the direct-volume directory for the first file
+/// that is not `mountInfo.json` and using its name as the sandbox id (see
+/// kata-ctl's `get_sandbox_id_for_volume`). Without this file the commands fail
+/// with "no sandbox found for <volume_path>".
+///
+/// The `mountInfo.json` file must already exist (i.e. the volume has been added
+/// via `add_volume_mount_info` / `kata-ctl direct-volume add`); otherwise an
+/// error is returned, matching the Go behaviour.
+#[cfg(feature = "safe-path")]
+pub fn record_sandbox_id(sandbox_id: &str, volume_path: &str) -> Result<()> {
+    let dir = join_path(kata_direct_volume_root_path().as_str(), volume_path)?;
+    let mount_info_file_path = dir.join(KATA_MOUNT_INFO_FILE_NAME);
+    if !mount_info_file_path.exists() {
+        return Err(anyhow!(
+            "mount info file {:?} does not exist for volume {}",
+            mount_info_file_path,
+            volume_path
+        ));
+    }
+
+    let sandbox_id_file_path = dir.join(sandbox_id);
+    std::fs::write(&sandbox_id_file_path, b"").with_context(|| {
+        format!(
+            "failed to write sandbox id file {:?}",
+            sandbox_id_file_path
+        )
+    })?;
+
+    Ok(())
+}
+
 /// Returns `true` if a `mountInfo.json` exists for the given `volume_path`.
 #[cfg(feature = "safe-path")]
 pub fn is_volume_mounted(volume_path: &str) -> bool {
@@ -833,5 +870,49 @@ mod tests {
         let (_prefix, encoded_vol) = option_str.split_once("io.katacontainers.volume=").unwrap();
 
         assert_eq!(encoded_vol, expected_b64_vol);
+    }
+
+    // Verifies that record_sandbox_id writes a file named after the sandbox id
+    // (which kata-ctl's get_sandbox_id_for_volume relies on) only when a
+    // mountInfo.json already exists. Mirrors runtime-go's TestRecordSandboxID.
+    // The well-known direct-volume root requires root privileges to create, so
+    // the test soft-skips when it cannot be created (e.g. unprivileged CI).
+    #[cfg(feature = "safe-path")]
+    #[test]
+    fn test_record_sandbox_id() {
+        use std::fs;
+
+        let root = kata_direct_volume_root_path();
+        if fs::create_dir_all(&root).is_err() {
+            // Not running as root; cannot exercise the well-known path.
+            return;
+        }
+
+        let volume_path = "/tmp/kata-types-test-record-sandbox-id-volume";
+        let dir = join_path(root.as_str(), volume_path).unwrap();
+        // Ensure a clean state from any previous run.
+        let _ = fs::remove_dir_all(&dir);
+
+        let sandbox_id = "test-sandbox-id";
+
+        // Without mountInfo.json present, recording must fail.
+        fs::create_dir_all(&dir).unwrap();
+        assert!(record_sandbox_id(sandbox_id, volume_path).is_err());
+
+        // With mountInfo.json present, recording must create a file whose name
+        // equals the sandbox id.
+        let mount_info = DirectVolumeMountInfo {
+            volume_type: "block".to_string(),
+            device: "/dev/sda".to_string(),
+            fs_type: "ext4".to_string(),
+            metadata: HashMap::new(),
+            options: vec![],
+        };
+        add_volume_mount_info(volume_path, &mount_info).unwrap();
+        record_sandbox_id(sandbox_id, volume_path).unwrap();
+        assert!(dir.join(sandbox_id).exists());
+
+        // cleanup
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src/runtime-rs/crates/resource/src/volume/direct_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volume.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use hypervisor::device::device_manager::DeviceManager;
 use kata_sys_util::mount::{get_mount_path, get_mount_type};
-use kata_types::mount::DirectVolumeMountInfo;
+use kata_types::mount::{record_sandbox_id, DirectVolumeMountInfo};
 use nix::sys::{stat, stat::SFlag};
 use oci_spec::runtime as oci;
 use tokio::sync::RwLock;
@@ -48,7 +48,8 @@ pub(crate) async fn handle_direct_volume(
     // If the source is not in the path with error kind *NotFound*, we ignore the error
     // and we treat it as block volume with oci Mount.type *bind*. Just fill in the block
     // volume info in the DirectVolumeMountInfo
-    let mount_info: DirectVolumeMountInfo = match volume_mount_info(&get_mount_path(m.source())) {
+    let volume_path = get_mount_path(m.source());
+    let mount_info: DirectVolumeMountInfo = match volume_mount_info(&volume_path) {
         Ok(mount_info) => mount_info,
         Err(e) => {
             // First, We need filter the non-io::ErrorKind.
@@ -75,6 +76,19 @@ pub(crate) async fn handle_direct_volume(
             return Ok(None);
         }
     };
+
+    // Record the association between this sandbox and the direct volume so that
+    // `kata-ctl direct-volume {stats,resize}` can locate the owning sandbox by
+    // scanning the direct-volume directory. This mirrors runtime-go's
+    // `createBlockDevices` -> `volume.RecordSandboxID`. A failure here must not
+    // abort volume setup (matches Go behaviour: log and continue), it only means
+    // online stats/resize via kata-ctl will be unavailable.
+    if let Err(e) = record_sandbox_id(sid, &volume_path) {
+        warn!(
+            sl!(),
+            "failed to record sandbox id {} for direct volume {}: {:?}", sid, volume_path, e
+        );
+    }
 
     let direct_volume: Arc<dyn Volume> = match to_volume_type(mount_info.volume_type.as_str()) {
         DirectVolumeType::RawBlock => Arc::new(


### PR DESCRIPTION
kata-ctl direct-volume {stats,resize} locate the owning sandbox by scanning the direct-volume directory for the first file that is not mountInfo.json and using its name as the sandbox id (see kata-ctl's get_sandbox_id_for_volume). runtime-go writes this file at container start via volume.RecordSandboxID, but runtime-rs never did, so with kata-cloud-hypervisor the commands failed with "no sandbox found for <volume_path>" even though the shim mgmt server already implements the /direct-volume/{stats,resize} handlers.

Add kata_types::mount::record_sandbox_id (mirroring runtime-go's RecordSandboxID) and call it from handle_direct_volume once the mount info is parsed, so the sandbox id file is written next to mountInfo.json. A failure to record is logged and ignored, matching the Go behaviour.

Fixes: #13442