### PR TITLE
tests: fix k8s-hostpath-volume test on ppc64le

### DIFF
--- a/tests/integration/kubernetes/k8s-hostpath-volume.bats
+++ b/tests/integration/kubernetes/k8s-hostpath-volume.bats
@@ -34,7 +34,14 @@ setup() {
 	# Check the mount info.
 
 	mount_info="$(kubectl exec "${pod_name}" -- "${cmd_mountinfo[@]}")"
-	read root mountpoint fstype < <(awk '{print $4, $5, $9}' <<< "$mount_info")
+	# /proc/self/mountinfo has a variable number of optional fields before
+	# the "-" separator, so fstype is not always at $9. Find "-" and take
+	# the immediately following field, which is always the fstype.
+	read root mountpoint fstype < <(awk '{
+		for (i = 1; i <= NF; i++) {
+			if ($i == "-") { print $4, $5, $(i+1); break }
+		}
+	}' <<< "$mount_info")
 
 	[ "$root" == "/kmsg" ] # Would look like "/<CONTAINER_ID>-<RANDOM_ID>-kmsg" with virtio-fs.
 	[ "$mountpoint" == "/dev/kmsg" ]


### PR DESCRIPTION
The test k8s-hostpath-volume has been failing on ppc64le since last week at
```
not ok 1 /dev hostPath volume bind mounts the guest device and skips virtio-fs in 17936ms
# (in test file k8s-hostpath-volume.bats, line 41)
#   `[ "$fstype" == "devtmpfs" ] # Would be "virtiofs" with virtio-fs.' failed
```

The container creation succeeds but the issue is with positioning of the fstype field in the command output on ppc64le and the fix atlers it to make sure it passes on all archs.

Sample output:
```
kubectl exec hostpath-kmsg -- sh -c "grep /dev/kmsg /proc/self/mountinfo"
86 81 0:6 /kmsg /dev/kmsg rw,nosuid,relatime - devtmpfs dev rw,size=998976k,nr_inodes=15609,mode=755
```
Ref: https://github.com/kata-containers/kata-containers/actions/runs/29969259270/job/89089381271#step:11:2041