### PR TITLE
kata-deploy: configure EROFS backing mode

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -835,37 +835,14 @@ function helm_helper() {
 				die "EROFS_SNAPSHOTTER_MODE is only supported with SNAPSHOTTER=erofs"
 			fi
 
-			# Honor an erofs snapshotter drop-in already shipped by the base
-			# values file (e.g. try-kata-nvidia-cpu.values.yaml pins the
-			# memory-backed default_size and disables fs-verity, which cannot
-			# be guaranteed on an arbitrary node's backing filesystem). Only
-			# synthesize the default drop-in when the profile does not provide
-			# its own.
-			local existing_dropin
-			existing_dropin="$(yq -r '.containerd.userDropIn // ""' "${values_yaml}")"
+			case "${EROFS_SNAPSHOTTER_MODE}" in
+				disk | memory) ;;
+				*)
+					die "Unsupported EROFS_SNAPSHOTTER_MODE: ${EROFS_SNAPSHOTTER_MODE}"
+					;;
+			esac
 
-			if [[ -z "${existing_dropin//[[:space:]]/}" ]]; then
-				local erofs_default_size
-				case "${EROFS_SNAPSHOTTER_MODE}" in
-					disk)
-						erofs_default_size="10G"
-						;;
-					memory)
-						erofs_default_size="0"
-						;;
-					*)
-						die "Unsupported EROFS_SNAPSHOTTER_MODE: ${EROFS_SNAPSHOTTER_MODE}"
-						;;
-				esac
-
-				HELM_CONTAINERD_USER_DROP_IN="[plugins.'io.containerd.snapshotter.v1.erofs']"$'\n'
-				HELM_CONTAINERD_USER_DROP_IN+="  default_size = \"${erofs_default_size}\""
-
-				HELM_CONTAINERD_USER_DROP_IN="${HELM_CONTAINERD_USER_DROP_IN}" \
-					yq -i '.containerd.userDropIn = strenv(HELM_CONTAINERD_USER_DROP_IN)' "${values_yaml}"
-			fi
-
-			# Propagate rwlayer backing mode to kata-deploy.
+			# Propagate rw-layer backing mode to kata-deploy.
 			yq -i ".snapshotter.erofsSnapshotterMode = \"${EROFS_SNAPSHOTTER_MODE}\"" "${values_yaml}"
 		fi
 

--- a/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
@@ -12,6 +12,17 @@ use log::{info, warn};
 use std::fs;
 use std::path::Path;
 
+fn erofs_default_size(mode: Option<&str>) -> Result<&'static str> {
+    match mode {
+        Some("memory") => Ok("\"0\""),
+        Some("disk") | None => Ok("\"10G\""),
+        Some(other) => Err(anyhow::anyhow!(
+            "Unsupported EROFS_SNAPSHOTTER_MODE: '{}'. Supported values: disk, memory",
+            other
+        )),
+    }
+}
+
 pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &Path) -> Result<()> {
     info!("Configuring erofs-snapshotter");
 
@@ -76,8 +87,7 @@ pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &P
 
     // dm-verity is orthogonal to rw-layer backing — it verifies lower (erofs)
     // layers via device-mapper regardless of whether the upper rw-layer lives on
-    // disk or in memory. When dm-verity is enabled, fsverity and immutable are
-    // disabled on the snapshotter side in favor of dm-verity.
+    // disk or in memory.
     let use_dmverity = config.erofs_dmverity;
     let dmverity_mode = if use_dmverity { "\"on\"" } else { "\"off\"" };
     let enable_dmverity = if use_dmverity { "true" } else { "false" };
@@ -116,10 +126,14 @@ pub async fn configure_erofs_snapshotter(config: &Config, configuration_file: &P
         "false",
     )?;
 
+    // Map EROFS_SNAPSHOTTER_MODE to containerd's default_size:
+    // - "memory" uses an in-memory rw layer (default_size = 0)
+    // - "disk" (or unset) uses a disk-backed rw layer (default_size = 10G)
+    let default_size = erofs_default_size(config.erofs_snapshotter_mode.as_deref())?;
     toml_utils::set_toml_value(
         configuration_file,
         ".plugins.\"io.containerd.snapshotter.v1.erofs\".default_size",
-        "\"10G\"",
+        default_size,
     )?;
     // In the default "merged" mode, force containerd to merge all layers into a
     // single fsmeta.erofs (max_unmerged_layers = 0). In "unmerged" mode we delete
@@ -429,4 +443,26 @@ pub async fn uninstall_snapshotter(snapshotter: &str, config: &Config) -> Result
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::erofs_default_size;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(None, "\"10G\"")]
+    #[case(Some("disk"), "\"10G\"")]
+    #[case(Some("memory"), "\"0\"")]
+    fn test_erofs_default_size(#[case] mode: Option<&str>, #[case] expected: &str) {
+        assert_eq!(erofs_default_size(mode).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_erofs_default_size_rejects_unknown_mode() {
+        let error = erofs_default_size(Some("unknown")).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Unsupported EROFS_SNAPSHOTTER_MODE"));
+    }
 }

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -630,6 +630,11 @@ impl Config {
         );
         info!("* EROFS_MERGE_MODE: {:?}", self.erofs_merge_mode);
         info!(
+            "* EROFS_SNAPSHOTTER_MODE: {:?}",
+            self.erofs_snapshotter_mode
+        );
+        info!("* EROFS_DMVERITY: {}", self.erofs_dmverity);
+        info!(
             "* EXPERIMENTAL_FORCE_GUEST_PULL: {}",
             self.experimental_force_guest_pull_for_arch.join(",")
         );

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -26,10 +26,10 @@ snapshotter:
 # cannot guarantee that on an arbitrary node. Rather than gate this profile on a
 # host feature we do not control, we disable fs-verity so it works on the widest
 # possible range of setups; we take that hit deliberately to keep the profile
-# generic. Combined with memory-backed EROFS rw layers, ship this as the default
-# containerd erofs snapshotter drop-in for the NVIDIA CPU profile so it does not
-# need to be injected out-of-band. It is loaded after kata-deploy's generated
-# config, so it overrides the built-in enable_fsverity default.
+# generic. Ship this as the default containerd erofs snapshotter drop-in for the
+# NVIDIA CPU profile so it does not need to be injected out-of-band. It is loaded
+# after kata-deploy's generated config, so it overrides the built-in
+# enable_fsverity default.
 #
 # NOTE: This drop-in targets containerd's built-in EROFS snapshotter, which is
 # only available on containerd >= 2.2.0 (config version 3, using the
@@ -43,7 +43,6 @@ containerd:
   userDropIn: |
     [plugins.'io.containerd.snapshotter.v1.erofs']
       enable_fsverity = false
-      default_size = "0"
 
 # Enable NVIDIA CPU shims
 # Disable all shims at once, then enable only the ones we need.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -16,9 +16,12 @@ deploymentMode: job
 snapshotter:
   setup: ["nydus", "erofs"]
   # The NVIDIA GPU runtime-rs handler runs with shared_fs=none and uses the
-  # EROFS snapshotter with memory-backed rw layers. TEE handlers keep
-  # nydus/guest-pull separately.
+  # EROFS snapshotter with memory-backed rw layers and dm-verity for lower
+  # (image) layer integrity. TEE handlers keep nydus/guest-pull separately.
+  # Nodes upgrading from an earlier profile must recreate cached EROFS layers
+  # that do not contain dm-verity metadata.
   erofsSnapshotterMode: "memory"
+  erofsDmverity: true
 
 # EROFS fs-verity requires the backing filesystem to support fs-verity, and we
 # cannot guarantee that on an arbitrary node. Rather than gate this profile on a

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -15,15 +15,19 @@ deploymentMode: job
 
 snapshotter:
   setup: ["nydus", "erofs"]
+  # The NVIDIA GPU runtime-rs handler runs with shared_fs=none and uses the
+  # EROFS snapshotter with memory-backed rw layers. TEE handlers keep
+  # nydus/guest-pull separately.
+  erofsSnapshotterMode: "memory"
 
 # EROFS fs-verity requires the backing filesystem to support fs-verity, and we
 # cannot guarantee that on an arbitrary node. Rather than gate this profile on a
 # host feature we do not control, we disable fs-verity so it works on the widest
 # possible range of setups; we take that hit deliberately to keep the profile
-# generic. Combined with memory-backed EROFS rw layers, ship this as the default
-# containerd erofs snapshotter drop-in for the NVIDIA GPU runtime-rs handler so
-# it does not need to be injected out-of-band. It is loaded after kata-deploy's
-# generated config, so it overrides the built-in enable_fsverity default.
+# generic. Ship this as the default containerd erofs snapshotter drop-in for the
+# NVIDIA GPU runtime-rs handler so it does not need to be injected out-of-band.
+# It is loaded after kata-deploy's generated config, so it overrides the
+# built-in enable_fsverity default.
 #
 # NOTE: This drop-in targets containerd's built-in EROFS snapshotter, which is
 # only available on containerd >= 2.2.0 (config version 3, using the
@@ -33,7 +37,6 @@ containerd:
   userDropIn: |
     [plugins.'io.containerd.snapshotter.v1.erofs']
       enable_fsverity = false
-      default_size = "0"
 
 # Enable NVIDIA GPU shims
 # Disable all shims at once, then enable only the ones we need

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -160,10 +160,15 @@ containerd:
   # Optional user-provided containerd drop-in TOML content.
   # This is written as an extra drop-in loaded after kata-deploy's generated drop-in,
   # so user keys can override kata-deploy defaults.
-  # Example: set erofs snapshotter default size to zero:
+  # NOTE: default_size = "0" selects memory-backed rw layers even when
+  # erofsSnapshotterMode is "disk"; do not set it when disk backing is intended.
+  # Example: disable erofs fs-verity when the host backing filesystem may not
+  # support it, and/or adjust the disk-backed rw-layer size (kata-deploy's
+  # default for disk/empty erofsSnapshotterMode is "10G"):
   # userDropIn: |
   #   [plugins.'io.containerd.snapshotter.v1.erofs']
-  #     default_size = 0
+  #     enable_fsverity = false
+  #     default_size = "20G"
   userDropIn: ""
 
 # Node selector and tolerations to control which nodes the kata-deploy daemonset runs on
@@ -362,8 +367,14 @@ snapshotter:
   # erofs snapshotter. When empty, kata-deploy uses its built-in default
   # (merged).
   erofsMergeMode: ""
-  # EROFS snapshotter mode. Controls the rw-layer backing strategy.
+  # EROFS snapshotter mode. Controls the rw-layer backing strategy via
+  # containerd's default_size:
+  #   - "memory" → default_size = "0"  (in-memory rw layer)
+  #   - "disk"   → default_size = "10G" (disk-backed rw layer)
+  #   - ""       → same as "disk"
   # Valid values: "" (default), "disk", or "memory".
+  # containerd.userDropIn is loaded later and can override default_size. Do not
+  # set default_size to "0" there when disk backing is intended.
   erofsSnapshotterMode: ""
   # Enable dm-verity integrity verification for EROFS lower layers.
   # Independent of erofsSnapshotterMode — works with both disk and memory.


### PR DESCRIPTION
## Motivation

The EROFS rw-layer backing mode and containerd `default_size` were configured in multiple places. In particular, CI and the NVIDIA values files could inject their own `default_size`, making the effective mode less systematic and allowing the Helm value and containerd configuration to disagree.

## General EROFS snapshotter deployment changes

- Make `snapshotter.erofsSnapshotterMode` drive the generated containerd
  `default_size`:
  - `memory` maps to `"0"`
  - `disk` maps to `"10G"`
  - an unset mode retains the disk-backed `"10G"` default
- Reject unsupported EROFS snapshotter modes.
- Propagate the requested mode through the Kubernetes CI Helm values instead of generating a separate containerd `default_size` override.
- Log the resolved EROFS mode and dm-verity configuration.
- Document that a later `containerd.userDropIn` can override `default_size`, and that setting it to `"0"` selects memory backing even when disk mode was requested.

## NVIDIA related changes

- Remove redundant `default_size` overrides from the NVIDIA CPU and GPU profiles.
- Explicitly configure the NVIDIA GPU profile to use memory-backed EROFS rw layers.
- Enable dm-verity for the NVIDIA GPU profile's lower EROFS image layers.