### PR TITLE
nvgpu: local CUDA repo support and build-race fixes

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -124,10 +124,13 @@ setup_apt_repositories() {
 	curl -fsSL -O "${cuda_repo_url}/${cuda_repo_pkg}"
 	dpkg -i "${cuda_repo_pkg}" && rm -f "${cuda_repo_pkg}"
 
-	# Copy keyring if local repo was installed
-	keyring="/var/cuda-repo-*-local/cuda-*-keyring.gpg"
-	# shellcheck disable=SC2128 # Intentional: expect exactly one match
-	[[ -e "${keyring}" ]] && cp "${keyring}" /usr/share/keyrings/
+	# A local repo ships its signing key inside its own tree, but apt only
+	# trusts keys under /usr/share/keyrings - without this copy `apt update`
+	# rejects the repo as unsigned. A loop because [[ -e ]] would test the
+	# glob literally (nullglob: remote-repo flow matches nothing, skips).
+	for keyring in /var/cuda-repo-*-local/cuda-*-keyring.gpg; do
+		cp "${keyring}" /usr/share/keyrings/
+	done
 
 	# Set priorities: CUDA repos highest, Ubuntu non-driver next, Ubuntu blocked for driver packages
 	cat <<-CHROOT_EOF > /etc/apt/preferences.d/nvidia-priority

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -433,6 +433,20 @@ get_latest_nvidia_nvat_version() {
 	get_from_kata_deps ".externals.nvidia.nvat.version"
 }
 
+# The CUDA and tools APT repositories feed setup_apt_repositories() in the
+# rootfs chroot; overriding them in versions.yaml (e.g. to point at an
+# internal release-candidate mirror) must invalidate the cached rootfs.
+get_latest_nvidia_repo_version() {
+	local arch
+	arch="$(uname -m)"
+
+	echo "$(get_from_kata_deps ".externals.nvidia.cuda.repo.${arch}.url")" \
+		"$(get_from_kata_deps ".externals.nvidia.cuda.repo.${arch}.pkg")" \
+		"$(get_from_kata_deps ".externals.nvidia.tools.repo.${arch}.url")" \
+		"$(get_from_kata_deps ".externals.nvidia.tools.repo.${arch}.pkg")" \
+		| sha256sum | cut -c1-9
+}
+
 #Install guest image
 install_image() {
 	local variant="${1:-}"
@@ -476,6 +490,7 @@ install_image() {
 			latest_artefact+="-$(get_latest_nvidia_ctk_version)"
 			latest_artefact+="-$(get_latest_nvidia_nvrc_version)"
 			latest_artefact+="-$(get_latest_nvidia_nvat_version)"
+			latest_artefact+="-$(get_latest_nvidia_repo_version)"
 		else
 			latest_artefact+="-$(get_latest_kernel_artefact_and_builder_image_version)"
 		fi
@@ -495,6 +510,7 @@ install_image() {
 		latest_artefact+="-$(get_latest_nvidia_driver_version)"
 		latest_artefact+="-$(get_latest_nvidia_ctk_version)"
 		latest_artefact+="-$(get_latest_nvidia_nvrc_version)"
+		latest_artefact+="-$(get_latest_nvidia_repo_version)"
 	fi
 
 	if [[ "${variant}" == "nvidia" ]]; then
@@ -788,6 +804,7 @@ install_initrd() {
 			latest_artefact+="-$(get_latest_nvidia_ctk_version)"
 			latest_artefact+="-$(get_latest_nvidia_nvrc_version)"
 			latest_artefact+="-$(get_latest_nvidia_nvat_version)"
+			latest_artefact+="-$(get_latest_nvidia_repo_version)"
 		else
 			latest_artefact+="-$(get_latest_kernel_artefact_and_builder_image_version)"
 		fi
@@ -801,6 +818,7 @@ install_initrd() {
 		latest_artefact+="-$(get_latest_nvidia_driver_version)"
 		latest_artefact+="-$(get_latest_nvidia_ctk_version)"
 		latest_artefact+="-$(get_latest_nvidia_nvrc_version)"
+		latest_artefact+="-$(get_latest_nvidia_repo_version)"
 	fi
 
 	latest_builder_image=""

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-copy-yq-installer.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-copy-yq-installer.sh
@@ -14,4 +14,14 @@ set -o errtrace
 script_dir=$(dirname "$(readlink -f "$0")")
 install_yq_script_path="${script_dir}/../../../../ci/install_yq.sh"
 
-cp "${install_yq_script_path}" "${script_dir}/dockerbuild/install_yq.sh"
+# Parallel targets each stage the docker build context on the host. When the
+# destination does not exist yet (fresh clone), coreutils cp opens it with
+# O_CREAT|O_EXCL, so concurrent copies race and the losers fail with
+# "File exists". Write to a private temp file and rename: rename is atomic,
+# never returns EEXIST, and all writers produce identical content.
+tmp="$(mktemp "${script_dir}/dockerbuild/.install_yq.sh.XXXXXX")"
+cp "${install_yq_script_path}" "${tmp}"
+# mktemp creates 0600 and cp into an existing file keeps it; the docker
+# build RUNs this script, so it must stay executable like the source.
+chmod --reference="${install_yq_script_path}" "${tmp}"
+mv -f "${tmp}" "${script_dir}/dockerbuild/install_yq.sh"


### PR DESCRIPTION
Fixes for building the nvgpu bundle against a local CUDA repository installer (`cuda-repo-*-local`) instead of the network repositories.

- rootfs cache key: overriding the CUDA/tools repos in versions.yaml must rebuild the rootfs; the cache key ignored them, so a stale rootfs built from the default repos was served.
- keyring: `[[ -e ]]` does not glob, so a local repo's signing key never reached /usr/share/keyrings and apt rejected the repo as unsigned.
- build-context staging: parallel targets race the host-side cp on a fresh clone (coreutils uses O_CREAT|O_EXCL for absent destinations); stage via mktemp + rename.

Signed-off-by: Zvonko Kaiser <zkaiser@nvidia.com>