### PR TITLE
ci: focus the testing on runtime-rs

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -89,6 +89,11 @@ jobs:
       matrix:
         containerd_version: ['minimum', 'latest']
         vmm: ['clh', 'clh-runtime-rs', 'dragonball', 'qemu', 'qemu-runtime-rs']
+        exclude:
+          - containerd_version: latest
+            vmm: clh
+          - containerd_version: latest
+            vmm: qemu
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-run-containerd-stability-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true
@@ -138,6 +143,11 @@ jobs:
       matrix:
         containerd_version: ['minimum', 'latest']
         vmm: ['clh', 'qemu', 'dragonball', 'qemu-runtime-rs', 'clh-runtime-rs']
+        exclude:
+          - containerd_version: latest
+            vmm: clh
+          - containerd_version: latest
+            vmm: qemu
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-run-nydus-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -504,12 +504,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Go runtime covers the minimum supported containerd only.
+        # runtime-rs covers both minimum and latest containerd.
         params: [
-          { containerd_version: latest,    vmm: clh              },
-          { containerd_version: latest,    vmm: dragonball       },
-          { containerd_version: latest,    vmm: qemu             },
-          { containerd_version: latest,    vmm: clh-runtime-rs   },
-          { containerd_version: latest,    vmm: qemu-runtime-rs  },
+          { containerd_version: latest,  vmm: dragonball       },
+          { containerd_version: latest,  vmm: clh-runtime-rs   },
+          { containerd_version: latest,  vmm: qemu-runtime-rs  },
           { containerd_version: minimum, vmm: clh              },
           { containerd_version: minimum, vmm: dragonball       },
           { containerd_version: minimum, vmm: qemu             },

--- a/.github/workflows/run-k8s-tests-on-free-runner.yaml
+++ b/.github/workflows/run-k8s-tests-on-free-runner.yaml
@@ -39,15 +39,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Go runtime covers the minimum supported containerd only, except
+        # for EROFS tests, which require the latest containerd.
+        # runtime-rs covers both minimum and latest containerd.
         environment: [
-          { vmm: clh, containerd_version: latest },
-          { vmm: clh, containerd_version: latest, snapshotter: erofs, erofs_mode: disk, erofs_merge_mode: unmerged },
-          { vmm: clh, containerd_version: minimum },
           { vmm: dragonball, containerd_version: latest },
+          { vmm: clh, containerd_version: minimum },
+          { vmm: clh, containerd_version: latest, snapshotter: erofs, erofs_mode: disk, erofs_merge_mode: unmerged },
           { vmm: dragonball, containerd_version: minimum },
-          { vmm: qemu, containerd_version: latest },
-          { vmm: qemu, containerd_version: latest, snapshotter: erofs, erofs_mode: disk, erofs_merge_mode: unmerged },
           { vmm: qemu, containerd_version: minimum },
+          { vmm: qemu, containerd_version: latest, snapshotter: erofs, erofs_mode: disk, erofs_merge_mode: unmerged },
           { vmm: qemu-runtime-rs, containerd_version: latest },
           { vmm: qemu-runtime-rs, containerd_version: minimum },
           { vmm: clh-runtime-rs, containerd_version: latest },

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         container_engine:
           - containerd
         containerd_version:
-          - latest
+          - minimum
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true


### PR DESCRIPTION
Go runtime, apart from EROFS stuff, should only be tested with the minimum containerd version, as no new features will come to it.