### PR TITLE
kata-deploy: support a values overlay when publishing the helm chart

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
@@ -38,6 +38,18 @@ fi
 yq eval ".version = \"${CHART_VERSION}\" | .appVersion = \"${CHART_VERSION}\"" -i "${tmp}/kata-deploy/Chart.yaml"
 yq eval ".image.reference = \"${REGISTRY}\" | .image.tag = \"${TAG}\"" -i "${tmp}/kata-deploy/values.yaml"
 yq eval ".job.dispatcherImage.reference = \"${JOB_DISPATCHER_IMAGE_REFERENCE}\" | .job.dispatcherImage.tag = \"${TAG}\"" -i "${tmp}/kata-deploy/values.yaml"
+
+# Optional values overlay baked into the packaged chart's defaults, so a
+# plain `helm install` of the published chart gives the intended profile
+# without every consumer having to pass -f. Relative paths resolve inside
+# the chart, so the bundled try-*.values.yaml presets work as-is.
+if [[ -n "${CHART_VALUES_OVERLAY:-}" ]]; then
+	overlay="${CHART_VALUES_OVERLAY}"
+	[[ "${overlay}" == /* ]] || overlay="${tmp}/kata-deploy/${overlay}"
+	[[ -f "${overlay}" ]] || { echo "CHART_VALUES_OVERLAY: no such values file: ${overlay}" >&2; exit 1; }
+	yq eval-all -i 'select(fileIndex == 0) * select(fileIndex == 1)' \
+		"${tmp}/kata-deploy/values.yaml" "${overlay}"
+fi
 helm dependencies update "${tmp}/kata-deploy"
 helm package "${tmp}/kata-deploy" -d "${tmp}"
 helm push "${tmp}/kata-deploy-${CHART_VERSION}.tgz" "oci://${CHART_REGISTRY}"


### PR DESCRIPTION
When we publish the kata-deploy chart for a specific consumer group (in our case an internal QA registry where only the NVIDIA GPU runtime classes should ever be deployed), the published chart still carries the stock defaults: a bare `helm install oci://...` enables every shim and creates all runtime classes on the cluster.

The chart already ships the right answer as presets (`try-kata-nvidia-gpu.values.yaml` et al.), but a preset inside a chart is awkward to consume from a registry. Helm cannot reference a values file that lives inside a remote chart, so today every consumer has to:

```
helm pull oci://<registry>/kata-deploy --version <ver> --untar
helm install kata-deploy ./kata-deploy -f ./kata-deploy/try-kata-nvidia-gpu.values.yaml
```

That pushes policy onto every consumer: each one has to know which preset to pass and remember the two-step dance, and any consumer who forgets gets all shims installed. Replicating the preset as `--set` flags or an out-of-band values file is worse - it drifts from the chart version it was written for.

This moves the decision to the publisher, who knows what the published chart is for. `CHART_VALUES_OVERLAY` names a values file (relative paths resolve inside the chart, so the bundled presets work as-is) that is deep-merged into `values.yaml` before packaging, after the image references are set. The published chart then does the right thing on a bare `helm install`, and per-install overrides still work exactly as before on top of the new defaults. Unset, nothing changes.

Example: publishing with `CHART_VALUES_OVERLAY=try-kata-nvidia-gpu.values.yaml` yields a chart whose plain install creates only the kata-qemu-nvidia-gpu* runtime classes instead of all of them.