### PR TITLE
kata-deploy: isolate guest debug in runtime classes

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy.bats
+++ b/tests/functional/kata-deploy/kata-deploy.bats
@@ -37,17 +37,22 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 setup() {
 	ensure_helm
 
-	# We expect 2 runtime classes because:
+	# We expect 3 runtime classes because:
 	# * `kata` is the default runtimeclass created by Helm, basically an alias for `kata-${KATA_HYPERVISOR}`.
 	# * `kata-${KATA_HYPERVISOR}` is the other one
 	#    * As part of the tests we're only deploying the specific runtimeclass that will be used (via HELM_SHIMS), instead of all of them.
 	#    * RuntimeClasses are now created by the Helm chart (runtimeClasses.enabled=true by default)
-	expected_runtime_classes=2
+	# * `kata-${KATA_HYPERVISOR}-debug` carries the guest debug settings, which are
+	#   kept off the other classes so their kernel cmdline (and its measurements)
+	#   stay stable. We deploy with `debug: true` (see lib/helm-deploy.bash).
+	expected_runtime_classes=3
 
-	# We expect both runtime classes to have the same handler: kata-${KATA_HYPERVISOR}
+	# The default and per-shim classes share the kata-${KATA_HYPERVISOR} handler;
+	# the debug class has its own handler, registered by kata-deploy as a custom runtime.
 	expected_handlers_re=( \
 		"kata\s+kata-${KATA_HYPERVISOR}" \
 		"kata-${KATA_HYPERVISOR}\s+kata-${KATA_HYPERVISOR}" \
+		"kata-${KATA_HYPERVISOR}-debug\s+kata-${KATA_HYPERVISOR}-debug" \
 	)
 }
 

--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -137,14 +137,17 @@ function create_coco_pod_yaml() {
 
 	kernel_params_value+=" agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
 
+	local runtime_class
+	runtime_class="$(get_test_runtime_class)"
+
 	# Note: this is not local as we use it in the caller test
-	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
+	kata_pod="$(new_pod_config "${image}" "${runtime_class}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
 	set_container_command "${kata_pod}" "0" "sleep" "30"
 
 	# Set annotations
 	set_metadata_annotation "${kata_pod}" \
 		"io.containerd.cri.runtime-handler" \
-		"kata-${KATA_HYPERVISOR}"
+		"${runtime_class}"
 	set_metadata_annotation "${kata_pod}" \
 		"${kernel_params_annotation}" \
 		"${kernel_params_value}"
@@ -174,14 +177,17 @@ function create_coco_pod_yaml_with_annotations() {
 	kernel_params_annotation_key="io.katacontainers.config.hypervisor.kernel_params"
 	cc_initdata_annotation_key="io.katacontainers.config.hypervisor.cc_init_data"
 
+	local runtime_class
+	runtime_class="$(get_test_runtime_class)"
+
 	# Note: this is not local as we use it in the caller test
-	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
+	kata_pod="$(new_pod_config "${image}" "${runtime_class}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
 	set_container_command "${kata_pod}" "0" "sleep" "30"
 
 	# Set annotations
 	set_metadata_annotation "${kata_pod}" \
 		"io.containerd.cri.runtime-handler" \
-		"kata-${KATA_HYPERVISOR}"
+		"${runtime_class}"
 	set_metadata_annotation "${kata_pod}" \
 		"${kernel_params_annotation_key}" \
 		"${kernel_params_annotation_value}"

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -11,7 +11,6 @@ load "${BATS_TEST_DIRNAME}/confidential_common.sh"
 export KBS="${KBS:-false}"
 export test_key="aatest"
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu-runtime-rs}"
-export RUNTIME_CLASS_NAME="kata-${KATA_HYPERVISOR}"
 export AA_KBC="${AA_KBC:-cc_kbc}"
 
 setup() {
@@ -22,6 +21,10 @@ setup() {
 	fi
 
 	setup_common || die "setup_common failed"
+
+	# Consumed by the pod templates below through envsubst.
+	RUNTIME_CLASS_NAME="$(get_test_runtime_class)"
+	export RUNTIME_CLASS_NAME
 
 	# install SNP measurement dependencies
 	if [[ "${KATA_HYPERVISOR}" == *snp* ]]; then

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -21,6 +21,7 @@ setup() {
     fi
 
     setup_common || die "setup_common failed"
+    runtime_class="$(get_test_runtime_class)"
     unencrypted_image="quay.io/prometheus/busybox:latest"
     image_pulled_time_less_than_default_time="ghcr.io/confidential-containers/test-container:rust-1.79.0" # unpacked size: 1.41GB
     large_image="quay.io/confidential-containers/test-images:largeimage" # unpacked size: 2.15GB
@@ -55,7 +56,7 @@ setup() {
     kubectl delete -f "$runc_pod_config"
 
     # 2. Create one kata pod with the $unencrypted_image image and nydus annotation
-    kata_pod_with_nydus_config="$(new_pod_config "$unencrypted_image" "kata-${KATA_HYPERVISOR}" \
+    kata_pod_with_nydus_config="$(new_pod_config "$unencrypted_image" "${runtime_class}" \
         "" "" "$unencrypted_image_supplemental_groups")"
     set_node "$kata_pod_with_nydus_config" "$node"
     set_container_command "$kata_pod_with_nydus_config" "0" "sleep" "30"
@@ -63,7 +64,7 @@ setup() {
     # Set annotation to pull image in guest
     set_metadata_annotation "$kata_pod_with_nydus_config" \
         "io.containerd.cri.runtime-handler" \
-        "kata-${KATA_HYPERVISOR}"
+        "${runtime_class}"
 
     # For debug sake
     echo "Pod $kata_pod_with_nydus_config file:"
@@ -81,14 +82,14 @@ setup() {
     # However, the unpacked size of image "ghcr.io/confidential-containers/test-container:rust-1.79.0" is 1.41GB.
     # It will fail to run the pod with pulling the image in the memory in the guest by default.
 
-    pod_config="$(new_pod_config "$image_pulled_time_less_than_default_time" "kata-${KATA_HYPERVISOR}")"
+    pod_config="$(new_pod_config "$image_pulled_time_less_than_default_time" "${runtime_class}")"
     set_node "$pod_config" "$node"
     set_container_command "$pod_config" "0" "sleep" "30"
 
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
         "io.containerd.cri.runtime-handler" \
-        "kata-${KATA_HYPERVISOR}"
+        "${runtime_class}"
 
     # For debug sake
     echo "Pod $pod_config file:"
@@ -142,7 +143,7 @@ setup() {
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
         "io.containerd.cri.runtime-handler" \
-        "kata-${KATA_HYPERVISOR}"
+        "${runtime_class}"
 
     # For debug sake
     echo "Pod $pod_config file:"
@@ -189,7 +190,7 @@ setup() {
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
         "io.containerd.cri.runtime-handler" \
-        "kata-${KATA_HYPERVISOR}"
+        "${runtime_class}"
 
     # For debug sake
     echo "Pod $pod_config file:"
@@ -251,7 +252,7 @@ setup() {
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
         "io.containerd.cri.runtime-handler" \
-        "kata-${KATA_HYPERVISOR}"
+        "${runtime_class}"
 
     # For debug sake
     echo "Pod $pod_config file:"

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -9,33 +9,34 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
-case "${KATA_HYPERVISOR}" in
-	*-runtime-rs)
-		shim_config_file="/opt/kata/share/defaults/kata-containers/runtime-rs/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
-		;;
-	*)
-		shim_config_file="/opt/kata/share/defaults/kata-containers/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
-		;;
-esac
-
 check_and_skip() {
 	# The CPU-only NVIDIA classes are not confidential, but they still boot
 	# the verity-backed nvidia base image, so measured rootfs applies to them
 	# just like it does to the confidential classes.
-	if is_verity_enabled_runtime_class "${KATA_HYPERVISOR}"; then
-		if [[ "$(uname -m)" == "s390x" ]]; then
-			skip "measured rootfs tests not implemented for s390x"
-		fi
-		return
+	if ! is_verity_enabled_runtime_class "${KATA_HYPERVISOR}"; then
+		skip "measured rootfs tests not implemented for hypervisor: ${KATA_HYPERVISOR}"
 	fi
 
-	skip "measured rootfs tests not implemented for hypervisor: ${KATA_HYPERVISOR}"
+	if [[ "$(uname -m)" == "s390x" ]]; then
+		skip "measured rootfs tests not implemented for s390x"
+	fi
+
+	# The dm-verity failure is reported on the guest console, which the
+	# hypervisor only forwards to the host journal when it runs with
+	# enable_debug, and that is exclusive to the kata-<shim>-debug RuntimeClass.
+	if ! test_runtime_class_has_guest_debug; then
+		skip "kata-${KATA_HYPERVISOR}-debug RuntimeClass not deployed (kata-deploy debug disabled)"
+	fi
 }
 
 setup() {
 	check_and_skip
 
 	setup_common || die "setup_common failed"
+
+	runtime_class="$(get_test_runtime_class)"
+	shim_config_file="$(get_kata_runtime_config_file "${node}")" || \
+		die "No Kata runtime config found for ${KATA_HYPERVISOR}"
 }
 
 @test "Test cannot launch pod with measured boot enabled and incorrect hash" {
@@ -44,7 +45,7 @@ setup() {
 	nginx_digest=$(get_from_kata_deps ".docker_images.nginx.digest")
 	nginx_image="${nginx_registry}@${nginx_digest}"
 
-	pod_config="$(new_pod_config "${nginx_image}" "kata-${KATA_HYPERVISOR}" \
+	pod_config="$(new_pod_config "${nginx_image}" "${runtime_class}" \
 		"" "" "1, 2, 3, 4, 6, 10, 11, 20, 26, 27")"
 	auto_generate_policy "${pod_config_dir}" "${pod_config}"
 

--- a/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
@@ -55,7 +55,7 @@ setup() {
 	yaml_template="${pod_config_dir}/pod-plain-ephemeral-data-storage.yaml.in"
 	yaml_file="${pod_config_dir}/pod-plain-ephemeral-data-storage.yaml"
 
-	RUNTIMECLASS="kata-${KATA_HYPERVISOR}" envsubst "\${RUNTIMECLASS}" \
+	RUNTIMECLASS="$(get_test_runtime_class)" envsubst "\${RUNTIMECLASS}" \
 		< "${yaml_template}" > "${yaml_file}"
 
 	runtime_config_dropin_file="${BATS_FILE_TMPDIR}/99-k8s-plain-ephemeral-data-storage.toml"
@@ -71,7 +71,7 @@ EOF
 	if [[ "${PULL_TYPE:-default}" == "guest-pull" ]] && is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
 		set_metadata_annotation "${yaml_file}" \
 			"io.containerd.cri.runtime-handler" \
-			"kata-${KATA_HYPERVISOR}"
+			"$(get_test_runtime_class)"
 	fi
 
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"

--- a/tests/integration/kubernetes/k8s-vm-templating.bats
+++ b/tests/integration/kubernetes/k8s-vm-templating.bats
@@ -55,9 +55,11 @@ DROPIN
 	dropin_path="$(set_kata_runtime_config_dropin_file "$node" "${runtime_config_dropin_file}")" \
 		|| die "Failed to install Kata runtime config drop-in on node $node"
 
-	# kata-runtime defaults to the QEMU config; point it at the active
-	# hypervisor so that factory init/destroy use the correct configuration.
-	kata_config_path="/opt/kata/share/defaults/kata-containers/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
+	# kata-runtime defaults to the QEMU config; point it at the configuration
+	# backing the RuntimeClass under test so that factory init/destroy read the
+	# same settings, and the same config.d drop-in installed above, as the pod.
+	kata_config_path="$(get_kata_runtime_config_file "$node")" \
+		|| die "Failed to resolve the Kata runtime config file on node $node"
 }
 
 @test "Pod can be created with a templated VM" {
@@ -104,8 +106,10 @@ teardown() {
 	# Destroy the VM template and remove the config drop-in on the target node.
 	# factory destroy must run in PID 1's mount namespace to unmount the template
 	# tmpfs that factory init created there (see the @test for details).
-	exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-runtime --config ${kata_config_path} factory destroy" \
-		|| echo "Warning: Failed to destroy VM template on node $node"
+	if [[ -n "${kata_config_path:-}" ]]; then
+		exec_host "$node" "nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-runtime --config ${kata_config_path} factory destroy" \
+			|| echo "Warning: Failed to destroy VM template on node $node"
+	fi
 
 	remove_kata_runtime_config_dropin_file "$node" "${dropin_path:-}" \
 		|| echo "Warning: Failed to remove Kata runtime config drop-in on node $node"

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -14,12 +14,24 @@ source "${kubernetes_dir}/../../common.bash"
 
 # Enable NVRC trace logging for NVIDIA GPU runtime via drop-in config
 enable_nvrc_trace() {
-	local kata_config_base="/opt/kata/share/defaults/kata-containers"
-	case "${KATA_HYPERVISOR}" in
-		*-runtime-rs) kata_config_base="${kata_config_base}/runtime-rs" ;;
-	esac
+	# A multi-install appends its suffix to the installation directory and to
+	# every handler name alike, so follow MULTI_INSTALL_SUFFIX for both or the
+	# drop-in lands where the pods under test never look.
+	local install_suffix="${MULTI_INSTALL_SUFFIX:+-${MULTI_INSTALL_SUFFIX}}"
+	local kata_config_base="/opt/kata${install_suffix}/share/defaults/kata-containers"
 
-	local config_dir="${kata_config_base}/runtimes/${KATA_HYPERVISOR}/config.d"
+	# The tests run on the kata-<shim>-debug RuntimeClass whenever kata-deploy
+	# creates it, and that handler reads its configuration from a directory of
+	# its own under custom-runtimes/.
+	local runtime_dir="${kata_config_base}/custom-runtimes/kata-${KATA_HYPERVISOR}${install_suffix}-debug"
+	if [[ ! -d "${runtime_dir}" ]]; then
+		case "${KATA_HYPERVISOR}" in
+			*-runtime-rs) kata_config_base="${kata_config_base}/runtime-rs" ;;
+		esac
+		runtime_dir="${kata_config_base}/runtimes/${KATA_HYPERVISOR}"
+	fi
+
+	local config_dir="${runtime_dir}/config.d"
 	local drop_in_file="${config_dir}/90-nvrc-trace.toml"
 	local kernel_params_drop_in="${config_dir}/30-kernel-params.toml"
 
@@ -35,7 +47,7 @@ enable_nvrc_trace() {
 	if [[ -f "${kernel_params_drop_in}" ]]; then
 		base_params=$(grep -E '^kernel_params\s*=' "${kernel_params_drop_in}" | sed 's/^kernel_params\s*=\s*"\(.*\)"/\1/' || true)
 	else
-		local runtime_config="${kata_config_base}/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
+		local runtime_config="${runtime_dir}/configuration-${KATA_HYPERVISOR}.toml"
 		if [[ -f "${runtime_config}" ]]; then
 			base_params=$(grep -E '^kernel_params\s*=' "${runtime_config}" | sed 's/^kernel_params\s*=\s*"\(.*\)"/\1/' || true)
 		fi

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -104,11 +104,35 @@ add_annotations_to_yaml() {
 	esac
 }
 
+# Point the workloads at the RuntimeClass the tests are meant to run on.
+#
+# They ship with the `kata` RuntimeClass, an alias for the deployment's default
+# shim. Rewrite it whenever the guest debug settings live on a class of their
+# own (see get_test_runtime_class), so that a failing test still comes with the
+# guest logs needed to triage it.
+set_workloads_runtime_class() {
+	local runtime_class
+
+	if ! test_runtime_class_has_guest_debug; then
+		info "Keeping the default RuntimeClass in the test workloads"
+		return
+	fi
+
+	runtime_class="$(get_test_runtime_class)"
+	info "Running the test workloads with the ${runtime_class} RuntimeClass"
+
+	find "${runtimeclass_workloads_work_dir}" -type f \
+		\( -name '*.yaml' -o -name '*.yaml.in' \) -print0 |
+		xargs -0 --no-run-if-empty sed -i -E \
+			"s/^([[:space:]]*runtimeClassName:[[:space:]]+)kata[[:space:]]*$/\1${runtime_class}/"
+}
+
 add_runtime_handler_annotation_to_yaml() {
 	local -r yaml_file="$1"
 	if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
 		local -r handler_annotation="io.containerd.cri.runtime-handler"
-		local -r handler_value="kata-${KATA_HYPERVISOR}"
+		local handler_value
+		handler_value="$(get_test_runtime_class)"
 		add_annotations_to_yaml "${yaml_file}" "${handler_annotation}" "${handler_value}"
 	fi
 }
@@ -133,6 +157,7 @@ add_runtime_handler_annotations() {
 main() {
 	ensure_yq
 	reset_workloads_work_dir
+	set_workloads_runtime_class
 	add_runtime_handler_annotations
 }
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -72,6 +72,37 @@ get_pod_config_dir() {
 	info "k8s configured to use runtimeclass"
 }
 
+# Return the RuntimeClass (and containerd runtime handler) the tests run on.
+#
+# kata-deploy applies the guest debug settings (enable_debug, the debug console,
+# agent.log=debug and initcall_debug on the kernel cmdline) solely to the extra
+# kata-<shim>-debug RuntimeClass it creates when deployed with debug enabled, so
+# that the plain kata-<shim> class keeps the kernel cmdline, and therefore the
+# guest measurements, of a non-debug installation. The tests depend on those
+# guest logs to triage failures, hence they run on the debug class whenever it
+# is deployed.
+#
+# A multi-install names every class after its own suffix (kata-<shim>-<suffix>,
+# and kata-<shim>-<suffix>-debug for the variant), so build the name from the
+# same MULTI_INSTALL_SUFFIX kata-deploy was given rather than assuming the plain
+# one, which is not deployed at all in that case.
+get_test_runtime_class() {
+	if [[ -z "${test_runtime_class:-}" ]]; then
+		test_runtime_class="kata-${KATA_HYPERVISOR}${MULTI_INSTALL_SUFFIX:+-${MULTI_INSTALL_SUFFIX}}"
+		if kubectl get runtimeclass "${test_runtime_class}-debug" &>/dev/null; then
+			test_runtime_class="${test_runtime_class}-debug"
+		fi
+		export test_runtime_class
+	fi
+
+	echo "${test_runtime_class}"
+}
+
+# Whether the tests run on a RuntimeClass that carries the guest debug settings.
+test_runtime_class_has_guest_debug() {
+	[[ "$(get_test_runtime_class)" == *-debug ]]
+}
+
 # Return the first worker found that is kata-runtime labeled.
 get_one_kata_node() {
 	local resource_name
@@ -127,19 +158,26 @@ get_kubelet_data_dir() {
 	esac
 }
 
-# Return the per-shim Kata runtime config directory on a k8s node.
+# Return the Kata runtime config directory of the RuntimeClass under test.
 #
 # This is the directory that holds configuration-<shim>.toml and config.d/.
+# kata-deploy gives every handler it derives from a shim, the kata-<shim>-debug
+# one included, a private copy of the configuration under custom-runtimes/, so
+# look there first: a drop-in written elsewhere would not reach the pods.
 # Probe the filesystem instead of parsing the shim name, since some runtime-rs
 # shims like dragonball do not use the -runtime-rs suffix.
 get_kata_runtime_config_dir() {
 	local node_name="$1"
 	local base="/opt/kata/share/defaults/kata-containers"
+	local handler_dir
+	handler_dir="${base}/custom-runtimes/$(get_test_runtime_class)"
 	local rs_dir="${base}/runtime-rs/runtimes/${KATA_HYPERVISOR}"
 	local go_dir="${base}/runtimes/${KATA_HYPERVISOR}"
 	local legacy_dir="${base}"
 
-	if exec_host "${node_name}" "test -d '${rs_dir}'" >/dev/null 2>&1; then
+	if exec_host "${node_name}" "test -d '${handler_dir}'" >/dev/null 2>&1; then
+		echo "${handler_dir}"
+	elif exec_host "${node_name}" "test -d '${rs_dir}'" >/dev/null 2>&1; then
 		echo "${rs_dir}"
 	elif exec_host "${node_name}" "test -d '${go_dir}'" >/dev/null 2>&1; then
 		echo "${go_dir}"

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -9,7 +9,7 @@ use crate::k8s::runtimeclasses;
 use crate::utils;
 use crate::utils::toml as toml_utils;
 use anyhow::{Context, Result};
-use log::info;
+use log::{info, warn};
 use std::collections::HashSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -120,6 +120,10 @@ pub async fn install_artifacts(config: &Config, container_runtime: &str) -> Resu
         install_custom_runtime_configs(config, container_runtime)?;
     }
 
+    // Drop stale kata-<shim>-debug handler dirs left by a previous deploy with
+    // DEBUG=true when this one no longer wants them.
+    reconcile_debug_variant_artifacts(config)?;
+
     let expand_runtime_classes_for_nfd = nfd::setup_nfd_rules(config).await?;
 
     if expand_runtime_classes_for_nfd {
@@ -155,11 +159,14 @@ pub async fn remove_artifacts(config: &Config) -> Result<()> {
 
 /// Write the common drop-in configuration files for a shim.
 /// This is shared between standard runtimes and custom runtimes.
+/// Guest debug settings are applied only when `apply_guest_debug` is true
+/// (debug variant custom runtimes); normal RuntimeClasses stay measurement-stable.
 fn write_common_drop_ins(
     config: &Config,
     shim: &str,
     config_d_dir: &str,
     container_runtime: &str,
+    apply_guest_debug: bool,
 ) -> Result<()> {
     info!("Generating drop-in configuration files for shim: {}", shim);
 
@@ -170,11 +177,11 @@ fn write_common_drop_ins(
         write_drop_in_file(config_d_dir, "10-installation-prefix.toml", &prefix_content)?;
     }
 
-    // 2. Debug configuration (boolean flags only via drop-in)
-    if config.debug {
-        info!("  - Debug mode: enabled");
-        let debug_content = generate_debug_drop_in(shim)?;
-        write_drop_in_file(config_d_dir, "20-debug.toml", &debug_content)?;
+    // 2. Guest debug configuration (boolean flags via drop-in)
+    if apply_guest_debug {
+        apply_guest_debug_drop_ins(shim, config_d_dir)?;
+    } else {
+        reconcile_stale_drop_in(config_d_dir, "20-debug.toml")?;
     }
 
     // 2b. k0s: set kubelet root dir so ConfigMap/Secret volume propagation works (non-Rust shims only)
@@ -186,9 +193,9 @@ fn write_common_drop_ins(
         write_drop_in_file(config_d_dir, "22-k0s-kubelet-root.toml", &k0s_content)?;
     }
 
-    // 3. Combined kernel_params (proxy, debug, etc.)
+    // 3. Combined kernel_params (proxy, and guest debug when requested)
     // Reads base kernel_params from original config and combines with new params
-    let kernel_params_content = generate_kernel_params_drop_in(config, shim)?;
+    let kernel_params_content = generate_kernel_params_drop_in(config, shim, apply_guest_debug)?;
     if !kernel_params_content.is_empty() {
         info!("  - Kernel parameters: configured");
         write_drop_in_file(
@@ -196,8 +203,35 @@ fn write_common_drop_ins(
             "30-kernel-params.toml",
             &kernel_params_content,
         )?;
+    } else {
+        reconcile_stale_drop_in(config_d_dir, "30-kernel-params.toml")?;
     }
 
+    Ok(())
+}
+
+/// Apply the full guest debug drop-in set (enable_debug flags + debug kernel params).
+fn apply_guest_debug_drop_ins(shim: &str, config_d_dir: &str) -> Result<()> {
+    info!("  - Guest debug mode: enabled");
+    let debug_content = generate_debug_drop_in(shim)?;
+    write_drop_in_file(config_d_dir, "20-debug.toml", &debug_content)?;
+    Ok(())
+}
+
+/// Remove a drop-in a previous deploy wrote that the current configuration no
+/// longer generates.
+///
+/// Installs only ever add files to config.d, so a drop-in that is no longer
+/// generated keeps applying forever. That matters most for the guest debug
+/// settings: left behind, they keep the debug kernel cmdline (and the
+/// measurements it changes) on a RuntimeClass that is meant to be production.
+fn reconcile_stale_drop_in(config_d_dir: &str, filename: &str) -> Result<()> {
+    let drop_in_path = format!("{config_d_dir}/{filename}");
+    if Path::new(&drop_in_path).exists() {
+        info!("  - Removing stale drop-in: {}", drop_in_path);
+        fs::remove_file(&drop_in_path)
+            .with_context(|| format!("Failed to remove stale drop-in: {drop_in_path}"))?;
+    }
     Ok(())
 }
 
@@ -295,12 +329,15 @@ fn install_custom_runtime_configs(config: &Config, container_runtime: &str) -> R
             );
         }
 
-        // Generate the common drop-in files (shared with standard runtimes)
+        // Generate the common drop-in files (shared with standard runtimes).
+        // Debug variant handlers carry guest debug settings; other custom runtimes
+        // inherit the same measurement-stable profile as the normal RuntimeClass.
         write_common_drop_ins(
             config,
             &runtime.base_config,
             &config_d_dir,
             container_runtime,
+            runtime.debug_variant,
         )?;
 
         // Copy user-provided drop-in file if provided (at 50-overrides.toml).
@@ -367,6 +404,73 @@ fn remove_custom_runtime_configs(config: &Config) -> Result<()> {
     }
 
     info!("Successfully removed custom runtime config files");
+    Ok(())
+}
+
+/// Remove on-node debug variant artifacts the current configuration no longer wants.
+///
+/// Debug variants are materialized as kata-<shim>-debug custom runtimes only while
+/// DEBUG=true. When a redeploy disables debug (or drops a shim) those runtimes vanish
+/// from `config.custom_runtimes`, so the normal custom-runtime cleanup never touches
+/// their leftovers. Installs only ever add files, so reconcile explicitly: drop stale
+/// kata-<shim>-debug handler directories.
+///
+/// Removing every unknown kata-*-debug directory is safe under a multi-install
+/// because the scan never leaves this installation: MULTI_INSTALL_SUFFIX is part
+/// of `dest_dir`, so a concurrent kata-deploy keeps its own custom-runtimes
+/// directory under a tree of its own and is never a candidate here.
+fn reconcile_debug_variant_artifacts(config: &Config) -> Result<()> {
+    let known: HashSet<&str> = config
+        .custom_runtimes
+        .iter()
+        .map(|r| r.handler.as_str())
+        .collect();
+
+    let custom_runtimes_dir = format!(
+        "/host/{}/share/defaults/kata-containers/custom-runtimes",
+        config.dest_dir
+    );
+    let custom_runtimes_path = Path::new(&custom_runtimes_dir);
+    if !custom_runtimes_path.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(custom_runtimes_path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let handler = entry.file_name();
+        let handler_str = handler.to_string_lossy();
+        if handler_str.starts_with("kata-")
+            && handler_str.ends_with("-debug")
+            && !known.contains(handler_str.as_ref())
+        {
+            let handler_dir = entry.path();
+            info!(
+                "Removing stale debug variant runtime directory: {}",
+                handler_dir.display()
+            );
+            if let Err(e) = fs::remove_dir_all(&handler_dir) {
+                warn!(
+                    "Failed to remove stale debug variant directory {}: {}",
+                    handler_dir.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    if custom_runtimes_path.exists() {
+        if let Ok(entries) = fs::read_dir(custom_runtimes_path) {
+            if entries.count() == 0 {
+                let _ = fs::remove_dir(custom_runtimes_path);
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -963,8 +1067,9 @@ async fn configure_shim_config(config: &Config, shim: &str, container_runtime: &
         ));
     }
 
-    // Generate common drop-in files (shared with custom runtimes)
-    write_common_drop_ins(config, shim, &config_d_dir, container_runtime)?;
+    // Generate common drop-in files (shared with custom runtimes).
+    // Normal RuntimeClasses never carry guest debug settings.
+    write_common_drop_ins(config, shim, &config_d_dir, container_runtime, false)?;
 
     // Apply user-provided drop-in for default runtimes, if present.
     install_default_runtime_drop_in(shim, &config_d_dir)?;
@@ -1247,7 +1352,11 @@ fn read_base_kernel_params(config: &Config, shim: &str) -> Result<String> {
 /// This reads the base kernel_params from the original config and combines
 /// with proxy settings, debug settings, and any other kernel_params.
 /// Using a single drop-in file avoids the TOML merge replacing behavior.
-fn generate_kernel_params_drop_in(config: &Config, shim: &str) -> Result<String> {
+fn generate_kernel_params_drop_in(
+    config: &Config,
+    shim: &str,
+    include_debug_params: bool,
+) -> Result<String> {
     let mut additional_params = Vec::new();
 
     // Add proxy settings
@@ -1258,8 +1367,8 @@ fn generate_kernel_params_drop_in(config: &Config, shim: &str) -> Result<String>
         additional_params.push(format!("agent.no_proxy={}", no_proxy));
     }
 
-    // Add debug settings
-    if config.debug {
+    // Guest debug kernel cmdline params (debug variant runtimes only)
+    if include_debug_params {
         additional_params.push("agent.log=debug".to_string());
         additional_params.push("initcall_debug".to_string());
     }
@@ -1655,5 +1764,82 @@ mod tests {
 
         fs::remove_dir_all(&runtime_dir).unwrap();
         assert!(!runtime_dir.exists());
+    }
+
+    #[test]
+    fn test_generate_debug_drop_in_contains_full_guest_debug_set() {
+        let content = generate_debug_drop_in("qemu").unwrap();
+        assert!(content.contains("[hypervisor.qemu]"));
+        assert!(content.contains("enable_debug = true"));
+        assert!(content.contains("[runtime]"));
+        assert!(content.contains("[agent.kata]"));
+        assert!(content.contains("debug_console_enabled = true"));
+    }
+
+    #[test]
+    fn test_generate_kernel_params_drop_in_guest_debug_only_when_requested() {
+        let config = crate::config::Config {
+            node_name: "test".to_string(),
+            debug: true,
+            shims_for_arch: vec!["qemu".to_string()],
+            default_shim_for_arch: "qemu".to_string(),
+            allowed_hypervisor_annotations_for_arch: vec![],
+            snapshotter_handler_mapping_for_arch: None,
+            agent_https_proxy: None,
+            agent_no_proxy: None,
+            pull_type_mapping_for_arch: None,
+            installation_prefix: None,
+            multi_install_suffix: None,
+            helm_post_delete_hook: false,
+            experimental_setup_snapshotter: None,
+            erofs_merge_mode: None,
+            experimental_force_guest_pull_for_arch: vec![],
+            dest_dir: "/opt/kata".to_string(),
+            host_install_dir: "/host/opt/kata".to_string(),
+            crio_drop_in_conf_dir: String::new(),
+            crio_drop_in_conf_file: String::new(),
+            crio_drop_in_conf_file_debug: String::new(),
+            containerd_conf_file: String::new(),
+            containerd_conf_file_backup: String::new(),
+            containerd_drop_in_conf_file: String::new(),
+            containerd_user_drop_in_source_file: None,
+            daemonset_name: "kata-deploy".to_string(),
+            custom_runtimes_enabled: false,
+            custom_runtimes: vec![],
+            erofs_snapshotter_mode: None,
+            erofs_dmverity: false,
+            startup_taints: vec![],
+        };
+
+        let without_debug = generate_kernel_params_drop_in(&config, "qemu", false).unwrap();
+        assert!(without_debug.is_empty());
+
+        let with_debug = generate_kernel_params_drop_in(&config, "qemu", true).unwrap();
+        assert!(with_debug.contains("agent.log=debug"));
+        assert!(with_debug.contains("initcall_debug"));
+    }
+
+    #[rstest]
+    #[case("20-debug.toml")]
+    #[case("30-kernel-params.toml")]
+    fn test_reconcile_stale_drop_in_removes_file(#[case] filename: &str) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config_d_dir = tmpdir.path().join("config.d");
+        fs::create_dir_all(&config_d_dir).unwrap();
+        let drop_in = config_d_dir.join(filename);
+        fs::write(&drop_in, "stale").unwrap();
+
+        reconcile_stale_drop_in(config_d_dir.to_str().unwrap(), filename).unwrap();
+
+        assert!(!drop_in.exists());
+    }
+
+    #[test]
+    fn test_reconcile_stale_drop_in_is_noop_when_absent() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config_d_dir = tmpdir.path().join("config.d");
+        fs::create_dir_all(&config_d_dir).unwrap();
+
+        reconcile_stale_drop_in(config_d_dir.to_str().unwrap(), "20-debug.toml").unwrap();
     }
 }

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -161,6 +161,9 @@ pub struct CustomRuntime {
     pub containerd_snapshotter: Option<String>,
     /// CRI-O pull type (e.g., "guest-pull")
     pub crio_pull_type: Option<String>,
+    /// True for kata-deploy-synthesized debug variant runtimes (kata-<shim>-debug).
+    /// Guest debug settings are applied only on these handlers.
+    pub debug_variant: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -238,7 +241,7 @@ impl Config {
         // Parse shims - only use arch-specific variable
         // Use architecture-specific default shims list (only shims supported for this arch)
         let default_shims = get_default_shims_for_arch(&arch);
-        let shims_for_arch = get_arch_var("SHIMS", default_shims, &arch)
+        let shims_for_arch: Vec<String> = get_arch_var("SHIMS", default_shims, &arch)
             .split_whitespace()
             .map(|s| s.to_string())
             .collect();
@@ -345,14 +348,28 @@ impl Config {
                 .map(|s| s.trim().to_string())
                 .collect();
 
-        // Parse custom runtimes from ConfigMap
-        let custom_runtimes_enabled =
+        // Parse custom runtimes from ConfigMap and synthesize debug variant runtimes.
+        let mut custom_runtimes_enabled =
             env::var("CUSTOM_RUNTIMES_ENABLED").unwrap_or_else(|_| "false".to_string()) == "true";
-        let custom_runtimes = if custom_runtimes_enabled {
+        let mut custom_runtimes = if custom_runtimes_enabled {
             parse_custom_runtimes()?
         } else {
             Vec::new()
         };
+
+        if debug {
+            synthesize_debug_variant_runtimes(
+                &shims_for_arch,
+                multi_install_suffix.as_deref(),
+                snapshotter_handler_mapping_for_arch.as_deref(),
+                pull_type_mapping_for_arch.as_deref(),
+                &mut custom_runtimes,
+            );
+        }
+
+        if !custom_runtimes.is_empty() {
+            custom_runtimes_enabled = true;
+        }
 
         let erofs_snapshotter_mode = env::var("EROFS_SNAPSHOTTER_MODE")
             .ok()
@@ -877,6 +894,7 @@ fn parse_custom_runtimes() -> Result<Vec<CustomRuntime>> {
             drop_in_file,
             containerd_snapshotter,
             crio_pull_type,
+            debug_variant: false,
         });
     }
 
@@ -886,6 +904,66 @@ fn parse_custom_runtimes() -> Result<Vec<CustomRuntime>> {
         list_file
     );
     Ok(custom_runtimes)
+}
+
+/// Look up `shim`'s value in a comma-separated "shim1:value1,shim2:value2"
+/// mapping (SNAPSHOTTER_HANDLER_MAPPING, PULL_TYPE_MAPPING). None if absent or
+/// empty.
+fn lookup_mapping_value(mapping: &str, shim: &str) -> Option<String> {
+    mapping.split(',').find_map(|entry| {
+        let parts: Vec<&str> = entry.split(':').collect();
+        if parts.len() == 2 && parts[0].trim() == shim {
+            let value = parts[1].trim();
+            (!value.is_empty()).then(|| value.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+/// When DEBUG=true, append a debug variant custom runtime per enabled shim.
+/// These handlers carry the full guest debug configuration so the normal shim
+/// RuntimeClass keeps a stable kernel cmdline for measurements.
+///
+/// The handler is derived from the standard runtime name (kata-<shim>, or
+/// kata-<shim>-<suffix> under a multi-install) so concurrent kata-deploy
+/// instances on the same node do not fight over one debug handler.
+fn synthesize_debug_variant_runtimes(
+    shims_for_arch: &[String],
+    multi_install_suffix: Option<&str>,
+    snapshotter_handler_mapping_for_arch: Option<&str>,
+    pull_type_mapping_for_arch: Option<&str>,
+    custom_runtimes: &mut Vec<CustomRuntime>,
+) {
+    for shim in shims_for_arch {
+        let handler = match multi_install_suffix {
+            Some(suffix) if !suffix.is_empty() => format!("kata-{shim}-{suffix}-debug"),
+            _ => format!("kata-{shim}-debug"),
+        };
+        if custom_runtimes.iter().any(|r| r.handler == handler) {
+            continue;
+        }
+
+        let containerd_snapshotter = snapshotter_handler_mapping_for_arch
+            .and_then(|mapping| lookup_mapping_value(mapping, shim));
+        let crio_pull_type =
+            pull_type_mapping_for_arch.and_then(|mapping| lookup_mapping_value(mapping, shim));
+
+        log::info!(
+            "Synthesizing debug variant runtime: handler={}, base_config={}",
+            handler,
+            shim
+        );
+
+        custom_runtimes.push(CustomRuntime {
+            handler,
+            base_config: shim.clone(),
+            drop_in_file: None,
+            containerd_snapshotter,
+            crio_pull_type,
+            debug_variant: true,
+        });
+    }
 }
 
 /// Get default shims list for a specific architecture
@@ -992,6 +1070,7 @@ mod tests {
             "EXPERIMENTAL_FORCE_GUEST_PULL_PPC64LE",
             "CONTAINERD_CONFIG_FILE_NAME",
             "STARTUP_TAINTS",
+            "CUSTOM_RUNTIMES_ENABLED",
         ];
         for var in &vars {
             std::env::remove_var(var);
@@ -1616,5 +1695,105 @@ mod tests {
 
             cleanup_env_vars();
         }
+    }
+
+    #[serial]
+    #[test]
+    fn test_debug_variant_not_synthesized_when_debug_disabled() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "false");
+
+        let config = Config::from_env().unwrap();
+
+        assert!(!config.custom_runtimes_enabled);
+        assert!(config.custom_runtimes.is_empty());
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_debug_variant_synthesizes_per_shim_runtime() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "true");
+
+        let config = Config::from_env().unwrap();
+
+        assert!(config.custom_runtimes_enabled);
+
+        let debug_variants: Vec<_> = config
+            .custom_runtimes
+            .iter()
+            .filter(|r| r.debug_variant)
+            .collect();
+        assert_eq!(debug_variants.len(), 1);
+        assert_eq!(debug_variants[0].handler, "kata-qemu-debug");
+        assert_eq!(debug_variants[0].base_config, "qemu");
+        assert!(debug_variants[0].drop_in_file.is_none());
+        assert!(debug_variants[0].containerd_snapshotter.is_none());
+        assert!(debug_variants[0].crio_pull_type.is_none());
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_debug_variant_handler_includes_multi_install_suffix() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "true");
+        std::env::set_var("MULTI_INSTALL_SUFFIX", "dev");
+
+        let config = Config::from_env().unwrap();
+
+        let debug_variant = config
+            .custom_runtimes
+            .iter()
+            .find(|r| r.debug_variant)
+            .expect("expected synthesized debug variant runtime");
+        // Mirrors the standard handler (kata-<shim>-<suffix>) so two kata-deploy
+        // instances on one node do not share a debug handler.
+        assert_eq!(debug_variant.handler, "kata-qemu-dev-debug");
+        assert_eq!(debug_variant.base_config, "qemu");
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_debug_variant_inherits_base_shim_snapshotter_and_pull_type() {
+        setup_minimal_env();
+        std::env::set_var("DEBUG", "true");
+        set_arch_var("SNAPSHOTTER_HANDLER_MAPPING", "qemu:nydus");
+        set_arch_var("PULL_TYPE_MAPPING", "qemu:guest-pull");
+
+        let config = Config::from_env().unwrap();
+
+        let debug_variant = config
+            .custom_runtimes
+            .iter()
+            .find(|r| r.debug_variant)
+            .expect("expected synthesized debug variant runtime");
+        assert_eq!(debug_variant.handler, "kata-qemu-debug");
+        assert_eq!(
+            debug_variant.containerd_snapshotter.as_deref(),
+            Some("nydus")
+        );
+        assert_eq!(debug_variant.crio_pull_type.as_deref(), Some("guest-pull"));
+
+        cleanup_env_vars();
+    }
+
+    #[test]
+    fn test_lookup_mapping_value() {
+        assert_eq!(
+            lookup_mapping_value("qemu:nydus,fc:devmapper", "qemu").as_deref(),
+            Some("nydus")
+        );
+        assert_eq!(
+            lookup_mapping_value("qemu:nydus,fc:devmapper", "fc").as_deref(),
+            Some("devmapper")
+        );
+        assert!(lookup_mapping_value("qemu:nydus", "missing").is_none());
+        assert!(lookup_mapping_value("", "qemu").is_none());
     }
 }

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -41,20 +41,41 @@
 
 {{- /*
   Render a single RuntimeClass. Params (dict): root (.), shim, config, shimConfig,
-  nameOverride (optional; if set, use as metadata.name for default RC), useShimNodeSelectors.
+  nameOverride (optional; if set, use as metadata.name for default RC),
+  variant (optional; e.g. "debug" -> name/handler kata-<shim>-debug),
+  useShimNodeSelectors.
+
+  Name/handler precedence: variant > multiInstallSuffix > nameOverride > default.
+  A variant RuntimeClass mirrors the handler kata-deploy registers for the same
+  variant, so it ignores the nameOverride path. It still honors
+  multiInstallSuffix (kata-<shim>-<suffix>-debug), otherwise concurrent
+  kata-deploy instances would collide on one variant name and handler.
 */ -}}
 {{- define "kata-deploy.runtimeclass" -}}
+{{- $rcName := "" -}}
+{{- $rcHandler := "" -}}
+{{- if .variant -}}
+{{- if .root.Values.env.multiInstallSuffix -}}
+{{- $rcName = printf "kata-%s-%s-%s" .shim .root.Values.env.multiInstallSuffix .variant -}}
+{{- else -}}
+{{- $rcName = printf "kata-%s-%s" .shim .variant -}}
+{{- end -}}
+{{- $rcHandler = $rcName -}}
+{{- else if .root.Values.env.multiInstallSuffix -}}
+{{- $rcName = printf "kata-%s-%s" .shim .root.Values.env.multiInstallSuffix -}}
+{{- $rcHandler = $rcName -}}
+{{- else if .nameOverride -}}
+{{- $rcName = .nameOverride -}}
+{{- $rcHandler = printf "kata-%s" .shim -}}
+{{- else -}}
+{{- $rcName = printf "kata-%s" .shim -}}
+{{- $rcHandler = $rcName -}}
+{{- end -}}
 ---
 kind: RuntimeClass
 apiVersion: node.k8s.io/v1
 metadata:
-{{- if .root.Values.env.multiInstallSuffix }}
-  name: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
-{{- else if .nameOverride }}
-  name: {{ .nameOverride }}
-{{- else }}
-  name: kata-{{ .shim }}
-{{- end }}
+  name: {{ $rcName }}
   labels:
     app.kubernetes.io/managed-by: kata-deploy
 {{- if .root.Values.env.multiInstallSuffix }}
@@ -64,11 +85,7 @@ metadata:
 {{- end }}
   annotations:
 {{- include "kata-deploy.runtimeclassAnnotations" .root | nindent 4 }}
-{{- if .root.Values.env.multiInstallSuffix }}
-handler: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
-{{- else }}
-handler: kata-{{ .shim }}
-{{- end }}
+handler: {{ $rcHandler }}
 {{- /* Overhead section - controlled by global or per-shim overheadEnabled flag (default: true) */ -}}
 {{- $shimOverheadEnabled := true -}}
 {{- if hasKey .root.Values.runtimeClasses "overheadEnabled" -}}
@@ -149,9 +166,28 @@ scheduling:
 {{- if and $shimConfig.runtimeClass $shimConfig.runtimeClass.overhead }}
 {{- $effectiveConfig = mergeOverwrite $effectiveConfig $shimConfig.runtimeClass.overhead }}
 {{- end }}
-{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" "" "variant" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- if and $createDefaultRC (not $multiInstallSuffix) (eq $shim $defaultShim) }}
-{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" $defaultRCName "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" $defaultRCName "variant" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* Debug RuntimeClasses: an extra kata-<shim>-debug per enabled shim, matching
+       the handler kata-deploy registers when DEBUG=true. Guest debug settings
+       (kernel cmdline, agent debug console, enable_debug) are applied only on
+       this class so the normal RuntimeClass keeps a stable measurement profile.
+       Reuses each shim's overhead/nodeSelectors. */ -}}
+{{- if .Values.debug }}
+{{- range $shim := $enabledShims }}
+{{- $config := index $runtimeClassConfigs $shim }}
+{{- $shimConfig := index $.Values.shims $shim }}
+{{- if $config }}
+{{- $effectiveConfig := deepCopy $config }}
+{{- if and $shimConfig.runtimeClass $shimConfig.runtimeClass.overhead }}
+{{- $effectiveConfig = mergeOverwrite $effectiveConfig $shimConfig.runtimeClass.overhead }}
+{{- end }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" "" "variant" "debug" "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -307,6 +307,12 @@ resources:
     cpu: 25m
     memory: 16Mi
 
+# When true, kata-deploy enables host-side debug logging (containerd/CRI-O/kata-deploy)
+# and creates an extra `kata-<shim>-debug` RuntimeClass per enabled shim. Guest debug
+# settings (enable_debug, debug console, agent.log=debug, initcall_debug on the kernel
+# cmdline) are applied only on that class so the normal `kata-<shim>` RuntimeClass
+# keeps a stable measurement profile. Use runtimeClassName: kata-<shim>-debug for
+# pods that need guest debugging.
 debug: false
 
 # Optional CLI log level override for kata-deploy.


### PR DESCRIPTION
Create per-shim debug RuntimeClasses so enabling deployment logging no longer changes the normal guest kernel command line or its measurements.

Also adjust the tests to this change.