### PR TITLE
ci: drop monolithic confidential/GPU rootfs images in favour of composable base+extension

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -208,11 +208,8 @@ jobs:
       matrix:
         asset:
           - rootfs-image
-          - rootfs-image-confidential
           - rootfs-image-coco-extension
           - rootfs-image-mariner
-          - rootfs-image-nvidia-gpu
-          - rootfs-image-nvidia-gpu-confidential
           - rootfs-image-nvidia
           - rootfs-image-nvidia-gpu-extension
           - rootfs-initrd

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -201,9 +201,7 @@ jobs:
       matrix:
         asset:
           - rootfs-image
-          - rootfs-image-confidential
           - rootfs-image-coco-extension
-          - rootfs-image-nvidia-gpu
           - rootfs-image-nvidia
           - rootfs-image-nvidia-gpu-extension
           - rootfs-initrd

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -185,7 +185,6 @@ jobs:
       matrix:
         asset:
           - rootfs-image
-          - rootfs-image-confidential
           - rootfs-image-coco-extension
           - rootfs-initrd
           - rootfs-initrd-confidential

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -62,11 +62,18 @@ IMAGENAME = $(PROJECT_TAG).img
 IMAGECONFIDENTIALNAME = $(PROJECT_TAG)-confidential.img
 INITRDNAME = $(PROJECT_TAG)-initrd.img
 INITRDCONFIDENTIALNAME = $(PROJECT_TAG)-initrd-confidential.img
+# CoCo guest-components extension (attestation-agent, confidential-data-hub, ...),
+# cold-plugged and mounted at /run/kata-extensions/coco on confidential guests.
+COCOIMAGENAME = $(PROJECT_TAG)-coco-extension.img
 
 IMAGENAME_NV = $(PROJECT_TAG)-nvidia-gpu.img
 IMAGENAME_CONFIDENTIAL_NV = $(PROJECT_TAG)-nvidia-gpu-confidential.img
-# Driver-agnostic NVIDIA base image (no GPU userspace), booted by qemu-nvidia-cpu.
+# Driver-agnostic NVIDIA base image (no GPU userspace), booted by qemu-nvidia-cpu
+# and the composable NVIDIA GPU configs.
 IMAGENAME_NV_BASE = $(PROJECT_TAG)-nvidia.img
+# Driver-versioned GPU extension (GPU userspace), cold-plugged and mounted at
+# /run/kata-extensions/gpu on GPU guests.
+IMAGENAME_NV_EXTENSION = $(PROJECT_TAG)-nvidia-gpu-extension.img
 
 TARGET = $(BIN_PREFIX)-runtime
 RUNTIME_OUTPUT = $(CURDIR)/$(TARGET)
@@ -131,12 +138,20 @@ KERNELDIR := $(PKGDATADIR)
 
 IMAGEPATH := $(PKGDATADIR)/$(IMAGENAME)
 IMAGECONFIDENTIALPATH := $(PKGDATADIR)/$(IMAGECONFIDENTIALNAME)
+COCOIMAGEPATH := $(PKGDATADIR)/$(COCOIMAGENAME)
+# dm-verity params for the CoCo extension (root_hash_coco-extension.txt); filled
+# in by the shim-v2 build from the emitted root-hash file.
+COCOVERITYPARAMS :=
 INITRDPATH := $(PKGDATADIR)/$(INITRDNAME)
 INITRDCONFIDENTIALPATH := $(PKGDATADIR)/$(INITRDCONFIDENTIALNAME)
 
 IMAGEPATH_NV := $(PKGDATADIR)/$(IMAGENAME_NV)
 IMAGEPATH_CONFIDENTIAL_NV := $(PKGDATADIR)/$(IMAGENAME_CONFIDENTIAL_NV)
 IMAGEPATH_NV_BASE := $(PKGDATADIR)/$(IMAGENAME_NV_BASE)
+IMAGEPATH_NV_EXTENSION := $(PKGDATADIR)/$(IMAGENAME_NV_EXTENSION)
+# dm-verity params for the gpu extension (root_hash_nvidia-gpu-extension.txt);
+# filled in by the shim-v2 build from the emitted root-hash file.
+NVIDIAGPUEXTENSIONVERITYPARAMS ?=
 
 ROOTFSTYPE_EXT4 := \"ext4\"
 ROOTFSTYPE_XFS := \"xfs\"
@@ -169,8 +184,8 @@ KERNELVERITYPARAMS ?= ""
 KERNELVERITYPARAMS_NV ?= ""
 KERNELVERITYPARAMS_CONFIDENTIAL_NV ?= ""
 # dm-verity params for the driver-agnostic nvidia base image (qemu-nvidia-cpu).
-# The Go runtime maps KERNELVERITYPARAMS_NV to the monolithic nvidia-gpu hash,
-# so qemu-nvidia-cpu needs its own var pointing at the "nvidia" base root hash.
+# Both runtimes now map KERNELVERITYPARAMS_NV to the "nvidia" base root hash, so
+# this mirrors it; kept as its own var to avoid churning the nvidia-cpu config.
 KERNELVERITYPARAMS_NV_BASE ?= ""
 
 # Name of default configuration file the runtime will use.
@@ -676,6 +691,9 @@ USER_VARS += IMAGECONFIDENTIALNAME
 USER_VARS += IMAGEPATH
 USER_VARS += IMAGEPATH_CLH_AZURE
 USER_VARS += IMAGECONFIDENTIALPATH
+USER_VARS += COCOIMAGENAME
+USER_VARS += COCOIMAGEPATH
+USER_VARS += COCOVERITYPARAMS
 USER_VARS += INITRDNAME
 USER_VARS += INITRDCONFIDENTIALNAME
 USER_VARS += INITRDPATH
@@ -686,6 +704,9 @@ USER_VARS += IMAGEPATH_NV
 USER_VARS += IMAGEPATH_CONFIDENTIAL_NV
 USER_VARS += IMAGENAME_NV_BASE
 USER_VARS += IMAGEPATH_NV_BASE
+USER_VARS += IMAGENAME_NV_EXTENSION
+USER_VARS += IMAGEPATH_NV_EXTENSION
+USER_VARS += NVIDIAGPUEXTENSIONVERITYPARAMS
 USER_VARS += KERNELNAME_NV
 USER_VARS += KERNELPATH_NV
 USER_VARS += KERNELNAME_CONFIDENTIAL_NV

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -15,7 +15,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELCONFIDENTIALPATH@"
-image = "@IMAGECONFIDENTIALPATH@"
+image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
 
 # rootfs filesystem type:
@@ -776,3 +776,11 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# Confidential guests boot the measured base image plus the CoCo guest-components
+# extension (attestation-agent, confidential-data-hub, ...), cold-plugged and
+# mounted at /run/kata-extensions/coco.
+[[hypervisor.qemu.guest_extension_images]]
+name = "coco"
+path = "@COCOIMAGEPATH@"
+verity_params = "@COCOVERITYPARAMS@"

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -15,7 +15,7 @@
 [hypervisor.qemu]
 path = "@QEMUSNPPATH@"
 kernel = "@KERNELPATH_CONFIDENTIAL_NV@"
-image = "@IMAGEPATH_CONFIDENTIAL_NV@"
+image = "@IMAGEPATH_NV_BASE@"
 
 machine_type = "@MACHINETYPE@"
 
@@ -95,7 +95,7 @@ kernel_params = "@KERNELPARAMS_CONFIDENTIAL_NV@"
 # Optional dm-verity parameters (comma-separated key=value list):
 # root_hash=...,salt=...,data_blocks=...,data_block_size=...,hash_block_size=...
 # These are used by the runtime to assemble dm-verity kernel params.
-kernel_verity_params = "@KERNELVERITYPARAMS_CONFIDENTIAL_NV@"
+kernel_verity_params = "@KERNELVERITYPARAMS_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty
@@ -822,3 +822,17 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# GPU guests boot the driver-agnostic nvidia base image plus the driver-versioned
+# GPU extension (GPU userspace), cold-plugged and mounted at /run/kata-extensions/gpu.
+[[hypervisor.qemu.guest_extension_images]]
+name = "gpu"
+path = "@IMAGEPATH_NV_EXTENSION@"
+verity_params = "@NVIDIAGPUEXTENSIONVERITYPARAMS@"
+
+# Confidential GPU guests additionally cold-plug the CoCo guest-components extension
+# (attestation-agent, confidential-data-hub, ...) mounted at /run/kata-extensions/coco.
+[[hypervisor.qemu.guest_extension_images]]
+name = "coco"
+path = "@COCOIMAGEPATH@"
+verity_params = "@COCOVERITYPARAMS@"

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUTDXEXPERIMENTALPATH@"
 kernel = "@KERNELPATH_CONFIDENTIAL_NV@"
-image = "@IMAGEPATH_CONFIDENTIAL_NV@"
+image = "@IMAGEPATH_NV_BASE@"
 
 machine_type = "@MACHINETYPE@"
 tdx_quote_generation_service_socket_port = @QEMUTDXQUOTEGENERATIONSERVICESOCKETPORT@
@@ -72,7 +72,7 @@ kernel_params = "@KERNELPARAMS_CONFIDENTIAL_NV@"
 # Optional dm-verity parameters (comma-separated key=value list):
 # root_hash=...,salt=...,data_blocks=...,data_block_size=...,hash_block_size=...
 # These are used by the runtime to assemble dm-verity kernel params.
-kernel_verity_params = "@KERNELVERITYPARAMS_CONFIDENTIAL_NV@"
+kernel_verity_params = "@KERNELVERITYPARAMS_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty
@@ -799,3 +799,17 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# GPU guests boot the driver-agnostic nvidia base image plus the driver-versioned
+# GPU extension (GPU userspace), cold-plugged and mounted at /run/kata-extensions/gpu.
+[[hypervisor.qemu.guest_extension_images]]
+name = "gpu"
+path = "@IMAGEPATH_NV_EXTENSION@"
+verity_params = "@NVIDIAGPUEXTENSIONVERITYPARAMS@"
+
+# Confidential GPU guests additionally cold-plug the CoCo guest-components extension
+# (attestation-agent, confidential-data-hub, ...) mounted at /run/kata-extensions/coco.
+[[hypervisor.qemu.guest_extension_images]]
+name = "coco"
+path = "@COCOIMAGEPATH@"
+verity_params = "@COCOVERITYPARAMS@"

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH_NV@"
-image = "@IMAGEPATH_NV@"
+image = "@IMAGEPATH_NV_BASE@"
 machine_type = "@MACHINETYPE@"
 
 # rootfs filesystem type:
@@ -796,3 +796,10 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK_NV@"
+
+# GPU guests boot the driver-agnostic nvidia base image plus the driver-versioned
+# GPU extension (GPU userspace), cold-plugged and mounted at /run/kata-extensions/gpu.
+[[hypervisor.qemu.guest_extension_images]]
+name = "gpu"
+path = "@IMAGEPATH_NV_EXTENSION@"
+verity_params = "@NVIDIAGPUEXTENSIONVERITYPARAMS@"

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -15,7 +15,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELCONFIDENTIALPATH@"
-image = "@IMAGECONFIDENTIALPATH@"
+image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
 
 # rootfs filesystem type:
@@ -784,3 +784,11 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# Confidential guests boot the measured base image plus the CoCo guest-components
+# extension (attestation-agent, confidential-data-hub, ...), cold-plugged and
+# mounted at /run/kata-extensions/coco.
+[[hypervisor.qemu.guest_extension_images]]
+name = "coco"
+path = "@COCOIMAGEPATH@"
+verity_params = "@COCOVERITYPARAMS@"

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELCONFIDENTIALPATH@"
-image = "@IMAGECONFIDENTIALPATH@"
+image = "@IMAGEPATH@"
 machine_type = "@MACHINETYPE@"
 tdx_quote_generation_service_socket_port = @QEMUTDXQUOTEGENERATIONSERVICESOCKETPORT@
 
@@ -761,3 +761,11 @@ kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 #      cold_plug_vfio != no_port AND pod_resource_api_sock != "" => kubelet
 #              based cold plug.
 pod_resource_api_sock = "@DEFPODRESOURCEAPISOCK@"
+
+# Confidential guests boot the measured base image plus the CoCo guest-components
+# extension (attestation-agent, confidential-data-hub, ...), cold-plugged and
+# mounted at /run/kata-extensions/coco.
+[[hypervisor.qemu.guest_extension_images]]
+name = "coco"
+path = "@COCOIMAGEPATH@"
+verity_params = "@COCOVERITYPARAMS@"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -75,8 +75,9 @@ destdir="${workdir}/kata-static"
 default_binary_permissions='0744'
 
 # Rootfs image variants that carry a dm-verity root hash (measured rootfs).
-# Their hashes are collected at build time and consumed by the Rust runtime,
-# so this list is walked in a few places - keep it in one spot to avoid drift.
+# Their hashes are collected at build time and consumed by both runtimes
+# (Go and Rust), so this list is walked in a few places - keep it in one spot to
+# avoid drift.
 readonly MEASURED_ROOTFS_VARIANTS=(
 	base
 	confidential
@@ -536,8 +537,10 @@ install_image() {
 		# Both the standard confidential image and the NVIDIA confidential
 		# image bake the CoCo guest components + pause image into the
 		# rootfs, so each stays a usable standalone monolithic CoCo image.
-		# The runtime-rs split path instead ships these in the separate
-		# CoCo extension image (rootfs-image-coco-extension).
+		# These monolithic images are no longer built in CI nor consumed by
+		# the shipped configs (both runtimes now use the composable split
+		# path: base image + CoCo extension, rootfs-image-coco-extension);
+		# they are retained only as manually buildable targets.
 		if [[ "${variant}" == *confidential ]]; then
 			COCO_GUEST_COMPONENTS_TARBALL="$(get_coco_guest_components_tarball_path)"
 			export COCO_GUEST_COMPONENTS_TARBALL
@@ -594,12 +597,11 @@ install_image_base() {
 
 #Install guest image for confidential guests
 #
-# During the transition to composable (base + extension) images this monolithic
-# confidential image still bakes in the CoCo guest components and is the image
-# used by the Go runtime. The runtime-rs shims instead use the base image plus
-# the separately built CoCo extension image (rootfs-image-coco-extension),
-# attached as an extra block device. Once the split path is validated for the
-# Go runtime too, the components can stop being baked in here.
+# This monolithic confidential image bakes the CoCo guest components into the
+# rootfs. It is no longer built in CI nor referenced by the shipped configs:
+# both the Go runtime and runtime-rs now boot the measured base image plus the
+# separately built CoCo extension image (rootfs-image-coco-extension), attached
+# as an extra block device. It is kept as a manually buildable standalone image.
 install_image_confidential() {
 	export CONFIDENTIAL_GUEST="yes"
 	if [[ "${ARCH}" == "s390x" ]]; then

--- a/tools/packaging/kata-deploy/shim-components.json
+++ b/tools/packaging/kata-deploy/shim-components.json
@@ -16,13 +16,13 @@
       "s390x":   ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image", "rootfs-initrd"]
     },
     "qemu-snp": {
-      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel", "rootfs-image-confidential", "ovmf-sev"]
+      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel", "rootfs-image", "rootfs-image-coco-extension", "ovmf-sev"]
     },
     "qemu-snp-runtime-rs": {
       "x86_64": ["shim-v2-rust", "qemu-snp-experimental", "kernel", "rootfs-image", "rootfs-image-coco-extension", "ovmf-sev"]
     },
     "qemu-tdx": {
-      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel", "rootfs-image-confidential", "ovmf-tdx"]
+      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel", "rootfs-image", "rootfs-image-coco-extension", "ovmf-tdx"]
     },
     "qemu-tdx-runtime-rs": {
       "x86_64": ["shim-v2-rust", "qemu-tdx-experimental", "virtiofsd", "kernel", "rootfs-image", "rootfs-image-coco-extension", "ovmf-tdx"]
@@ -34,7 +34,7 @@
       "s390x": ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-initrd-confidential", "boot-image-se"]
     },
     "qemu-nvidia-gpu": {
-      "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu", "ovmf"]
+      "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "ovmf"]
     },
     "qemu-nvidia-gpu-runtime-rs": {
       "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "ovmf"]
@@ -48,20 +48,20 @@
       "aarch64": ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia"]
     },
     "qemu-nvidia-gpu-snp": {
-      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-sev"]
+      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "rootfs-image-coco-extension", "ovmf-sev"]
     },
     "qemu-nvidia-gpu-snp-runtime-rs": {
       "x86_64": ["shim-v2-rust", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "rootfs-image-coco-extension", "ovmf-sev"]
     },
     "qemu-nvidia-gpu-tdx": {
-      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-tdx"]
+      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "rootfs-image-coco-extension", "ovmf-tdx"]
     },
     "qemu-nvidia-gpu-tdx-runtime-rs": {
       "x86_64": ["shim-v2-rust", "qemu-tdx-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia", "rootfs-image-nvidia-gpu-extension", "rootfs-image-coco-extension", "ovmf-tdx"]
     },
     "qemu-coco-dev": {
-      "x86_64": ["shim-v2-go", "qemu", "kernel", "kernel-debug", "rootfs-image-confidential"],
-      "s390x":  ["shim-v2-go", "qemu", "kernel", "rootfs-image-confidential"]
+      "x86_64": ["shim-v2-go", "qemu", "kernel", "kernel-debug", "rootfs-image", "rootfs-image-coco-extension"],
+      "s390x":  ["shim-v2-go", "qemu", "kernel", "rootfs-image", "rootfs-image-coco-extension"]
     },
     "qemu-coco-dev-runtime-rs": {
       "x86_64":  ["shim-v2-rust", "qemu", "kernel", "kernel-debug", "rootfs-image", "rootfs-image-coco-extension"],

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -39,22 +39,17 @@ esac
 
 # Variants (targets) that build a measured rootfs as of now are:
 # - rootfs-image (the base image, measured; root hash labelled "base")
-# - rootfs-image-confidential (monolithic CoCo image, root hash "confidential")
-# - rootfs-image-coco-extension
-# - rootfs-image-nvidia-gpu / rootfs-image-nvidia-gpu-confidential (monolithic)
+# - rootfs-image-coco-extension (the CoCo guest-components extension)
 # - rootfs-image-nvidia (the driver-agnostic NVIDIA boot image)
 # - rootfs-image-nvidia-gpu-extension (the driver-versioned gpu extension)
 #
-# Both the CoCo and the NVIDIA GPU configs come in two flavours during the
-# transition to split images, and the two runtimes are built in separate `make`
-# invocations so each maps the same make var to a different root hash:
-# - runtime-rs (Rust) uses the split layout: the measured base image
-#   (@KERNELVERITYPARAMS@) plus the CoCo extension (@COCOVERITYPARAMS@), and for
-#   NVIDIA the nvidia base image (@KERNELVERITYPARAMS_NV@) plus the gpu extension
+# Both runtimes now boot the composable split layout (base image plus
+# cold-plugged extensions), so the Go and Rust `make` invocations map the same
+# make vars to the same root hashes:
+# - the measured base image (@KERNELVERITYPARAMS@) plus the CoCo extension
+#   (@COCOVERITYPARAMS@), and for NVIDIA the nvidia base image
+#   (@KERNELVERITYPARAMS_NV@) plus the gpu extension
 #   (@NVIDIAGPUEXTENSIONVERITYPARAMS@).
-# - runtime (Go) still uses the monolithic images: the confidential image
-#   (@KERNELVERITYPARAMS@) and, for NVIDIA, nvidia-gpu (@KERNELVERITYPARAMS_NV@)
-#   and nvidia-gpu-confidential (@KERNELVERITYPARAMS_CONFIDENTIAL_NV@).
 #
 # shellcheck disable=SC2154
 root_hash_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
@@ -76,27 +71,22 @@ read_verity_param() {
 	printf ' %s=%s' "${param_var}" "${root_measure_config}"
 }
 
-# The NVIDIA GPU verity params differ per runtime: runtime-rs boots the
-# composable split layout (nvidia base + gpu extension) while the Go runtime
-# still boots the monolithic nvidia-gpu / nvidia-gpu-confidential images.  Since
-# both runtimes reuse KERNELVERITYPARAMS_NV but map it to different root hashes,
-# the reads live in each runtime's own EXTRA_OPTS rather than the shared one.
+# Both runtimes boot the composable split layout, so they share the same
+# root-hash-to-make-var mapping: the measured base image plus the CoCo extension,
+# and for NVIDIA the nvidia base image plus the gpu extension.  qemu-nvidia-cpu
+# (Go) also boots the driver-agnostic nvidia base image verity-backed and reads
+# it through its own KERNELVERITYPARAMS_NV_BASE var.
+SPLIT_EXTRA_OPTS="$(read_verity_param "base" "KERNELVERITYPARAMS")"
+SPLIT_EXTRA_OPTS+="$(read_verity_param "coco-extension" "COCOVERITYPARAMS")"
+SPLIT_EXTRA_OPTS+="$(read_verity_param "nvidia" "KERNELVERITYPARAMS_NV")"
+SPLIT_EXTRA_OPTS+="$(read_verity_param "nvidia-gpu-extension" "NVIDIAGPUEXTENSIONVERITYPARAMS")"
 
-# runtime-rs (Rust): split images -> base hash + CoCo extension hash, plus the
-# nvidia base and gpu extension hashes for the NVIDIA GPU configs.
-RUST_EXTRA_OPTS="$(read_verity_param "base" "KERNELVERITYPARAMS")"
-RUST_EXTRA_OPTS+="$(read_verity_param "coco-extension" "COCOVERITYPARAMS")"
-RUST_EXTRA_OPTS+="$(read_verity_param "nvidia" "KERNELVERITYPARAMS_NV")"
-RUST_EXTRA_OPTS+="$(read_verity_param "nvidia-gpu-extension" "NVIDIAGPUEXTENSIONVERITYPARAMS")"
+# runtime-rs (Rust): composable split layout.
+RUST_EXTRA_OPTS="${SPLIT_EXTRA_OPTS}"
 
-# runtime (Go): monolithic confidential image -> confidential hash, plus the
-# monolithic nvidia-gpu / nvidia-gpu-confidential hashes for the NVIDIA configs.
-GO_EXTRA_OPTS="$(read_verity_param "confidential" "KERNELVERITYPARAMS")"
-GO_EXTRA_OPTS+="$(read_verity_param "nvidia-gpu" "KERNELVERITYPARAMS_NV")"
-GO_EXTRA_OPTS+="$(read_verity_param "nvidia-gpu-confidential" "KERNELVERITYPARAMS_CONFIDENTIAL_NV")"
-# qemu-nvidia-cpu (Go) boots the driver-agnostic nvidia base image verity-backed;
-# it needs the "nvidia" base hash in its own var since KERNELVERITYPARAMS_NV
-# above is the monolithic nvidia-gpu hash.
+# runtime (Go): also the composable split layout, plus the nvidia base hash in
+# KERNELVERITYPARAMS_NV_BASE consumed by the qemu-nvidia-cpu config.
+GO_EXTRA_OPTS="${SPLIT_EXTRA_OPTS}"
 GO_EXTRA_OPTS+="$(read_verity_param "nvidia" "KERNELVERITYPARAMS_NV_BASE")"
 
 # shellcheck disable=SC2154,SC2086


### PR DESCRIPTION
The Go runtime's confidential and NVIDIA GPU QEMU configs still booted the **monolithic** rootfs images (`kata-containers-confidential.img`, `kata-containers-nvidia-gpu.img`, `kata-containers-nvidia-gpu-confidential.img`), which bake every guest component into a single rootfs. runtime-rs already boots the **composable** layout: a measured base image plus purpose-specific guest extension images cold-plugged as virtio-blk devices.

This series migrates the Go runtime to the same composable layout and then removes the now-unused monolithic image builds from CI.

The main motivation is the fact that released `kata-static` tarball is bumping against GitHub's release asset size limit (2 GiB). The monolithic images duplicate content that already ships in the base image plus the coco/gpu extensions, so
building and packaging them just inflates the tarball for no benefit once both runtimes boot the composable layout. Dropping them keeps the tarball comfortably under the limit (and saves the corresponding CI build time).

**The monolithic image build targets and `install_*` helpers stay in the tree so they can still be built manually; they are simply no longer produced by CI nor referenced by any shipped config.**