### PR TITLE
Add a generic devkit debug guest extension (runtime-rs only!)

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -210,6 +210,7 @@ jobs:
           - rootfs-image
           - rootfs-image-confidential
           - rootfs-image-coco-extension
+          - rootfs-image-devkit-extension
           - rootfs-image-mariner
           - rootfs-image-nvidia-gpu
           - rootfs-image-nvidia-gpu-confidential

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -378,6 +378,7 @@ jobs:
       matrix:
         asset:
           - genpolicy
+          - kata-ctl
         stage:
           - ${{ inputs.stage }}
     steps:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -203,6 +203,7 @@ jobs:
           - rootfs-image
           - rootfs-image-confidential
           - rootfs-image-coco-extension
+          - rootfs-image-devkit-extension
           - rootfs-image-nvidia-gpu
           - rootfs-image-nvidia
           - rootfs-image-nvidia-gpu-extension

--- a/.github/workflows/publish-kata-images.yaml
+++ b/.github/workflows/publish-kata-images.yaml
@@ -119,6 +119,16 @@ jobs:
           path: tools/packaging/kata-deploy/local-build/build
           merge-multiple: true
 
+      # kata-ctl ships in the kata-tools bundle under its own artifact name, so
+      # stage it into the build dir separately to bake it into the deploy image.
+      - name: get-kata-ctl for ${{ inputs.arch }}
+        if: ${{ inputs.artifact-name == '' && matrix.image-kind == 'deploy' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: kata-tools-artifacts-${{ inputs.arch }}-kata-ctl${{ inputs.tarball-suffix }}
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
+
       - name: get-kata-static-tarball for ${{ inputs.arch }}
         if: ${{ inputs.artifact-name == '' && matrix.image-kind == 'monitor' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -28,6 +28,7 @@ const CDI_TIMEOUT_OPTION: &str = "agent.cdi_timeout";
 const LAUNCH_PROCESS_TIMEOUT_OPTION: &str = "agent.launch_process_timeout";
 const VISIBLE_CDI_DEVICES_OPTION: &str = "agent.visible_cdi_devices";
 const DEBUG_CONSOLE_VPORT_OPTION: &str = "agent.debug_console_vport";
+const DEBUG_CONSOLE_SHELL_OPTION: &str = "agent.debug_console_shell";
 const LOG_VPORT_OPTION: &str = "agent.log_vport";
 const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
 const CGROUP_NO_V1: &str = "cgroup_no_v1";
@@ -136,6 +137,9 @@ pub struct AgentConfig {
     pub launch_process_timeout: time::Duration,
     pub visible_cdi_devices: bool,
     pub debug_console_vport: i32,
+    // Guest path of the shell the debug console execs; empty uses the built-in
+    // candidates (/bin/bash, /bin/sh).
+    pub debug_console_shell: String,
     pub log_vport: i32,
     pub container_pipe_size: i32,
     pub server_addr: String,
@@ -171,6 +175,7 @@ pub struct AgentConfigBuilder {
     pub launch_process_timeout: Option<time::Duration>,
     pub visible_cdi_devices: Option<bool>,
     pub debug_console_vport: Option<i32>,
+    pub debug_console_shell: Option<String>,
     pub log_vport: Option<i32>,
     pub container_pipe_size: Option<i32>,
     pub server_addr: Option<String>,
@@ -267,6 +272,7 @@ impl Default for AgentConfig {
             launch_process_timeout: DEFAULT_LAUNCH_PROCESS_TIMEOUT,
             visible_cdi_devices: false,
             debug_console_vport: 0,
+            debug_console_shell: String::from(""),
             log_vport: 0,
             container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
             server_addr: format!("{VSOCK_ADDR}:{DEFAULT_AGENT_VSOCK_PORT}"),
@@ -310,6 +316,7 @@ impl FromStr for AgentConfig {
         config_override!(agent_config_builder, agent_config, launch_process_timeout);
         config_override!(agent_config_builder, agent_config, visible_cdi_devices);
         config_override!(agent_config_builder, agent_config, debug_console_vport);
+        config_override!(agent_config_builder, agent_config, debug_console_shell);
         config_override!(agent_config_builder, agent_config, log_vport);
         config_override!(agent_config_builder, agent_config, container_pipe_size);
         config_override!(agent_config_builder, agent_config, server_addr);
@@ -514,6 +521,12 @@ impl AgentConfig {
                 config.debug_console_vport,
                 get_number_value,
                 |port: &i32| *port > 0
+            );
+            parse_cmdline_param!(
+                param,
+                DEBUG_CONSOLE_SHELL_OPTION,
+                config.debug_console_shell,
+                get_string_value
             );
             parse_cmdline_param!(
                 param,
@@ -902,6 +915,7 @@ mod tests {
             contents: &'a str,
             env_vars: Vec<&'a str>,
             debug_console: bool,
+            debug_console_shell: &'a str,
             dev_mode: bool,
             log_level: slog::Level,
             hotplug_timeout: time::Duration,
@@ -926,6 +940,7 @@ mod tests {
                     contents: "",
                     env_vars: Vec::new(),
                     debug_console: false,
+                    debug_console_shell: "",
                     dev_mode: false,
                     log_level: DEFAULT_LOG_LEVEL,
                     hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
@@ -999,6 +1014,11 @@ mod tests {
             TestData {
                 contents: "agent.debug_console",
                 debug_console: true,
+                ..Default::default()
+            },
+            TestData {
+                contents: "agent.debug_console_shell=/run/kata-extensions/devkit/bin/devkit-sh",
+                debug_console_shell: "/run/kata-extensions/devkit/bin/devkit-sh",
                 ..Default::default()
             },
             TestData {
@@ -1498,6 +1518,7 @@ mod tests {
                 AgentConfig::from_cmdline(filename, vec![]).expect("Failed to parse command line");
 
             assert_eq!(d.debug_console, config.debug_console, "{msg}");
+            assert_eq!(d.debug_console_shell, config.debug_console_shell, "{msg}");
             assert_eq!(d.dev_mode, config.dev_mode, "{msg}");
             assert_eq!(d.cgroup_no_v1, config.cgroup_no_v1, "{msg}");
             assert_eq!(

--- a/src/agent/src/console.rs
+++ b/src/agent/src/console.rs
@@ -29,6 +29,16 @@ use tokio::sync::watch::Receiver;
 
 const CONSOLE_PATH: &str = "/dev/console";
 
+// A configured debug_console_shell is honored only if it resolves under this
+// prefix (a guest extension mount). Extension images are dm-verity measured and
+// read-only, so this confines the debug console to trusted binaries: a host that
+// can influence the agent cmdline (untrusted under CoCo) cannot repoint it at a
+// container rootfs to run tenant binaries or read guest-root data.
+//
+// Only referenced under `#[cfg(not(test))]`, so it reads as dead code in tests.
+#[cfg_attr(test, allow(dead_code))]
+const DEBUG_CONSOLE_SHELL_ALLOWED_PREFIX: &str = "/run/kata-extensions/";
+
 lazy_static! {
     static ref SHELLS: Arc<SyncMutex<Vec<String>>> = {
         let mut v = Vec::new();
@@ -46,6 +56,20 @@ pub fn initialize() {
     lazy_static::initialize(&SHELLS);
 }
 
+// Honor `shell` only if it canonicalizes (resolving symlinks and `..`) to a path
+// under `prefix`. Canonicalization is what makes this safe: a raw prefix check
+// could be bypassed by a symlink or `..` escape. The original path is returned so
+// an entrypoint symlink under the prefix (devkit-sh -> devkit-enter) stays the
+// exec target, since it is equally trusted.
+fn shell_under_prefix(shell: &str, prefix: &str) -> Option<String> {
+    if shell.is_empty() {
+        return None;
+    }
+
+    let canonical = std::fs::canonicalize(shell).ok()?;
+    canonical.starts_with(prefix).then(|| shell.to_string())
+}
+
 pub async fn debug_console_handler(
     logger: Logger,
     port: u32,
@@ -53,7 +77,26 @@ pub async fn debug_console_handler(
 ) -> Result<()> {
     let logger = logger.new(o!("subsystem" => "debug-console"));
 
-    let shells = SHELLS.lock().unwrap().to_vec();
+    // Only mutated under `#[cfg(not(test))]`, so it need not be mut in tests.
+    #[cfg_attr(test, allow(unused_mut))]
+    let mut shells = SHELLS.lock().unwrap().to_vec();
+
+    // Prefer a configured debug_console_shell over the built-ins, but only if it
+    // passes the extension-prefix guard.
+    #[cfg(not(test))]
+    {
+        let configured = crate::AGENT_CONFIG.debug_console_shell.clone();
+        match shell_under_prefix(&configured, DEBUG_CONSOLE_SHELL_ALLOWED_PREFIX) {
+            Some(sh) => shells.insert(0, sh),
+            None if !configured.is_empty() => warn!(
+                logger,
+                "ignoring debug_console_shell outside {}: {}",
+                DEBUG_CONSOLE_SHELL_ALLOWED_PREFIX,
+                configured
+            ),
+            None => {}
+        }
+    }
 
     let shell = shells
         .into_iter()
@@ -304,6 +347,62 @@ mod tests {
         assert_eq!(
             result.unwrap_err().to_string(),
             "no shell found to launch debug console"
+        );
+    }
+
+    #[test]
+    fn test_shell_under_prefix() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().expect("failed to create tmpdir");
+        let root = dir.path();
+
+        // Simulate an extension mount ("allowed") and a container rootfs
+        // ("other") side by side under the same tmpdir.
+        let allowed = root.join("allowed");
+        let other = root.join("other");
+        std::fs::create_dir_all(allowed.join("bin")).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let prefix = allowed.to_str().unwrap();
+
+        // Inside the prefix: honored.
+        let inside = allowed.join("bin").join("devkit-enter");
+        std::fs::write(&inside, b"#!/bin/sh\n").unwrap();
+        let inside = inside.to_str().unwrap();
+        assert_eq!(shell_under_prefix(inside, prefix), Some(inside.to_string()));
+
+        // A symlink that lives inside the prefix but targets another file inside
+        // the prefix is honored, and the (symlink) path is what gets returned.
+        let link = allowed.join("bin").join("devkit-sh");
+        symlink("devkit-enter", &link).unwrap();
+        let link = link.to_str().unwrap();
+        assert_eq!(shell_under_prefix(link, prefix), Some(link.to_string()));
+
+        // Outside the prefix (e.g. a container binary): rejected.
+        let outside = other.join("sh");
+        std::fs::write(&outside, b"#!/bin/sh\n").unwrap();
+        assert_eq!(shell_under_prefix(outside.to_str().unwrap(), prefix), None);
+
+        // A symlink under the prefix that escapes it via its target: rejected,
+        // because canonicalization resolves it outside the prefix.
+        let escape = allowed.join("escape");
+        symlink(&outside, &escape).unwrap();
+        assert_eq!(shell_under_prefix(escape.to_str().unwrap(), prefix), None);
+
+        // A `..` traversal that escapes the prefix: rejected.
+        let traversal = allowed.join("bin").join("..").join("..").join("other");
+        let traversal = traversal.join("sh");
+        assert_eq!(
+            shell_under_prefix(traversal.to_str().unwrap(), prefix),
+            None
+        );
+
+        // Empty and non-existent paths: rejected (no shell configured / bad path).
+        assert_eq!(shell_under_prefix("", prefix), None);
+        assert_eq!(
+            shell_under_prefix(allowed.join("bin").join("enoent").to_str().unwrap(), prefix),
+            None
         );
     }
 }

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -93,6 +93,12 @@ pub struct Agent {
     #[serde(default)]
     pub debug_console_enabled: bool,
 
+    /// Guest path of the shell the debug console execs; empty uses the agent's
+    /// built-in candidates (/bin/bash, /bin/sh). The agent only honors it if it
+    /// resolves under /run/kata-extensions/ (a guest extension mount).
+    #[serde(default)]
+    pub debug_console_shell: String,
+
     /// When enabled, the agent translates a container's VISIBLE_CDI_DEVICES
     /// environment variable into CDI GPU device requests (nvidia.com/gpu) so
     /// that the container sees the matching GPUs present in the VM.
@@ -186,6 +192,7 @@ impl std::default::Default for Agent {
             log_level: "info".to_string(),
             enable_tracing: false,
             debug_console_enabled: false,
+            debug_console_shell: String::new(),
             visible_cdi_devices: false,
             server_port: DEFAULT_AGENT_VSOCK_PORT,
             log_port: DEFAULT_AGENT_LOG_PORT,

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -53,6 +53,8 @@ pub const LOG_LEVEL_OPTION: &str = "agent.log";
 pub const LOG_LEVEL_DEBUG: &str = "debug";
 /// Option of which port will the debug console connect to
 pub const DEBUG_CONSOLE_VPORT_OPTION: &str = "agent.debug_console_vport";
+/// Option selecting the guest shell the debug console execs
+pub const DEBUG_CONSOLE_SHELL_OPTION: &str = "agent.debug_console_shell";
 /// Option of which port the agent's log will connect to
 pub const LOG_VPORT_OPTION: &str = "agent.log_vport";
 /// Option of setting the container's pipe size
@@ -246,6 +248,12 @@ impl TomlConfig {
                 kv.insert(
                     DEBUG_CONSOLE_VPORT_OPTION.to_string(),
                     DEFAULT_AGENT_DBG_CONSOLE_PORT.to_string(),
+                );
+            }
+            if !cfg.debug_console_shell.is_empty() {
+                kv.insert(
+                    DEBUG_CONSOLE_SHELL_OPTION.to_string(),
+                    cfg.debug_console_shell.clone(),
                 );
             }
             if cfg.visible_cdi_devices {
@@ -504,6 +512,7 @@ mod tests {
             enable_tracing: true,
             container_pipe_size: 20,
             debug_console_enabled: true,
+            debug_console_shell: "/run/kata-extensions/devkit/bin/devkit-sh".to_string(),
             launch_process_timeout: 60,
             visible_cdi_devices: true,
             ..Default::default()
@@ -518,7 +527,29 @@ mod tests {
         assert_eq!(kv.get("agent.container_pipe_size").unwrap(), "20");
         kv.get("agent.debug_console").unwrap();
         assert_eq!(kv.get("agent.debug_console_vport").unwrap(), "1026"); // 1026 is the default port
+        assert_eq!(
+            kv.get("agent.debug_console_shell").unwrap(),
+            "/run/kata-extensions/devkit/bin/devkit-sh"
+        );
         assert_eq!(kv.get("agent.launch_process_timeout").unwrap(), "60");
         assert_eq!(kv.get("agent.visible_cdi_devices").unwrap(), "true");
+    }
+
+    #[test]
+    fn test_get_agent_kernel_params_no_debug_console_shell() {
+        let mut config = TomlConfig {
+            ..Default::default()
+        };
+        let agent_config = Agent {
+            debug_console_enabled: true,
+            ..Default::default()
+        };
+        let agent_name = "test_agent";
+        config.runtime.agent_name = agent_name.to_string();
+        config.agent.insert(agent_name.to_owned(), agent_config);
+
+        // An empty debug_console_shell must not be emitted on the cmdline.
+        let kv = config.get_agent_kernel_params().unwrap();
+        assert!(kv.get("agent.debug_console_shell").is_none());
     }
 }

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -25,6 +25,7 @@ HELM_ALLOWED_HYPERVISOR_ANNOTATIONS="${HELM_ALLOWED_HYPERVISOR_ANNOTATIONS:-}"
 HELM_CREATE_RUNTIME_CLASSES="${HELM_CREATE_RUNTIME_CLASSES:-}"
 HELM_CREATE_DEFAULT_RUNTIME_CLASS="${HELM_CREATE_DEFAULT_RUNTIME_CLASS:-}"
 HELM_DEBUG="${HELM_DEBUG:-}"
+HELM_DEVKIT="${HELM_DEVKIT:-}"
 HELM_DEFAULT_SHIM="${HELM_DEFAULT_SHIM:-}"
 HELM_IMAGE_REFERENCE="${HELM_IMAGE_REFERENCE:-}"
 HELM_IMAGE_TAG="${HELM_IMAGE_TAG:-}"
@@ -763,6 +764,16 @@ function helm_helper() {
 				yq -i ".debug = true" "${values_yaml}"
 			else
 				yq -i ".debug = false" "${values_yaml}"
+			fi
+		fi
+
+		# Deploy the devkit debug extension + per-shim kata-<shim>-devkit
+		# RuntimeClasses (only effective together with debug).
+		if [[ -n "${HELM_DEVKIT}" ]]; then
+			if [[ "${HELM_DEVKIT}" == "true" ]]; then
+				yq -i ".devkit = true" "${values_yaml}"
+			else
+				yq -i ".devkit = false" "${values_yaml}"
 			fi
 		fi
 

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -237,6 +237,19 @@ function deploy_kata() {
 	export HELM_IMAGE_REFERENCE="${DOCKER_REGISTRY}/${DOCKER_REPO}"
 	export HELM_IMAGE_TAG="${DOCKER_TAG}"
 	export HELM_DEBUG="true"
+	# Deploy the devkit debug extension for the (non-confidential) runtime-rs
+	# class that k8s-devkit-debug-console.bats exercises. Restricted to
+	# x86_64/aarch64: the devkit image and kata-ctl (its debug-console client)
+	# are not shipped on s390x/ppc64le, so devkit is neither built nor testable
+	# there.
+	export HELM_DEVKIT="false"
+	case "${TARGET_ARCH}" in
+		x86_64 | aarch64)
+			case "${KATA_HYPERVISOR}" in
+				qemu-nvidia-cpu-runtime-rs) export HELM_DEVKIT="true" ;;
+			esac
+			;;
+	esac
 	export HELM_SHIMS="${KATA_HYPERVISOR}"
 	export HELM_DEFAULT_SHIM="${KATA_HYPERVISOR}"
 	export HELM_CREATE_DEFAULT_RUNTIME_CLASS="true"

--- a/tests/integration/kubernetes/k8s-devkit-debug-console.bats
+++ b/tests/integration/kubernetes/k8s-devkit-debug-console.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Exercises the devkit debug guest extension through the agent debug console
+# (kata-ctl exec <sandbox-id>) on the NVIDIA CPU runtime-rs class: with the
+# kata-<shim>-devkit RuntimeClass, the console drops into the rich Ubuntu-based
+# devkit shell overlaid on the read-only guest rootfs.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+# The devkit debug console is a non-confidential debugging aid. For now it is
+# validated only on the (non-confidential) NVIDIA CPU runtime-rs class; other
+# hypervisors don't ship it in CI.
+devkit_supported() {
+	case "${KATA_HYPERVISOR}" in
+		qemu-nvidia-cpu-runtime-rs) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+devkit_runtimeclass() {
+	echo "kata-${KATA_HYPERVISOR}-devkit"
+}
+
+# A probe the *guest* shell must evaluate: $((6*7)) only becomes "SHELL_OK=42"
+# when a real shell runs it. The literal command text, even if echoed back by
+# the PTY, never contains the expanded value - so "SHELL_OK=42" in the output is
+# unambiguous proof that a debug console shell actually executed. The /real_root
+# symlink is created only by devkit-init when the overlay is set up, so it tells
+# the devkit chroot apart from the (also Ubuntu-based) NVIDIA base rootfs.
+DEVKIT_PROBE='echo "SHELL_OK=$((6*7))"; . /etc/os-release 2>/dev/null; echo "GUEST_ID=${ID}"; test -L /real_root && echo "DEVKIT_OVERLAY=yes" || true'
+
+check_and_skip() {
+	if ! devkit_supported; then
+		skip "devkit debug console not exercised for hypervisor: ${KATA_HYPERVISOR}"
+	fi
+
+	# The debug console client used here is kata-ctl, which ships only on x86_64
+	# and aarch64. s390x and ppc64le cannot build it statically (it needs glibc),
+	# so it is not installed there and this test cannot run.
+	case "$(uname -m)" in
+		x86_64 | aarch64) ;;
+		*) skip "kata-ctl not shipped for $(uname -m); devkit debug console not exercised" ;;
+	esac
+
+	# The kata-<shim>-devkit RuntimeClass only exists when kata-deploy was
+	# installed with both debug and devkit enabled. Skip (rather than fail)
+	# where the extension was not deployed.
+	if ! kubectl get runtimeclass "$(devkit_runtimeclass)" >/dev/null 2>&1; then
+		skip "RuntimeClass $(devkit_runtimeclass) not found; devkit not deployed"
+	fi
+}
+
+# Resolves the sandbox id into the global sandbox_id.
+launch_pod() {
+	local runtimeclass="$1"
+
+	pod_config="$(new_pod_config "${nginx_image}" "${runtimeclass}")"
+	set_node "${pod_config}" "${node}"
+	yq -i ".metadata.name = \"${pod_name}\"" "${pod_config}"
+
+	echo "Pod ${pod_config} (runtimeClass=${runtimeclass}):"
+	cat "${pod_config}"
+
+	kubectl create -f "${pod_config}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" "pod/${pod_name}"
+
+	sandbox_id="$(get_node_kata_sandbox_id "${node}")"
+	[[ -n "${sandbox_id}" ]] || die "Failed to resolve kata sandbox id on node ${node}"
+	echo "sandbox id: ${sandbox_id}"
+}
+
+# Drive the interactive agent debug console for sandbox_id with DEVKIT_PROBE and
+# echo the combined output.
+#
+# The console is an interactive PTY, so a bare pipe races the guest login shell
+# startup and loses the input. Drive it with a real terminal via `script`
+# (util-linux), feeding commands through a FIFO whose writer stays open long
+# enough for the shell to be ready before input arrives and to flush output
+# before we send `exit`.
+run_debug_console() {
+	local sandbox_id="$1"
+	local remote="
+fifo=\$(mktemp -u); mkfifo \"\${fifo}\"
+( sleep 2; printf '%s\\n' '${DEVKIT_PROBE}'; sleep 3; printf 'exit\\n'; sleep 1 ) > \"\${fifo}\" &
+timeout 120 script -qec \"nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-ctl exec ${sandbox_id}\" /dev/null < \"\${fifo}\" 2>&1
+rm -f \"\${fifo}\"
+"
+	exec_host "${node}" "${remote}" || true
+}
+
+setup() {
+	check_and_skip
+
+	setup_common || die "setup_common failed"
+
+	ensure_yq
+	nginx_registry=$(get_from_kata_deps ".docker_images.nginx.registry")
+	nginx_digest=$(get_from_kata_deps ".docker_images.nginx.digest")
+	nginx_image="${nginx_registry}@${nginx_digest}"
+
+	pod_name="devkit-debug-console"
+}
+
+@test "Debug console drops into the devkit shell" {
+	launch_pod "$(devkit_runtimeclass)"
+
+	local output
+	output="$(run_debug_console "${sandbox_id}")"
+	echo "debug console output:"
+	echo "${output}"
+
+	echo "${output}" | grep -q 'SHELL_OK=42' \
+		|| die "devkit debug console did not provide a working shell"
+	echo "${output}" | grep -q 'GUEST_ID=ubuntu' \
+		|| die "devkit debug console did not report an Ubuntu guest"
+	echo "${output}" | grep -q 'DEVKIT_OVERLAY=yes' \
+		|| die "devkit debug console shell lacks /real_root; not the devkit overlay"
+}
+
+teardown() {
+	check_and_skip
+
+	kubectl describe "pod/${pod_name}" || true
+	kubectl delete pod "${pod_name}" --ignore-not-found || true
+
+	teardown_common "${node:-}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -73,6 +73,7 @@ else
 		"k8s-credentials-secrets.bats" \
 		"k8s-cron-job.bats" \
 		"k8s-custom-dns.bats" \
+		"k8s-devkit-debug-console.bats" \
 		"k8s-empty-dirs.bats" \
 		"k8s-env.bats" \
 		"k8s-erofs-dmverity.bats" \

--- a/tools/osbuilder/rootfs-builder/devkit/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/devkit/Dockerfile.in
@@ -1,0 +1,19 @@
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG IMAGE_REGISTRY=docker.io
+FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
+@SET_PROXY@
+
+# mmdebstrap builds the devkit rootfs; the extension ships no agent, so none of
+# the language toolchains the guest rootfs builder carries are needed here.
+# hadolint ignore=DL3009
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get --no-install-recommends -y install \
+    ca-certificates \
+    file \
+    mmdebstrap \
+    zstd && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/tools/osbuilder/rootfs-builder/devkit/config.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Variables are consumed externally by the osbuilder rootfs build system.
+# shellcheck disable=SC2034
+
+OS_NAME=ubuntu
+# Ubuntu code name (e.g. "noble"), passed down from the guest image release so
+# the devkit matches the base userspace ABI (glibc).
+OS_VERSION=${OS_VERSION:-""}
+[[ -z "${OS_VERSION}" ]] && echo "OS_VERSION is required, but was not set" && exit 1
+
+# Debug tools prebaked so the extension works offline; `apt install <pkg>` pulls
+# anything else on demand inside the overlay. apt itself is not in the "required"
+# priority set mmdebstrap installs, so it is listed explicitly (it also pulls
+# gpgv for repo verification). busybox-static bootstraps the overlay/chroot from
+# the shell-less guest base (see devkit-init.sh); pciutils and util-linux inspect
+# the guest's devices and namespaces from the chroot. Kept lean: heavier tools
+# are pulled on demand.
+PACKAGES="apt busybox-static bash ca-certificates strace ltrace iproute2 procps psmisc lsof tcpdump curl wget file less netcat-openbsd dnsutils pciutils util-linux"
+
+# ltrace and busybox-static live in universe.
+REPO_COMPONENTS=${REPO_COMPONENTS:-"main universe"}
+
+# shellcheck disable=SC2154
+case "${ARCH}" in
+	aarch64) DEB_ARCH=arm64;;
+	ppc64le) DEB_ARCH=ppc64el;;
+	s390x) DEB_ARCH="${ARCH}";;
+	x86_64) DEB_ARCH=amd64; REPO_URL=${REPO_URL_X86_64:-${REPO_URL:-http://archive.ubuntu.com/ubuntu}};;
+	*) die "${ARCH} not supported"
+esac
+REPO_URL=${REPO_URL:-http://ports.ubuntu.com}

--- a/tools/osbuilder/rootfs-builder/devkit/devkit-add-nvidia-repos.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/devkit-add-nvidia-repos.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run from inside the devkit debug shell (i.e. already in the overlay/chroot) to
+# add NVIDIA's CUDA apt repository, so `apt-get install <pkg>` can then pull
+# NVIDIA userspace (nvidia-utils, cuda-toolkit, ...) on demand. Kept out of the
+# prebaked toolset to keep the generic devkit image small and vendor-neutral.
+set -euo pipefail
+
+if [[ ! -r /etc/os-release ]]; then
+	echo "add-nvidia-repos: /etc/os-release missing; run me inside the devkit shell" >&2
+	exit 1
+fi
+
+# shellcheck disable=SC1091
+. /etc/os-release
+if [[ "${ID:-}" != "ubuntu" ]]; then
+	echo "add-nvidia-repos: expected an Ubuntu devkit (got ID='${ID:-}')" >&2
+	exit 1
+fi
+
+# NVIDIA publishes repos per distro tag (24.04 -> ubuntu2404) and per arch, with
+# 'sbsa' standing in for arm64.
+version_id="${VERSION_ID:-}"
+distro="ubuntu${version_id//./}"
+case "$(uname -m)" in
+	x86_64) repo_arch="x86_64" ;;
+	aarch64) repo_arch="sbsa" ;;
+	*) echo "add-nvidia-repos: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+base_url="https://developer.download.nvidia.com/compute/cuda/repos/${distro}/${repo_arch}"
+keyring_deb="cuda-keyring_1.1-1_all.deb"
+
+echo "add-nvidia-repos: adding ${base_url}"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# The cuda-keyring package drops the signed-by GPG key and the sources.list entry
+# NVIDIA expects, so a plain apt-get update trusts the repo afterwards.
+curl -fsSL -o "${tmpdir}/${keyring_deb}" "${base_url}/${keyring_deb}"
+dpkg -i "${tmpdir}/${keyring_deb}"
+apt-get update
+
+cat <<'EOM'
+add-nvidia-repos: NVIDIA CUDA repository ready.
+Install packages on demand, e.g.:
+  apt-get install -y nvidia-utils-<version>   # provides nvidia-smi
+  apt-get install -y cuda-toolkit
+EOM

--- a/tools/osbuilder/rootfs-builder/devkit/devkit-enter.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/devkit-enter.sh
@@ -1,0 +1,42 @@
+#!/run/kata-extensions/devkit/bin/busybox.static sh
+# shellcheck shell=dash
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Interactive devkit debug shell: the debug_console_shell target, reached via
+# ${DEVKIT}/bin/devkit-sh -> this.
+#
+# NOTE: the bootstrap busybox ash has no builtin/PATH `[`, so use "${BB}" test.
+DEVKIT=/run/kata-extensions/devkit
+# BB and MERGED are exported by the sourced devkit-init, resolved at runtime.
+# shellcheck source=tools/osbuilder/rootfs-builder/devkit/devkit-init.sh
+. "${DEVKIT}/usr/bin/devkit-init"
+
+devkit_setup_chroot || {
+	"${BB}" echo "devkit: failed to set up chroot environment" >&2
+	exit 1
+}
+
+# Prefer the prebaked bash, falling back to busybox ash (/bin/sh) if bash is
+# missing or not executable in the merged tree.
+shell=/bin/bash
+"${BB}" test -x "${MERGED}${shell}" || shell=/bin/sh
+
+# The agent execs the shell with no arguments, so default to a login shell; any
+# arguments (-i, -c "cmd", ...) pass straight through.
+"${BB}" test "$#" -eq 0 && set -- -l
+
+# Enter the chroot in a private UTS namespace whose hostname is "devkit", so the
+# prompt makes the devkit overlay obvious without renaming the guest (the change
+# is confined to this shell and gone once it exits). Setting the name is
+# best-effort; fall back to a plain chroot if unshare is unavailable.
+if "${BB}" test -x "${MERGED}/usr/bin/unshare"; then
+	# shellcheck disable=SC2016  # $@ must expand in the inner sh, not here
+	exec "${BB}" chroot "${MERGED}" /usr/bin/unshare --uts /bin/sh -c \
+		'echo devkit > /proc/sys/kernel/hostname 2>/dev/null || true; exec "$@"' \
+		devkit-enter "${shell}" "$@"
+fi
+
+exec "${BB}" chroot "${MERGED}" "${shell}" "$@"

--- a/tools/osbuilder/rootfs-builder/devkit/devkit-init.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/devkit-init.sh
@@ -1,0 +1,116 @@
+#!/run/kata-extensions/devkit/bin/busybox.static sh
+# shellcheck shell=dash
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared devkit guest runtime library, sourced by devkit-enter.
+#
+# The devkit extension (read-only at ${DEVKIT}) is a full minimal Ubuntu rootfs.
+# We overlay a writable, exec-enabled tmpfs on it and chroot in, so apt and the
+# prebaked tools run natively against a normal root filesystem.
+#
+# BB is a statically-linked busybox (busybox-static, /bin/busybox.static), the
+# ONLY binary we can exec on the shell-less guest base before the glibc dynamic
+# loader is reachable there. It is installed at a dedicated path so it never
+# clobbers the rootfs's own /bin/busybox or GNU coreutils.
+
+DEVKIT_INIT_VERSION=1
+
+DEVKIT="${DEVKIT:-/run/kata-extensions/devkit}"
+WRITABLE="${WRITABLE:-/run/kata-devkit-writable}"
+BB="${BB:-${DEVKIT}/bin/busybox.static}"
+
+UPPER="${WRITABLE}/upper"
+WORK="${WRITABLE}/work"
+MERGED="${WRITABLE}/merged"
+
+devkit_is_mounted() {
+	"${BB}" grep -q "[[:space:]]${1}[[:space:]]" /proc/mounts 2>/dev/null
+}
+
+# Mount an exec-enabled tmpfs at ${WRITABLE}: /run is typically noexec, so the
+# overlay upper/work (and the fallback rootfs copy) must live on our own tmpfs
+# for the prebaked and apt-installed binaries to exec.
+devkit_mount_writable() {
+	"${BB}" mkdir -p "${WRITABLE}"
+	devkit_is_mounted "${WRITABLE}" && return 0
+	"${BB}" mount -t tmpfs -o mode=755,size=2G tmpfs "${WRITABLE}"
+}
+
+# Overlay (devkit ro lower + tmpfs rw upper), falling back to a plain copy of the
+# rootfs into the tmpfs if this kernel refuses an overlay mount.
+devkit_mount_root() {
+	"${BB}" mkdir -p "${UPPER}" "${WORK}" "${MERGED}"
+	devkit_is_mounted "${MERGED}" && return 0
+	"${BB}" test -f "${WRITABLE}/.copied" && return 0
+
+	local ovl_err
+	if ovl_err="$("${BB}" mount -t overlay overlay "${MERGED}" \
+		-o "lowerdir=${DEVKIT},upperdir=${UPPER},workdir=${WORK}" 2>&1)" \
+		&& devkit_is_mounted "${MERGED}"; then
+		return 0
+	fi
+
+	# Fallback: overlay unavailable on this kernel - copy the rootfs into tmpfs.
+	"${BB}" echo "devkit: overlay mount unavailable (${ovl_err:-unknown}), copying rootfs into tmpfs" >&2
+	"${BB}" cp -a "${DEVKIT}/." "${MERGED}/"
+	"${BB}" touch "${WRITABLE}/.copied"
+}
+
+# Bind the kernel virtual filesystems so apt and the debug tools behave; /dev is
+# rbind'd to bring in pts/shm for interactive shells.
+devkit_bind_mounts() {
+	"${BB}" mkdir -p "${MERGED}/proc" "${MERGED}/sys" "${MERGED}/dev"
+
+	devkit_is_mounted "${MERGED}/proc" || "${BB}" mount -t proc proc "${MERGED}/proc"
+	devkit_is_mounted "${MERGED}/sys"  || "${BB}" mount -t sysfs sysfs "${MERGED}/sys"
+
+	if ! devkit_is_mounted "${MERGED}/dev"; then
+		if ! "${BB}" mount -o rbind /dev "${MERGED}/dev" 2>/dev/null; then
+			"${BB}" mount -t devtmpfs devtmpfs "${MERGED}/dev" 2>/dev/null \
+				|| "${BB}" mount -t tmpfs tmpfs "${MERGED}/dev"
+			"${BB}" mkdir -p "${MERGED}/dev/pts"
+			"${BB}" mount -t devpts devpts "${MERGED}/dev/pts" 2>/dev/null || true
+		fi
+	fi
+}
+
+# Give apt/curl working DNS by importing the guest resolver config.
+devkit_seed_resolv_conf() {
+	"${BB}" test -e /etc/resolv.conf || return 0
+	"${BB}" mkdir -p "${MERGED}/etc"
+	"${BB}" cp -L /etc/resolv.conf "${MERGED}/etc/resolv.conf" 2>/dev/null || true
+}
+
+# Expose the guest's real root as /real_root so container rootfses and other
+# guest state are reachable from the debug shell (e.g.
+# /real_root/run/kata-containers/<id>/rootfs).
+#
+# A symlink to /proc/1/root, not a bind mount: proc is mounted in the chroot, so
+# the kernel resolves it to PID 1's root regardless of the chroot, with no
+# bind-mount recursion or teardown ordering to worry about.
+devkit_link_real_root() {
+	"${BB}" test -e "${MERGED}/real_root" && return 0
+	"${BB}" ln -s /proc/1/root "${MERGED}/real_root" 2>/dev/null || true
+}
+
+# Idempotent: safe to call from every devkit-* invocation.
+devkit_setup_chroot() {
+	devkit_mount_writable || return 1
+	devkit_mount_root || return 1
+	devkit_bind_mounts || return 1
+	devkit_seed_resolv_conf
+	devkit_link_real_root
+	"${BB}" echo "${DEVKIT_INIT_VERSION}" > "${WRITABLE}/.initialized" 2>/dev/null || true
+	return 0
+}
+
+devkit_chroot_exec() {
+	devkit_setup_chroot || {
+		"${BB}" echo "devkit: failed to set up chroot environment" >&2
+		return 1
+	}
+	exec "${BB}" chroot "${MERGED}" "$@"
+}

--- a/tools/osbuilder/rootfs-builder/devkit/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/rootfs_lib.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Kata Containers Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
+build_rootfs() {
+	local rootfs_dir="$1"
+
+	# mmdebstrap resolves apt dependencies natively (the same tool the base guest
+	# rootfs uses), so the devkit needs no chroot or docker-export gymnastics.
+	# shellcheck disable=SC2154
+	if ! mmdebstrap --mode auto --arch "${DEB_ARCH}" --variant required \
+			--components="${REPO_COMPONENTS}" \
+			--include "${PACKAGES}${EXTRA_PKGS:+ ${EXTRA_PKGS}}" \
+			"${OS_VERSION}" "${rootfs_dir}" "${REPO_URL}"; then
+		die "mmdebstrap failed for the devkit rootfs"
+	fi
+
+	# Expose busybox-static at the path devkit-init bootstraps from on the
+	# shell-less guest base.
+	local bb_src="" cand
+	for cand in usr/bin/busybox bin/busybox usr/sbin/busybox sbin/busybox; do
+		[[ -f "${rootfs_dir}/${cand}" ]] && { bb_src="${cand}"; break; }
+	done
+	[[ -n "${bb_src}" ]] || die "busybox-static not found in the devkit rootfs"
+	cp -a "${rootfs_dir}/${bb_src}" "${rootfs_dir}/usr/bin/busybox.static"
+
+	# Install the guest-side helper scripts and expose the debug console entry as
+	# devkit-sh (a sibling symlink to devkit-enter; Ubuntu's /bin is a symlink to
+	# /usr/bin, so /run/kata-extensions/devkit/bin/devkit-sh resolves here).
+	local script dest
+	# CONFIG_DIR is exported by rootfs.sh (the sourcing build system).
+	# shellcheck disable=SC2154
+	for script in devkit-init.sh devkit-enter.sh devkit-add-nvidia-repos.sh; do
+		[[ -f "${CONFIG_DIR}/${script}" ]] || die "missing ${CONFIG_DIR}/${script}"
+		dest="${script%.sh}"
+		install -D -m0755 "${CONFIG_DIR}/${script}" "${rootfs_dir}/usr/bin/${dest}"
+	done
+	ln -sf devkit-enter "${rootfs_dir}/usr/bin/devkit-sh"
+
+	# apt in the debug overlay runs as root: this is a single-user chroot and the
+	# _apt sandbox user cannot create its temp files (apt-key config, partials) on
+	# the tmpfs overlay, which otherwise breaks `apt-get update`. Keep /tmp sticky
+	# for the same reason.
+	install -d -m0755 "${rootfs_dir}/etc/apt/apt.conf.d"
+	echo 'APT::Sandbox::User "root";' > "${rootfs_dir}/etc/apt/apt.conf.d/99-devkit.conf"
+	chmod 0644 "${rootfs_dir}/etc/apt/apt.conf.d/99-devkit.conf"
+	chmod 1777 "${rootfs_dir}/tmp" 2>/dev/null || true
+
+	# Trim what a debug rootfs does not need (man/doc/info, apt lists/cache) and
+	# the seeded resolver (devkit-init re-seeds one at runtime).
+	rm -rf \
+		"${rootfs_dir}/usr/share/man"/* \
+		"${rootfs_dir}/usr/share/doc"/* \
+		"${rootfs_dir}/usr/share/info"/* \
+		"${rootfs_dir}/var/lib/apt/lists"/* \
+		"${rootfs_dir}/var/cache/apt"/* \
+		"${rootfs_dir}/etc/resolv.conf" \
+		2>/dev/null || true
+
+	# The mount point must be searchable once the extension is mounted read-only.
+	chmod 0755 "${rootfs_dir}"
+}

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -64,6 +64,11 @@ KBUILD_SIGN_PIN=${KBUILD_SIGN_PIN:-""}
 NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-""}
 BUILD_VARIANT=${BUILD_VARIANT:-""}
 
+# When set to "yes", build only the distro rootfs and skip the agent/systemd
+# setup. Used to assemble shell/agent-less guest extension rootfses (e.g. the
+# devkit debug extension) that ship no kata-agent.
+ROOTFS_ONLY=${ROOTFS_ONLY:-""}
+
 # All NVIDIA build variants (nvidia, nvidia-gpu, nvidia-gpu-confidential,
 # nvidia-gpu-extension) are handled by the NVIDIA rootfs builder.
 is_nvidia_variant() { [[ "${BUILD_VARIANT}" == "nvidia" || "${BUILD_VARIANT}" == "nvidia-"* ]]; }
@@ -303,7 +308,7 @@ docker_extra_args()
 		# shellcheck disable=SC2154
 		args+=" --volumes-from ${gentoo_portage_container}"
 		;;
-	debian | ubuntu | suse)
+	debian | ubuntu | suse | devkit)
 		source /etc/os-release
 
 		case "${ID}" in
@@ -572,6 +577,7 @@ build_rootfs_distro()
 			--env OSBUILDER_VERSION="${OSBUILDER_VERSION}" \
 			--env OS_VERSION="${OS_VERSION}" \
 			--env BUILD_VARIANT="${BUILD_VARIANT}" \
+			--env ROOTFS_ONLY="${ROOTFS_ONLY}" \
 			--env INSIDE_CONTAINER=1 \
 			--env SECCOMP="${SECCOMP}" \
 			--env SELINUX="${SELINUX}" \
@@ -910,6 +916,14 @@ main()
 		# Set the distro for dracut build method
 		detect_host_distro
 		prepare_overlay
+	fi
+
+	# Guest extension rootfses (e.g. the devkit debug extension) ship no
+	# kata-agent, so stop after the distro rootfs is built and skip the
+	# agent/systemd setup below.
+	if [[ "${ROOTFS_ONLY}" == "yes" ]]; then
+		info "ROOTFS_ONLY set: skipping agent and systemd setup"
+		return 0
 	fi
 
 	init="${ROOTFS_DIR}/sbin/init"

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -107,6 +107,9 @@ pub async fn install_artifacts(config: &Config, container_runtime: &str) -> Resu
 
     let mut extracted: HashSet<String> = HashSet::new();
     extract_component_tarballs(config, &mut extracted)?;
+    // Not tied to any shim, so reconcile separately: turning debug off on a
+    // redeploy must also remove it.
+    reconcile_debug_tools(config, &mut extracted)?;
     install_versions_yaml(config)?;
 
     set_executable_permissions(&config.host_install_dir)?;
@@ -736,6 +739,106 @@ fn extract_component_tarballs(config: &Config, extracted: &mut HashSet<String>) 
         })?;
 
         extracted.insert(component.clone());
+    }
+
+    Ok(())
+}
+
+/// Debug-only tools pulled in by the debug flag rather than per-shim membership:
+/// kata-ctl ships in the kata-tools bundle, not with the shims.
+const DEBUG_TOOL_COMPONENTS: &[&str] = &["kata-ctl"];
+
+/// Static list of a tool's installed files, needed to remove it when debug is
+/// off: nothing is extracted then, so paths can't be discovered dynamically.
+fn debug_tool_paths(component: &str) -> &'static [&'static str] {
+    match component {
+        "kata-ctl" => &["bin/kata-ctl"],
+        _ => &[],
+    }
+}
+
+/// Extract debug tooling when debug is on, remove it when off so a redeploy
+/// never leaves it behind. Extraction is best-effort: a missing tarball only
+/// warns, since an image may be built without the tools.
+fn reconcile_debug_tools(config: &Config, extracted: &mut HashSet<String>) -> Result<()> {
+    if config.debug {
+        extract_debug_tools_in(
+            DEBUG_TOOL_COMPONENTS,
+            Path::new(TARBALLS_DIR),
+            &config.host_install_dir,
+            true,
+            extracted,
+        )
+    } else {
+        remove_debug_tools_in(DEBUG_TOOL_COMPONENTS, Path::new(&config.host_install_dir));
+        Ok(())
+    }
+}
+
+/// Remove the given debug tools' files. Best-effort and idempotent: only
+/// existing files are touched and a failed removal warns instead of aborting.
+fn remove_debug_tools_in(components: &[&str], install_dir: &Path) {
+    for component in components {
+        for rel in debug_tool_paths(component) {
+            let path = install_dir.join(rel);
+            if path.exists() {
+                info!(
+                    "debug disabled: removing debug tool '{}' ({})",
+                    component,
+                    path.display()
+                );
+                if let Err(e) = fs::remove_file(&path) {
+                    log::warn!("debug: failed to remove {}: {}", path.display(), e);
+                }
+            }
+        }
+    }
+}
+
+/// Testable core of the debug-tool extraction: takes explicit paths so it can
+/// be unit tested without the container image layout.
+fn extract_debug_tools_in(
+    components: &[&str],
+    tarballs_dir: &Path,
+    host_install_dir: &str,
+    debug: bool,
+    extracted: &mut HashSet<String>,
+) -> Result<()> {
+    if !debug {
+        return Ok(());
+    }
+
+    for component in components {
+        if extracted.contains(*component) {
+            continue;
+        }
+
+        let tarball_name = format!("kata-static-{}.tar.zst", component);
+        let tarball_path = tarballs_dir.join(&tarball_name);
+
+        if !tarball_path.exists() {
+            log::warn!(
+                "debug: optional tool '{}' not found at {}; skipping. Rebuild the \
+                 kata-deploy image with the '{}' component to enable it.",
+                component,
+                tarball_path.display(),
+                component
+            );
+            continue;
+        }
+
+        info!("debug: extracting optional tool '{}'", component);
+        if let Err(e) = extract_tarball(&tarball_path, host_install_dir) {
+            log::warn!(
+                "debug: failed to extract optional tool '{}' from {}: {:#}; skipping",
+                component,
+                tarball_path.display(),
+                e
+            );
+            continue;
+        }
+
+        extracted.insert((*component).to_string());
     }
 
     Ok(())
@@ -1655,5 +1758,77 @@ mod tests {
 
         fs::remove_dir_all(&runtime_dir).unwrap();
         assert!(!runtime_dir.exists());
+    }
+
+    #[test]
+    fn test_extract_debug_tools_disabled_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().to_str().unwrap();
+        let mut extracted: HashSet<String> = HashSet::new();
+
+        extract_debug_tools_in(&["kata-ctl"], tmp.path(), dest, false, &mut extracted).unwrap();
+
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn test_extract_debug_tools_missing_tarball_is_best_effort() {
+        let tarballs = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let mut extracted: HashSet<String> = HashSet::new();
+
+        extract_debug_tools_in(
+            &["kata-ctl"],
+            tarballs.path(),
+            dest.path().to_str().unwrap(),
+            true,
+            &mut extracted,
+        )
+        .unwrap();
+
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn test_extract_debug_tools_skips_already_extracted() {
+        let tarballs = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let mut extracted: HashSet<String> = ["kata-ctl".to_string()].into_iter().collect();
+
+        extract_debug_tools_in(
+            &["kata-ctl"],
+            tarballs.path(),
+            dest.path().to_str().unwrap(),
+            true,
+            &mut extracted,
+        )
+        .unwrap();
+
+        assert_eq!(extracted.len(), 1);
+        assert!(extracted.contains("kata-ctl"));
+    }
+
+    #[test]
+    fn test_remove_debug_tools_removes_installed_files() {
+        let install = tempfile::tempdir().unwrap();
+        let bin = install.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let kata_ctl = bin.join("kata-ctl");
+        fs::write(&kata_ctl, "binary").unwrap();
+        // A sibling that must be left untouched.
+        let shim = bin.join("containerd-shim-kata-v2");
+        fs::write(&shim, "shim").unwrap();
+
+        remove_debug_tools_in(&["kata-ctl"], install.path());
+
+        assert!(!kata_ctl.exists(), "kata-ctl removed when debug is off");
+        assert!(shim.exists(), "unrelated binaries untouched");
+    }
+
+    #[test]
+    fn test_remove_debug_tools_is_noop_when_absent() {
+        let install = tempfile::tempdir().unwrap();
+        remove_debug_tools_in(&["kata-ctl"], install.path());
+        assert!(!install.path().join("bin/kata-ctl").exists());
     }
 }

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -14,6 +14,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
 #[cfg(test)]
 use walkdir::WalkDir;
 
@@ -122,6 +123,10 @@ pub async fn install_artifacts(config: &Config, container_runtime: &str) -> Resu
     if config.custom_runtimes_enabled && !config.custom_runtimes.is_empty() {
         install_custom_runtime_configs(config, container_runtime)?;
     }
+
+    // Drop any devkit artifacts a previous deploy left behind but this one no
+    // longer wants (e.g. devkit toggled off, or a shim removed).
+    reconcile_devkit_artifacts(config)?;
 
     let expand_runtime_classes_for_nfd = nfd::setup_nfd_rules(config).await?;
 
@@ -306,6 +311,44 @@ fn install_custom_runtime_configs(config: &Config, container_runtime: &str) -> R
             container_runtime,
         )?;
 
+        // Everything devkit needs (the extension image + the debug console shell)
+        // goes into the drop-in (25-devkit.toml), leaving the copied base config
+        // untouched for users to inspect.
+        //
+        // The drop-in merge REPLACES the guest_extension_images array rather than
+        // appending, so it must re-emit the base's existing extensions in order and
+        // append devkit last: this preserves them (stable device enumeration) and
+        // makes devkit the last image attached, perturbing the guest we want to
+        // debug as little as possible.
+        if runtime.devkit {
+            let image_path = format!(
+                "{}/share/kata-containers/kata-containers-devkit-extension.img",
+                config.dest_dir
+            );
+            let verity_params = devkit_verity_params(&config.dest_dir);
+            let hypervisor_name = get_hypervisor_name(&runtime.base_config)?;
+            let existing = if Path::new(&dest_config).exists() {
+                read_guest_extension_images(Path::new(&dest_config), hypervisor_name)?
+            } else {
+                log::warn!(
+                    "devkit: base config {} is missing; the devkit drop-in will only \
+                     carry the devkit extension image",
+                    dest_config
+                );
+                Vec::new()
+            };
+            write_drop_in_file(
+                &config_d_dir,
+                "25-devkit.toml",
+                &generate_devkit_drop_in(
+                    hypervisor_name,
+                    &existing,
+                    &image_path,
+                    verity_params.as_deref(),
+                ),
+            )?;
+        }
+
         // Copy user-provided drop-in file if provided (at 50-overrides.toml).
         // If it was removed from values in a later upgrade/migration, remove stale file.
         let drop_in_dest = format!("{}/50-overrides.toml", config_d_dir);
@@ -370,6 +413,97 @@ fn remove_custom_runtime_configs(config: &Config) -> Result<()> {
     }
 
     info!("Successfully removed custom runtime config files");
+    Ok(())
+}
+
+/// Remove on-node devkit artifacts the current configuration no longer wants.
+///
+/// Devkit is materialized as kata-<shim>-devkit custom runtimes only while
+/// DEVKIT=true. When a redeploy disables devkit (or drops a shim) those runtimes
+/// vanish from `config.custom_runtimes`, so the normal custom-runtime cleanup
+/// never touches their leftovers. Installs only ever add files, so reconcile
+/// explicitly: drop stale kata-<shim>-devkit handler directories and, once no
+/// devkit runtime remains, the now-unreferenced extension image and root-hash.
+///
+/// The RuntimeClasses are Helm-managed and the containerd handlers regenerated
+/// every install, so only these binary-installed files need reconciling here.
+fn reconcile_devkit_artifacts(config: &Config) -> Result<()> {
+    // Handlers the current config owns (devkit-synthesized or user-provided). Any
+    // kata-<shim>-devkit directory not in this set is a stale devkit leftover; a
+    // handler that happens to match a user's own custom runtime is protected.
+    let known: HashSet<&str> = config
+        .custom_runtimes
+        .iter()
+        .map(|r| r.handler.as_str())
+        .collect();
+
+    let custom_runtimes_dir = format!(
+        "/host/{}/share/defaults/kata-containers/custom-runtimes",
+        config.dest_dir
+    );
+    let share_dir = format!("{}/share/kata-containers", config.host_install_dir);
+
+    reconcile_devkit_artifacts_in(
+        &known,
+        Path::new(&custom_runtimes_dir),
+        Path::new(&share_dir),
+        config.devkit_enabled,
+    )
+}
+
+/// Pure core of [`reconcile_devkit_artifacts`], separated so it can be unit
+/// tested against real directories without a full [`Config`].
+///
+/// `known_handlers` are preserved; every other kata-<shim>-devkit directory under
+/// `custom_runtimes_dir` is removed. When `devkit_enabled` is false the
+/// unreferenced extension image and root-hash under `share_dir` are removed too.
+fn reconcile_devkit_artifacts_in(
+    known_handlers: &HashSet<&str>,
+    custom_runtimes_dir: &Path,
+    share_dir: &Path,
+    devkit_enabled: bool,
+) -> Result<()> {
+    for shim in ALL_SHIMS {
+        let handler = format!("kata-{shim}-devkit");
+        if known_handlers.contains(handler.as_str()) {
+            continue;
+        }
+        let handler_dir = custom_runtimes_dir.join(&handler);
+        if handler_dir.exists() {
+            info!(
+                "devkit: removing stale runtime directory {}",
+                handler_dir.display()
+            );
+            if let Err(e) = fs::remove_dir_all(&handler_dir) {
+                log::warn!("devkit: failed to remove {}: {}", handler_dir.display(), e);
+            }
+        }
+    }
+
+    if custom_runtimes_dir.exists() {
+        if let Ok(entries) = fs::read_dir(custom_runtimes_dir) {
+            if entries.count() == 0 {
+                let _ = fs::remove_dir(custom_runtimes_dir);
+            }
+        }
+    }
+
+    // With no devkit runtime left, the extracted extension image is unreferenced.
+    if !devkit_enabled {
+        for name in [
+            "kata-containers-devkit-extension.img",
+            "root_hash_devkit-extension.txt",
+        ] {
+            let path = share_dir.join(name);
+            if path.exists() {
+                info!("devkit: removing unreferenced {}", path.display());
+                if let Err(e) = fs::remove_file(&path) {
+                    log::warn!("devkit: failed to remove {}: {}", path.display(), e);
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -502,6 +636,13 @@ fn collect_required_tarballs(config: &Config) -> Result<HashSet<String>> {
             }
         }
     }
+
+    // Generic, not tied to any shim in shim-components.json, so it is pulled in
+    // by the devkit flag rather than per-shim membership.
+    if config.devkit_enabled {
+        required.insert("rootfs-image-devkit-extension".to_string());
+    }
+
     Ok(required)
 }
 
@@ -1302,6 +1443,154 @@ enable_debug = true
     Ok(content)
 }
 
+/// Guest path of the devkit debug console shell. Must live under
+/// /run/kata-extensions/, the prefix the agent enforces for debug_console_shell.
+const DEVKIT_DEBUG_CONSOLE_SHELL: &str = "/run/kata-extensions/devkit/bin/devkit-sh";
+
+/// Read the devkit extension's dm-verity params from its root-hash file. Absent
+/// (e.g. s390x, built without a measured rootfs) means `None` and the image is
+/// mounted unverified.
+fn devkit_verity_params(dest_dir: &str) -> Option<String> {
+    let root_hash_file = format!(
+        "/host{}/share/kata-containers/root_hash_devkit-extension.txt",
+        dest_dir
+    );
+    match fs::read_to_string(&root_hash_file) {
+        Ok(content) => content
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(|l| l.to_string()),
+        Err(_) => {
+            log::warn!(
+                "devkit: {} not found; mounting the devkit extension without dm-verity",
+                root_hash_file
+            );
+            None
+        }
+    }
+}
+
+/// A `guest_extension_images` entry read from a runtime's base config.
+struct GuestExtension {
+    name: String,
+    path: String,
+    verity_params: Option<String>,
+}
+
+/// Read the base config's existing `guest_extension_images`, in order, so the
+/// drop-in can re-emit them ahead of devkit (the merge replaces the array, so
+/// anything omitted is lost). Any pre-existing `devkit` entry is skipped, since
+/// the drop-in always appends its own.
+fn read_guest_extension_images(
+    config_file: &Path,
+    hypervisor_name: &str,
+) -> Result<Vec<GuestExtension>> {
+    let content = fs::read_to_string(config_file)
+        .with_context(|| format!("Failed to read config for devkit extension: {config_file:?}"))?;
+    let doc = content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("Failed to parse config as TOML: {config_file:?}"))?;
+
+    let images = doc
+        .get("hypervisor")
+        .and_then(|h| h.get(hypervisor_name))
+        .and_then(|hv| hv.get("guest_extension_images"))
+        .and_then(|i| i.as_array_of_tables());
+
+    let mut out = Vec::new();
+    if let Some(images) = images {
+        for t in images.iter() {
+            let name = t.get("name").and_then(|i| i.as_str());
+            let path = t.get("path").and_then(|i| i.as_str());
+            if let (Some(name), Some(path)) = (name, path) {
+                if name == "devkit" {
+                    continue;
+                }
+                out.push(GuestExtension {
+                    name: name.to_string(),
+                    path: path.to_string(),
+                    verity_params: t
+                        .get("verity_params")
+                        .and_then(|i| i.as_str())
+                        .map(str::to_string),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn push_guest_extension(
+    images: &mut ArrayOfTables,
+    name: &str,
+    path: &str,
+    verity_params: Option<&str>,
+) {
+    let mut entry = Table::new();
+    entry["name"] = value(name);
+    entry["path"] = value(path);
+    if let Some(vp) = verity_params {
+        entry["verity_params"] = value(vp);
+    }
+    images.push(entry);
+}
+
+/// Generate the devkit drop-in (25-devkit.toml): the agent debug-console scalars
+/// plus the full guest_extension_images array (base extensions in order, devkit
+/// last). The base config is left untouched so the shipped configuration.toml
+/// stays clean for users.
+fn generate_devkit_drop_in(
+    hypervisor_name: &str,
+    existing: &[GuestExtension],
+    image_path: &str,
+    verity_params: Option<&str>,
+) -> String {
+    let mut doc = DocumentMut::new();
+
+    // [agent.kata] scalars. The intermediate `agent` table is implicit so only
+    // the `[agent.kata]` header is emitted, not an empty `[agent]`.
+    let mut agent_kata = Table::new();
+    agent_kata["debug_console_enabled"] = value(true);
+    agent_kata["debug_console_shell"] = value(DEVKIT_DEBUG_CONSOLE_SHELL);
+    let mut agent = Table::new();
+    agent.set_implicit(true);
+    agent.insert("kata", Item::Table(agent_kata));
+    doc.insert("agent", Item::Table(agent));
+
+    // [[hypervisor.<hv>.guest_extension_images]]: base extensions first, devkit
+    // last. Built as explicit (non-inline) tables so the array of tables renders
+    // as headers; the intermediate `hypervisor` table is implicit.
+    let mut images = ArrayOfTables::new();
+    for ext in existing {
+        push_guest_extension(
+            &mut images,
+            &ext.name,
+            &ext.path,
+            ext.verity_params.as_deref(),
+        );
+    }
+    push_guest_extension(&mut images, "devkit", image_path, verity_params);
+    let mut hv = Table::new();
+    hv.insert("guest_extension_images", Item::ArrayOfTables(images));
+    let mut hypervisor = Table::new();
+    hypervisor.set_implicit(true);
+    hypervisor.insert(hypervisor_name, Item::Table(hv));
+    doc.insert("hypervisor", Item::Table(hypervisor));
+
+    let mut content = String::new();
+    content.push_str("# Devkit debug extension\n");
+    content.push_str("# Generated by kata-deploy\n");
+    content.push_str("#\n");
+    content.push_str("# Points the agent debug console at the shell shipped by the devkit\n");
+    content.push_str("# extension, and cold-plugs the extension image as the last\n");
+    content.push_str("# guest_extension_images entry (any extensions the base config already\n");
+    content
+        .push_str("# ships are re-listed here first, since drop-in merging replaces arrays).\n\n");
+    content.push_str(&doc.to_string());
+    content
+}
+
 /// Get proxy value for a specific shim from config.
 /// Handles both per-shim format ("qemu-tdx=http://proxy:8080;qemu-snp=http://proxy2:8080")
 /// and global format ("http://proxy:8080").
@@ -1515,6 +1804,179 @@ mod tests {
             err_msg.contains("Valid shims are:"),
             "Error message should list valid shims"
         );
+    }
+
+    const DEVKIT_IMG: &str = "/opt/kata/share/kata-containers/kata-containers-devkit-extension.img";
+
+    /// Parse a generated drop-in and return the ordered `name` values of its
+    /// guest_extension_images array under the given hypervisor.
+    fn drop_in_extension_names(content: &str, hypervisor_name: &str) -> Vec<String> {
+        let doc = content.parse::<DocumentMut>().unwrap();
+        doc["hypervisor"][hypervisor_name]["guest_extension_images"]
+            .as_array_of_tables()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_generate_devkit_drop_in_scalars() {
+        // The drop-in always carries the agent debug-console scalars.
+        let content = generate_devkit_drop_in("qemu", &[], DEVKIT_IMG, None);
+
+        assert!(content.contains("[agent.kata]"));
+        assert!(content.contains("debug_console_enabled = true"));
+        assert!(
+            content.contains("debug_console_shell = \"/run/kata-extensions/devkit/bin/devkit-sh\"")
+        );
+    }
+
+    #[test]
+    fn test_generate_devkit_drop_in_only_devkit_when_base_empty() {
+        // A base config with no extensions yields an array with devkit only.
+        let content = generate_devkit_drop_in("qemu", &[], DEVKIT_IMG, None);
+
+        assert_eq!(drop_in_extension_names(&content, "qemu"), vec!["devkit"]);
+        assert!(content.contains(&format!("path = \"{DEVKIT_IMG}\"")));
+        // No root hash provided -> no verity params emitted (raw mount).
+        assert!(!content.contains("verity_params"));
+    }
+
+    #[test]
+    fn test_generate_devkit_drop_in_reemits_existing_then_devkit() {
+        // A base config that already ships an extension (e.g. coco) must have it
+        // re-listed first, with devkit strictly after it, so the array-replacing
+        // drop-in merge does not drop it.
+        let existing = vec![GuestExtension {
+            name: "coco".to_string(),
+            path: "/opt/kata/share/kata-containers/coco.img".to_string(),
+            verity_params: Some("root_hash=abc".to_string()),
+        }];
+        let content = generate_devkit_drop_in("qemu", &existing, DEVKIT_IMG, Some("root_hash=def"));
+
+        assert_eq!(
+            drop_in_extension_names(&content, "qemu"),
+            vec!["coco", "devkit"]
+        );
+        // The pre-existing coco entry (path + verity) is re-emitted verbatim.
+        assert!(content.contains("name = \"coco\""));
+        assert!(content.contains("path = \"/opt/kata/share/kata-containers/coco.img\""));
+        assert!(content.contains("root_hash=abc"));
+        // devkit is present with its own image path and verity params.
+        assert!(content.contains(&format!("path = \"{DEVKIT_IMG}\"")));
+        assert!(content.contains("root_hash=def"));
+    }
+
+    #[test]
+    fn test_read_guest_extension_images_skips_devkit_and_keeps_order() {
+        // Base config carries two extensions plus a stray devkit; the reader keeps
+        // the real ones in order and drops any pre-existing devkit entry.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "[hypervisor.qemu]\npath = \"/usr/bin/qemu\"\n\n\
+             [[hypervisor.qemu.guest_extension_images]]\n\
+             name = \"coco\"\npath = \"/opt/kata/share/kata-containers/coco.img\"\n\
+             verity_params = \"root_hash=abc\"\n\n\
+             [[hypervisor.qemu.guest_extension_images]]\n\
+             name = \"gpu\"\npath = \"/opt/kata/share/kata-containers/gpu.img\"\n\n\
+             [[hypervisor.qemu.guest_extension_images]]\n\
+             name = \"devkit\"\npath = \"/stale/devkit.img\"\n",
+        )
+        .unwrap();
+
+        let existing = read_guest_extension_images(tmp.path(), "qemu").unwrap();
+        let names: Vec<_> = existing.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["coco", "gpu"]);
+        assert_eq!(existing[0].verity_params.as_deref(), Some("root_hash=abc"));
+        assert_eq!(existing[1].verity_params, None);
+    }
+
+    #[test]
+    fn test_read_guest_extension_images_none_when_absent() {
+        // A base config with no extension array yields an empty list.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "[hypervisor.qemu]\npath = \"/usr/bin/qemu\"\n").unwrap();
+
+        assert!(read_guest_extension_images(tmp.path(), "qemu")
+            .unwrap()
+            .is_empty());
+    }
+
+    /// Lay down a fake devkit handler directory and the extension image + root
+    /// hash, mimicking what a devkit-enabled install leaves on the node.
+    fn seed_devkit_layout(custom_runtimes_dir: &Path, share_dir: &Path, handlers: &[&str]) {
+        for handler in handlers {
+            let d = custom_runtimes_dir.join(handler).join("config.d");
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("25-devkit.toml"), "[agent.kata]\n").unwrap();
+        }
+        fs::create_dir_all(share_dir).unwrap();
+        fs::write(
+            share_dir.join("kata-containers-devkit-extension.img"),
+            "img",
+        )
+        .unwrap();
+        fs::write(
+            share_dir.join("root_hash_devkit-extension.txt"),
+            "root_hash=x",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_reconcile_devkit_disabled_removes_everything() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom-runtimes");
+        let share = tmp.path().join("share/kata-containers");
+        seed_devkit_layout(&custom, &share, &["kata-qemu-devkit", "kata-fc-devkit"]);
+
+        // devkit disabled -> no known devkit handlers, image should go too.
+        reconcile_devkit_artifacts_in(&HashSet::new(), &custom, &share, false).unwrap();
+
+        assert!(!custom.join("kata-qemu-devkit").exists());
+        assert!(!custom.join("kata-fc-devkit").exists());
+        // Emptied custom-runtimes dir is dropped.
+        assert!(!custom.exists());
+        assert!(!share.join("kata-containers-devkit-extension.img").exists());
+        assert!(!share.join("root_hash_devkit-extension.txt").exists());
+    }
+
+    #[test]
+    fn test_reconcile_devkit_keeps_active_and_protects_user_runtimes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom-runtimes");
+        let share = tmp.path().join("share/kata-containers");
+        // kata-qemu-devkit is still active; kata-fc-devkit is stale.
+        seed_devkit_layout(&custom, &share, &["kata-qemu-devkit", "kata-fc-devkit"]);
+        // A user custom runtime that must never be touched.
+        let user = custom.join("kata-mine");
+        fs::create_dir_all(&user).unwrap();
+        fs::write(user.join("marker"), "keep").unwrap();
+
+        let known: HashSet<&str> = ["kata-qemu-devkit", "kata-mine"].into_iter().collect();
+        // devkit still enabled -> image is preserved.
+        reconcile_devkit_artifacts_in(&known, &custom, &share, true).unwrap();
+
+        assert!(custom.join("kata-qemu-devkit").exists(), "active kept");
+        assert!(!custom.join("kata-fc-devkit").exists(), "stale removed");
+        assert!(user.join("marker").exists(), "user runtime untouched");
+        assert!(
+            share.join("kata-containers-devkit-extension.img").exists(),
+            "image kept while devkit enabled"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_devkit_is_noop_without_leftovers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom-runtimes");
+        let share = tmp.path().join("share/kata-containers");
+        // Nothing seeded: reconcile must succeed and create nothing.
+        reconcile_devkit_artifacts_in(&HashSet::new(), &custom, &share, false).unwrap();
+        assert!(!custom.exists());
+        assert!(!share.exists());
     }
 
     #[test]

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -161,6 +161,9 @@ pub struct CustomRuntime {
     pub containerd_snapshotter: Option<String>,
     /// CRI-O pull type (e.g., "guest-pull")
     pub crio_pull_type: Option<String>,
+    /// Internally-synthesized devkit runtime (kata-<shim>-devkit): gets an extra
+    /// drop-in wiring the extension image and debug console shell.
+    pub devkit: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -199,6 +202,11 @@ pub struct Config {
     pub daemonset_name: String,
     pub custom_runtimes_enabled: bool,
     pub custom_runtimes: Vec<CustomRuntime>,
+    /// Install the devkit extension and a kata-<shim>-devkit custom runtime per
+    /// enabled shim. From the DEVKIT env var, honored only when debug is also on:
+    /// the devkit drop-in enables the agent debug console, which must never come
+    /// up without debug.
+    pub devkit_enabled: bool,
     /// EROFS snapshotter rw-layer backing mode ("disk" or "memory").
     pub erofs_snapshotter_mode: Option<String>,
     /// Enable dm-verity integrity for EROFS lower layers.
@@ -238,7 +246,7 @@ impl Config {
         // Parse shims - only use arch-specific variable
         // Use architecture-specific default shims list (only shims supported for this arch)
         let default_shims = get_default_shims_for_arch(&arch);
-        let shims_for_arch = get_arch_var("SHIMS", default_shims, &arch)
+        let shims_for_arch: Vec<String> = get_arch_var("SHIMS", default_shims, &arch)
             .split_whitespace()
             .map(|s| s.to_string())
             .collect();
@@ -346,13 +354,53 @@ impl Config {
                 .collect();
 
         // Parse custom runtimes from ConfigMap
-        let custom_runtimes_enabled =
+        let custom_runtimes_from_configmap =
             env::var("CUSTOM_RUNTIMES_ENABLED").unwrap_or_else(|_| "false".to_string()) == "true";
-        let custom_runtimes = if custom_runtimes_enabled {
+        let mut custom_runtimes = if custom_runtimes_from_configmap {
             parse_custom_runtimes()?
         } else {
             Vec::new()
         };
+
+        // Model devkit as one custom runtime per shim (kata-<shim>-devkit) to
+        // reuse the whole custom-runtime install/register/cleanup machinery; the
+        // only devkit-specific bit is an extra drop-in (in install.rs).
+        //
+        // Gate it on debug: the devkit drop-in turns on the agent debug console,
+        // so honoring DEVKIT without DEBUG would silently enable it, breaking the
+        // "only effective with debug" contract.
+        let devkit_requested = env::var("DEVKIT").unwrap_or_else(|_| "false".to_string()) == "true";
+        if devkit_requested && !debug {
+            log::warn!("DEVKIT=true ignored: it requires DEBUG=true to take effect");
+        }
+        let devkit_enabled = devkit_requested && debug;
+        if devkit_enabled {
+            for shim in &shims_for_arch {
+                // Inherit the base shim's image-pulling config: the devkit
+                // RuntimeClass shares the base config (same shared_fs), so it must
+                // pull the same way. Otherwise containerd/CRI-O default to
+                // overlayfs/node-pull, which breaks shims running shared_fs = none
+                // (e.g. nvidia runtime-rs) and makes every devkit pod terminate.
+                let containerd_snapshotter = snapshotter_handler_mapping_for_arch
+                    .as_ref()
+                    .and_then(|mapping| lookup_mapping_value(mapping, shim));
+                let crio_pull_type = pull_type_mapping_for_arch
+                    .as_ref()
+                    .and_then(|mapping| lookup_mapping_value(mapping, shim));
+
+                custom_runtimes.push(CustomRuntime {
+                    handler: format!("kata-{shim}-devkit"),
+                    base_config: shim.to_string(),
+                    drop_in_file: None,
+                    containerd_snapshotter,
+                    crio_pull_type,
+                    devkit: true,
+                });
+            }
+        }
+
+        // Enable the custom-runtime code paths if either source produced entries.
+        let custom_runtimes_enabled = !custom_runtimes.is_empty();
 
         let erofs_snapshotter_mode = env::var("EROFS_SNAPSHOTTER_MODE")
             .ok()
@@ -401,6 +449,7 @@ impl Config {
             daemonset_name,
             custom_runtimes_enabled,
             custom_runtimes,
+            devkit_enabled,
             erofs_snapshotter_mode,
             erofs_dmverity,
             startup_taints,
@@ -795,6 +844,21 @@ fn get_arch() -> Result<String> {
     .to_string())
 }
 
+/// Look up `shim`'s value in a comma-separated "shim1:value1,shim2:value2"
+/// mapping (SNAPSHOTTER_HANDLER_MAPPING, PULL_TYPE_MAPPING). None if absent or
+/// empty.
+fn lookup_mapping_value(mapping: &str, shim: &str) -> Option<String> {
+    mapping.split(',').find_map(|entry| {
+        let parts: Vec<&str> = entry.split(':').collect();
+        if parts.len() == 2 && parts[0].trim() == shim {
+            let value = parts[1].trim();
+            (!value.is_empty()).then(|| value.to_string())
+        } else {
+            None
+        }
+    })
+}
+
 /// Parse custom runtimes from the mounted ConfigMap at /custom-configs/
 /// Reads the custom-runtimes.list file which contains entries in the format:
 /// handler:baseConfig:containerd_snapshotter:crio_pulltype
@@ -872,6 +936,7 @@ fn parse_custom_runtimes() -> Result<Vec<CustomRuntime>> {
             drop_in_file,
             containerd_snapshotter,
             crio_pull_type,
+            devkit: false,
         });
     }
 
@@ -987,6 +1052,8 @@ mod tests {
             "EXPERIMENTAL_FORCE_GUEST_PULL_PPC64LE",
             "CONTAINERD_CONFIG_FILE_NAME",
             "STARTUP_TAINTS",
+            "CUSTOM_RUNTIMES_ENABLED",
+            "DEVKIT",
         ];
         for var in &vars {
             std::env::remove_var(var);
@@ -1133,6 +1200,100 @@ mod tests {
         );
 
         cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_devkit_disabled_by_default() {
+        setup_minimal_env();
+
+        let config = Config::from_env().unwrap();
+
+        assert!(!config.devkit_enabled);
+        assert!(config.custom_runtimes.iter().all(|r| !r.devkit));
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_devkit_requires_debug() {
+        setup_minimal_env();
+        // DEBUG defaults to false in setup_minimal_env.
+        std::env::set_var("DEVKIT", "true");
+
+        let config = Config::from_env().unwrap();
+
+        assert!(!config.devkit_enabled);
+        assert!(config.custom_runtimes.iter().all(|r| !r.devkit));
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_devkit_synthesizes_per_shim_runtime() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "true");
+        std::env::set_var("DEVKIT", "true");
+
+        let config = Config::from_env().unwrap();
+
+        assert!(config.devkit_enabled);
+        assert!(config.custom_runtimes_enabled);
+
+        // setup_minimal_env configures a single "qemu" shim for this arch.
+        let devkit: Vec<_> = config.custom_runtimes.iter().filter(|r| r.devkit).collect();
+        assert_eq!(devkit.len(), 1);
+        assert_eq!(devkit[0].handler, "kata-qemu-devkit");
+        assert_eq!(devkit[0].base_config, "qemu");
+        assert!(devkit[0].drop_in_file.is_none());
+        // With no snapshotter/pull-type mapping, the devkit runtime inherits
+        // nothing and containerd/CRI-O use their defaults for the base shim.
+        assert!(devkit[0].containerd_snapshotter.is_none());
+        assert!(devkit[0].crio_pull_type.is_none());
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_devkit_inherits_base_shim_snapshotter_and_pull_type() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "true");
+        std::env::set_var("DEVKIT", "true");
+        // The base "qemu" shim is mapped to the erofs snapshotter / guest-pull;
+        // its devkit variant must inherit both so pods on the devkit
+        // RuntimeClass pull images the same way as the base shim (crucial for
+        // shims running with shared_fs = none).
+        set_arch_var("SNAPSHOTTER_HANDLER_MAPPING", "qemu:erofs");
+        set_arch_var("PULL_TYPE_MAPPING", "qemu:guest-pull");
+
+        let config = Config::from_env().unwrap();
+
+        let devkit: Vec<_> = config.custom_runtimes.iter().filter(|r| r.devkit).collect();
+        assert_eq!(devkit.len(), 1);
+        assert_eq!(devkit[0].handler, "kata-qemu-devkit");
+        assert_eq!(devkit[0].containerd_snapshotter.as_deref(), Some("erofs"));
+        assert_eq!(devkit[0].crio_pull_type.as_deref(), Some("guest-pull"));
+
+        cleanup_env_vars();
+    }
+
+    #[test]
+    fn test_lookup_mapping_value() {
+        let mapping = "qemu:erofs, fc:nydus,clh:";
+        assert_eq!(
+            lookup_mapping_value(mapping, "qemu").as_deref(),
+            Some("erofs")
+        );
+        // Entries may carry surrounding whitespace.
+        assert_eq!(
+            lookup_mapping_value(mapping, "fc").as_deref(),
+            Some("nydus")
+        );
+        // Empty value is treated as absent.
+        assert!(lookup_mapping_value(mapping, "clh").is_none());
+        // Unknown shim.
+        assert!(lookup_mapping_value(mapping, "stratovirt").is_none());
     }
 
     #[serial]

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -696,6 +696,12 @@ e.g. `{{- include "kata-deploy.commonEnv" . | nindent 8 }}`.
 - name: CUSTOM_RUNTIMES_ENABLED
   value: "true"
 {{- end }}
+{{- /* Devkit debug extension: only effective together with debug (the debug
+       console must be enabled for it to be reachable). */ -}}
+{{- if and .Values.debug .Values.devkit }}
+- name: DEVKIT
+  value: "true"
+{{- end }}
 {{- with .Values.startupTaints }}
 - name: STARTUP_TAINTS
   value: {{ join "," . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -41,20 +41,36 @@
 
 {{- /*
   Render a single RuntimeClass. Params (dict): root (.), shim, config, shimConfig,
-  nameOverride (optional; if set, use as metadata.name for default RC), useShimNodeSelectors.
+  nameOverride (optional; if set, use as metadata.name for default RC),
+  variant (optional; e.g. "devkit" -> name/handler kata-<shim>-devkit),
+  useShimNodeSelectors.
+
+  Name/handler precedence: variant > multiInstallSuffix > nameOverride > default.
+  A variant RuntimeClass mirrors the handler kata-deploy registers for the same
+  variant (e.g. the kata-<shim>-devkit custom runtime), so it ignores the
+  multiInstallSuffix/nameOverride paths.
 */ -}}
 {{- define "kata-deploy.runtimeclass" -}}
+{{- $rcName := "" -}}
+{{- $rcHandler := "" -}}
+{{- if .variant -}}
+{{- $rcName = printf "kata-%s-%s" .shim .variant -}}
+{{- $rcHandler = $rcName -}}
+{{- else if .root.Values.env.multiInstallSuffix -}}
+{{- $rcName = printf "kata-%s-%s" .shim .root.Values.env.multiInstallSuffix -}}
+{{- $rcHandler = $rcName -}}
+{{- else if .nameOverride -}}
+{{- $rcName = .nameOverride -}}
+{{- $rcHandler = printf "kata-%s" .shim -}}
+{{- else -}}
+{{- $rcName = printf "kata-%s" .shim -}}
+{{- $rcHandler = $rcName -}}
+{{- end -}}
 ---
 kind: RuntimeClass
 apiVersion: node.k8s.io/v1
 metadata:
-{{- if .root.Values.env.multiInstallSuffix }}
-  name: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
-{{- else if .nameOverride }}
-  name: {{ .nameOverride }}
-{{- else }}
-  name: kata-{{ .shim }}
-{{- end }}
+  name: {{ $rcName }}
   labels:
     app.kubernetes.io/managed-by: kata-deploy
 {{- if .root.Values.env.multiInstallSuffix }}
@@ -64,11 +80,7 @@ metadata:
 {{- end }}
   annotations:
 {{- include "kata-deploy.runtimeclassAnnotations" .root | nindent 4 }}
-{{- if .root.Values.env.multiInstallSuffix }}
-handler: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
-{{- else }}
-handler: kata-{{ .shim }}
-{{- end }}
+handler: {{ $rcHandler }}
 {{- /* Overhead section - controlled by global or per-shim overheadEnabled flag (default: true) */ -}}
 {{- $shimOverheadEnabled := true -}}
 {{- if hasKey .root.Values.runtimeClasses "overheadEnabled" -}}
@@ -152,6 +164,24 @@ scheduling:
 {{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- if and $createDefaultRC (not $multiInstallSuffix) (eq $shim $defaultShim) }}
 {{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" $defaultRCName "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* Devkit debug RuntimeClasses: an extra kata-<shim>-devkit per enabled shim,
+       matching the handler kata-deploy registers when DEVKIT=true. Gated by
+       debug (reachable only with the debug console) and devkit; reuses each
+       shim's overhead/nodeSelectors. */ -}}
+{{- if and .Values.debug .Values.devkit }}
+{{- range $shim := $enabledShims }}
+{{- $config := index $runtimeClassConfigs $shim }}
+{{- $shimConfig := index $.Values.shims $shim }}
+{{- if $config }}
+{{- $effectiveConfig := deepCopy $config }}
+{{- if and $shimConfig.runtimeClass $shimConfig.runtimeClass.overhead }}
+{{- $effectiveConfig = mergeOverwrite $effectiveConfig $shimConfig.runtimeClass.overhead }}
+{{- end }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "variant" "devkit" "nameOverride" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -304,6 +304,15 @@ resources:
 
 debug: false
 
+# Deploy the optional "devkit" debug guest extension and, per enabled shim, an
+# extra `kata-<shim>-devkit` RuntimeClass wired to it. Pods on that class boot
+# with the extension cold-plugged, so the agent debug console drops into a rich
+# shell (Ubuntu + apt + debug tools) overlaid on the read-only guest.
+#
+# Debugging aid: only effective with `debug: true`, ignored otherwise. Leave it
+# off in production and in confidential (CoCo/TEE) deployments.
+devkit: false
+
 # Optional CLI log level override for kata-deploy.
 # Supported values: error, warn, info, debug, trace
 # When empty, debug:true implies --log-level debug; otherwise kata-deploy falls

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -32,6 +32,7 @@ BASE_TARBALLS = serial-targets \
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
 	rootfs-image-coco-extension-tarball \
+	rootfs-image-devkit-extension-tarball \
 	rootfs-image-mariner-tarball \
 	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-tarball \
@@ -58,6 +59,7 @@ BASE_TARBALLS = serial-targets \
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
 	rootfs-image-coco-extension-tarball \
+	rootfs-image-devkit-extension-tarball \
 	rootfs-initrd-tarball
 endif
 
@@ -260,6 +262,12 @@ rootfs-image-confidential-tarball: $(DEPS)
 
 DEPS := pause-image-tarball coco-guest-components-tarball
 rootfs-image-coco-extension-tarball: $(DEPS)
+	${MAKE} $@-build
+
+# Self-contained debug rootfs (no kata-agent, kernel or driver tree), so it has
+# no build-time dependency on any other target.
+DEPS :=
+rootfs-image-devkit-extension-tarball: $(DEPS)
 	${MAKE} $@-build
 
 DEPS := agent-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -81,6 +81,7 @@ readonly MEASURED_ROOTFS_VARIANTS=(
 	base
 	confidential
 	coco-extension
+	devkit-extension
 	nvidia-gpu
 	nvidia-gpu-confidential
 	nvidia
@@ -738,6 +739,93 @@ EOF
 	fi
 
 	rm -rf "${extension_rootfs}"
+}
+
+# Install the generic devkit debug extension image (erofs+verity): a
+# self-contained minimal Ubuntu rootfs with debug tools prebaked. It ships no
+# kata-agent, kernel or driver userspace, so it is built as an agent-less
+# ROOTFS_ONLY rootfs through the osbuilder "devkit" distro (mmdebstrap, like the
+# base guest rootfs) and handed to image_builder.sh, never through rootfs.sh's
+# agent path.
+install_image_devkit_extension() {
+	local component="rootfs-image-devkit-extension"
+
+	# Reuse the guest image's Ubuntu release (e.g. "noble") so the devkit matches
+	# the base userspace ABI (glibc) the guest ships.
+	local os_name os_version
+	os_name="$(get_from_kata_deps ".assets.image.architecture.${ARCH}.name")"
+	os_version="$(get_from_kata_deps ".assets.image.architecture.${ARCH}.version")"
+	[[ "${os_name}" == "ubuntu" ]] || die "devkit extension expects an ubuntu base, got '${os_name}' for ${ARCH}"
+	[[ -n "${os_version}" ]] || die "assets.image.architecture.${ARCH}.version must be set in versions.yaml"
+
+	# Self-contained (Ubuntu release + guest scripts), so key the cache on the
+	# Ubuntu version and the devkit source directory.
+	local devkit_last_commit
+	devkit_last_commit="$(git -C "${repo_root_dir}" log -1 --abbrev=9 --pretty=format:"%h" \
+		-- tools/osbuilder/rootfs-builder/devkit 2>/dev/null || echo "unknown")"
+	latest_artefact="$(get_kata_version)-devkit-extension-${os_version}-${devkit_last_commit}"
+	latest_builder_image=""
+
+	install_cached_tarball_component \
+		"${component}" \
+		"${latest_artefact}" \
+		"${latest_builder_image}" \
+		"${final_tarball_name}" \
+		"${final_tarball_path}" \
+		&& return 0
+
+	info "Create devkit extension image"
+
+	# Temp dir under the repo root so the path is valid both in the outer build
+	# container and the nested osbuilder/image-builder (Docker-in-Docker uses
+	# host paths).
+	local extension_rootfs
+	extension_rootfs="$(mktemp -d "${repo_root_dir}/.devkit-extension-rootfs.XXXX")"
+
+	# Build the agent-less debug rootfs through the osbuilder "devkit" distro
+	# (mmdebstrap inside the builder container), mirroring how the base guest
+	# rootfs is built. ROOTFS_ONLY stops rootfs.sh before the agent/systemd setup.
+	info "Building devkit ubuntu rootfs (${os_name}:${os_version}) with mmdebstrap"
+	local rootfs_sh="${repo_root_dir}/tools/osbuilder/rootfs-builder/rootfs.sh"
+	ROOTFS_ONLY="yes" \
+		ROOTFS_DIR="${extension_rootfs}" \
+		USE_DOCKER="1" \
+		OS_VERSION="${os_version}" \
+		AGENT_INIT="no" \
+		AGENT_POLICY="no" \
+		AGENT_TARBALL="" \
+		"${rootfs_sh}" devkit || die "building the devkit rootfs failed"
+
+	local install_dir="${destdir}/${prefix}/share/kata-containers/"
+	mkdir -p "${install_dir}"
+
+	local image_builder="${repo_root_dir}/tools/osbuilder/image-builder/image_builder.sh"
+
+	export USE_DOCKER="1"
+	export BUILD_VARIANT="devkit-extension"
+	export FS_TYPE="erofs"
+	# s390x does not use a measured rootfs, so no dm-verity hash is produced.
+	if [[ "${ARCH}" == "s390x" ]]; then
+		export MEASURED_ROOTFS="no"
+	else
+		export MEASURED_ROOTFS="yes"
+	fi
+	export SKIP_DAX_HEADER="yes"
+	export SKIP_ROOTFS_CHECK="yes"
+
+	"${image_builder}" -o "${install_dir}/kata-containers-devkit-extension.img" "${extension_rootfs}"
+
+	if [[ -e "${install_dir}/root_hash_devkit-extension.txt" ]]; then
+		info "Root hash file: ${install_dir}/root_hash_devkit-extension.txt"
+	fi
+
+	# mmdebstrap builds a root-owned tree; remove it with sudo (passwordless in
+	# the build container) so cleanup works from the unprivileged build user.
+	if command -v sudo >/dev/null 2>&1; then
+		sudo rm -rf "${extension_rootfs}"
+	else
+		rm -rf "${extension_rootfs}"
+	fi
 }
 
 #Install cbl-mariner guest image
@@ -1717,6 +1805,8 @@ handle_build() {
 	rootfs-image-confidential) install_image_confidential ;;
 
 	rootfs-image-coco-extension) install_image_coco_extension ;;
+
+	rootfs-image-devkit-extension) install_image_devkit_extension ;;
 
 	rootfs-image-mariner) install_image_mariner ;;
 


### PR DESCRIPTION
# Summary

This series adds a generic "devkit" debug guest extension: a self-contained, composable image full of debugging tools that can be cold-plugged into a Kata sandbox on demand, giving you a rich interactive debug shell (via the agent debug console) overlaid on top of the real, read-only guest rootfs — **without rebuilding or modifying that rootfs**.

It is **opt-in**, **gated behind debug**, and **deliberately not wired into production or confidential deployments**.

# Motivation

Kata guest rootfses are getting smaller and more locked-down, which is great for security and boot time but painful for debugging:

They're minimal. The stock images ship few tools; the agent debug console gives you little more than a shell and whatever busybox/coreutils happen to be present.

However, some are **shell-less**.

The NVIDIA base (NVRC init, distroless-style)  has **no `/bin/bash` or `/bin/sh` at all**, so the debug console can't even spawn a shell — you connect and immediately get dropped.

**The obvious fix is bad** as baking strace/tcpdump/… into every base image **bloats every image for everyone**, and it **changes the very thing you're trying to debug**.

**We want: on a node where debugging is enabled, the ability to attach a fully-featured toolbox to a running sandbox, inspect it, and install anything else on the fly, while leaving the base image (and its integrity guarantees) untouched.**

# How it works

The devkit is built on Kata's composable guest-extension mechanism (the same cold-plug path CoCo uses), so it's a generic building block, **not an NVIDIA-specific hack**.

~The extension image is a **minimal Alpine** (musl + busybox + apk) rootfs **with a lean set of debug tools prebaked** (strace, ltrace, tcpdump, lsof, iproute2, procps, pciutils, util-linux, …). It's packaged as a **measured erofs + dm-verity image** and mounted read-only at /run/kata-extensions/devkit. It ships no kata-agent, kernel, or driver userspace, so it's assembled directly (mirroring the CoCo extension) and stays small (**~25 MB**).~

The extension image is a **minimal Ubuntu** rootfs **with a lean set of debug tools prebaked** (strace, ltrace, tcpdump, lsof, iproute2, procps, pciutils, util-linux, …). It's packaged as a **measured erofs + dm-verity image** and mounted read-only at /run/kata-extensions/devkit. It ships no kata-agent, kernel, or driver userspace, so it's assembled directly (mirroring the CoCo extension) and stays small (**~85 MB**).  Although the original idea was having an Alpine rootfs due to its size, it'd actually not be so helpful when debugging GPU stuff, as that requires NVIDIA repos from Canonical.

Runtime overlay + chroot, as the extension is read-only (and the base may be shell-less), guest helper scripts **overlay a writable tmpfs on the extension** and **chroot into the merged tree**. Inside, **apt and every tool run natively against a normal root filesystem**, and apt install <pkg> pulls anything not prebaked on demand. A statically-linked busybox.static bootstraps this from a shell-less base (the dynamic musl loader doesn't exist there yet).

Reaching the base guest is easy, as the **`chroot` exposes /real_root → /proc/1/root**, so container rootfses and other guest state (e.g. /real_root/run/kata-containers/<id>/rootfs) are reachable from the debug shell.

Agent integration + a security guard is treated seriously. The agent gains an `agent.debug_console_shell` option (kernel cmdline + config). The debug console prefers it over the built-in /bin/bash//bin/sh. **Crucially, it is only honored if it canonicalizes to a path under `/run/kata-extensions/`** (a dm-verity-measured, read-only extension mount). **This prefix guard means a host that can influence the agent cmdline cannot repoint the debug console at a container's rootfs to run tenant binaries or read guest data.**

Deployment is hooked up via kata-deploy, where a Helm devkit flag (only effective together with debug) makes kata-deploy, per enabled shim, generate a kata-<shim>-devkit RuntimeClass plus a drop-in that cold-plugs the extension image and points the debug console at its shell. Redeploys that disable devkit clean up the artifacts they left behind.

The client. kata-ctl exec <sandbox-id> is the entry point into the console. It ships in the kata-tools bundle, so it's now built for arm64 and staged onto the node whenever debug is enabled (and removed again when debug is turned off).

# Usage sketch

```
# pod uses e.g. runtimeClassName: kata-<shim>-devkit
sudo /opt/kata/bin/kata-ctl exec "${sandbox_id}"
```

# Limitations & non-goals
**Debugging aid only:** Gated behind debug; intended to stay off in production and in confidential (CoCo/TEE) deployments.

~**musl/Alpine world:** You get an Alpine toolbox, not the guest's own userspace. Glibc binaries from the base (e.g. nvidia-smi) won't run inside the Alpine chroot; you run those against the real guest root instead (chroot /real_root /usr/bin/nvidia-smi). The base itself remains shell-less as devkit is what provides the shell.~

**Arch coverage:** Built and CI-exercised on x86_64/aarch64. kata-ctl can't be built statically on s390x/ppc64le (needs glibc), so devkit is not shipped or tested there. The k8s test currently runs on qemu-nvidia-cpu-runtime-rs.