### PR TITLE
agent: create new session for init process instead of inheriting parent's

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -653,6 +653,9 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     if !oci_process.cwd().as_os_str().is_empty() {
         unistd::chdir(oci_process.cwd().display().to_string().as_str())?;
     }
+    // Create new session for init/exec process rather than inheriting parent's session
+    // This ensures the init/exec process owns independent session ID, which aligns with runc behavior.
+    unistd::setsid().context("create a new session")?;
 
     let guser = &oci_process.user();
 
@@ -783,7 +786,6 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     let _ = unistd::close(cwfd);
 
     if oci_process.terminal().unwrap_or_default() {
-        unistd::setsid().context("create a new session")?;
         unsafe { libc::ioctl(0, libc::TIOCSCTTY) };
     }
 


### PR DESCRIPTION
create new session for init process instead of inheriting parent's

reproduce 

when I try use criu to checkpoint the container (231 is the container init process)
```
(00.060827) Error (criu/cr-dump.c:1657): A session leader of 231(2) is outside of its pid namespace
```

create  a sleep  infinity as init process in the container.
```
 kata-runtime exec 2f96fd885ec23b9946992e106f1549a9b415ddf09884fc5f50cbc707cd3be10c
bash-5.2# ps -ef|grep sleep
  231 root      0:00 sleep infinity
bash-5.2# ps -o pid,ppid,pgid,sid |grep 231
  231   216   216   216

bash-5.2# ps -ef |grep 216                 
  216 root      0:00 /usr/bin/kata-agent
```

we can see  pgid and sid is kata-agent's pid  but  for runc

```
ps -o pid,ppid,pgid,sid,cmd  -p  1484508
    PID    PPID    PGID     SID CMD
1484508 1484452 1484508 1484508 sleep infinity

```
this behavior will cause failed to checkpoint the container when use criu.

ping @fidencio  @stevenhorsman   can you take a look?