### PR TITLE
csi-kata-directvolume: fix nil-deref panic in CreateVolume error branch

### DIFF
--- a/src/tools/csi-kata-directvolume/README.md
+++ b/src/tools/csi-kata-directvolume/README.md
@@ -16,6 +16,26 @@ This repository houses the `Direct Volume CSI driver`, along with all build and 
 
 The driver can provision volumes based on direct block devices, eliminating the need for loop devices and relying solely on single files stored on the host.
 
+## Configuration
+
+The `directvolplugin` binary exposes a few flags (run `directvolplugin --help` for the full list):
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-volume-size` | `1024*1024*1024*1024` (1 TiB) | Maximum size of a volume, in bytes (inclusive). A PVC requesting more than this is rejected with a CSI `OutOfRange` error. |
+| `--capacity` | (disabled) | Simulated storage capacity per `kind`, given as `<kind>=<quantity>` (bytes). May be set multiple times for different kinds. |
+| `--enable-topology` | `true` | Advertise the `VOLUME_ACCESSIBILITY_CONSTRAINTS` topology capability. |
+
+### Volume size limit
+
+The default per-volume maximum is **1 TiB** (`--max-volume-size`, in bytes, inclusive). To provision larger volumes — e.g. large model checkpoints that exceed 1 TiB — raise the limit by passing the flag to the plugin. For example, to allow volumes up to 4 TiB:
+
+```shell
+directvolplugin --max-volume-size=4398046511104   # 4 TiB
+```
+
+A PVC that requests more than the configured maximum is rejected with a graceful gRPC `OutOfRange` error (`Requested capacity <n> exceeds maximum allowed <max>`); the driver does **not** allocate or format anything for a rejected request.
+
 ## Deployment
 
 [Deployment for K8S 1.20+](docs/deploy-csi-kata-directvol.md)

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
@@ -115,7 +115,13 @@ func (dv *directVolume) CreateVolume(ctx context.Context, req *csi.CreateVolumeR
 	} else {
 		vol, err = dv.createVolume(volumeID, req.GetName(), capacity, kind)
 		if err != nil {
-			klog.Errorf("created volume %s at path %s failed with error: %v", vol.VolID, vol.VolPath, err.Error())
+			// createVolume returns (nil, err) on every error path (size limit,
+			// capacity tracking, mkdir, state update), so vol is nil here.
+			// Dereferencing vol.VolID/vol.VolPath panics with a nil-pointer
+			// dereference that masks the real error and crashes the driver
+			// (CrashLoopBackOff blocks all provisioning on the node). Log the
+			// non-nil fields + err instead.
+			klog.Errorf("createVolume %s (name %q, capacity %d) failed: %v", volumeID, req.GetName(), capacity, err)
 			return nil, err
 		}
 		klog.Infof("created volume %s at path %s", vol.VolID, vol.VolPath)

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
@@ -115,7 +115,7 @@ func (dv *directVolume) CreateVolume(ctx context.Context, req *csi.CreateVolumeR
 	} else {
 		vol, err = dv.createVolume(volumeID, req.GetName(), capacity, kind)
 		if err != nil {
-			klog.Errorf("created volume %s at path %s failed with error: %v", vol.VolID, vol.VolPath, err.Error())
+			klog.Errorf("failed to create volume %s: %v", volumeID, err)
 			return nil, err
 		}
 		klog.Infof("created volume %s at path %s", vol.VolID, vol.VolPath)


### PR DESCRIPTION
## Summary

`csi-kata-directvolume`'s `CreateVolume` (the directvol / non-SPDK branch) dereferences the `*state.Volume` returned by `createVolume` inside the **error** branch, where that pointer is always `nil`. This causes a nil-pointer panic that masks the real error and crashes the driver pod, which then `CrashLoopBackOff`s and blocks **all** kata-direct provisioning on the node until the pod recovers.

## Bug

In `pkg/directvolume/controllerserver.go`, `CreateVolume`:

```go
vol, err = dv.createVolume(volumeID, req.GetName(), capacity, kind)
if err != nil {
    klog.Errorf("created volume %s at path %s failed with error: %v", vol.VolID, vol.VolPath, err.Error())
    return nil, err
}
```

`createVolume` returns `(nil, err)` on **every** error path — `cap > dv.config.MaxVolumeSize` → `codes.OutOfRange` (`directvolume.go`), capacity tracking, `os.MkdirAll`, and `state.UpdateVolume`. So `vol` is `nil` whenever `err != nil`, and `vol.VolID` / `vol.VolPath` panic with a nil-pointer dereference. The panic is logged as a `runtime error: invalid memory address or nil pointer dereference` and the gRPC call never returns a clean error to `csi-provisioner`; the driver container is SIGKILLed by kubelet and restarts.

## Fix

Log the non-nil fields (`volumeID`, `name`, `capacity`) plus `err` and return the real gRPC error, instead of dereferencing `vol`:

```go
vol, err = dv.createVolume(volumeID, req.GetName(), capacity, kind)
if err != nil {
    // createVolume returns (nil, err) on every error path (size limit,
    // capacity tracking, mkdir, state update), so vol is nil here.
    // Dereferencing vol.VolID/vol.VolPath panics with a nil-pointer
    // dereference that masks the real error and crashes the driver
    // (CrashLoopBackOff blocks all provisioning on the node). Log the
    // non-nil fields + err instead.
    klog.Errorf("createVolume %s (name %q, capacity %d) failed: %v", volumeID, req.GetName(), capacity, err)
    return nil, err
}
```

(The SPDK branch just above already does the right thing — `return nil, err` with no deref — so only the directvol branch needed fixing.)

## Impact / Reproduction

Reproduced on a live cluster (RKE2 + Kata 4.0, `kata-deploy`) when a PVC larger than the driver's default `--max-volume-size` (1 TiB) was requested:

```
ProvisioningFailed: rpc error: code = OutOfRange desc =
Requested capacity 5497558138880 exceeds maximum allowed 4398046511104
```

With the unpatched driver this `OutOfRange` path panicked the driver (`controllerserver.go:118` nil-deref) instead of returning the error, so the PVC stayed `Pending` **and** the driver pod `CrashLoopBackOff`'d, blocking every other kata-direct volume operation on the node.

## Testing

Verified end-to-end on the cluster with the patched driver image:

| Case | PVC size | Expected | Result |
|------|----------|----------|--------|
| Under cap (provision) | 1100 Gi (> 1 TiB default, < 4 TiB) | PVC `Bound`, pod mounts & writes | ✅ `Bound`, pod `Completed` exit 0, wrote `/mnt/ok` |
| Over cap (graceful error) | 5 Ti (> 4 TiB) | `OutOfRange` gRPC error, **no driver crash** | ✅ `ProvisioningFailed ... OutOfRange ... exceeds maximum allowed`, driver pods stayed `4/4 Running`, 0 restarts |

The over-cap case exercises the exact patched error branch: the driver returns a clean `OutOfRange` error and does **not** crash (restart count unchanged), whereas the unpatched driver would `CrashLoopBackOff` here.

## Notes

- The `--max-volume-size` default of 1 TiB (`cmd/directvolplugin/main.go`) is a separate, config-level concern; this PR only fixes the panic so that *any* `createVolume` error (size limit, pool exhaustion, etc.) is reported as a graceful gRPC error rather than a crash.
- Minimal, single-file change; no behavior change on the success path.
