### PR TITLE
feat: Update nr_inodes on ephemeral mount updates

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2582,7 +2582,11 @@ func (s *Sandbox) prepareEphemeralMounts(memoryMB uint32) ([]*grpc.Storage, erro
 					continue
 				}
 
-				mountOptions := []string{"remount", fmt.Sprintf("size=%dM", memoryMB)}
+				mountOptions := []string{
+					"remount",
+					fmt.Sprintf("size=%dM", memoryMB),
+					fmt.Sprintf("nr_inodes=%d", utils.TmpfsMaxInodes(memoryMB)),
+				}
 
 				origin_src := mount.Source
 				stat := syscall.Stat_t{}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -229,11 +229,12 @@ func TestPrepareEphemeralMounts(t *testing.T) {
 		assert.Equal(t, s.Source, "tmpfs")
 		assert.Equal(t, s.Fstype, "tmpfs")
 		assert.Equal(t, s.MountPoint, filepath.Join(ephemeralPath(), "tmp"))
-		assert.Equal(t, len(s.Options), 2) // remount, size=1024M
+		assert.Equal(t, len(s.Options), 3) // remount, size=1024M, nr_inodes=131072
 
 		validSet := map[string]struct{}{
-			"remount":    {},
-			"size=1024M": {},
+			"remount":          {},
+			"size=1024M":       {},
+			"nr_inodes=131072": {},
 		}
 		for _, opt := range s.Options {
 			if _, ok := validSet[opt]; !ok {

--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -42,6 +42,9 @@ const DefaultRateLimiterRefillTimeMilliSecs = 1000
 // MibToBytesShift the number to shift needed to convert MiB to Bytes
 const MibToBytesShift = 20
 
+// MibToKibShift the number to shift needed to convert MiB to KiB
+const MibtoKibShift = 10
+
 // MaxSocketPathLen is the effective maximum Unix domain socket length.
 //
 // See unix(7).
@@ -842,4 +845,14 @@ func DistributeVCPUsProportionally(numaNodes []types.GuestNUMANode, totalVCPUs u
 	}
 
 	return vcpusPerNode, nil
+}
+
+// TmpfsMaxInodes computes the max number of inodes
+// for a tmpfs mount as defined by the default calculation of nr_inodes at:
+// https://docs.kernel.org/filesystems/tmpfs.html
+//
+// Assumes 4K pages.
+func TmpfsMaxInodes(sizeMiB uint32) uint64 {
+	// There's 256 4k pages in 1MiB, which translates to 128 inodes.
+	return uint64(sizeMiB) * 128
 }

--- a/src/runtime/virtcontainers/utils/utils_test.go
+++ b/src/runtime/virtcontainers/utils/utils_test.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -879,4 +880,35 @@ func TestFilterNUMANodesByCPUSet(t *testing.T) {
 	filtered = FilterNUMANodesByCPUSet(singleNode, sandboxCPUs)
 	assert.Len(filtered, 1)
 	assert.Equal("0", filtered[0].HostNodes)
+}
+
+func TestTmpfsMaxInodes(t *testing.T) {
+	tcs := []struct {
+		name     string
+		size     uint32
+		expected uint64
+	}{
+		{
+			name:     "empty",
+			size:     0,
+			expected: 0,
+		},
+		{
+			name:     "1 MB",
+			size:     1,
+			expected: 128,
+		},
+		{
+			name:     "uint32 overflow",
+			size:     math.MaxInt32,
+			expected: 274877906816,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := TmpfsMaxInodes(tc.size)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
More details in #13470

This change ensures that nr_inodes are updated when increasing the size of a tmpfs mount following a memory hot-plug. Not doing so causes max inodes to be capped at the value calculated by the kernel from the initial tmpfs size.

## Why this is fixed only in the Go runtime

This PR only touches the Go runtime because the code path it fixes does not exist in runtime-rs. The nr_inodes option is applied during the ephemeral tmpfs remount that the Go runtime performs on memory hotplug. runtime-rs has no equivalent of that chain: Its memory-resize path [only calls hypervisor.resize_memory()](https://github.com/kata-containers/kata-containers/blob/8dd6c888193b80a90a82d1bde9bd0ac905bf6ec7/src/runtime-rs/crates/resource/src/cpu_mem/mem.rs#L116-L129) and never remounts ephemeral volumes. I believe bringing runtime-rs to parity is a larger amount of work that should tracked separately.