### PR TITLE
runtime-rs: file path in open() error message

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -172,9 +172,7 @@ fn create_fds(device: &str, num_fds: usize) -> Result<Vec<File>> {
             Err(e) => {
                 fds.clear();
                 return Err(anyhow!(
-                    "It failed with error {:?} when opened the {:?} device.",
-                    e,
-                    i
+                    "Failed to open {device} fd index {i}, with error {e}"
                 ));
             }
         };


### PR DESCRIPTION
Include the file path in open() error message, allowing users to easier understand which required kernel module has not been loaded.