### PR TITLE
kata-deploy: Do not ship virtiofsd when using shared_fs=none

### DIFF
--- a/tools/packaging/kata-deploy/shim-components.json
+++ b/tools/packaging/kata-deploy/shim-components.json
@@ -37,15 +37,15 @@
       "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu", "ovmf"]
     },
     "qemu-nvidia-gpu-runtime-rs": {
-      "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "ovmf"]
+      "x86_64":  ["shim-v2-rust", "qemu", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "ovmf"]
     },
     "qemu-nvidia-cpu": {
       "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia"],
       "aarch64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia"]
     },
     "qemu-nvidia-cpu-runtime-rs": {
-      "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia"],
-      "aarch64": ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia"]
+      "x86_64":  ["shim-v2-rust", "qemu", "kernel-nvidia-gpu", "rootfs-image-nvidia"],
+      "aarch64": ["shim-v2-rust", "qemu", "kernel-nvidia-gpu", "rootfs-image-nvidia"]
     },
     "qemu-nvidia-gpu-snp": {
       "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-sev"]


### PR DESCRIPTION
This helps hardening the host by not having unused components deployed.