### PR TITLE
kata-deploy: start nydus-snapshotter at boot on RKE2/k3s (WantedBy=multi-user.target)

### DIFF
--- a/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
+++ b/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
@@ -9,4 +9,11 @@ Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=containerd.service
+# Use multi-user.target (not containerd.service) so the snapshotter is pulled in
+# at boot on every runtime. On RKE2/k3s containerd is not a standalone
+# containerd.service unit (it runs as a child of rke2-server/k3s), so
+# WantedBy=containerd.service never activates and the snapshotter stays dead
+# after every reboot — breaking all kata guest-pull pods until manually
+# started. Before=containerd.service below still orders us before containerd
+# on standalone-containerd hosts (containerd is itself WantedBy=multi-user.target).
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

The `nydus-snapshotter` systemd unit installed by kata-deploy uses
`WantedBy=containerd.service` (softened from `RequiredBy` in #12765, which
also added `Restart=always`). On **RKE2/k3s** containerd is **not** a
standalone `containerd.service` unit — it runs as a child of
`rke2-server`/`k3s` — so the `containerd.service.wants/` symlink created by
`systemctl enable` **never activates at boot**. The snapshotter therefore
stays `inactive (dead)` after every reboot, and every kata guest-pull pod
hangs in `ContainerCreating`:

```
Failed to create pod sandbox: rpc error: code = Unavailable desc =
failed to start sandbox "...": failed to create containerd container:
connection error: desc = "transport: Error while dialing: dial
unix:///run/nydus-for-kata-tee/containerd-nydus-grpc.sock: timeout"
```

until the service is manually `systemctl start`ed. `Restart=always` only
helps once the service is running — nothing starts it at boot on these
runtimes.

## Fix

Switch `WantedBy` to `multi-user.target` so the snapshotter is pulled in at
boot on **every** runtime. Keep `Before=containerd.service` for ordering on
standalone-containerd hosts (containerd is itself
`WantedBy=multi-user.target`, so `Before=` still orders the snapshotter
before it there); it is a harmless no-op on RKE2/k3s.

```diff
 [Install]
-WantedBy=containerd.service
+# ... see commit for rationale ...
+WantedBy=multi-user.target
```

## Reproduction / verification

Reproduced on two HGX H200/B200 Intel-TDX nodes (single-node RKE2) across
multiple cold reboots: after each reboot the `nydus-for-kata-tee.service`
came up `inactive (dead)` (despite being `enabled`), and all kata
guest-pull pods (runtime-rs, `image_guest_pull`) hung at sandbox-create
with the socket-timeout above until a manual `systemctl start`.

After changing `WantedBy=containerd.service` → `WantedBy=multi-user.target`
(`systemctl daemon-reload && systemctl disable && systemctl enable --now`),
the snapshotter auto-starts on every subsequent reboot and guest-pull pods
proceed to `Running` without manual intervention.

## Scope

One-line change to a single template file
(`tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service`).
Complementary to the merged #12765 (same file). No behaviour change on
standalone-containerd hosts (ordering preserved via `Before=`).

Refs: #12765

Made with [Cursor](https://cursor.com)