### PR TITLE
ci: Disable k8s tests on arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -355,18 +355,6 @@ jobs:
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
 
-  run-k8s-tests-on-arm64:
-    if: ${{ inputs.skip-test != 'yes' }}
-    needs: publish-kata-deploy-image-arm64
-    uses: ./.github/workflows/run-k8s-tests-on-arm64.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ inputs.tag }}-arm64
-      commit-hash: ${{ inputs.commit-hash }}
-      pr-number: ${{ inputs.pr-number }}
-      target-branch: ${{ inputs.target-branch }}
-
   run-kata-coco-tests-on-arm64:
     if: ${{ inputs.skip-test != 'yes' }}
     needs:


### PR DESCRIPTION
We partially cover them with the NVIDIA CPU k8s tests and as we only have one runner up, let's focus on the qemu-coco-dev-runtime-rs tests.