### PR TITLE
runtime-rs: align Cloud Hypervisor CPU schema with v51.1

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -326,16 +326,14 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
             return Err(CpusConfigError::BootVCPUsTooSmall);
         }
 
-        let default_vcpus = u8::try_from(cpu.default_vcpus.ceil() as u32)
-            .map_err(CpusConfigError::BootVCPUsTooBig)?;
+        let default_vcpus = cpu.default_vcpus.ceil() as u32;
 
         // This can only happen if runtime-rs fails to set default values.
         if cpu.default_maxvcpus == 0 {
             return Err(CpusConfigError::MaxVCPUsTooSmall);
         }
 
-        let default_max_vcpus =
-            u8::try_from(cpu.default_maxvcpus).map_err(CpusConfigError::MaxVCPUsTooBig)?;
+        let default_max_vcpus = cpu.default_maxvcpus;
 
         let boot_vcpus = default_vcpus;
 
@@ -351,8 +349,11 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
             return Err(CpusConfigError::BootVPUsGtThanMaxVCPUs);
         }
 
+        let cores_per_die = u16::try_from(max_vcpus)
+            .map_err(CpusConfigError::MaxVCPUsExceedsTopology)?;
+
         let topology = CpuTopology {
-            cores_per_die: max_vcpus,
+            cores_per_die,
             threads_per_core: 1,
             dies_per_package: 1,
             packages: 1,
@@ -636,11 +637,11 @@ mod tests {
         }
     }
 
-    fn make_cpu_objects(cpu_default: u8, cpu_max: u8, tdx: bool) -> (CpuInfo, CpusConfig) {
+    fn make_cpu_objects(cpu_default: u32, cpu_max: u32, tdx: bool) -> (CpuInfo, CpusConfig) {
         let default_maxvcpus = if tdx {
-            cpu_default as u32
+            cpu_default
         } else {
-            cpu_max as u32
+            cpu_max
         };
 
         let cpu_info = CpuInfo {
@@ -653,15 +654,18 @@ mod tests {
         let max_vcpus = if tdx {
             cpu_default
         } else {
-            default_maxvcpus as u8
+            default_maxvcpus
         };
+
+        let cores_per_die =
+            u16::try_from(max_vcpus).expect("test max_vcpus must fit CpuTopology u16 fields");
 
         let cpus_config = CpusConfig {
             boot_vcpus: cpu_default,
             max_vcpus,
             nested: cpu_nested_config(),
             topology: Some(CpuTopology {
-                cores_per_die: max_vcpus,
+                cores_per_die,
 
                 ..make_bare_topology()
             }),
@@ -1285,6 +1289,38 @@ mod tests {
                     ..Default::default()
                 }),
             },
+            TestData {
+                cpu_info: CpuInfo {
+                    default_vcpus: 1.0,
+                    default_maxvcpus: 256,
+                    ..Default::default()
+                },
+                guest_protection: GuestProtection::NoProtection,
+                result: Ok(CpusConfig {
+                    boot_vcpus: 1,
+                    max_vcpus: 256,
+                    nested: cpu_nested_config(),
+                    topology: Some(CpuTopology {
+                        cores_per_die: 256,
+
+                        ..topology
+                    }),
+                    max_phys_bits: DEFAULT_CH_MAX_PHYS_BITS,
+
+                    ..Default::default()
+                }),
+            },
+            TestData {
+                cpu_info: CpuInfo {
+                    default_vcpus: 1.0,
+                    default_maxvcpus: u16::MAX as u32 + 1,
+                    ..Default::default()
+                },
+                guest_protection: GuestProtection::NoProtection,
+                result: Err(CpusConfigError::MaxVCPUsExceedsTopology(
+                    u16::try_from(u16::MAX as u32 + 1).unwrap_err(),
+                )),
+            },
         ];
 
         for (i, d) in tests.iter().enumerate() {
@@ -1697,8 +1733,8 @@ mod tests {
         let valid_vsock =
             VsockConfig::try_from((vsock_socket_path.to_string(), DEFAULT_VSOCK_CID)).unwrap();
 
-        let (cpu_info, cpus_config) = make_cpu_objects(7, u8::MAX, false);
-        let (cpu_info_tdx, cpus_config_tdx) = make_cpu_objects(7, u8::MAX, true);
+        let (cpu_info, cpus_config) = make_cpu_objects(7, 255, false);
+        let (cpu_info_tdx, cpus_config_tdx) = make_cpu_objects(7, 255, true);
 
         let (memory_info_std, mem_config_std) =
             make_memory_objects(79, usable_max_mem_bytes, false);

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/errors.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -70,17 +69,14 @@ pub enum CpusConfigError {
     #[error("Boot vCPUs cannot be zero or negative")]
     BootVCPUsTooSmall,
 
-    #[error("Too many boot vCPUs specified: {0}")]
-    BootVCPUsTooBig(<u8 as TryFrom<i32>>::Error),
-
-    #[error("Max vCPUs cannot be zero or negative")]
+    #[error("Max vCPUs cannot be zero")]
     MaxVCPUsTooSmall,
-
-    #[error("Too many max vCPUs specified: {0}")]
-    MaxVCPUsTooBig(<u8 as TryFrom<u32>>::Error),
 
     #[error("Boot vCPUs cannot be larger than max vCPUs")]
     BootVPUsGtThanMaxVCPUs,
+
+    #[error("Max vCPUs exceeds topology field capacity: {0}")]
+    MaxVCPUsExceedsTopology(<u16 as std::convert::TryFrom<u32>>::Error),
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -62,14 +62,14 @@ pub enum ConsoleOutputMode {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpuAffinity {
-    pub vcpu: u8,
-    pub host_cpus: Vec<u8>,
+    pub vcpu: u32,
+    pub host_cpus: Vec<usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpusConfig {
-    pub boot_vcpus: u8,
-    pub max_vcpus: u8,
+    pub boot_vcpus: u32,
+    pub max_vcpus: u32,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topology: Option<CpuTopology>,
@@ -96,10 +96,10 @@ pub struct CpuFeatures {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct CpuTopology {
-    pub threads_per_core: u8,
-    pub cores_per_die: u8,
-    pub dies_per_package: u8,
-    pub packages: u8,
+    pub threads_per_core: u16,
+    pub cores_per_die: u16,
+    pub dies_per_package: u16,
+    pub packages: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]


### PR DESCRIPTION
Cloud Hypervisor v51.1 models CPU counts as u32 and topology fields as u16, but runtime-rs still used u8. With default_maxvcpus set to MAX_CH_VCPUS (256), conversion failed with MaxVCPUsTooBig before the config reached Cloud Hypervisor.

Widen CpusConfig, CpuTopology, and CpuAffinity to match the pinned CH schema, drop the u8 try_from guards that encoded that mismatch, and add a unit test for max_vcpus=256.

Fixes: #13449

Assisted-By: Grok 4.5