### PR TITLE
docs: add an agent-oriented contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,549 @@
+# Kata Containers Agent Guide
+
+This file tells an AI coding agent how to work in this repository: what the
+tree contains, which checks to run before proposing a change, how commits must
+be formatted, and which mistakes are made over and over again here.
+
+Humans are welcome to read it too. Everything below is also good advice for a
+first-time contributor, and it complements rather than replaces
+[`CONTRIBUTING.md`](CONTRIBUTING.md), which owns the project-wide process, and
+[`docs/code-pr-advice.md`](docs/code-pr-advice.md), which owns code style.
+
+If you only remember four things, remember these:
+
+1. Nothing you do becomes visible to anyone else, and nothing irreversible
+   happens, without the user asking for it. See
+   [What only the user may do](#what-only-the-user-may-do).
+2. Every commit must build and must pass the checks for the components it
+   touches. Not the branch tip: **every commit**.
+3. Every commit must follow the [commit format](#commit-format). The format is
+   enforced by CI and a malformed commit blocks the whole pull request.
+4. Kata has **two runtimes**. New functionality goes into `runtime-rs` only,
+   but a bug fix in one runtime is usually incomplete until you have checked
+   the other for the same bug. See
+   [Two runtimes, one behaviour](#two-runtimes-one-behaviour).
+
+## What only the user may do
+
+These are hard rules, and they matter more than anything else in this file.
+Everything else here is about not wasting a reviewer's time; these are about not
+speaking in somebody else's name and not destroying their work.
+
+**Never post anything to GitHub.** Not a reply to a review comment, not a pull
+request comment, not a review, not an approval, not an issue, not a comment on an
+issue, not a label or a milestone. Not "on the user's behalf", and not with a
+disclaimer saying an agent wrote it. A reviewer is having a conversation with a
+person, and an agent that answers in that person's account misrepresents what
+they think and signs them up to positions they have never read. Draft the reply,
+show it in the chat, and let the user post it if they agree with it. This applies
+just as much when the reply is obviously correct and the change is already made.
+
+**Never rewrite or discard history that exists outside your own session.** A
+force push, in either form; a rebase of a branch that has already been pushed; an
+amend of a commit that is already on a remote. Each of these can silently destroy
+commits the user made somewhere else, and a force push additionally detaches
+every line comment on the open pull request from the code it referred to. Prepare
+the branch locally, say what pushing it will require, and let the user push.
+Consent is per push: a "yes" earlier in the conversation is not a standing
+permission.
+
+**Never take any other irreversible action unasked**, whether or not it is listed
+above: deleting branches or tags, closing or merging pull requests, changing
+repository settings, or pushing anywhere other than where the user told you to.
+
+The shape of the rule is simple. Read anything. Change files in the working tree
+and make local commits freely. Anything that other people can see, or that cannot
+be undone with a command you know how to run, is the user's decision and the
+user's keystroke.
+
+## Project overview
+
+Kata Containers runs each pod inside a lightweight virtual machine so that
+container workloads get hardware-backed isolation while still looking and
+behaving like ordinary containers to Kubernetes and containerd.
+
+The moving parts you will most often touch:
+
+| Part | Runs where | Language | Path |
+| --- | --- | --- | --- |
+| Shim (`containerd-shim-kata-v2`) | Host | Go | `src/runtime` |
+| Shim (`containerd-shim-kata-v2`) | Host | Rust | `src/runtime-rs` |
+| Agent (`kata-agent`) | Guest, as PID 1 or under an init | Rust | `src/agent` |
+| Dragonball hypervisor | Host, in-process VMM | Rust | `src/dragonball` |
+| Shared Rust libraries | Both | Rust | `src/libs` |
+| Policy generator (`genpolicy`) | Host, build time | Rust | `src/tools/genpolicy` |
+| Guest image and asset builders | Host, build time | Shell | `tools/packaging` |
+| Deployment (`kata-deploy`, Helm chart) | Kubernetes | Rust, YAML | `tools/packaging/kata-deploy` |
+| Tests | CI and locally | Shell, Go, Rust | `tests` |
+| Documentation | - | Markdown | `docs` |
+
+Two shims exist because Kata is midway through a rewrite. Since Kata 4.0
+`runtime-rs` is the default shim, and the Go runtime is deprecated: still
+shipped and still supported, but closed to new functionality.
+
+## Repository map
+
+Beyond `src/` and `tools/`, four things at the top level matter more than their
+size suggests:
+
+- `versions.yaml` — the single source of truth for every external dependency
+  version (Go, Rust, QEMU, kernel, `golangci-lint`, and so on). Never hardcode
+  a version elsewhere; read it from here.
+- `Makefile` and `utils.mk` — the per-component `build`/`check`/`test`/`install`
+  rules, plus `standard_rust_check`, the shared `cargo fmt` and `cargo clippy`
+  invocation.
+- `tools/packaging/kata-deploy/local-build/Makefile` — every `*-tarball` target
+  that produces a shippable artefact. It is included by the root `Makefile`, so
+  those targets work from the repository root.
+- `.github/workflows/` — the definitive answer to "what will CI actually run on
+  my pull request". `static-checks.yaml` and `build-checks.yaml` gate almost
+  every change.
+
+## Commit format
+
+This is not stylistic advice. `.github/workflows/commit-message-check.yaml`
+rejects pull requests whose commits do not comply, and it checks every commit,
+not just the last one. [`CONTRIBUTING.md`](CONTRIBUTING.md#patch-format) is the
+canonical statement of the format; what follows is the operational version of
+it, with the mechanically enforced parts called out.
+
+```text
+subsystem: Short summary in the imperative mood
+
+A real paragraph of prose that explains why the change is needed and, if it
+is not obvious from the diff, how it works. Wrap at 72 characters. Somebody
+bisecting to this commit in three years should be able to understand it
+without opening a browser.
+
+Fixes: #12345
+
+Generated-By: <tool name, and the model if you know it>
+Signed-off-by: Your Name <you@example.com>
+```
+
+The `Fixes:` line above is optional. The first five rules below are enforced by
+CI; the rest are project convention, and reviewers will ask for them.
+
+- **Subsystem prefix.** The subject must start with `something:`. It is a hint
+  to the reader, not a validated enum, so pick the most specific thing that is
+  true: `runtime-rs:`, `runtime:`, `agent:`, `libs:`, `kata-types:`,
+  `dragonball:`, `genpolicy:`, `kata-deploy:`, `packaging:`, `tests:`, `ci:`,
+  `docs:`, `versions:`. Use `runtimes:` when a single commit deliberately
+  changes both shims. Nested prefixes such as `runtime-rs/qemu:` are common and
+  fine. To see the ones actually in use, run
+  `git log --no-merges --pretty=%s | cut -d: -f1 | sort | uniq -c | sort -rn | head -20`;
+  the long tail below that is not a set of prefixes worth copying.
+- **Subject length: 75 characters or fewer**, including the prefix.
+- **A body is required.** A subject-only commit fails CI. The body is a
+  standalone paragraph, not a continuation of the subject line.
+- **Body lines: 150 characters or fewer.** Lines that start with a
+  non-alphabetic character, lines without spaces, and sign-off lines are
+  exempt, which is how log excerpts and long URLs get through.
+- **`Signed-off-by:` is required** on every commit (DCO). Use `git commit -s`
+  and let git read the identity from your `~/.gitconfig`.
+- **`Fixes: #NNN`** is no longer required, but add it when the change resolves
+  a reported issue: it closes the issue automatically and gives the next reader
+  the background that the diff cannot. One commit in the series carries it,
+  normally the main one. Use `Related: #NNN` when the change is connected to an
+  issue it does not close.
+- **AI involvement must be disclosed.** Kata follows the
+  [OpenInfra Foundation AI policy](https://openinfra.org/legal/ai-policy/), as
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#ai-generated-code) spells out: use
+  `Generated-By:` when a tool produced a substantial part of the change, and
+  `Assisted-By:` when it only assisted, such as auto-complete or a small edit.
+  Name the tool, and the model when you know it. Do not use `Co-authored-by:`
+  for a tool; that trailer is for humans and carries a DCO implication. Put the
+  disclosure *above* `Signed-off-by:`, so that the human sign-off comes last and
+  reads as what it is: a statement that a person understands the change and
+  takes responsibility for it.
+
+### Writing the body
+
+Write the way a human reviewer writes. Prose paragraphs, present tense,
+explaining the problem and the reasoning. Do not dump a bullet list of the
+files you touched; the diff already says that. Bullets are acceptable when the
+content is genuinely a list, such as a set of measurements or an enumeration of
+affected configuration flavours.
+
+Do not paste tool output, task lists, or a narration of your own process into a
+commit message.
+
+### Splitting a series
+
+One commit does one thing. A pull request may carry several commits, but each
+one has to stand on its own: it must build, it must pass the checks for what it
+touches, and its message has to make sense in isolation. Refactoring that
+enables a fix belongs in its own commit, before the fix.
+
+### Verifying before you push
+
+```bash
+base=upstream/main   # or whatever you branched from
+rc=0
+for commit in $(git rev-list --no-merges "${base}..HEAD"); do
+	subject=$(git show -s --format=%s "${commit}")
+	body=$(git show -s --format=%b "${commit}")
+	id="${commit:0:12}"
+	[[ "${#subject}" -le 75 ]] || { echo "${id}: subject is ${#subject} characters, the limit is 75"; rc=1; }
+	[[ "${subject}" =~ ^[^:[:space:]]+: ]] || { echo "${id}: subject has no 'subsystem:' prefix"; rc=1; }
+	grep -q '^Signed-off-by:' <<<"${body}" || { echo "${id}: no Signed-off-by trailer"; rc=1; }
+	grep -qE '^[^[:space:]]' <<<"$(grep -viE '^([a-z-]+-by|fixes|related|closes):|^$' <<<"${body}")" \
+		|| { echo "${id}: no commit body, only a subject"; rc=1; }
+	awk -v id="${id}" 'length > 150 && /^[a-zA-Z]/ { print id": body line is " length " characters, the limit is 150" }' <<<"${body}"
+done
+exit "${rc}"
+```
+
+## Before you submit
+
+Work down this ladder. Each rung is cheap relative to the one below it, and
+skipping a rung is how a pull request ends up with a red CI run over a
+missing newline.
+
+### Rung 0: the components you touched
+
+CI runs exactly three commands in each component directory
+(`.github/workflows/build-checks.yaml`), so run the same ones:
+
+```bash
+make -C src/agent check          # cargo fmt --check + cargo clippy -D warnings
+make -C src/agent test           # cargo test
+sudo -E PATH="$PATH" make -C src/agent test
+```
+
+Substitute the component you changed. `make check-all` and `make test-all` from
+the repository root fan out to most components, but not to
+`src/tools/genpolicy` even though CI checks it, so run
+`make -C src/tools/genpolicy check test` yourself if you touched it.
+
+Two exceptions worth knowing:
+
+- **`make -C src/runtime check` does nothing.** The target is declared `.PHONY`
+  and `make -C src/runtime help` advertises it, but it has no recipe. For the
+  Go runtime run `make -C src/runtime lint`, which builds everything and then
+  runs `golangci-lint` against `tests/.golangci.yml`, and
+  `make -C src/runtime test`. `make -C src/runtime pre-commit` is `lint` plus a
+  faster test pass. `golangci-lint` has to be on your `PATH` already; the
+  version is pinned in `versions.yaml`.
+- **`runtime-rs` and `dragonball` tests need virtualization**, and CI runs them
+  differently:
+
+  ```bash
+  sudo -E env PATH="$PATH" LIBC=gnu SUPPORT_VIRTUALIZATION=true make -C src/runtime-rs test
+  sudo -E env PATH="$PATH" LIBC=gnu SUPPORT_VIRTUALIZATION=true make -C src/dragonball test
+  ```
+
+The `kata-deploy` crates under `tools/packaging/kata-deploy/binary` and
+`tools/packaging/kata-deploy/job-dispatcher` are not part of `make check-all`,
+and have their own CI job:
+
+```bash
+cargo fmt -p kata-deploy --check
+cargo clippy -p kata-deploy --all-targets --all-features -- -D warnings
+RUSTFLAGS="-D warnings" cargo test -p kata-deploy -- --test-threads=1
+```
+
+### Rung 1: whole-tree static checks
+
+```bash
+make static-checks
+```
+
+This is `tests/static-checks.sh`, and it is the check that surprises people
+most often. Two things to know before running it:
+
+- It needs `moreutils` (for `chronic`), and depending on which checks fire it
+  also wants `yamllint`, `jq`, `xmllint`, `hadolint`, `opa`, and `regorus`.
+  `tests/install_opa.sh` and `tests/install_regorus.sh` handle the last two.
+  `golangci-lint` is downloaded automatically if missing.
+- It works out what you changed by diffing against `origin/<branch>`. The
+  remote name `origin` is hardcoded and no flag overrides it; `--branch` only
+  chooses the branch, which otherwise defaults to whatever `origin`'s HEAD
+  points at. In CI `origin` is the upstream repository, so this works out. On a
+  developer machine `origin` is usually your fork, and anything upstream has
+  that your fork's default branch does not is counted as part of your change.
+  Point the tracking ref at upstream before running the script:
+
+  ```bash
+  git fetch <your-upstream-remote> '+main:refs/remotes/origin/main'
+  ```
+
+  That rewrites only the local `origin/main` tracking ref, not your fork.
+
+`make static-checks` assumes the CI checkout layout, `$GOPATH/src/github.com/kata-containers/kata-containers`.
+From a checkout anywhere else, drive the script directly:
+
+```bash
+test_path=tests bash tests/static-checks.sh --repo-path "$(pwd)"
+```
+
+To iterate quickly, run one check at a time. `bash tests/static-checks.sh --list`
+prints them all; the useful flags are:
+
+| Flag | What it checks |
+| --- | --- |
+| `--golang` | `golangci-lint` over every changed Go package |
+| `--scripts` | `bash -n` over changed shell scripts |
+| `--licenses` | SPDX and copyright headers on new files (Markdown is exempt) |
+| `--json`, `--xml` | That changed data files still parse |
+| `--dockerfiles` | `hadolint` |
+| `--rego` | `opa parse` and `regorus parse` over policy files |
+| `--versions` | `yamllint versions.yaml` |
+| `--force --files` | TODO and FIXME comments without a linked issue |
+
+Beware: `--commits` and `--docs` appear in the help output but are not wired
+up. Use the commit snippet above instead.
+
+### Rung 2: the checks that only fire for certain changes
+
+These are separate CI jobs, and each one is a single local command:
+
+| If you changed | Run | Why |
+| --- | --- | --- |
+| Any Go file, `go.mod`, `go.sum`, or `versions.yaml` | `find . -name go.mod -execdir go mod tidy \; && git diff --exit-code` | The `go-mod-tidy` job fails on any diff |
+| `src/libs/protocols/protos/**` | `make -C src/agent generate-protocols && git diff --exit-code` | The `codegen` job regenerates and diffs the bindings |
+| Agent RPC surface or the policy | `bash ci/check_agent_policy_coverage.sh` | Every agent endpoint needs policy coverage |
+| `Cargo.toml` or `Cargo.lock` | `cargo deny check bans licenses sources` | The `cargo-deny` job |
+| Anything under `tools/packaging/kernel/` other than its README | Bump `tools/packaging/kernel/kata_config_version` | A dedicated job enforces the bump |
+| Any `.md` file | `make docs-lint` | Runs `cspell` and `editorconfig-checker` in Docker |
+| A `.github/workflows/` file | `actionlint` and `zizmor` | Workflow linting and workflow security auditing |
+| Any shell script | `shellcheck` at severity `style` | `shellcheck_required.yaml` |
+
+Two notes on documentation. New project-specific vocabulary has to be added to
+`tests/spellcheck/kata-dictionary.txt` or `cspell` will reject it, though
+anything inside backticks is ignored. And new pages under `docs/` must be
+registered in `docs/.nav.yml`; the repository ships a skill at
+`.claude/skills/mkdocs-docs/SKILL.md` describing the documentation conventions.
+
+### Rung 3: build the artefacts
+
+Every commit must build. For a shim change that means, from the repository
+root:
+
+```bash
+make shim-v2-rust-tarball     # runtime-rs
+make shim-v2-go-tarball       # the Go runtime
+```
+
+Other useful targets from the same Makefile: `make agent-tarball`,
+`make kernel-tarball`, `make rootfs-image-tarball`, `make genpolicy-tarball`,
+and `make kata-tarball` for the complete bundle. They all build inside Docker,
+so you need a working Docker daemon and enough disk.
+
+To validate a whole series rather than just its tip:
+
+```bash
+git rebase --exec 'make shim-v2-rust-tarball' upstream/main
+```
+
+Stop there. Installing a build onto the host and running the end-to-end suites
+under `tests/integration/kubernetes` need a machine you are willing to
+reconfigure and a cluster to talk to. Leave both to CI unless the user asks for
+them, and if they do ask, follow `tests/README.md` rather than improvising.
+
+## Two runtimes, one behaviour
+
+`src/runtime` (Go) and `src/runtime-rs` (Rust) are two implementations of the
+same architecture. They share no business logic. They do share a configuration
+file shape, an annotation namespace, an agent protocol, and a set of user
+expectations.
+
+The Go runtime is deprecated, which makes the rule asymmetric. Getting the
+direction right matters:
+
+- **New functionality goes into `runtime-rs` only.** Do not add a feature, a
+  configuration option or an annotation to the Go runtime. If a request seems
+  to call for that, say that the Go runtime is closed to new functionality and
+  implement it in `runtime-rs` instead.
+- **Bug fixes go wherever the bug is, which is usually both runtimes.** The two
+  implementations were written from the same design, so a logic error, a
+  missing validation or a wrong default in one is very often present in the
+  other.
+
+**So: before you consider a bug fix finished, look for the same bug in the
+other runtime.** This is the single most common source of incomplete Kata
+patches. If you are an agent working from a bug report, treat it as a required
+step rather than a nicety.
+
+### How to look
+
+```bash
+# Where does the same identifier, config key or log message live elsewhere?
+git grep -n '<identifier>' -- src/runtime src/runtime-rs src/libs
+
+# History of the concept, whichever tree it was touched in
+git log --oneline -S'<string you changed>'
+
+# Commits that deliberately changed both shims at once, as worked examples
+git log --oneline --grep='^runtimes:'
+```
+
+Then read the mirror of the file you edited:
+
+| Concern | Go | Rust |
+| --- | --- | --- |
+| Shim entry point | `src/runtime/cmd/containerd-shim-kata-v2/` | `src/runtime-rs/crates/shim/` |
+| Sandbox and container lifecycle | `src/runtime/virtcontainers/sandbox.go`, `container.go` | `src/runtime-rs/crates/runtimes/virt_container/src/` |
+| Hypervisor drivers | `src/runtime/virtcontainers/{qemu,clh,fc,remote}*.go` | `src/runtime-rs/crates/hypervisor/src/{qemu,ch,firecracker,remote}/` |
+| Device management | `src/runtime/pkg/device/` | `src/runtime-rs/crates/hypervisor/src/device/` |
+| Network endpoints | `src/runtime/virtcontainers/*_endpoint.go` | `src/runtime-rs/crates/resource/src/network/endpoint/` |
+| Storage, mounts, cgroups | `src/runtime/virtcontainers/`, `src/runtime/pkg/resourcecontrol/` | `src/runtime-rs/crates/resource/` |
+| Agent client | `src/runtime/virtcontainers/kata_agent.go` | `src/runtime-rs/crates/agent/src/kata/` |
+| Sandbox state persistence | `src/runtime/virtcontainers/persist/` | `src/runtime-rs/crates/persist/` |
+| Configuration parsing | `src/runtime/pkg/katautils/config.go` | `src/libs/kata-types/src/config/` |
+| Annotations | `src/runtime/virtcontainers/pkg/annotations/annotations.go` | `src/libs/kata-types/src/annotations/mod.rs` |
+| Configuration templates | `src/runtime/config/configuration-*.toml.in` | `src/runtime-rs/config/configuration-*-runtime-rs.toml.in` |
+
+Note the last three rows: the `runtime-rs` side of configuration and
+annotations does not live under `src/runtime-rs/` at all. It lives in
+`src/libs/kata-types/`, which is shared. Agents routinely miss this and
+conclude, wrongly, that `runtime-rs` has no equivalent.
+
+### Configuration options and annotations
+
+A *new* option is `runtime-rs` only, so the touch list is:
+
+1. The templates in `src/runtime-rs/config/`, for every hypervisor flavour the
+   option applies to (`qemu`, `clh`, `fc`, `remote`, `dragonball`, plus the
+   confidential and NVIDIA GPU variants).
+2. The parser in `src/libs/kata-types/src/config/`, including the
+   per-hypervisor `validate()` and `adjust_config()` under
+   `src/libs/kata-types/src/config/hypervisor/`.
+3. `docs/how-to/how-to-set-sandbox-config-kata.md` if users can set it, and
+   `docs/migrating-config-go-runtime-to-runtime-rs.md`, since a new
+   `runtime-rs` option widens the documented gap between the two runtimes.
+4. Tests under `src/libs/kata-types/tests/`.
+
+*Fixing* how an existing option is parsed, validated or defaulted is a
+different matter. That option almost certainly exists on the Go side too, so
+check `src/runtime/pkg/katautils/config.go`, the struct in
+`src/runtime/virtcontainers/hypervisor.go`, the templates under
+`src/runtime/config/`, and `src/runtime/pkg/katautils/config_test.go`.
+
+Annotations split the same way. A new one is a constant in
+`src/libs/kata-types/src/annotations/mod.rs`, the code that applies it, a
+documentation row, and an entry in `enable_annotations` in the affected
+templates. A fix to an existing annotation should also be checked against
+`src/runtime/virtcontainers/pkg/annotations/annotations.go`.
+
+### What is deliberately not mirrored
+
+Do not manufacture parity where none is intended:
+
+- **Dragonball** is a real hypervisor only in `runtime-rs`. The Go runtime
+  returns a mock for it.
+- **StratoVirt** exists only in the Go runtime.
+- **`kata-monitor` and the `kata-runtime` CLI** live in `src/runtime` and serve
+  the Go runtime. The successor to `kata-runtime` is `kata-ctl`, a Rust rewrite
+  in `src/tools/kata-ctl` that is its own component rather than part of either
+  shim. `shim-ctl` in `runtime-rs` is not a CLI for users; it is a development
+  tool for driving the shim without containerd.
+- **VM cache and the `[factory]` machinery** are Go-only and deprecated.
+- **`mem-agent`, `use_passfd_io`, and component plugin selection** are
+  `runtime-rs`-only.
+- **`ppc64le`** ships only the Go runtime.
+- **NUMA mapping and network rate limiters** are not implemented in
+  `runtime-rs` yet. Closing that gap is legitimate work, but it is a feature in
+  its own right, not something to slip in alongside a bug fix.
+
+`docs/migrating-config-go-runtime-to-runtime-rs.md` is the authoritative list
+of intentional divergences. Read it before claiming a difference is a bug.
+
+### When you genuinely cannot do both
+
+Sometimes the counterpart change needs hardware you do not have, or is large
+enough to deserve its own review. That is fine, but say so:
+
+- Note it explicitly in the commit message or the pull request description.
+- Suggest that the user open a GitHub issue for the other runtime, with the
+  detail [any issue needs](#issues), and reference it with `Related: #NNN`.
+
+What is not fine is fixing a bug in one runtime, saying nothing, and leaving
+the identical bug in the other for somebody else to rediscover in production.
+
+## Code conventions
+
+Read [`docs/code-pr-advice.md`](docs/code-pr-advice.md): it covers error
+handling, the narrow cases where Rust `unwrap()` and `expect()` are acceptable,
+Go struct construction, comments, logging and architecture-specific code. Three
+things it does not say, which a check here does enforce:
+
+- **Copyright and SPDX headers** on every new file, required by the
+  `--licenses` static check for everything except Markdown. Write the copyright
+  line **without a year**, as in `Copyright (c) Example Corporation`: a year is
+  not needed and only goes stale.
+- **A `TODO` or `FIXME` must link to a GitHub issue**, or the
+  `--force --files` static check flags it.
+- **Dependency versions come from `versions.yaml`.** Nowhere else.
+
+## Traps
+
+Things that have cost real time in this repository:
+
+- **`make -C src/runtime check` silently does nothing.** Running it proves
+  nothing. Use `lint` and `test`.
+- **`cargo` commands run against the root workspace.** Most crates, including
+  `src/agent`, `src/libs/*`, `src/runtime-rs`, and the tools, are members of
+  the workspace defined by the root `Cargo.toml`. Running `cargo clippy` inside
+  a component directory still resolves upward, so `-p <crate>` is usually what
+  you want.
+- **The default Rust target is musl** (`LIBC=musl` in `utils.mk`), overridden
+  to gnu on `ppc64le`, `riscv64`, and `s390x`. A build that works for you with
+  the default host toolchain can still fail in CI. Install `musl-tools`.
+- **`clippy` runs with `-D warnings`.** A warning is a build failure. This
+  includes lints such as `too_many_arguments`, which will make you restructure
+  a function signature rather than suppress it.
+- **`Cargo.lock` is checked in and `clippy` runs with `--locked`.** Adding a
+  dependency means committing the lock file update, and `cargo deny` then has
+  an opinion about the licence.
+- **Generated files are diffed by CI.** Protocol bindings and the generated
+  configuration files must be regenerated and committed, not left for CI.
+- **Configuration templates are `.toml.in`, not `.toml`.** Editing a generated
+  `.toml` under a build directory changes nothing.
+- **Falling behind upstream inflates the "changed files" set.** Both
+  `tests/static-checks.sh` and `tools/testing/gatekeeper/skips.py` derive it
+  from a diff against `origin/<branch>`, so a branch that is behind gets linted
+  over files it never touched and, in CI, has gatekeeper schedule test suites
+  the change does not need. Rebase on upstream `main` as you go rather than once
+  at the end, and expect unrelated CI failures when you do not.
+- **`shim-v2-tarball` no longer exists.** It was split into
+  `shim-v2-go-tarball` and `shim-v2-rust-tarball`.
+
+## Issues
+
+You do not file, close or comment on issues; see
+[What only the user may do](#what-only-the-user-may-do). You draft them.
+
+What you draft still has to be actionable, because an issue without these two
+things will sit untouched until somebody asks for them:
+
+- **A reproducer.** The smallest set of commands or the pod YAML that triggers
+  the problem, along with the Kata version, the hypervisor, the container
+  manager, and the host kernel and distribution.
+- **Logs captured with debug enabled.** Turn on full debug first, following
+  [`docs/Developer-Guide.md`](docs/Developer-Guide.md#enable-full-debug), then
+  reproduce, then include the output of `kata-collect-data.sh`, which gathers
+  the configuration and the runtime, agent and hypervisor logs in one go.
+
+## Pull requests
+
+- Base your branch on an up-to-date `main`, rebase rather than merge, and rebase
+  again when it falls behind.
+- Keep unfinished work as a draft pull request. The `wip` and `do-not-merge`
+  labels and a `WIP` in the title also block the merge, and CI recognises them.
+- New features need documentation that says what the feature does, why it is
+  useful, how to use it, and what its limitations are.
+- Read [`docs/code-pr-advice.md`](docs/code-pr-advice.md) and the
+  [PR review guide](https://github.com/kata-containers/community/blob/main/PR-Review-Guide.md)
+  to see what a reviewer will be looking for.
+
+## Further reading
+
+- [`docs/Developer-Guide.md`](docs/Developer-Guide.md) — building and installing from source
+- [`docs/code-pr-advice.md`](docs/code-pr-advice.md) — what reviewers expect from code
+- [`docs/Unit-Test-Advice.md`](docs/Unit-Test-Advice.md) — the table-driven test style used here
+- [`docs/migrating-config-go-runtime-to-runtime-rs.md`](docs/migrating-config-go-runtime-to-runtime-rs.md) — how the two runtimes differ
+- [`docs/how-to/how-to-set-sandbox-config-kata.md`](docs/how-to/how-to-set-sandbox-config-kata.md) — the annotation reference
+- [`docs/Documentation-Requirements.md`](docs/Documentation-Requirements.md) — documentation style rules
+- [`tests/README.md`](tests/README.md) — the test suites and how to run them
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — the project-wide process, patch format and review flow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,475 @@
+# Kata Containers Agent Guide
+
+This file tells an AI coding agent how to work in this repository: what the
+tree contains, which checks to run before proposing a change, how commits must
+be formatted, and which mistakes are made over and over again here.
+
+Humans are welcome to read it too. Everything below is also good advice for a
+first-time contributor, and it complements rather than replaces
+[`CONTRIBUTING.md`](CONTRIBUTING.md), which owns the project-wide process, and
+[`docs/code-pr-advice.md`](docs/code-pr-advice.md), which owns code style.
+
+If you only remember one thing, remember that nothing you do becomes visible to
+anyone else, nothing irreversible happens, and no prose goes out under the
+user's name, unless the user asks for it. See
+[What the agent must not do](#what-the-agent-must-not-do).
+
+## What the agent must not do
+
+These are hard rules, and they matter more than anything else in this file
+(unless specifically instructed otherwise by the user).
+
+- Never post anything to GitHub.
+- Never write the prose that goes out in the user's name: commit message bodies,
+  pull request descriptions, issue reports, review replies. See
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#dont-use-ai-for-prose). Hand over the raw
+  material instead and let the user write it up.
+- Never rewrite or discard history that exists outside your own session. Consent
+  is per push; an earlier "yes" is not a standing permission.
+- Never take any other irreversible action unasked.
+
+Generally: you can read anything, change files in the working tree and make
+local commits freely. Anything that other people can see, or that cannot be
+undone with a command you know how to run, is the user's decision.
+
+## Project overview
+
+Kata Containers runs each pod inside a lightweight virtual machine so that
+container workloads get hardware-backed isolation while still looking and
+behaving like ordinary containers to Kubernetes and containerd.
+
+The moving parts you will most often touch:
+
+| Part | Runs where | Language | Path |
+| --- | --- | --- | --- |
+| Shim (`containerd-shim-kata-v2`) | Host | Go | `src/runtime` |
+| Shim (`containerd-shim-kata-v2`) | Host | Rust | `src/runtime-rs` |
+| Agent (`kata-agent`) | Guest, as PID 1 or under an init | Rust | `src/agent` |
+| Dragonball hypervisor | Host, in-process VMM | Rust | `src/dragonball` |
+| Shared Rust libraries | Both | Rust | `src/libs` |
+| Policy generator (`genpolicy`) | Host, build time | Rust | `src/tools/genpolicy` |
+| Guest image and asset builders | Host, build time | Shell | `tools/packaging` |
+| Deployment (`kata-deploy`, Helm chart) | Kubernetes | Rust, YAML | `tools/packaging/kata-deploy` |
+| Tests | CI and locally | Shell, Go, Rust | `tests` |
+| Documentation | - | Markdown | `docs` |
+
+Two shims exist because Kata is midway through a rewrite. Since Kata 4.0
+`runtime-rs` is the default shim, and the Go runtime is deprecated: still
+shipped and still supported, but closed to new functionality.
+
+## Repository map
+
+Beyond `src/` and `tools/`, four things at the top level matter more than their
+size suggests:
+
+- `versions.yaml` — the single source of truth for every external dependency
+  version (Go, Rust, QEMU, kernel, `golangci-lint`, and so on). Never hardcode
+  a version elsewhere; read it from here.
+- `Makefile` and `utils.mk` — the per-component `build`/`check`/`test`/`install`
+  rules, plus `standard_rust_check`, the shared `cargo fmt` and `cargo clippy`
+  invocation.
+- `tools/packaging/kata-deploy/local-build/Makefile` — every `*-tarball` target
+  that produces a shippable artefact. It is included by the root `Makefile`, so
+  those targets work from the repository root.
+- `.github/workflows/` — the definitive answer to "what will CI actually run on
+  my pull request". `static-checks.yaml` and `build-checks.yaml` gate almost
+  every change.
+
+## Commit format
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md#patch-format) is the canonical statement of
+the format. What matters operationally is that
+`.github/workflows/commit-message-check.yaml` rejects the pull request when a
+commit does not comply, and it checks every commit, not just the last one. It
+rejects on exactly five things:
+
+- **No `subsystem:` prefix** on the subject. It is a hint to the reader, not a
+  validated enum. To see the ones in use, run
+  `git log --no-merges --pretty=%s | cut -d: -f1 | sort | uniq -c | sort -rn | head -20`.
+- **A subject longer than 75 characters**, including the prefix.
+- **A missing body.** A subject-only commit fails. The body is a standalone
+  paragraph, not a continuation of the subject line.
+- **A body line longer than 150 characters.** Lines starting with a
+  non-alphabetic character, lines without spaces, and sign-off lines are exempt,
+  which is how log excerpts and long URLs get through.
+- **A missing `Signed-off-by:`** (DCO).
+
+Three things CI does not check and reviewers do. Put the `Generated-By:` or
+`Assisted-By:` disclosure *above* `Signed-off-by:` so the human sign-off comes
+last. Never use `Co-authored-by:` for a tool, since that trailer is for humans
+and carries a DCO implication. And add `Fixes: #NNN` to one commit in the series
+when the change resolves a reported issue, or `Related: #NNN` when it does not
+close it.
+
+### Verifying before you push
+
+```bash
+base=upstream/main   # or whatever you branched from
+rc=0
+for commit in $(git rev-list --no-merges "${base}..HEAD"); do
+	subject=$(git show -s --format=%s "${commit}")
+	body=$(git show -s --format=%b "${commit}")
+	id="${commit:0:12}"
+	[[ "${#subject}" -le 75 ]] || { echo "${id}: subject is ${#subject} characters, the limit is 75"; rc=1; }
+	[[ "${subject}" =~ ^[^:[:space:]]+: ]] || { echo "${id}: subject has no 'subsystem:' prefix"; rc=1; }
+	grep -q '^Signed-off-by:' <<<"${body}" || { echo "${id}: no Signed-off-by trailer"; rc=1; }
+	grep -qE '^[^[:space:]]' <<<"$(grep -viE '^([a-z-]+-by|fixes|related|closes):|^$' <<<"${body}")" \
+		|| { echo "${id}: no commit body, only a subject"; rc=1; }
+	awk -v id="${id}" 'length > 150 && /^[a-zA-Z]/ { print id": body line is " length " characters, the limit is 150" }' <<<"${body}"
+done
+exit "${rc}"
+```
+
+## Before you submit
+
+Every commit has to build and pass the checks for the components it touches, not
+just the branch tip, so that a later bisect lands on something that works.
+
+Work down this ladder. Each rung is cheap relative to the one below it, and
+skipping a rung is how a pull request ends up with a red CI run over a
+missing newline.
+
+### Rung 0: the components you touched
+
+CI runs exactly three commands in each component directory
+(`.github/workflows/build-checks.yaml`), so run the same ones:
+
+```bash
+make -C src/agent check          # cargo fmt --check + cargo clippy -D warnings
+make -C src/agent test           # cargo test
+sudo -E PATH="$PATH" make -C src/agent test
+```
+
+Substitute the component you changed. `make check-all` and `make test-all` from
+the repository root fan out to most components, but not to
+`src/tools/genpolicy` even though CI checks it, so run
+`make -C src/tools/genpolicy check test` yourself if you touched it.
+
+Two exceptions worth knowing:
+
+- **`make -C src/runtime check` does nothing.** The target is declared `.PHONY`
+  and `make -C src/runtime help` advertises it, but it has no recipe. For the
+  Go runtime run `make -C src/runtime lint`, which builds everything and then
+  runs `golangci-lint` against `tests/.golangci.yml`, and
+  `make -C src/runtime test`. `make -C src/runtime pre-commit` is `lint` plus a
+  faster test pass. `golangci-lint` has to be on your `PATH` already; the
+  version is pinned in `versions.yaml`.
+- **`runtime-rs` and `dragonball` tests need virtualization**, and CI runs them
+  differently:
+
+  ```bash
+  sudo -E env PATH="$PATH" LIBC=gnu SUPPORT_VIRTUALIZATION=true make -C src/runtime-rs test
+  sudo -E env PATH="$PATH" LIBC=gnu SUPPORT_VIRTUALIZATION=true make -C src/dragonball test
+  ```
+
+The `kata-deploy` crates under `tools/packaging/kata-deploy/binary` and
+`tools/packaging/kata-deploy/job-dispatcher` are not part of `make check-all`,
+and have their own CI job:
+
+```bash
+cargo fmt -p kata-deploy --check
+cargo clippy -p kata-deploy --all-targets --all-features -- -D warnings
+RUSTFLAGS="-D warnings" cargo test -p kata-deploy -- --test-threads=1
+```
+
+### Rung 1: whole-tree static checks
+
+```bash
+make static-checks
+```
+
+This is `tests/static-checks.sh`, and it is the check that surprises people
+most often. Two things to know before running it:
+
+- It needs `moreutils` (for `chronic`), and depending on which checks fire it
+  also wants `yamllint`, `jq`, `xmllint`, `hadolint`, `opa`, and `regorus`.
+  `tests/install_opa.sh` and `tests/install_regorus.sh` handle the last two.
+  `golangci-lint` is downloaded automatically if missing.
+- It works out what you changed by diffing against `origin/<branch>`. The
+  remote name `origin` is hardcoded and no flag overrides it; `--branch` only
+  chooses the branch, which otherwise defaults to whatever `origin`'s HEAD
+  points at. In CI `origin` is the upstream repository, so this works out. On a
+  developer machine `origin` is usually your fork, and anything upstream has
+  that your fork's default branch does not is counted as part of your change.
+  Point the tracking ref at upstream before running the script:
+
+  ```bash
+  git fetch <your-upstream-remote> '+main:refs/remotes/origin/main'   # before
+  git fetch origin '+main:refs/remotes/origin/main'                   # after
+  ```
+
+  Only the local `origin/main` tracking ref changes, never your fork, and the
+  second command puts it back so that later `git log origin/main` and branch
+  comparisons mean what you expect again.
+
+In general, prefer running the script directly:
+
+```bash
+test_path=tests bash tests/static-checks.sh --repo-path "$(pwd)"
+```
+
+To iterate quickly, run one check at a time. `bash tests/static-checks.sh --list`
+prints them all; the useful flags are:
+
+| Flag | What it checks |
+| --- | --- |
+| `--golang` | `golangci-lint` over every changed Go package |
+| `--scripts` | `bash -n` over changed shell scripts |
+| `--licenses` | SPDX and copyright headers on new files (Markdown is exempt) |
+| `--json`, `--xml` | That changed data files still parse |
+| `--dockerfiles` | `hadolint` |
+| `--rego` | `opa parse` and `regorus parse` over policy files |
+| `--versions` | `yamllint versions.yaml` |
+| `--force --files` | TODO and FIXME comments without a linked issue |
+
+Beware: `--commits` and `--docs` appear in the help output but are not wired
+up. Use the commit snippet above instead.
+
+### Rung 2: the checks that only fire for certain changes
+
+These are separate CI jobs, and each one is a single local command:
+
+| If you changed | Run | Why |
+| --- | --- | --- |
+| Any Go file, `go.mod`, `go.sum`, or `versions.yaml` | `find . -name go.mod -execdir go mod tidy \; && git diff --exit-code` | The `go-mod-tidy` job fails on any diff |
+| `src/libs/protocols/protos/**` | `make -C src/agent generate-protocols && git diff --exit-code` | The `codegen` job regenerates and diffs the bindings |
+| Agent RPC surface or the policy | `bash ci/check_agent_policy_coverage.sh` | Every agent endpoint needs policy coverage |
+| `Cargo.toml` or `Cargo.lock` | `cargo deny check bans licenses sources` | The `cargo-deny` job |
+| Anything under `tools/packaging/kernel/` other than its README | Bump `tools/packaging/kernel/kata_config_version` | A dedicated job enforces the bump |
+| Any `.md` file | `make docs-lint` | Runs `cspell` and `editorconfig-checker` in Docker |
+| A `.github/workflows/` file | `actionlint` and `zizmor` | Workflow linting and workflow security auditing |
+| Any shell script | `shellcheck` at severity `style` | `shellcheck_required.yaml` |
+
+Two notes on documentation. New project-specific vocabulary has to be added to
+`tests/spellcheck/kata-dictionary.txt` or `cspell` will reject it, though
+anything inside backticks is ignored. And new pages under `docs/` must be
+registered in `docs/.nav.yml`; the repository ships a skill at
+`.claude/skills/mkdocs-docs/SKILL.md` describing the documentation conventions.
+
+### Rung 3: build the artefacts
+
+Every commit must build. For a shim change that means, from the repository
+root:
+
+```bash
+make shim-v2-rust-tarball     # runtime-rs
+make shim-v2-go-tarball       # the Go runtime
+```
+
+Other useful targets from the same Makefile: `make agent-tarball`,
+`make kernel-tarball`, `make rootfs-image-tarball`, `make genpolicy-tarball`,
+and `make kata-tarball` for the complete bundle. They all build inside Docker,
+so you need a working Docker daemon and enough disk.
+
+To validate a whole series rather than just its tip:
+
+```bash
+git rebase --exec 'make shim-v2-rust-tarball' upstream/main
+```
+
+Stop there. Installing a build onto the host and running the end-to-end suites
+under `tests/integration/kubernetes` need a machine you are willing to
+reconfigure and a cluster to talk to. Leave both to CI unless the user asks for
+them, and if they do ask, follow `tests/README.md` rather than improvising.
+
+## Two runtimes, one behaviour
+
+`src/runtime` (Go) and `src/runtime-rs` (Rust) are two implementations of the
+same architecture. They share no business logic. They do share a configuration
+file shape, an annotation namespace, an agent protocol, and a set of user
+expectations.
+
+The Go runtime is deprecated, which makes the rule asymmetric. Getting the
+direction right matters:
+
+- **New functionality goes into `runtime-rs` only.** Do not add a feature, a
+  configuration option or an annotation to the Go runtime. If a request seems
+  to call for that, say that the Go runtime is closed to new functionality and
+  implement it in `runtime-rs` instead.
+- **Bug fixes go wherever the bug is, which is usually both runtimes.** The two
+  implementations were written from the same design, so a logic error, a
+  missing validation or a wrong default in one is very often present in the
+  other.
+
+**So: before you consider a bug fix finished, look for the same bug in the
+other runtime.** This is the single most common source of incomplete Kata
+patches. If you are an agent working from a bug report, treat it as a required
+step rather than a nicety.
+
+### How to look
+
+```bash
+# Where does the same identifier, config key or log message live elsewhere?
+git grep -n '<identifier>' -- src/runtime src/runtime-rs src/libs
+
+# History of the concept, whichever tree it was touched in
+git log --oneline -S'<string you changed>'
+
+# Commits that deliberately changed both shims at once, as worked examples
+git log --oneline --grep='^runtimes:'
+```
+
+Then read the mirror of the file you edited:
+
+| Concern | Go | Rust |
+| --- | --- | --- |
+| Shim entry point | `src/runtime/cmd/containerd-shim-kata-v2/` | `src/runtime-rs/crates/shim/` |
+| Sandbox and container lifecycle | `src/runtime/virtcontainers/sandbox.go`, `container.go` | `src/runtime-rs/crates/runtimes/virt_container/src/` |
+| Hypervisor drivers | `src/runtime/virtcontainers/{qemu,clh,fc,remote}*.go` | `src/runtime-rs/crates/hypervisor/src/{qemu,ch,firecracker,remote}/` |
+| Device management | `src/runtime/pkg/device/` | `src/runtime-rs/crates/hypervisor/src/device/` |
+| Network endpoints | `src/runtime/virtcontainers/*_endpoint.go` | `src/runtime-rs/crates/resource/src/network/endpoint/` |
+| Storage, mounts, cgroups | `src/runtime/virtcontainers/`, `src/runtime/pkg/resourcecontrol/` | `src/runtime-rs/crates/resource/` |
+| Agent client | `src/runtime/virtcontainers/kata_agent.go` | `src/runtime-rs/crates/agent/src/kata/` |
+| Sandbox state persistence | `src/runtime/virtcontainers/persist/` | `src/runtime-rs/crates/persist/` |
+| Configuration parsing | `src/runtime/pkg/katautils/config.go` | `src/libs/kata-types/src/config/` |
+| Annotations | `src/runtime/virtcontainers/pkg/annotations/annotations.go` | `src/libs/kata-types/src/annotations/mod.rs` |
+| Configuration templates | `src/runtime/config/configuration-*.toml.in` | `src/runtime-rs/config/configuration-*-runtime-rs.toml.in` |
+
+Note the last three rows: the `runtime-rs` side of configuration and
+annotations does not live under `src/runtime-rs/` at all. It lives in
+`src/libs/kata-types/`, which is shared. Agents routinely miss this and
+conclude, wrongly, that `runtime-rs` has no equivalent.
+
+### Configuration options and annotations
+
+A *new* option is `runtime-rs` only, so the touch list is:
+
+1. The templates in `src/runtime-rs/config/`, for every hypervisor flavour the
+   option applies to (`qemu`, `clh`, `fc`, `remote`, `dragonball`, plus the
+   confidential and NVIDIA GPU variants).
+2. The parser in `src/libs/kata-types/src/config/`, including the
+   per-hypervisor `validate()` and `adjust_config()` under
+   `src/libs/kata-types/src/config/hypervisor/`.
+3. `docs/how-to/how-to-set-sandbox-config-kata.md` if users can set it, and
+   `docs/migrating-config-go-runtime-to-runtime-rs.md`, since a new
+   `runtime-rs` option widens the documented gap between the two runtimes.
+4. Tests under `src/libs/kata-types/tests/`.
+
+*Fixing* how an existing option is parsed, validated or defaulted is a
+different matter. That option almost certainly exists on the Go side too, so
+check `src/runtime/pkg/katautils/config.go`, the struct in
+`src/runtime/virtcontainers/hypervisor.go`, the templates under
+`src/runtime/config/`, and `src/runtime/pkg/katautils/config_test.go`.
+
+Annotations split the same way. A new one is a constant in
+`src/libs/kata-types/src/annotations/mod.rs`, the code that applies it, a
+documentation row, and an entry in `enable_annotations` in the affected
+templates. A fix to an existing annotation should also be checked against
+`src/runtime/virtcontainers/pkg/annotations/annotations.go`.
+
+### What is deliberately not mirrored
+
+Do not manufacture parity where none is intended:
+
+- **Dragonball** is a real hypervisor only in `runtime-rs`. The Go runtime
+  returns a mock for it.
+- **StratoVirt** exists only in the Go runtime.
+- **`kata-monitor` and the `kata-runtime` CLI** live in `src/runtime` and serve
+  the Go runtime. The successor to `kata-runtime` is `kata-ctl`, a Rust rewrite
+  in `src/tools/kata-ctl` that is its own component rather than part of either
+  shim. `shim-ctl` in `runtime-rs` is not a CLI for users; it is a development
+  tool for driving the shim without containerd.
+- **VM cache and the `[factory]` machinery** are Go-only and deprecated.
+- **`mem-agent`, `use_passfd_io`, and component plugin selection** are
+  `runtime-rs`-only.
+- **`ppc64le`** ships only the Go runtime.
+- **NUMA mapping and network rate limiters** are not implemented in
+  `runtime-rs` yet. Closing that gap is legitimate work, but it is a feature in
+  its own right, not something to slip in alongside a bug fix.
+
+`docs/migrating-config-go-runtime-to-runtime-rs.md` is the authoritative list
+of intentional divergences. Read it before claiming a difference is a bug.
+
+### When you genuinely cannot do both
+
+Sometimes the counterpart change needs hardware you do not have, or is large
+enough to deserve its own review. That is fine, but say so:
+
+- Note it explicitly in the commit message or the pull request description.
+- Suggest that the user open a GitHub issue for the other runtime, with the
+  detail [any issue needs](#issues), and reference it with `Related: #NNN`.
+
+## Code conventions
+
+Read [`docs/code-pr-advice.md`](docs/code-pr-advice.md): it covers error
+handling, the narrow cases where Rust `unwrap()` and `expect()` are acceptable,
+Go struct construction, comments, logging and architecture-specific code. One
+thing it does not say:
+
+- **Copyright and SPDX headers** on every new file, required by the
+  `--licenses` static check for everything except Markdown. State the year of
+  first publication, as in `Copyright (c) 2026 Example Corporation`.
+
+## Traps
+
+Things that have cost real time in this repository:
+
+- **`make -C src/runtime check` silently does nothing.** Running it proves
+  nothing. Use `lint` and `test`.
+- **`cargo` commands run against the root workspace.** Most crates, including
+  `src/agent`, `src/libs/*`, `src/runtime-rs`, and the tools, are members of
+  the workspace defined by the root `Cargo.toml`. Running `cargo clippy` inside
+  a component directory still resolves upward, so `-p <crate>` is usually what
+  you want.
+- **The default Rust target is musl** (`LIBC=musl` in `utils.mk`), overridden
+  to gnu on `ppc64le`, `riscv64`, and `s390x`. A build that works for you with
+  the default host toolchain can still fail in CI. Install `musl-tools`.
+- **`clippy` runs with `-D warnings`.** A warning is a build failure. This
+  includes lints such as `too_many_arguments`, which will make you restructure
+  a function signature rather than suppress it.
+- **`Cargo.lock` is checked in and `clippy` runs with `--locked`.** Adding a
+  dependency means committing the lock file update, and `cargo deny` then has
+  an opinion about the licence.
+- **Generated files are diffed by CI.** Protocol bindings and the generated
+  configuration files must be regenerated and committed, not left for CI.
+- **Configuration templates are `.toml.in`, not `.toml`.** Editing a generated
+  `.toml` under a build directory changes nothing.
+- **Falling behind upstream inflates the "changed files" set.** Both
+  `tests/static-checks.sh` and `tools/testing/gatekeeper/skips.py` derive it
+  from a diff against `origin/<branch>`, so a branch that is behind gets linted
+  over files it never touched and, in CI, has gatekeeper schedule test suites
+  the change does not need. Rebase on upstream `main` as you go rather than once
+  at the end, and expect unrelated CI failures when you do not.
+- **`shim-v2-tarball` no longer exists.** It was split into
+  `shim-v2-go-tarball` and `shim-v2-rust-tarball`.
+
+## Issues
+
+You do not file, close or comment on issues, and you do not write the report
+either; see [What the agent must not do](#what-the-agent-must-not-do). What you can
+do is assemble the evidence, which is the laborious part and the part that bug
+reports most often lack. An issue without these two things sits untouched until
+somebody asks for them:
+
+- **A reproducer.** The smallest set of commands or the pod YAML that triggers
+  the problem, along with the Kata version, the hypervisor, the container
+  manager, and the host kernel and distribution.
+- **Logs captured with debug enabled.** Turn on full debug first, following
+  [`docs/Developer-Guide.md`](docs/Developer-Guide.md#enable-full-debug), then
+  reproduce, then collect the output of `kata-collect-data.sh`, which gathers
+  the configuration and the runtime, agent and hypervisor logs in one go.
+
+Hand those to the user and let them write the report.
+
+## Pull requests
+
+- Base your branch on an up-to-date `main`, rebase rather than merge, and rebase
+  again when it falls behind.
+- Keep unfinished work as a draft pull request. The `wip` and `do-not-merge`
+  labels and a `WIP` in the title also block the merge, and CI recognises them.
+- New features need documentation that says what the feature does, why it is
+  useful, how to use it, and what its limitations are.
+- Read [`docs/code-pr-advice.md`](docs/code-pr-advice.md) and the
+  [PR review guide](https://github.com/kata-containers/community/blob/main/PR-Review-Guide.md)
+  to see what a reviewer will be looking for.
+
+## Further reading
+
+- [`docs/Developer-Guide.md`](docs/Developer-Guide.md) — building and installing from source
+- [`docs/code-pr-advice.md`](docs/code-pr-advice.md) — what reviewers expect from code
+- [`docs/Unit-Test-Advice.md`](docs/Unit-Test-Advice.md) — the table-driven test style used here
+- [`docs/migrating-config-go-runtime-to-runtime-rs.md`](docs/migrating-config-go-runtime-to-runtime-rs.md) — how the two runtimes differ
+- [`docs/how-to/how-to-set-sandbox-config-kata.md`](docs/how-to/how-to-set-sandbox-config-kata.md) — the annotation reference
+- [`docs/Documentation-Requirements.md`](docs/Documentation-Requirements.md) — documentation style rules
+- [`tests/README.md`](tests/README.md) — the test suites and how to run them
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — the project-wide process, patch format and review flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ process documented here.
 > out of date were corrected on the way in. Process changes should land in both
 > places.
 
+[`AGENTS.md`](AGENTS.md) is a companion to this document aimed at AI coding
+agents. It describes the layout of this repository, the checks to run locally
+before submitting a pull request, and the traps that catch newcomers. Anybody
+sending a first patch may find it a useful quick reference.
+
 ## Code of Conduct
 
 All contributors must agree to the project [code of conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,1002 @@
-# Contributing
+# Contribute to the Kata Containers project
 
-## This repo is part of [Kata Containers](https://katacontainers.io)
+* [Code of Conduct](#code-of-conduct)
+* [AI generated code](#ai-generated-code)
+* [Pull requests](#pull-requests)
+* [GitHub basic setup](#github-basic-setup)
+    * [Prerequisites](#prerequisites)
+    * [Contributor roles](#contributor-roles)
+    * [Golang coding style](#golang-coding-style)
+    * [Rust coding style](#rust-coding-style)
+    * [Certificate of Origin](#certificate-of-origin)
+* [GitHub best practices](#github-best-practices)
+    * [Submit issues before PRs](#submit-issues-before-prs)
+    * [Issue tracking](#issue-tracking)
+    * [Closing issues](#closing-issues)
+* [GitHub workflow](#github-workflow)
+    * [Configure your environment](#configure-your-environment)
+    * [GitHub labels and keywords that block PRs](#github-labels-and-keywords-that-block-prs)
+* [Re-vendor PRs](#re-vendor-prs)
+* [Use static checks for validation](#use-static-checks-for-validation)
+    * [Fix failed static checks after submitting PRs](#fix-failed-static-checks-after-submitting-prs)
+    * [Kata runtime static checks](#kata-runtime-static-checks)
+* [Porting](#porting)
+    * [Porting labels](#porting-labels)
+    * [Stable branch backports](#stable-branch-backports)
+    * [Porting issue numbers](#porting-issue-numbers)
+    * [Porting comments](#porting-comments)
+    * [Forward ports](#forward-ports)
+    * [Porting examples](#porting-examples)
+* [Patch format](#patch-format)
+    * [General format](#general-format)
+    * [Subsystem](#subsystem)
+    * [Best practices for patches](#best-practices-for-patches)
+    * [Verification](#verification)
+    * [Examples](#examples)
+* [Reviews](#reviews)
+    * [Review Examples](#review-examples)
+* [Continuous Integration](#continuous-integration)
+* [Contact](#contact)
+* [Project maintainers](#project-maintainers)
 
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md).
+The Kata Containers project is an open source project licensed under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+It comprises a number of repositories under the [GitHub Kata
+Containers organisation](https://github.com/kata-containers). Unless
+explicitly stated otherwise, all the Kata Containers repositories follow the
+process documented here.
+
+> **Note:**
+>
+> This document originates in the
+> [community repository](https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md)
+> and lives here so that it is available to contributors and to tooling that
+> does not follow links out of the repository. A few statements that had gone
+> out of date were corrected on the way in. Process changes should land in both
+> places.
+
+## Code of Conduct
+
+All contributors must agree to the project [code of conduct](CODE_OF_CONDUCT.md).
+
+## AI generated code
+
+Contributions produced with the help of AI tools are accepted, provided
+they follow the
+[OpenInfra Foundation AI Policy](https://openinfra.org/legal/ai-policy/).
+In particular, contributors must:
+
+* Disclose AI usage in the commit message using the trailers defined by
+  the policy:
+    * `Assisted-By:` for predictive auto-complete or minor generative
+      assistance.
+    * `Generated-By:` when substantial portions of the change were
+      produced by a generative AI tool.
+* Stay "in the loop" and be able to fully understand, explain, and debug
+  any AI-produced code they submit.
+* Configure AI tools to respect open source licensing, and ensure the
+  output is compatible with the project license and does not infringe
+  third-party copyrights.
+
+The standard [Certificate of Origin](#certificate-of-origin) sign-off
+still applies, and reviewers may apply additional scrutiny to AI-assisted
+contributions as the policy recommends.
+
+## Pull requests
+
+All the repositories accept contributions via [GitHub Pull requests (PR)](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). Submit PRs by following the [GitHub workflow](#github-workflow).
+
+## GitHub basic setup
+
+To get started, complete the prerequisites below.
+
+### Prerequisites
+
+- Review [Contributor roles](#contributor-roles) that require special Git
+  configuration.
+
+- [Set up Git](https://help.github.com/en/github/getting-started-with-github/set-up-git).
+
+  >**Note:** The email address you specify must match the email address you
+  >use to sign-off commits.
+
+- [Fork and Clone](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the relevant repository at the
+  [Kata Containers Project](https://github.com/kata-containers).
+
+   Example: Your local clone should show `your-github-username`, as follows.
+   `https://github.com/${your-github-username}/community`.
+
+### Contributor roles
+
+Special Git configuration is required for these contributors:
+
+* [Golang coding style](#golang-coding-style)
+* [Rust coding style](#rust-coding-style)
+* [Kata runtime static checks](#kata-runtime-static-checks)
+
+For all other contributor roles, follow the standard configuration, shown in
+Prerequisites.
+
+### Golang coding style
+
+* Review [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) to avoid common `Golang` errors.
+* Use `gofmt` to fix any mechanical style issues.
+
+### Rust coding style
+
+* Use `rustfmt` to fix any mechanical style issues. `Rustfmt` uses a style which conforms to the
+[Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md).
+* Use `clippy` to catch common mistakes and improve your Rust code.
+
+You can install the above tools as follows.
+
+```sh
+$ rustup component add rustfmt clippy
+```
+
+### Certificate of Origin
+
+In order to get a clear contribution chain of trust we use the [signed-off-by
+language](https://ltsi.linuxfoundation.org/software/signed-off-process/)
+used by the Linux kernel project.
+
+## GitHub best practices
+
+### Submit issues before PRs
+
+It can be helpful to raise a GitHub issue before starting work on a PR for a new feature/bug to let the community
+know that you are planning to work on an item.
+
+### Issue tracking
+
+To report a bug that is not already documented, please open a GitHub issue for the repository in question.
+
+If it is unclear which repository to raise your query against, first try to
+get in [contact](#contact) with us. If in doubt, raise the issue
+[here](https://github.com/kata-containers/community/issues/new) and we will
+help you to handle the query by routing it to the correct area for resolution.
+
+### Closing issues
+
+When a PR resolves a reported issue, add a `Fixes` comment to at least one of its commits. This is not enforced by tooling, but it triggers GitHub to close the issue automatically once the PR is merged:
+
+```
+pod: Remove token from Cmd structure
+
+The token and pid data will be hold by the new Process structure and
+they are related to a container.
+
+Fixes #123
+
+Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
+```
+
+The issue is automatically closed by GitHub when the
+[commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) is parsed.
+
+## GitHub workflow
+
+Kata Containers employs certain augmentations to a
+[standard GitHub workflow](https://guides.github.com/introduction/flow/).
+In this section, we explain these augmentations in more detail. Follow these guidelines when contributing to Kata Containers repositories, except where noted below.
+
+* Complete the [GitHub basic setup](#github-basic-setup) above before continuing.
+
+* Ensure each PR only covers one topic. If you mix up different items in
+  your patches or PR, they will likely need to be reworked.
+
+* Follow a [topic branch method](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches) for development.
+
+* Follow carefully the [patch format](#patch-format) for PRs.
+
+* Apply the appropriate GitHub labels to your PR. This
+  is particularly relevant to maintain [Stable branch backports](#stable-branch-backports). See also [GitHub labels and keywords that block PRs](#github-labels-and-keywords-that-block-prs)
+
+  >**Note:** External contributors should use keywords, explained in the
+  >link above. Labels may not be visible to external contributors.
+
+* [Rebase](https://help.github.com/en/github/using-git/about-git-rebase)
+  commits on your branch and `force push` after each cycle of feedback.
+
+### Configure your environment
+
+Most [Kata Containers repositories](https://github.com/kata-containers)
+contain code written in the [Go language (golang)](https://golang.org/). Go
+requires all code to be put inside the directory specified by the `$GOPATH`
+variable. Follow this example to put the code in the standard location.
+
+```sh
+$ export GOPATH=${GOPATH:-$HOME/go}
+$ mkdir -p "$GOPATH"
+```
+
+For further details on `golang`, refer to the
+[requirements section of the Kata Developer Guide](https://github.com/kata-containers/kata-containers/blob/main/docs/Developer-Guide.md#requirements-to-build-individual-components).
+
+>*Note*: If you intend to make minor edits, it's acceptable
+> to simply fork and clone without adding the GOPATH variable.
+
+#### Fork and clone
+
+In this example, we configure a Git environment to contribute to this very
+`Community` repo. We create a sample branch, incorporate reviewer feedback, and rebase our commits.
+
+1. Fork the [upstream repository](https://help.github.com/articles/cloning-a-repository):
+
+1. [Clone your forked copy of the upstream repository](https://help.github.com/articles/cloning-a-repository):
+
+1. While on your *forked copy*, select the green button `Clone or download`
+   and copy the URL.
+
+1. Run the commands below and **paste the copied URL** (previous step),
+   so your real GitHub user name replaces `your-github-username` below.
+
+```sh
+$ dir="$GOPATH/src/github.com/kata-containers"
+$ mkdir -p "$dir"
+$ cd "$dir"
+$ git clone https://github.com/{your-github-username}/community
+$ cd community
+```
+
+>**Note:** Cloning a forked repository automatically gives a remote `origin`.
+
+#### Configure the upstream remote
+
+Next, add the remote `upstream`. Configuring this remote allows you to
+synchronize your forked copy, `origin`, with the `upstream`. The
+`upstream` URL varies by repository. We use the `upstream` from the Community for this example.
+
+1. Change directory into `community`.
+
+1. Set the remote `upstream` as follows.
+
+    ```sh
+    $ git remote add upstream https://github.com/kata-containers/community
+    ```
+
+1. Run `git remote -v`. Your remotes should appear similar to these:
+
+    ```
+    origin  https://github.com/your-github-username/community.git (fetch)
+    origin  https://github.com/your-github-username/community.git (push)
+    upstream  https://github.com/kata-containers/community (fetch)
+    upstream  https://github.com/kata-containers/community (push)
+    ```
+
+For more details, see how to [set up a git remote](https://help.github.com/articles/configuring-a-remote-for-a-fork).
+
+#### Create a topic branch
+
+1. Create a new "topic branch" to do your work on:
+
+    ```
+    $ git checkout -b fix-contrib-bugs
+    ```
+
+    >**Warning:** *Never* make changes directly to the `main` branch
+    >--*always* create a new "topic branch" for PR work.
+
+1. Make some editorial changes. In this example, we modify the file that
+   you are reading.
+
+    ```
+    $ $EDITOR CONTRIBUTING.md
+    ```
+
+   >**Note:** If editing in Windows make sure that all documents end with LF
+   > and not CRLF. The CI system will fail if carriage returns are in the
+   > document. Many editors support the ability to change this. There is a
+   > tool called dos2unix available on Git Bash for Windows and also available
+   > on Linux systems that can convert files to LF endings. See the
+   > [Configuring Git to handle line endings](https://docs.github.com/en/github/getting-started-with-github/getting-started-with-git/configuring-git-to-handle-line-endings)
+   > guide for more details on how to configure `git` to automatically insert
+   > the correct line endings.
+
+1. Commit your changes to the current (`fix-contrib-bugs`) branch. Assure
+   you use the correct [patch format](#patch-format):
+
+    ```
+    $ git commit -as
+    ```
+
+1. Push your local `fix-contrib-bugs` branch to your remote fork:
+
+    ```
+    $ git push -u origin fix-contrib-bugs
+    ```
+
+   >**Note:** The `-u` option tells `git` to "link" your local clone with
+   > your remote fork so that it knows from now on that the local repository
+   > and the remote fork refer to "the same" upstream repository. Strictly
+   >speaking, this option is only required the first time you call `git push`
+   >for a new clone.
+
+1. Create the PR:
+  - Browse to https://github.com/kata-containers/community.
+  - Click the "Compare & pull request" button that appears.
+  - Click the "Create pull request" button.
+
+  >**Note:** You do not need to change any of the defaults on this page.
+
+#### Update your PR based on review comments
+
+Suppose you received some reviewer feedback that asked you to make some
+changes to your PR. You updated your local branch and committed those
+review changes by creating three commits. There are now four commits in your
+local branch: the original commit you created for the PR and three other
+commits you created to apply the review changes to your branch. Your branch
+now looks something like this:
+
+```sh
+$ git log main.. --oneline --decorate=no
+4928d57 docs: Fix typos and fold long lines
+829c6c8 apply review feedback changes
+7c9b1b2 remove blank lines
+60e2b2b doh - missed one
+```
+
+>**Note:** The `git log` command compares your current branch
+>(`fix-contrib-bugs`) with the `main` branch and lists all the commits,
+>one per line.
+
+#### Git rebase if multiple commits
+
+Since all four commits are related to *the same change*, it makes sense to
+combine all four commits into a *single commit* on your PR. You need to
+[git rebase](https://help.github.com/github/using-git/about-git-rebase)
+multiple commits on your branch. Follow these steps.
+
+1. Update the `main` branch in your local copy of the upstream
+   repository:
+
+    ```
+    $ cd $GOPATH/src/github.com/kata-containers/community
+    $ git checkout main
+    $ git pull --rebase upstream main
+    ```
+
+    The previous command downloads all the latest changes from the upstream
+    repository and adds them to your *local copy*.
+
+1. Now, switch back to your PR branch:
+
+    ```
+    $ git checkout fix-contrib-bugs
+    ```
+
+1. Rebase your changes against the `main` branch.
+
+    ```sh
+    $ git rebase -i main
+    ```
+
+    Example output:
+
+    ```sh
+    pick 2e335ac docs: Fix typos and fold long lines
+    pick 6d6deb0 apply review feedback changes
+    pick 23bc01d remove blank lines
+    pick 3a4ba3f doh - missed one
+    ```
+
+1. In your editor, read the comments at the bottom of the screen.
+   Do not modify the first line, `pick 2e335ac docs: Fix typos ...`. Instead, revise `pick` to `squash` at the start of all following lines.
+
+    Example output:
+
+    ```sh
+    pick 2e335ac docs: Fix typos and fold long lines
+    squash 6d6deb0 apply review feedback changes
+    squash 23bc01d remove blank lines
+    squash 3a4ba3f doh - missed one
+    ```
+
+1. Save your changes and quit the editor. Git puts you *back* into your
+   editor. You will see all the commit *messages*.
+
+1. At top is your first commit, which should be in the
+   [correct format](#patch-format). Keep your first commit and delete
+   all the following commits, as appropriate, based on
+   the review feedback.
+
+1. Save the file and quit the editor. Once this operation completes, the four
+   commits will have been converted into a single new commit. Check this by
+   running the `git log` command again:
+
+    ```sh
+    $ git log main.. --oneline --decorate=no
+    3ea3aef docs: Fix typo
+    ```
+
+1. Force push your updated local `fix-contrib-bugs` branch to `origin`
+   remote:
+
+    ```sh
+    $ git push -f origin fix-contrib-bugs
+    ```
+
+>**Note:** Not only does this command upload your changes to your fork, it
+>also includes the *latest upstream changes* to your fork since you ran
+>`git pull --rebase upstream main` on the main branch and then merged
+>those changes into your PR branch. This ensures your fork is now "up to
+>date" with the upstream repository. The `-f` option is a "force push". Since
+>you created a new commit using `git rebase`, you must "overwrite" the old
+>copy of your branch in your fork on GitHub.
+
+Your PR is now updated on GitHub. To ensure team members are aware of this,
+leave a message on the PR stating something like, "Review feedback applied".
+This notification allows the team to once again review your PR more quickly.
+
+### GitHub labels and keywords that block PRs
+
+Kata Containers CI systems have two methods that allow marking
+PRs to prevent them being merged. This practice is often used during
+development. The two methods are: 1) Use
+[GitHub labels](https://help.github.com/articles/about-labels/)
+or; 2) Use keywords in the PR subject line. The keywords can appear anywhere
+in the subject line.
+
+The following table summarises some common scenarios and appropriate use
+of labels or keywords:
+
+| Scenario | GitHub label | PR description contains |
+| -------- | ------------ | ----------------------- |
+| PR created "as an idea" and feedback sought | `rfc` | RFC |
+| PR incomplete - needs more work or rework | `do-not-merge` `wip` | WIP |
+| PR should not be merged (has all required approvals, but needs more reviewer input) | `do-not-merge` | |
+| PR is a "work In progress", raised to get early feedback | `wip` | WIP |
+| PR is complete but depends on another so should not be merged (yet) | `do-not-merge` | |
+
+If any of the values in the table above are set on a PR, it will be
+automatically blocked from merging.
+
+>**Note:** Often during discussions, the abbreviated and full terms are
+>used interchangeably. For instance, often `DNM` is used in discussions as
+>shorthand for `do-not-merge`. The CI systems only recognise the above
+>phrases as shown.
+
+## Re-vendor PRs
+
+If you raise a PR to update the vendored copy of one or more golang packages,
+after running the
+[`dep`](https://github.com/kata-containers/community/blob/main/VENDORING.md) command, ensure you add any modified files under the `vendor/` directory to Git before committing the changes:
+
+```sh
+$ git add vendor/
+```
+
+There are two critical pieces of information you need to add to the commit
+body:
+
+- A brief explanation why the re-vendor is required.
+
+  For example, you should state if an important bug fix or new feature is
+  required, or if a particular commit is needed.
+
+- The range of commits being added for these third-party packages.
+
+  It is possible that re-vendoring a particular package will also result in
+  updates to other dependent packages. However, it is important to include
+  the commit range (even if it is big) for the primary package(s) the
+  re-vendor PR is raised for.
+
+  These details allow for easier troubleshooting if the re-vendor PR
+  introduces bug or behavioral changes.
+
+  Generate the list of new commits added to the primary re-vendored
+  package by comparing the previous and latest commits for the package being re-vendored.
+
+  The following example lists the steps you should take if a new version of
+  `libcontainer` (part of the `runc` repository) is required:
+
+  1. Determine the previous and latest commits for the package by looking at
+     the `diff` of the `Gopkg.toml` file in your branch.
+
+  1. Run the commands below:
+
+     ```bash
+     $ go get -d -u github.com/opencontainers/runc
+     $ cd $GOPATH/src/github.com/opencontainers/runc
+     $ old_commit="..."
+     $ new_commit="..."
+     $ git log --no-merges --abbrev-commit --pretty=oneline "${old_commit}..${new_commit}" | sed 's/^/    /g'
+     ```
+
+  Paste the output of the previous command directly into the commit "as-is".
+  Note that the four space indent added by the `sed` command is used to force
+  GitHub to render the list in a fixed-width font, which makes it easier to
+  read.
+
+For additional information on using the `dep` tool, see
+"[Performing vendoring for the Kata Containers project](https://github.com/kata-containers/community/blob/main/VENDORING.md)".
+
+## Use static checks for validation
+
+* Kata Containers utilizes [Continuous Integration (CI)](#continuous-integration) to automatically check every PR.
+
+* We strongly encourage you to run the same CI tests on individual PRs, using [static checks](https://github.com/kata-containers/tests/blob/main/.ci/static-checks.sh)
+
+In repositories where a `Makefile` is present, you can execute
+static checks for testing and development. To do so, invoke the `make check` and `make test` rules, after developer mode is enabled.
+
+```sh
+$ export KATA_DEV_MODE=true
+$ make check
+$ make test
+```
+Running these checks should result in **no errors**. If errors are reported, fix them before submitting your PR.
+
+To replicate the static checks performed by the CI system:
+
+- [x] Ensure you have a "clean" source tree, as the checks cover all files
+  present. Checks might fail if you have extra files or your files are out of date in your tree.
+
+- [x] Ensure [`golangci-lint`](https://github.com/golangci/golangci-lint) is
+current or has not been previously installed (the static check scripts will
+install it if necessary). Changing the linters used or the Kata
+Containers code base can produce spurious errors that do not fail inside the
+CI systems.
+
+### Fix failed static checks after submitting PRs
+
+Some submitted PRs fail to pass static checks. After such a PR fails,
+view its build logs to determine the cause of failure.
+
+1. At the bottom of the PR, if a message appears, "Some checks were not
+   successful,"  select "Details", as shown below.
+
+    ![Failed CI-CD](https://raw.githubusercontent.com/kata-containers/community/main/fig1-ci-cd-failure.png)
+
+1. Upon entering the Travis CI* web page, select the first number that
+   appears below "Build jobs."
+
+1. Scroll to the bottom of the build log and view the `ERROR` message(s).
+   In the example below, the `ERROR` reads: `... no
+   signed-off-by specified`. This is a requirement. To fix, use the signed-off-by method while pushing a commit. See [Patch format](
+   #patch-format) for more details.
+
+    ![Build log error messages](https://raw.githubusercontent.com/kata-containers/community/main/fig2-ci-cd-log.png)
+
+### Kata runtime static checks
+
+If working on `kata-runtime`, first ensure you run `make` and `make install`
+in the `virtcontainers` subdirectory, as shown below. For more information,
+see [virtcontainers](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/documentation/Developers.md#testing).
+
+```bash
+$ pushd runtime/virtcontainers
+$ make
+$ sudo -E PATH=$PATH make install
+$ popd
+```
+
+>**Note:** The final `popd` is required to return to the top-level directory
+>from where other build rules can be executed.
+
+## Porting
+
+Porting applies a patch set to an older ("backport") or a newer
+("forward-port") branch or repository.
+
+Backporting is necessary to ensure that older -- but still maintained --
+releases benefit from bug fixes already applied to newer releases.
+
+Forward porting is necessary where there are multiple development streams and
+bug fixes or new features have been applied to the older stream, but not the
+newer one.
+
+> **Note:**
+>
+> Stable branches are considered maintenance branches, not development
+> branches. Bug fixes must land in a newer development branch before landing
+> in a stable branch to ensure the changes have been tested thoroughly before
+> being applied to a stable release (maintenance) branch.
+
+Porting is performed with a new PR meaning porting PRs *must* have an
+associated "parent" PR (the original bug fix or feature PR).
+
+Every PR must indicate whether it should be ported in either direction;
+*backwards* (backport) or *forwards* (forward port). This is achieved by
+adding up to two labels per PR which signal the porting requirements for the
+PR.
+
+The [stable branch backports](#stable-branch-backports) section provides
+information on the sorts of changes which should be backported.
+
+### Porting labels
+
+The table below lists all valid combinations of GitHub labels. Every PR must
+be labelled as shown in the table row that most closely corresponds to the
+type of PR the user is raising.
+
+> **Notes:**
+>
+> - The porting labels are enforced by a
+>   [GitHub action](https://github.com/kata-containers/.github/blob/main/scripts/pr-porting-checks.sh).
+>   This means that *PRs that do not have a valid set of porting labels cannot be merged*.
+> - The "Common PR type" column in the table shows the most likely type of PR, but
+>   this is just a guide.
+> - A `backport` or `forward-port` labelled PR **must** have an associated
+>   parent PR which caused the backport or forward port PR to be raised.
+
+| PR summary | Common PR type | Backport label | Forward port label | Notes |
+|-|-|-|-|-|
+| A "standalone" PR | Feature | `no-backport-needed` | `no-forward-port-needed` | PR does not need to be ported. For example, a PR used to add a new feature to the latest release. |
+| PR that needs to be backported only | Bug fix | `needs-backport` | `no-forward-port-needed` | |
+| PR that needs to be forward ported only | Bug fix or feature | `no-backport-needed` | `needs-forward-port` | |
+| PR that needs to be ported backwards *and* forwards | Bug fix | `needs-backport` |  `needs-forward-port` | For example a Kata 1.x PR that needs to be ported to Kata 2.0 *and* to one or more Kata 1.x stable branches. |
+| A backport PR | Bug fix | `backport` | | PR to actually make the backport changes.<br/><br/>Must have an associated "parent" PR.<br/><br/>Title **must** contain original PRs title. |
+| A forward port PR | Bug fix or feature | |  `forward-port` | PR to actually make the forward port changes.<br/><br/>Must have an associated "parent" PR.<br/><br/>Title **must** contain original PRs title. |
+
+If you are not a member of the GitHub repository the PR is raised in, you may
+not be able to see the GitHub labels. In this scenario, please add a comment
+asking for the porting labels to be applied.
+
+Forward port and backport PRs by definition should not be raised in isolation:
+there must be an existing PR that caused the porting PR to be raised.
+
+If you know whether a PR should be backported or forward ported, please add
+a comment on the PR if you are unable to add the appropriate labels. If you do
+not know whether a PR should be backported or forward ported, the community
+will work with you to identify any porting requirements and to help with
+porting activities.
+
+### Stable branch backports
+
+Kata Containers maintains a number of stable branch releases. Bug fixes to
+the main branch are selectively applied to (or "backported") these stable branches.
+
+In order to aid identification of commits that potentially should be
+backported to the stable branches, all PRs submitted must be labeled with
+one or more of the following labels. At least one label that is *not*
+`stable-candidate` must be included.
+
+| Label              | Meaning |
+| -----              | ------- |
+| `bug`              | A bug fix, which will potentially be a backport candidate |
+| `cleanup`          | A cleanup, which will likely not be backported                 |
+| `feature`          | A new feature/enhancement, that will likely not be backported  |
+| `stable-candidate` | A PR selected for backporting - very likely a bug fix          |
+| `vendor`           | A golang vendor update. Might be considered for backport if the vendor update includes critical bug fixes |
+
+In the event that a bug fix PR is selected for backporting to the stable
+branches, the `stable-candidate` label is added if not already present, and
+the original author of the PR is asked if they will submit the relevant
+backport PRs. For a quick guide on how to perform and submit a backport, see
+the [Backport Guide](https://github.com/kata-containers/community/blob/main/Backport-Guide.md) in this repository.
+
+### Porting issue numbers
+
+For ports that are within the same repository (for example a stable backport
+to a 1.x PR), specify the same issue number as the original PR in the "fixes
+comment". See the [patch format](#patch-format) section for further details.
+
+For ports in different repositories, create a new issue, referencing the
+original issue URL in the issue text.
+
+### Porting comments
+
+Issues and PRs can only be linked if they are within the same repository.
+Since Kata 2.x uses a new central repository, it is essential to add a special
+comment to the **original PR** when new port PRs are created.
+
+| Port type | Port comment format |
+|-|-|
+| backport | `backport PR: <backport-pr-url>` |
+| forward port| `forward port PR: <forward-port-pr-url>` |
+
+> **Notes:**
+>
+> - The special comments **must** appear at the start of a line.
+>
+> - The special comments are used by tooling to check that porting has been
+>   completed correctly.
+>
+> - Although these comments strictly make the `backport` and `forward-port`
+>   labels redundant, these labels are useful for general reporting since
+>   users can search for "all port PRs in a particular repository" for
+>   example.
+
+### Forward ports
+
+Forward ports tend to be much less common than backports. However,
+consolidating a number of standalone repositories into a single repository for
+the Kata 2.0 development effort introduced a potential forward port
+requirement. At the time, both Kata 1.x and 2.0 versions were being developed
+in parallel. This meant that lots of PRs raised in the Kata 1.x repositories
+needed to be forward ported to the Kata 2.0 repository (since this was to be
+the next major release and needed to contain all bug fixes and features where
+possible).
+
+| Initial PR raised | PR type | Backport? | Forward port? |
+|-|-|-|-|
+| Particular 1.x repository | bug fix | stable branches | 2.0 repository |
+| Particular 1.x repository | feature | | 2.0 repository |
+| The 2.0 repository | bug fix | 1.x (and maybe stable branches) | - |
+| The 2.0 repository | feature | | - |
+
+### Porting examples
+
+#### Backport and forward port example
+
+Imagine that you have just raised a new PR on a Kata 1.x repository. The PR
+contains three commits:
+
+- A commit to fix a "typo" in a comment.
+- A commit that changes the way a container is destroyed (and updates the tests).
+- A commit that updates the documentation explaining the new contain
+  destruction behaviour.
+
+Since the PR is not adding any new functionality and since it is correcting
+problems with existing code, it can be considered a bug fix PR. Bug fixes
+should generally be backported. However, this PR was raised in a Kata 1.x
+repository meaning it should also potentially be forward-ported to the Kata
+2.0 repository.
+
+Looking at the tables in the [porting labels](#porting-labels) and the [stable
+branch backports](#stable-branch-backports) sections shows that this PR needs
+to be labelled with the following labels:
+
+- `needs-backport`
+- `needs-forward-port`
+- `stable-candidate`
+
+Once this PR is approved and is merged in the Kata 1.x repository, it should
+now be backported and forward ported:
+
+- Backport: Raise new PRs on the currently maintained stable releases
+
+  - These PRs should be labelled with the `backport` label.
+  - The commit message should mention the original PR.
+  - The commit message should reference the *original* issue number in the
+    ["fixes" comment](#patch-format).
+
+- Forward port: Raise a new PR on the Kata 2.0 repository
+
+  - This PR should be labelled with the `forward-port` label.
+  - The commit message should mention the original PR.
+  - A new issue should be used for the PR and the original issue URL
+    referenced in the issue text.
+
+- Add [porting comments](#porting-comments) to the *original PR* with two comments,
+  one for each port:
+
+  ```
+  backport PR: https://github.com/kata-containers/runtime/pull/XXX
+  forward port PR: https://github.com/kata-containers/kata-containers/pull/YYY
+  ```
+
+#### Double backport example
+
+Imagine that you have just raised a new PR on the Kata 2.x repository. The PR
+fixes a nasty runtime bug, and adds some new unit tests to guarantee no future
+regression.
+
+This is a pure bug fix PR. There is no "newer" branch or version, so it is not
+possible to forward port. However, since the PR is an important bug fix, it
+should be backported, both to Kata 1.x *and* the Kata 1.x stable branches.
+
+Looking at the tables in the [porting labels](#porting-labels) and the [stable
+branch backports](#stable-branch-backports) sections shows that this PR needs
+to be labelled with the following labels:
+
+- `needs-backport`
+- `no-forward-port-needed`
+- `stable-candidate`
+
+Once this PR is approved and is merged in the Kata 2.0 repository, it should
+now be backported *twice*:
+
+- Kata 1.x: Raise a new PR on the Kata 1.x runtime repository
+
+  - This PR should be labelled with the `backport` label.
+  - The commit message should mention the original PR.
+
+- Stable backports: Raise new PRs on each of the currently maintained stable
+  branches in the Kata 1.x runtime repository
+
+  - These PRs should be labelled with the `backport` label.
+  - The commit message should mention the original PR.
+  - The commit message should reference the issue number used in the
+    ["fixes" comment](#patch-format) for the 1.x PR
+    (since that is in the same repository).
+
+- Add [porting comments](#porting-comments) to the *original PR* with two comments,
+  one for each port:
+
+  ```
+  backport PR: https://github.com/kata-containers/runtime/pull/XXX
+  backport PR: https://github.com/kata-containers/runtime/pull/YYY
+  ```
+
+## Patch format
+
+### General format
+
+Beside the `Signed-off-by` footer, we expect each patch to comply with the
+following format:
+
+```
+subsystem: One line change summary
+
+More detailed explanation of your changes (why and how)
+that spans as many lines as required.
+
+A "Fixes #XXX" comment listing the GitHub issue this change resolves, if it
+resolves one. Add it to the main patch in a sequence. See the following examples.
+
+Signed-off-by: Contributors Name <contributor@foo.com>
+```
+
+#### Pull request format
+
+As shown above, pull requests must adhere to these guidelines:
+
+* Preface the PR title with the appropriate keyword found in [Subsystem](#subsystem)
+
+* Ensure PR title length is 75 characters or fewer, including whichever
+  `subsystem` term is used.
+
+* Ensure the PR body line length is 150 characters or fewer.
+
+The body of the message is **not** a continuation of the subject line and is
+not used to extend the subject line beyond its character limit. The subject
+line is a complete sentence and the body is a complete, standalone paragraph.
+
+Additionally, PR body line length is not checked for special lines:
+
+* Lines that do not start with an alphabetic character
+
+* Sign-off lines (as to not penalize long names)
+
+* Lines without spaces
+
+These should allow contributors to pass checks while including relevant
+information **if needed**.
+
+### Subsystem
+
+The "subsystem" describes the area of the code that the change applies to.
+It does not have to match a particular directory name in the source tree
+because it is a "hint" to the reader. The subsystem is generally a single
+word. Although the subsystem must be specified, it is not validated. The
+author decides what is a relevant subsystem for each patch.
+
+Examples:
+
+| Subsystem | Description |
+|--|--|
+| `build` | `Makefile` or configuration script change |
+| `cli` | Change affecting command line options or commands |
+| `docs` | Documentation change |
+| `logging` | Logging change |
+| `vendor` | [Re-vendoring](#re-vendor-prs) change |
+
+To see the subsystem values chosen for existing commits:
+
+```
+$ git log --no-merges --pretty="%s" | cut -d: -f1 | sort -u
+```
+
+### Best practices for patches
+
+We recommend that each patch fixes one thing. Smaller patches are easier to
+review, more likely to be accepted and merged, and more conducive for
+identifying problems during review.
+
+A PR can contain multiple patches. These patches should generally be related
+to the [main patch](#main-patch) and the overall goal of the PR. However, it
+is also acceptable to include additional or
+[supplementary patches](#supplementary-patch) for things such as:
+
+- Formatting (or whitespace) fixes
+- Comment improvements
+- Tidy up work
+- Refactoring to simplify the codebase
+
+### Verification
+
+Correct formatting of the PR patches is verified using the commit-message-check GitHub Action.
+
+### Examples
+
+#### Main patch
+
+The following is an example of a full patch description for the main change, showing a "`Fixes #XXX`" comment that references the GitHub issue this patch resolves:
+
+```
+pod: Remove token from Cmd structure
+
+The token and pid data will be hold by the new Process structure and
+they are related to a container.
+
+Fixes: #123
+
+Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
+```
+
+#### Supplementary patch
+
+If a PR contains multiple patches, [only one of those patches](#main-patch) should specify the "`Fixes #XXX`" comment. Supplementary patches have an identical format to the main patch, but do not specify a "`Fixes #XXX`"
+comment.
+
+Example:
+
+```
+image-builder: Fix incorrect error message
+
+Fixed an error message which was referring to an incorrect rootfs
+variable name.
+
+Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
+```
+
+## Reviews
+
+Before your PRs are merged into the main code base, they are reviewed. We
+encourage anybody to review any PR and leave feedback.
+
+See the [PR review guide](https://github.com/kata-containers/community/blob/main/PR-Review-Guide.md) for tips on performing a
+careful review.
+
+We use the GitHub [Required Reviews](https://help.github.com/articles/approving-a-pull-request-with-required-reviews/)
+system for reviewers to note if they agree or disagree with a PR. To have
+an acknowledgment or "nack" registered with GitHub, you **must** use the
+GitHub "Review changes" dialog to leave feedback. Notes left only in the
+comments fields, whilst sometimes useful, will not get registered
+in the acknowledgment counting system.
+
+Documentation PRs can sometimes use a modified process explained in the
+[Documentation Review Process](https://github.com/kata-containers/community/blob/main/Documentation-Review-Process.md) guide.
+
+### Review Examples
+
+The following is an example of a valid "ack", as long as
+the "Approve" box is ticked in the Review changes dialog:
+
+```
+Excellent work - thanks for your contribution.
+
+lgtm
+```
+
+## Continuous Integration
+
+The Kata Containers project has a gating process to prevent introducing
+regressions. When your PR is submitted, a Continuous Integration (CI) system
+will run different checks on different platforms, based upon your changes. Currently Kata uses [Jenkins](http://jenkins.katacontainers.io)
+for testing your changes.
+
+Some of the checks are:
+
+- Static analysis checks.
+- Unit tests.
+- Functional tests.
+- Integration tests.
+
+The Jenkins jobs will wait to be triggered. A maintainer must add a `/test`
+comment on the PR to let the CI jobs run.
+
+All CI jobs must pass in order to merge your PR.
+
+## Contact
+
+The Kata Containers community can be reached
+[through various channels](https://github.com/kata-containers/community#join-us).
+
+## Project maintainers
+
+The Kata Containers project maintainers are the people accepting or
+rejecting any PR. Although [anyone can review PRs](#reviews), only the
+acknowledgement (or "ack") from an Approver counts towards the approval of a PR.
+
+Approvers are listed in GitHub teams, one for each repository. The project
+uses the
+[GitHub required status checks](https://help.github.com/en/articles/enabling-required-status-checks)
+along with the [GitHub `CODEOWNERS`file](https://help.github.com/en/articles/about-code-owners) to specify who can approve PRs. All repositories are configured to require:
+
+- Two approvals from the repository-specific approval team.
+
+- One [documentation team](https://github.com/orgs/kata-containers/teams/documentation/members) approval if the PR modifies documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,11 @@ Containers organisation](https://github.com/kata-containers). Unless
 explicitly stated otherwise, all the Kata Containers repositories follow the
 process documented here.
 
+[`AGENTS.md`](AGENTS.md) is a companion to this document aimed at AI coding
+agents. It describes the layout of this repository, the checks to run locally
+before submitting a pull request, and the traps that catch newcomers. Anybody
+sending a first patch may find it a useful quick reference.
+
 ## Code of Conduct
 
 All contributors must agree to the project [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Add AGENTS.md, a guide for AI coding agents working in this repository,
with CLAUDE.md symlinked to it. AGENTS.md is the name Cursor, Codex,
Gemini and Copilot look for, CLAUDE.md the one Claude Code looks for.

It covers a map of the repository, the commit format and which parts of
it commit-message-check enforces, the checks to run locally before
submitting ordered by how long they take, how to find the counterpart of
a change in the other runtime and where parity is deliberately not
intended, and which actions are the contributor's to take rather than
the agent's.

CONTRIBUTING.md links to it.

Fixes: https://github.com/kata-containers/kata-containers/issues/13028

Assisted-by: Cursor (Claude Opus 5)