### PR TITLE
agent: Release sandbox lock before blocking stats read

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -211,7 +211,7 @@ impl CgroupManager for Manager {
         Ok(())
     }
 
-    fn destroy(&mut self) -> Result<()> {
+    fn destroy(&self) -> Result<()> {
         if let Err(err) = self.cgroup.delete() {
             warn!(
                 sl(),

--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -52,7 +52,7 @@ impl CgroupManager for Manager {
         Ok(())
     }
 
-    fn destroy(&mut self) -> Result<()> {
+    fn destroy(&self) -> Result<()> {
         Ok(())
     }
 

--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -43,7 +43,7 @@ pub trait Manager {
         Err(anyhow!("not supported!"))
     }
 
-    fn destroy(&mut self) -> Result<()> {
+    fn destroy(&self) -> Result<()> {
         Err(anyhow!("not supported!"))
     }
 

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -84,7 +84,7 @@ impl CgroupManager for Manager {
         }
     }
 
-    fn destroy(&mut self) -> Result<()> {
+    fn destroy(&self) -> Result<()> {
         self.dbus_client.kill_unit()?;
         self.fs_manager.destroy()
     }

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -255,7 +255,7 @@ pub struct LinuxContainer {
     pub id: String,
     pub root: String,
     pub config: Config,
-    pub cgroup_manager: Box<dyn Manager + Send + Sync>,
+    pub cgroup_manager: Arc<dyn Manager + Send + Sync>,
     pub init_process_pid: pid_t,
     pub init_process_start_time: u64,
     pub uid_map_path: String,
@@ -1318,7 +1318,7 @@ impl BaseContainer for LinuxContainer {
         // Kill all of the processes created in this container to prevent
         // the leak of some daemon process when this container shared pidns
         // with the sandbox.
-        let cgm = self.cgroup_manager.as_mut();
+        let cgm = self.cgroup_manager.as_ref();
         let pids = cgm.get_pids().context("get cgroup pids")?;
         info!(
             self.logger,
@@ -1779,10 +1779,10 @@ impl LinuxContainer {
             linux_cgroups_path.replace(':', "/")
         };
 
-        let cgroup_manager: Box<dyn Manager + Send + Sync> = if config.use_systemd_cgroup {
-            Box::new(SystemdManager::new(cpath.as_str()).context("Create systemd manager")?)
+        let cgroup_manager: Arc<dyn Manager + Send + Sync> = if config.use_systemd_cgroup {
+            Arc::new(SystemdManager::new(cpath.as_str()).context("Create systemd manager")?)
         } else {
-            Box::new(
+            Arc::new(
                 FsManager::new(cpath.as_str(), spec, devcg_info)
                     .context("Create cgroupfs manager")?,
             )
@@ -2102,7 +2102,7 @@ mod tests {
     fn test_linuxcontainer_pause() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.cgroup_manager =
-                Box::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
+                Arc::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
                     anyhow!(format!("fail to create cgroup manager with path: {:}", e))
                 })?);
             c.pause().map_err(|e| anyhow!(e))
@@ -2127,7 +2127,7 @@ mod tests {
     fn test_linuxcontainer_resume() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.cgroup_manager =
-                Box::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
+                Arc::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
                     anyhow!(format!("fail to create cgroup manager with path: {:}", e))
                 })?);
             // Change status to paused, this way we can resume it

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -255,7 +255,7 @@ pub struct LinuxContainer {
     pub id: String,
     pub root: String,
     pub config: Config,
-    pub cgroup_manager: Box<dyn Manager + Send + Sync>,
+    pub cgroup_manager: Arc<dyn Manager + Send + Sync>,
     pub init_process_pid: pid_t,
     pub init_process_start_time: u64,
     pub uid_map_path: String,
@@ -1284,7 +1284,7 @@ impl BaseContainer for LinuxContainer {
         // Kill all of the processes created in this container to prevent
         // the leak of some daemon process when this container shared pidns
         // with the sandbox.
-        let cgm = self.cgroup_manager.as_mut();
+        let cgm = self.cgroup_manager.as_ref();
         let pids = cgm.get_pids().context("get cgroup pids")?;
         info!(
             self.logger,
@@ -1721,10 +1721,10 @@ impl LinuxContainer {
             linux_cgroups_path.replace(':', "/")
         };
 
-        let cgroup_manager: Box<dyn Manager + Send + Sync> = if config.use_systemd_cgroup {
-            Box::new(SystemdManager::new(cpath.as_str()).context("Create systemd manager")?)
+        let cgroup_manager: Arc<dyn Manager + Send + Sync> = if config.use_systemd_cgroup {
+            Arc::new(SystemdManager::new(cpath.as_str()).context("Create systemd manager")?)
         } else {
-            Box::new(
+            Arc::new(
                 FsManager::new(cpath.as_str(), spec, devcg_info)
                     .context("Create cgroupfs manager")?,
             )
@@ -1985,7 +1985,7 @@ mod tests {
     fn test_linuxcontainer_pause() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.cgroup_manager =
-                Box::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
+                Arc::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
                     anyhow!(format!("fail to create cgroup manager with path: {:}", e))
                 })?);
             c.pause().map_err(|e| anyhow!(e))
@@ -2010,7 +2010,7 @@ mod tests {
     fn test_linuxcontainer_resume() {
         let ret = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.cgroup_manager =
-                Box::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
+                Arc::new(FsManager::new("", &Spec::default(), None).map_err(|e| {
                     anyhow!(format!("fail to create cgroup manager with path: {:}", e))
                 })?);
             // Change status to paused, this way we can resume it

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1034,11 +1034,35 @@ impl agent_ttrpc::AgentService for AgentService {
         trace_rpc_call!(ctx, "stats_container", req);
         is_allowed(&req).await?;
 
-        let mut sandbox = self.sandbox.lock().await;
-        let ctr = sandbox
-            .get_container(&req.container_id)
-            .map_ttrpc_err(ttrpc::Code::INVALID_ARGUMENT, "invalid container id")?;
-        ctr.stats().map_ttrpc_err(same)
+        // Clone the container's cgroup manager (an Arc) while holding the sandbox lock, then
+        // release the lock BEFORE the blocking cgroup read below.
+        //
+        // The sandbox lock is a single global mutex taken by nearly every agent RPC,
+        // including the signal_process/kill path. Previously stats_container held it across
+        // the synchronous get_stats() cgroup read; if that read blocked on a container whose
+        // cgroup is being torn down (e.g. during pod termination), it serialized the whole
+        // agent and starved the kill RPC, leaving the pod stuck Terminating with the host
+        // seeing ttrpc "Receive packet timeout". Cloning the Arc lets stats read the cgroup
+        // without blocking any other RPC.
+        let cgroup_manager = {
+            let mut sandbox = self.sandbox.lock().await;
+            let ctr = sandbox
+                .get_container(&req.container_id)
+                .map_ttrpc_err(ttrpc::Code::INVALID_ARGUMENT, "invalid container id")?;
+            ctr.cgroup_manager.clone()
+        };
+
+        // get_stats() performs blocking synchronous cgroup file reads; run it on the blocking
+        // thread pool so a slow/stuck read cannot park an async reactor worker.
+        let cgroup_stats = tokio::task::spawn_blocking(move || cgroup_manager.get_stats())
+            .await
+            .map_ttrpc_err(same)?
+            .map_ttrpc_err(same)?;
+
+        Ok(StatsContainerResponse {
+            cgroup_stats: MessageField::some(cgroup_stats),
+            ..Default::default()
+        })
     }
 
     async fn pause_container(
@@ -2741,6 +2765,7 @@ mod tests {
         LinuxNamespaceBuilder, LinuxResourcesBuilder, SpecBuilder,
     };
     use oci_spec::runtime::{LinuxNamespaceType, Root};
+    use serial_test::serial;
     use tempfile::{tempdir, TempDir};
     use test_utils::{assert_result, skip_if_not_root};
     use ttrpc::{r#async::TtrpcContext, MessageHeader};
@@ -2943,6 +2968,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(not(target_arch = "powerpc64"))]
+    #[serial]
     async fn test_do_write_stream() {
         skip_if_not_root!();
 
@@ -4217,5 +4243,115 @@ COMMIT
             }
             other => panic!("expected RpcStatus, got: {:?}", other),
         }
+    }
+
+    // A cgroup Manager whose get_stats() blocks until released, used to prove that
+    // stats_container does not hold the global sandbox lock across the (blocking) cgroup
+    // read.
+    struct BlockingStatsManager {
+        started: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl rustjail::cgroups::Manager for BlockingStatsManager {
+        fn get_stats(&self) -> anyhow::Result<protocols::agent::CgroupStats> {
+            self.started
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            while !self.release.load(std::sync::atomic::Ordering::SeqCst) {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            Ok(protocols::agent::CgroupStats::default())
+        }
+
+        fn name(&self) -> &str {
+            "blocking-stats-test"
+        }
+    }
+
+    // Regression test for the stats_container / kill starvation deadlock: while
+    // stats_container is reading a container's cgroup stats (a blocking operation), the
+    // global sandbox lock must remain free so other RPCs — crucially signal_process/kill —
+    // can proceed. Previously the lock was held across get_stats(), so a stats read that
+    // blocked on a torn-down cgroup during teardown wedged the whole agent and left the pod
+    // stuck Terminating.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial]
+    async fn test_stats_container_does_not_hold_sandbox_lock() {
+        skip_if_not_root!();
+
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let (mut linux_container, _root) = create_linuxcontainer();
+        linux_container.id = "1".to_string();
+
+        let started = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+
+        // Always release the blocking get_stats() thread, even if the test panics before the
+        // explicit release below. Tokio cannot cancel spawn_blocking tasks, so a still-looping
+        // thread would otherwise hang the whole test binary at runtime shutdown.
+        struct ReleaseOnDrop(Arc<AtomicBool>);
+        impl Drop for ReleaseOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let _release_guard = ReleaseOnDrop(release.clone());
+
+        linux_container.cgroup_manager = Arc::new(BlockingStatsManager {
+            started: started.clone(),
+            release: release.clone(),
+        });
+
+        let mut sandbox = Sandbox::new(&logger).unwrap();
+        sandbox.add_container(linux_container);
+
+        let agent_service = Arc::new(AgentService {
+            sandbox: Arc::new(Mutex::new(sandbox)),
+            init_mode: true,
+            oma: None,
+        });
+
+        // Fire stats_container; get_stats() will block on the blocking thread pool.
+        let svc = agent_service.clone();
+        let handle = tokio::spawn(async move {
+            svc.stats_container(
+                &mk_ttrpc_context(),
+                protocols::agent::StatsContainerRequest {
+                    container_id: "1".to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+        });
+
+        // Wait until get_stats() is actually executing.
+        for _ in 0..500 {
+            if started.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(started.load(Ordering::SeqCst), "get_stats never started");
+
+        // The regression assertion: the sandbox lock must be acquirable while stats is
+        // mid-read. With the old code (lock held across get_stats) this times out — exactly
+        // the condition that starves the kill and wedges pod teardown.
+        let lock_res = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            agent_service.sandbox.lock(),
+        )
+        .await;
+        assert!(
+            lock_res.is_ok(),
+            "sandbox lock held during stats_container get_stats: signal_process/kill would be starved"
+        );
+        drop(lock_res);
+
+        // Unblock the read and confirm the RPC completes successfully.
+        release.store(true, Ordering::SeqCst);
+        let res = handle.await.unwrap();
+        assert!(res.is_ok(), "stats_container returned error: {:?}", res);
     }
 }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1008,11 +1008,35 @@ impl agent_ttrpc::AgentService for AgentService {
         trace_rpc_call!(ctx, "stats_container", req);
         is_allowed(&req).await?;
 
-        let mut sandbox = self.sandbox.lock().await;
-        let ctr = sandbox
-            .get_container(&req.container_id)
-            .map_ttrpc_err(ttrpc::Code::INVALID_ARGUMENT, "invalid container id")?;
-        ctr.stats().map_ttrpc_err(same)
+        // Clone the container's cgroup manager (an Arc) while holding the sandbox lock, then
+        // release the lock BEFORE the blocking cgroup read below.
+        //
+        // The sandbox lock is a single global mutex taken by nearly every agent RPC,
+        // including the signal_process/kill path. Previously stats_container held it across
+        // the synchronous get_stats() cgroup read; if that read blocked on a container whose
+        // cgroup is being torn down (e.g. during pod termination), it serialized the whole
+        // agent and starved the kill RPC, leaving the pod stuck Terminating with the host
+        // seeing ttrpc "Receive packet timeout". Cloning the Arc lets stats read the cgroup
+        // without blocking any other RPC.
+        let cgroup_manager = {
+            let mut sandbox = self.sandbox.lock().await;
+            let ctr = sandbox
+                .get_container(&req.container_id)
+                .map_ttrpc_err(ttrpc::Code::INVALID_ARGUMENT, "invalid container id")?;
+            ctr.cgroup_manager.clone()
+        };
+
+        // get_stats() performs blocking synchronous cgroup file reads; run it on the blocking
+        // thread pool so a slow/stuck read cannot park an async reactor worker.
+        let cgroup_stats = tokio::task::spawn_blocking(move || cgroup_manager.get_stats())
+            .await
+            .map_ttrpc_err(same)?
+            .map_ttrpc_err(same)?;
+
+        Ok(StatsContainerResponse {
+            cgroup_stats: MessageField::some(cgroup_stats),
+            ..Default::default()
+        })
     }
 
     async fn pause_container(
@@ -2715,6 +2739,7 @@ mod tests {
         LinuxNamespaceBuilder, LinuxResourcesBuilder, SpecBuilder,
     };
     use oci_spec::runtime::{LinuxNamespaceType, Root};
+    use serial_test::serial;
     use tempfile::{tempdir, TempDir};
     use test_utils::{assert_result, skip_if_not_root};
     use ttrpc::{r#async::TtrpcContext, MessageHeader};
@@ -2917,6 +2942,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(not(target_arch = "powerpc64"))]
+    #[serial]
     async fn test_do_write_stream() {
         skip_if_not_root!();
 
@@ -4162,5 +4188,116 @@ COMMIT
             }
             (tc.assertions)(&base).context(tc.name).unwrap()
         }
+    }
+
+    // A cgroup Manager whose get_stats() blocks until released, used to prove that
+    // stats_container does not hold the global sandbox lock across the (blocking) cgroup
+    // read. Only get_stats and name have no/overridden behavior; all other Manager methods
+    // use the trait defaults.
+    struct BlockingStatsManager {
+        started: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl rustjail::cgroups::Manager for BlockingStatsManager {
+        fn get_stats(&self) -> anyhow::Result<protocols::agent::CgroupStats> {
+            self.started
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            while !self.release.load(std::sync::atomic::Ordering::SeqCst) {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            Ok(protocols::agent::CgroupStats::default())
+        }
+
+        fn name(&self) -> &str {
+            "blocking-stats-test"
+        }
+    }
+
+    // Regression test for the stats_container / kill starvation deadlock: while
+    // stats_container is reading a container's cgroup stats (a blocking operation), the
+    // global sandbox lock must remain free so other RPCs — crucially signal_process/kill —
+    // can proceed. Previously the lock was held across get_stats(), so a stats read that
+    // blocked on a torn-down cgroup during teardown wedged the whole agent and left the pod
+    // stuck Terminating.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial]
+    async fn test_stats_container_does_not_hold_sandbox_lock() {
+        skip_if_not_root!();
+
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let (mut linux_container, _root) = create_linuxcontainer();
+        linux_container.id = "1".to_string();
+
+        let started = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+
+        // Always release the blocking get_stats() thread, even if the test panics before the
+        // explicit release below. Tokio cannot cancel spawn_blocking tasks, so a still-looping
+        // thread would otherwise hang the whole test binary at runtime shutdown.
+        struct ReleaseOnDrop(Arc<AtomicBool>);
+        impl Drop for ReleaseOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+        let _release_guard = ReleaseOnDrop(release.clone());
+
+        linux_container.cgroup_manager = Arc::new(BlockingStatsManager {
+            started: started.clone(),
+            release: release.clone(),
+        });
+
+        let mut sandbox = Sandbox::new(&logger).unwrap();
+        sandbox.add_container(linux_container);
+
+        let agent_service = Arc::new(AgentService {
+            sandbox: Arc::new(Mutex::new(sandbox)),
+            init_mode: true,
+            oma: None,
+        });
+
+        // Fire stats_container; get_stats() will block on the blocking thread pool.
+        let svc = agent_service.clone();
+        let handle = tokio::spawn(async move {
+            svc.stats_container(
+                &mk_ttrpc_context(),
+                protocols::agent::StatsContainerRequest {
+                    container_id: "1".to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+        });
+
+        // Wait until get_stats() is actually executing.
+        for _ in 0..500 {
+            if started.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(started.load(Ordering::SeqCst), "get_stats never started");
+
+        // The regression assertion: the sandbox lock must be acquirable while stats is
+        // mid-read. With the old code (lock held across get_stats) this times out — exactly
+        // the condition that starves the kill and wedges pod teardown.
+        let lock_res = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            agent_service.sandbox.lock(),
+        )
+        .await;
+        assert!(
+            lock_res.is_ok(),
+            "sandbox lock held during stats_container get_stats: signal_process/kill would be starved"
+        );
+        drop(lock_res);
+
+        // Unblock the read and confirm the RPC completes successfully.
+        release.store(true, Ordering::SeqCst);
+        let res = handle.await.unwrap();
+        assert!(res.is_ok(), "stats_container returned error: {:?}", res);
     }
 }


### PR DESCRIPTION
stats_container acquired the global Arc<Mutex<Sandbox>> and held it across the synchronous, blocking cgroup get_stats() read. Because signal_process (kill), remove_container and other RPCs take the same lock, a stats read that is slow or blocks on an exited container's cgroup during teardown serialized the whole agent and starved the kill path, leaving pods stuck Terminating with the host reporting "ttrpc Receive packet timeout".

Clone the container's cgroup manager (now an Arc) under the lock, drop the guard, then run the blocking get_stats() under spawn_blocking so it can no longer hold the sandbox lock or park a reactor worker. Manager::destroy is relaxed from &mut self to &self so the manager can be shared; all impls only perform &self work.

Fixes: #13452

Generated-By: Claude Opus 4.8 (Anthropic Claude Code)