### PR TITLE
runtime-rs: Create shared volume paths under rw path

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -131,7 +131,7 @@ impl SPDKVolume {
         }
 
         // generate host guest shared path
-        let guest_path = generate_shared_path(m.destination().clone(), read_only, &device_id, sid)
+        let guest_path = generate_shared_path(m.destination().clone(), &device_id, sid)
             .await
             .context("generate host-guest shared path failed")?;
         storage.mount_point = guest_path.clone();

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/vfio_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/vfio_volume.rs
@@ -84,7 +84,7 @@ impl VfioVolume {
         }
 
         // generate host guest shared path
-        let guest_path = generate_shared_path(m.destination().clone(), read_only, &device_id, sid)
+        let guest_path = generate_shared_path(m.destination().clone(), &device_id, sid)
             .await
             .context("generate host-guest shared path failed")?;
         storage.mount_point = guest_path.clone();

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -103,7 +103,6 @@ pub fn get_file_name<P: AsRef<Path>>(src: P) -> Result<String> {
 
 pub(crate) async fn generate_shared_path(
     dest: PathBuf,
-    read_only: bool,
     device_id: &str,
     sid: &str,
 ) -> Result<String> {
@@ -112,7 +111,7 @@ pub(crate) async fn generate_shared_path(
     let guest_path = do_get_guest_path(&mount_name, device_id, true, false);
     // Note: directories should always be created under the rw/ path. The ro/ directory is a
     // read-only bind mount of rw/, so creating directories directly under ro/ would fail with a read-only FS.
-    let host_path = do_get_host_path(&mount_name, sid, device_id, true, read_only);
+    let host_path = do_get_host_path(&mount_name, sid, device_id, true, false);
 
     if get_mount_path(&Some(dest)).starts_with("/dev") {
         fs::File::create(&host_path).context(format!("failed to create file {:?}", &host_path))?;
@@ -203,7 +202,7 @@ pub async fn handle_block_volume(
     }
 
     // generate host guest shared path
-    let guest_path = generate_shared_path(m.destination().clone(), read_only, &device_id, sid)
+    let guest_path = generate_shared_path(m.destination().clone(), &device_id, sid)
         .await
         .context("generate host-guest shared path failed")?;
     storage.mount_point = guest_path.clone();
@@ -241,6 +240,8 @@ pub async fn handle_block_volume(
 mod tests {
     use super::*;
 
+    const GENERATE_SHARED_PATH_TEST_ENV: &str = "KATA_TEST_GENERATE_SHARED_PATH";
+
     #[test]
     fn test_build_bind_mount_options_merges_volume_options() {
         let volume_options = vec!["ro".to_string(), "nosuid".to_string()];
@@ -274,6 +275,50 @@ mod tests {
                 "nodev".to_string(),
                 KATA_MOUNT_BIND_TYPE.to_string(),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_shared_path_read_only() {
+        if std::env::var_os(GENERATE_SHARED_PATH_TEST_ENV).is_some() {
+            kata_types::rootless::set_rootless(true);
+
+            let sid = "test-sandbox";
+            let device_id = "test-device";
+            let host_rw_path = crate::share_fs::get_host_rw_shared_path(sid);
+            let host_shared_path = host_rw_path.parent().unwrap();
+            let host_ro_path = host_shared_path.join("ro");
+            fs::create_dir_all(host_shared_path).unwrap();
+
+            // A file makes a write through ro fail even when running as root.
+            fs::write(&host_ro_path, b"must not be modified").unwrap();
+
+            let guest_path =
+                generate_shared_path(PathBuf::from("/mnt/test-volume"), device_id, sid)
+                    .await
+                    .unwrap();
+            let mount_name = Path::new(&guest_path).file_name().unwrap();
+
+            assert!(host_rw_path.join("passthrough").join(mount_name).is_dir());
+            assert!(host_ro_path.is_file());
+            return;
+        }
+
+        // Rootless state is process-global, so isolate it from parallel tests.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("test_generate_shared_path_read_only")
+            .arg("--test-threads=1")
+            .env(GENERATE_SHARED_PATH_TEST_ENV, "1")
+            .env("XDG_RUNTIME_DIR", temp_dir.path())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "isolated shared-path test failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
     }
 }


### PR DESCRIPTION
The host ro shared directory is a read-only bind mount of the rw directory, so creating a mount point directly below ro fails for read-only volumes.

Always create the host-side shared path below rw while preserving the volume read-only value for the storage and device configuration.

Log the value when generating the shared path so the information remains available for diagnostics.

And add the related UT to make it work as expected.