### PR TITLE
versions: Bump virtiofsd to 1.14.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -379,14 +379,14 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.13.3"
+    version: "v1.14.0"
     toolchain: "1.85.1"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.13.1,
-      # this is the link labelled virtiofsd-v1.13.1.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.14.0,
+      # this is the link labelled virtiofsd-v1.14.0.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/-/project/21523468/uploads/05d4925181301a59b8c322cd9f9d44a7/virtiofsd-v1.13.1.zip"
+      binary: "https://gitlab.com/-/project/21523468/uploads/f505704014ae7a816e515f2a05a93d8b/virtiofsd-v1.14.0.zip"
 
 languages:
   description: |


### PR DESCRIPTION
## Summary

Bump the `virtiofsd` external dependency from `v1.13.3` to `v1.14.0` (released 2026-07-06).

The motivating change is [virtiofsd MR !319](https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/319) — *"read_dir: handle u64 directory cookies that exceed i64::MAX"*. On NFSv4-backed shared directories (e.g. Amazon EFS), directory cookies are unsigned 64-bit and frequently exceed `INT64_MAX`. virtiofsd cast the offset `u64 -> i64` before `lseek64()`, so large cookies went negative and the host kernel returned `EINVAL`. In guests this surfaces as `ls`, `find`, and `chown -R` failing with *"Invalid argument"* and returning partial listings. This is tracked in #12749.

## Changes

- `versions.yaml`: `externals.virtiofsd.version` `v1.13.3` -> `v1.14.0`.
- `versions.yaml`: `externals.virtiofsd.meta.binary` and its comment updated to the v1.14.0 release asset. Because `tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh` downloads this prebuilt x86_64 musl zip directly (only falling back to a source build for other arches), the URL must move in lockstep with `version` or x86_64 builds would keep shipping the old binary. The v1.14.0 zip's internal path (`target/x86_64-unknown-linux-musl/release/virtiofsd`) matches what the build script expects.

The rust `toolchain` is left at `1.85.1`: v1.14.0's `Cargo.toml` stays on edition 2018 with no raised `rust-version`.

Full changelog: https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.14.0

## Scope / caveat

This is a partial fix for #12749, matching the scope of MR !319: it covers the external `virtiofsd` daemon (QEMU / Cloud Hypervisor, `shared_fs = "virtio-fs"`). The Dragonball in-process path (`inline-virtio-fs`, `fuse-backend-rs`) still needs its own dependency bump and is not addressed here.

## Test plan

- [ ] CI static-build of virtiofsd pulls the v1.14.0 x86_64 binary
- [ ] Guest `ls -la` / `find` / `chown -R` on an NFSv4 (EFS)-backed virtio-fs mount returns a full listing with rc=0
