### PR TITLE
kata-deploy: bind nydus-snapshotter to the node's actual CRI unit

### DIFF
--- a/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::{Config, NYDUS_FOR_KATA_TEE};
+use crate::runtime;
 use crate::runtime::containerd;
 use crate::utils;
 use crate::utils::toml as toml_utils;
@@ -254,7 +255,7 @@ pub async fn configure_snapshotter(
     Ok(())
 }
 
-pub async fn install_nydus_snapshotter(config: &Config) -> Result<()> {
+pub async fn install_nydus_snapshotter(config: &Config, runtime: &str) -> Result<()> {
     info!("Deploying {NYDUS_FOR_KATA_TEE}");
 
     let nydus_snapshotter = match config.multi_install_suffix.as_ref() {
@@ -264,6 +265,12 @@ pub async fn install_nydus_snapshotter(config: &Config) -> Result<()> {
 
     // Stop the service if it is currently running so we can replace the binaries safely.
     let _ = utils::host_systemctl(&["stop", &format!("{nydus_snapshotter}.service")]);
+
+    // Disable it as well: the [Install] section we are about to write may name a
+    // different CRI unit than the one currently installed (e.g. after a kata-deploy
+    // upgrade), and `systemctl disable` is the only thing that removes the stale
+    // <old-cri-unit>.service.wants/ symlink.
+    let _ = utils::host_systemctl(&["disable", &format!("{nydus_snapshotter}.service")]);
 
     // The nydus data directory (/var/lib/nydus-for-kata-tee) is intentionally preserved
     // across reinstalls.  Removing it would create a split-brain state: the nydus backend
@@ -332,6 +339,11 @@ pub async fn install_nydus_snapshotter(config: &Config) -> Result<()> {
                 .unwrap_or(&config.host_install_dir)
         ),
     );
+
+    // Hook the snapshotter onto whichever unit actually runs containerd on this node.
+    let cri_service = runtime::cri_systemd_unit(runtime);
+    info!("Binding {nydus_snapshotter}.service to {cri_service}");
+    service_content = service_content.replace("@CRI_SERVICE@", &cri_service);
 
     fs::create_dir_all(format!("{}/{NYDUS_FOR_KATA_TEE}", config.host_install_dir))?;
 
@@ -416,13 +428,13 @@ pub async fn uninstall_nydus_snapshotter(config: &Config) -> Result<()> {
     Ok(())
 }
 
-pub async fn install_snapshotter(snapshotter: &str, config: &Config) -> Result<()> {
+pub async fn install_snapshotter(snapshotter: &str, config: &Config, runtime: &str) -> Result<()> {
     match snapshotter {
         "erofs" => {
             // erofs is a containerd built-in snapshotter, no installation needed
         }
         "nydus" => {
-            install_nydus_snapshotter(config).await?;
+            install_nydus_snapshotter(config, runtime).await?;
         }
         _ => {
             return Err(anyhow::anyhow!("Unsupported snapshotter: {snapshotter}"));

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -744,7 +744,7 @@ async fn install_stage_artifacts(config: &config::Config, runtime: &str) -> Resu
     if runtime != "crio" {
         if let Some(snapshotters) = config.experimental_setup_snapshotter.as_ref() {
             for snapshotter in snapshotters {
-                artifacts::snapshotters::install_snapshotter(snapshotter, config).await?;
+                artifacts::snapshotters::install_snapshotter(snapshotter, config, runtime).await?;
             }
         }
     }

--- a/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
@@ -6,6 +6,8 @@
 use crate::config::Config;
 use crate::k8s;
 use crate::utils;
+
+use super::manager;
 use anyhow::Result;
 use log::info;
 use std::time::Duration;
@@ -61,20 +63,13 @@ pub async fn restart_runtime(config: &Config, runtime: &str) -> Result<()> {
             // k0s automatically loads config on the fly
             info!("k0s runtime - no restart needed");
         }
-        "microk8s" => {
-            info!("restart_runtime: Restarting microk8s containerd service");
-            utils::host_systemctl(&["restart", "snap.microk8s.daemon-containerd.service"])?;
-            info!("restart_runtime: Successfully restarted microk8s containerd");
-        }
         _ => {
+            let unit = manager::cri_systemd_unit(runtime);
             info!("restart_runtime: Running daemon-reload");
             utils::host_systemctl(&["daemon-reload"])?;
-            info!("restart_runtime: Restarting {} service", runtime);
-            utils::host_systemctl(&["restart", runtime])?;
-            info!(
-                "restart_runtime: Successfully restarted {} service",
-                runtime
-            );
+            info!("restart_runtime: Restarting {}", unit);
+            utils::host_systemctl(&["restart", &unit])?;
+            info!("restart_runtime: Successfully restarted {}", unit);
         }
     }
 
@@ -90,12 +85,9 @@ pub async fn restart_cri_runtime(_config: &Config, runtime: &str) -> Result<()> 
             // k0s automatically unloads config on the fly
             info!("k0s runtime - no restart needed");
         }
-        "microk8s" => {
-            utils::host_systemctl(&["restart", "snap.microk8s.daemon-containerd.service"])?;
-        }
         _ => {
             utils::host_systemctl(&["daemon-reload"])?;
-            utils::host_systemctl(&["restart", runtime])?;
+            utils::host_systemctl(&["restart", &manager::cri_systemd_unit(runtime)])?;
         }
     }
 

--- a/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
@@ -85,6 +85,22 @@ pub async fn get_container_runtime(config: &Config) -> Result<String> {
     Ok(runtime)
 }
 
+/// Returns the systemd unit that runs the node's CRI runtime.
+///
+/// For most runtimes the detected runtime name doubles as the unit name, but k3s,
+/// RKE2 and k0s embed containerd in their own daemon instead of running a
+/// standalone `containerd.service`, and microk8s ships containerd as a snap
+/// daemon.  Note that the k0s units carry no dash: the `k0s-controller` and
+/// `k0s-worker` names above are ours, the units are `k0scontroller`/`k0sworker`.
+pub fn cri_systemd_unit(runtime: &str) -> String {
+    match runtime {
+        "k0s-controller" => "k0scontroller.service".to_string(),
+        "k0s-worker" => "k0sworker.service".to_string(),
+        "microk8s" => "snap.microk8s.daemon-containerd.service".to_string(),
+        _ => format!("{runtime}.service"),
+    }
+}
+
 /// Returns true if containerRuntimeVersion (e.g. "containerd://2.1.5-k3s1", "containerd://2.2.2-bd1.34") indicates
 /// containerd 2.x or newer, false for 1.x or unparseable. Used for drop-in support
 /// and for K3s/RKE2 template selection (config-v3.toml.tmpl vs config.toml.tmpl).
@@ -248,6 +264,28 @@ mod tests {
             "version: {}",
             version
         );
+    }
+
+    // --- cri_systemd_unit ---
+
+    /// The runtime name doubles as the unit name everywhere except k0s (no dash in
+    /// the unit) and microk8s (snap daemon), which are the cases worth pinning down.
+    #[rstest]
+    #[case::vanilla_containerd("containerd", "containerd.service")]
+    #[case::crio("crio", "crio.service")]
+    #[case::k3s_server("k3s", "k3s.service")]
+    #[case::k3s_agent("k3s-agent", "k3s-agent.service")]
+    #[case::rke2_server("rke2-server", "rke2-server.service")]
+    #[case::rke2_agent("rke2-agent", "rke2-agent.service")]
+    #[case::k0s_controller_unit_has_no_dash("k0s-controller", "k0scontroller.service")]
+    #[case::k0s_worker_unit_has_no_dash("k0s-worker", "k0sworker.service")]
+    #[case::microk8s_containerd_is_a_snap_daemon(
+        "microk8s",
+        "snap.microk8s.daemon-containerd.service"
+    )]
+    #[case::unknown_runtime_falls_back_to_its_own_name("something-else", "something-else.service")]
+    fn test_cri_systemd_unit(#[case] runtime: &str, #[case] expected: &str) {
+        assert_eq!(cri_systemd_unit(runtime), expected, "runtime: {}", runtime);
     }
 
     // --- is_containerd_capable_of_drop_in (pure version) ---

--- a/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
+++ b/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Nydus snapshotter
 After=network.target local-fs.target
-Before=containerd.service
+Before=@CRI_SERVICE@
 
 [Service]
 ExecStart=@CONTAINERD_NYDUS_GRPC_BINARY@ --config @CONFIG_GUEST_PULLING@ --log-to-stdout
@@ -9,4 +9,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=containerd.service
+WantedBy=@CRI_SERVICE@


### PR DESCRIPTION
The nydus-snapshotter unit is installed with a hardcoded `WantedBy=containerd.service`, which assumes every node runs containerd as a standalone systemd unit.  That only holds for vanilla containerd:

* k3s and RKE2 run containerd as a child of k3s/k3s-agent/rke2-server/ rke2-agent;
* k0s runs it inside k0scontroller/k0sworker (note: no dash in the unit names, unlike the runtime names kata-deploy detects);
* microk8s ships it as snap.microk8s.daemon-containerd.service.

On those distributions the containerd.service.wants/ symlink created by `systemctl enable` is never activated, so the snapshotter stays `inactive (dead)` after every reboot even though it is `enabled`, and every guest-pull pod hangs at sandbox creation with:

  failed to create containerd container: connection error: desc =
  "transport: Error while dialing: dial
  unix:///run/nydus-for-kata-tee/containerd-nydus-grpc.sock: timeout"

until the service is started by hand.  Restart=always does not help: it only applies once the service has been started at least once.

kata-deploy already detects which runtime the node uses and already renders this unit from a template, so resolve the unit name at install time via the new cri_systemd_unit() helper and substitute it into both Before= and WantedBy=, instead of enumerating every distribution's unit in a static file that would need a new entry for every new distribution.

lifecycle.rs kept its own copy of the same knowledge (a microk8s special case, with the runtime name used verbatim as the unit name for everyone else), so move it onto the helper too and keep the mapping in one place. This makes microk8s go through the daemon-reload that the other runtimes already did, which is harmless and arguably more correct.

Also disable the service before rewriting the unit, so that upgrading from a kata-deploy that wrote a different [Install] section does not leave a stale <old-unit>.wants/ symlink behind.

Fixes: #13459
Supersedes: #13458

Assisted-by: Cursor <cursoragent@cursor.com>