### PR TITLE
packaging: split the static release tarball by runtime

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: ${{ (matrix.vmm == 'dragonball' || endsWith(matrix.vmm, '-runtime-rs')) && format('kata-static-tarball-amd64{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-amd64{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata
@@ -118,11 +118,20 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: ${{ (matrix.vmm == 'dragonball' || endsWith(matrix.vmm, '-runtime-rs')) && format('kata-static-tarball-amd64{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-amd64{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
+
+      - name: get-kata-tools-tarball
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-tools-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-tools-artifacts
 
       - name: Install kata
         run: bash tests/stability/gha-run.sh install-kata kata-artifacts
+
+      - name: Install kata-tools
+        run: bash tests/stability/gha-run.sh install-kata-tools kata-tools-artifacts
 
       - name: Run containerd-stability tests
         timeout-minutes: 15
@@ -167,7 +176,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: ${{ (matrix.vmm == 'dragonball' || endsWith(matrix.vmm, '-runtime-rs')) && format('kata-static-tarball-amd64{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-amd64{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: get-kata-tools-tarball
@@ -225,7 +234,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: ${{ (matrix.vmm == 'dragonball' || endsWith(matrix.vmm, '-runtime-rs')) && format('kata-static-tarball-amd64{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-amd64{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata
@@ -279,7 +288,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: ${{ (matrix.vmm == 'dragonball' || endsWith(matrix.vmm, '-runtime-rs')) && format('kata-static-tarball-amd64{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-amd64{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata
@@ -329,8 +338,18 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
+          # No VMM matrix: the pod VM tests boot the default runtime-rs
+          # package.
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
+
+      - name: get-kata-agent-tarball
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          # The host agent binary lives in the per-component agent artifact:
+          # the merged tarballs only ship the agent inside the guest images.
+          name: kata-artifacts-amd64-agent${{ inputs.tarball-suffix }}
+          path: kata-agent-artifacts
 
       - name: get-kata-tools-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -338,9 +357,10 @@ jobs:
           name: kata-tools-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-tools-artifacts
 
-      - name: Install kata & kata-tools
+      - name: Install kata, kata-agent & kata-tools
         run: |
           bash tests/functional/kata-agent-apis/gha-run.sh install-kata kata-artifacts
+          bash tests/functional/kata-agent-apis/gha-run.sh install-kata-agent kata-agent-artifacts
           bash tests/functional/kata-agent-apis/gha-run.sh install-kata-tools kata-tools-artifacts
 
       - name: Run kata agent api tests with agent-ctl

--- a/.github/workflows/basic-ci-s390x.yaml
+++ b/.github/workflows/basic-ci-s390x.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
+          name: ${{ endsWith(matrix.vmm, '-runtime-rs') && format('kata-static-tarball-s390x{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-s390x{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata
@@ -124,7 +124,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
+          name: ${{ endsWith(matrix.vmm, '-runtime-rs') && format('kata-static-tarball-s390x{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-s390x{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata
@@ -167,7 +167,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
+          name: ${{ endsWith(matrix.vmm, '-runtime-rs') && format('kata-static-tarball-s390x{0}', inputs.tarball-suffix) || format('kata-go-static-tarball-s390x{0}', inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -411,24 +411,33 @@ jobs:
           merge-multiple: true
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh kata-artifacts versions.yaml amd64
         env:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-      - name: Check kata tarball size (GitHub release asset limit)
+      - name: Check kata tarball sizes (GitHub release asset limit)
         run: |
           # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
           GITHUB_ASSET_MAX_BYTES=2147483648
-          tarball_size=$(stat -c "%s" kata-static.tar.zst)
-          if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
-            echo "::error::tarball size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
-            exit 1
-          fi
-          echo "tarball size: ${tarball_size} bytes"
-      - name: store-artifacts
+          for tarball in kata-static.tar.zst kata-go-static.tar.zst; do
+            tarball_size=$(stat -c "%s" "${tarball}")
+            if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
+              echo "::error::${tarball} size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
+              exit 1
+            fi
+            echo "${tarball} size: ${tarball_size} bytes"
+          done
+      - name: store runtime-rs artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-static.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+      - name: store Go runtime artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-go-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-go-static.tar.zst
           retention-days: 15
           if-no-files-found: error
 

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -502,23 +502,32 @@ jobs:
           merge-multiple: true
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh kata-artifacts versions.yaml arm64
         env:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-      - name: Check kata tarball size (GitHub release asset limit)
+      - name: Check kata tarball sizes (GitHub release asset limit)
         run: |
           # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
           GITHUB_ASSET_MAX_BYTES=2147483648
-          tarball_size=$(stat -c "%s" kata-static.tar.zst)
-          if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
-            echo "::error::tarball size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
-            exit 1
-          fi
-          echo "tarball size: ${tarball_size} bytes"
-      - name: store-artifacts
+          for tarball in kata-static.tar.zst kata-go-static.tar.zst; do
+            tarball_size=$(stat -c "%s" "${tarball}")
+            if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
+              echo "::error::${tarball} size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
+              exit 1
+            fi
+            echo "${tarball} size: ${tarball_size} bytes"
+          done
+      - name: store runtime-rs artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: kata-static-tarball-arm64${{ inputs.tarball-suffix }}
           path: kata-static.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+      - name: store Go runtime artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-go-static-tarball-arm64${{ inputs.tarball-suffix }}
+          path: kata-go-static.tar.zst
           retention-days: 15
           if-no-files-found: error

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -322,23 +322,23 @@ jobs:
           merge-multiple: true
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh kata-artifacts versions.yaml ppc64le
         env:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-      - name: Check kata tarball size (GitHub release asset limit)
+      - name: Check kata-go-static tarball size (GitHub release asset limit)
         run: |
           # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
           GITHUB_ASSET_MAX_BYTES=2147483648
-          tarball_size=$(stat -c "%s" kata-static.tar.zst)
+          tarball_size=$(stat -c "%s" kata-go-static.tar.zst)
           if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
-            echo "::error::tarball size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
+            echo "::error::kata-go-static.tar.zst size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
             exit 1
           fi
-          echo "tarball size: ${tarball_size} bytes"
-      - name: store-artifacts
+          echo "kata-go-static.tar.zst size: ${tarball_size} bytes"
+      - name: store Go runtime artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
-          path: kata-static.tar.zst
+          name: kata-go-static-tarball-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-go-static.tar.zst
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -367,23 +367,32 @@ jobs:
           merge-multiple: true
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh kata-artifacts versions.yaml s390x
         env:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-      - name: Check kata tarball size (GitHub release asset limit)
+      - name: Check kata tarball sizes (GitHub release asset limit)
         run: |
           # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
           GITHUB_ASSET_MAX_BYTES=2147483648
-          tarball_size=$(stat -c "%s" kata-static.tar.zst)
-          if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
-            echo "::error::tarball size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
-            exit 1
-          fi
-          echo "tarball size: ${tarball_size} bytes"
-      - name: store-artifacts
+          for tarball in kata-static.tar.zst kata-go-static.tar.zst; do
+            tarball_size=$(stat -c "%s" "${tarball}")
+            if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
+              echo "::error::${tarball} size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
+              exit 1
+            fi
+            echo "${tarball} size: ${tarball_size} bytes"
+          done
+      - name: store runtime-rs artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-static.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+      - name: store Go runtime artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-go-static-tarball-s390x${{ inputs.tarball-suffix }}
+          path: kata-go-static.tar.zst
           retention-days: 15
           if-no-files-found: error

--- a/.github/workflows/publish-kata-images.yaml
+++ b/.github/workflows/publish-kata-images.yaml
@@ -119,11 +119,11 @@ jobs:
           path: tools/packaging/kata-deploy/local-build/build
           merge-multiple: true
 
-      - name: get-kata-static-tarball for ${{ inputs.arch }}
+      - name: get-kata-go-static-tarball for ${{ inputs.arch }}
         if: ${{ inputs.artifact-name == '' && matrix.image-kind == 'monitor' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-${{ inputs.arch }}${{ inputs.tarball-suffix }}
+          name: kata-go-static-tarball-${{ inputs.arch }}${{ inputs.tarball-suffix }}
           path: tools/packaging/kata-deploy/local-build/build
 
       - name: get-kata-artifact by name for ${{ inputs.arch }}
@@ -185,15 +185,19 @@ jobs:
               fi
 
               build_dir="tools/packaging/kata-deploy/local-build/build"
-              monitor_tarball="${build_dir}/kata-static.tar.zst"
+              monitor_tarball="${build_dir}/kata-go-static.tar.zst"
+
+              if [ ! -f "${monitor_tarball}" ] && [ -f "${build_dir}/kata-static.tar.zst" ]; then
+                # Backward compatibility with older artifacts.
+                monitor_tarball="${build_dir}/kata-static.tar.zst"
+              fi
 
               if [ ! -f "${monitor_tarball}" ] && [ -f "${build_dir}/kata-static-shim-v2-go.tar.zst" ]; then
-                # Backward compatibility with older artifacts.
                 monitor_tarball="${build_dir}/kata-static-shim-v2-go.tar.zst"
               fi
 
               if [ ! -f "${monitor_tarball}" ]; then
-                echo "Neither kata-static.tar.zst nor kata-static-shim-v2-go.tar.zst found" >&2
+                echo "No kata-go-static, legacy kata-static, or shim-v2-go tarball found" >&2
                 exit 1
               fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,6 +146,11 @@ jobs:
           tarball=$(pwd)/kata-static.tar.zst
           echo "KATA_STATIC_TARBALL=${tarball}" >> "$GITHUB_ENV"
 
+      - name: Set KATA_GO_STATIC_TARBALL env var
+        run: |
+          tarball=$(pwd)/kata-go-static.tar.zst
+          echo "KATA_GO_STATIC_TARBALL=${tarball}" >> "$GITHUB_ENV"
+
       - name: Download amd64 artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -154,6 +159,18 @@ jobs:
       - name: Upload amd64 static tarball to GitHub
         run: |
           ./tools/packaging/release/release.sh upload-kata-static-tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHITECTURE: amd64
+
+      - name: Download amd64 Go runtime artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-go-static-tarball-amd64
+
+      - name: Upload amd64 Go runtime tarball to GitHub
+        run: |
+          ./tools/packaging/release/release.sh upload-kata-go-static-tarball
         env:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: amd64
@@ -170,6 +187,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: arm64
 
+      - name: Download arm64 Go runtime artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-go-static-tarball-arm64
+
+      - name: Upload arm64 Go runtime tarball to GitHub
+        run: |
+          ./tools/packaging/release/release.sh upload-kata-go-static-tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHITECTURE: arm64
+
       - name: Download s390x artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -182,14 +211,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: s390x
 
-      - name: Download ppc64le artifacts
+      - name: Download s390x Go runtime artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-ppc64le
+          name: kata-go-static-tarball-s390x
 
-      - name: Upload ppc64le static tarball to GitHub
+      - name: Upload s390x Go runtime tarball to GitHub
         run: |
-          ./tools/packaging/release/release.sh upload-kata-static-tarball
+          ./tools/packaging/release/release.sh upload-kata-go-static-tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHITECTURE: s390x
+
+      - name: Download ppc64le Go runtime artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-go-static-tarball-ppc64le
+
+      - name: Upload ppc64le Go runtime tarball to GitHub
+        run: |
+          ./tools/packaging/release/release.sh upload-kata-go-static-tarball
         env:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: ppc64le

--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: get-kata-tarball for ${{ inputs.arch }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-${{ inputs.arch }}${{ inputs.tarball-suffix }}
+          name: ${{ (inputs.vmm == 'dragonball' || endsWith(inputs.vmm, '-runtime-rs')) && format('kata-static-tarball-{0}{1}', inputs.arch, inputs.tarball-suffix) || format('kata-go-static-tarball-{0}{1}', inputs.arch, inputs.tarball-suffix) }}
           path: kata-artifacts
 
       - name: Install kata

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          name: kata-go-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata

--- a/docs/how-to/how-to-use-kata-with-docker.md
+++ b/docs/how-to/how-to-use-kata-with-docker.md
@@ -2,25 +2,34 @@
 
 This document describes the basics of running a kata container, using the docker command line tool.
 
-> This might be helpful for those getting started with kata containers or just wanting to employ kata's confinement to existing workflows with docker.
+!!! note
+    This might be helpful for those getting started with Kata Containers or
+    wanting to employ Kata's confinement in existing workflows with Docker.
 
 ## Requirements
 
 - A working docker installation.
 
-> **Note:** Newer versions of docker (v26+) require Kata Containers 3.29.0 (for the go runtime) and 3.30.0 (for the rust runtime), and the support is only tested with QEMU as the VMM.
+!!! warning "Deprecated Go runtime"
+    This guide uses the deprecated Go runtime. Docker v26+ requires Kata
+    Containers 3.29.0 or newer for the Go runtime. Docker support is tested
+    only with QEMU as the VMM.
 
 ## Install and configure Kata Containers
 
-Download the appropriate architecture's package from the Releases on Github https://github.com/kata-containers/kata-containers/releases Extract the files to a temporary location and install into /opt:
-```
-$ tar -xvf kata-static-${VERSION}-${ARCH}.tar.zst
-$ sudo mv opt/kata/ /opt/
+Download the appropriate architecture's `kata-go-static` package from the
+[GitHub releases](https://github.com/kata-containers/kata-containers/releases).
+Extract the files to a temporary location and install them into `/opt`:
+
+```sh
+tar -xvf kata-go-static-${VERSION}-${ARCH}.tar.zst
+sudo mv opt/kata/ /opt/
 ```
 
 Configure the docker daemon for the kata runtime (assuming no such file exists):
-```
-$ sudo cat <<EOF > /etc/docker/daemon.json
+
+```sh
+sudo tee /etc/docker/daemon.json >/dev/null <<EOF
 {
   "runtimes": {
     "kata": {
@@ -28,13 +37,16 @@ $ sudo cat <<EOF > /etc/docker/daemon.json
     }
   }
 }
-$ sudo systemctl reload docker
+EOF
+sudo systemctl reload docker
 ```
 
-Optionally at this point, to use a custom configuration for kata itself, create it in /etc/kata-containers/configuration.toml.
+Optionally, to use a custom Kata configuration, create
+`/etc/kata-containers/configuration.toml`.
 
-To launched a kata container and observe the guest kernel version:
-```
-$ docker run --runtime kata -it --rm ubuntu:24.04 uname -r
+To launch a Kata container and observe the guest kernel version:
+
+```sh
+docker run --runtime kata -it --rm ubuntu:24.04 uname -r
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -221,24 +221,40 @@ case "$(uname -m)" in
     ;;
 esac
 
-curl -fsSL -o kata-static.tar.zst \
-  "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-${ARCH}.tar.zst"
+if [[ "${ARCH}" != "ppc64le" ]]; then
+  curl -fsSL -o kata-static.tar.zst \
+    "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-${ARCH}.tar.zst"
 
-# The archive uses an /opt/kata/ prefix.
-sudo tar -xvf kata-static.tar.zst -C /
+  # The archive uses an /opt/kata/ prefix.
+  sudo tar -xvf kata-static.tar.zst -C /
+fi
 ```
 
-The release installs both runtimes side by side:
+The `kata-static` archive contains runtime-rs, its configurations, composable
+guest images, and the shared host components:
 
 | Path | Runtime |
 |-|-|
 | `/opt/kata/runtime-rs/bin/containerd-shim-kata-v2` | runtime-rs (default) |
-| `/opt/kata/bin/containerd-shim-kata-v2` | Go runtime (deprecated) |
 
 Packaged configuration files live under
 `/opt/kata/share/defaults/kata-containers/`. The `runtime-rs` configurations
 use the `-runtime-rs` suffix (for example `configuration-qemu-runtime-rs.toml`),
 and `configuration-dragonball.toml` selects the built-in Dragonball VMM.
+
+!!! warning "The Go runtime is deprecated"
+    Users who still require the Go runtime or monolithic guest images must
+    install the separate `kata-go-static` archive. This is also the only release
+    tarball available for `ppc64le`, where runtime-rs is not supported.
+
+```sh
+curl -fsSL -o kata-go-static.tar.zst \
+  "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-go-static-${VERSION}-${ARCH}.tar.zst"
+
+sudo tar -xvf kata-go-static.tar.zst -C /
+```
+
+The Go shim is installed at `/opt/kata/bin/containerd-shim-kata-v2`.
 
 ## Use Kata Containers with Docker
 

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -264,6 +264,7 @@ function extract_kata_env() {
 	RUNTIME_VERSION="$(echo "${kata_env}" | jq -r "${runtime_version}" | grep "${runtime_version_semver}" | cut -d'"' -f4)"
 	# shellcheck disable=SC2034
 	RUNTIME_COMMIT="$(echo "${kata_env}" | jq -r "${runtime_version}" | grep "${runtime_version_commit}" | cut -d'"' -f4)"
+	# shellcheck disable=SC2034
 	RUNTIME_PATH="$(echo "${kata_env}" | jq -r "${runtime_path}")"
 	# shellcheck disable=SC2034
 	SHARED_FS="$(echo "${kata_env}" | jq -r "${shared_fs}")"
@@ -302,21 +303,6 @@ function extract_kata_env() {
 # Checks that processes are not running
 function check_processes() {
 	extract_kata_env
-
-	# Only check the kata-env if we have managed to find the kata executable...
-	if [[ -x "${RUNTIME_PATH}" ]]; then
-		local vsock_configured
-		# shellcheck disable=SC2034
-		vsock_configured=$(${RUNTIME_PATH} env | awk '/UseVSock/ {print $3}')
-		local vsock_supported
-		# shellcheck disable=SC2034
-		vsock_supported=$(${RUNTIME_PATH} env | awk '/SupportVSock/ {print $3}')
-	else
-		# shellcheck disable=SC2034
-		local vsock_configured="false"
-		# shellcheck disable=SC2034
-		local vsock_supported="false"
-	fi
 
 	general_processes=( "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -229,7 +229,7 @@ function extract_kata_env() {
 	local req_num_vcpus
 
 	case "${KATA_HYPERVISOR}" in
-		dragonball)
+		dragonball|*-runtime-rs)
 			cmd=kata-ctl
 			config_path=".runtime.config.path"
 			runtime_version=".runtime.version"
@@ -759,15 +759,35 @@ function install_kata_tools() {
 	done
 }
 
+# Install the standalone agent component tarball (provides /usr/bin/kata-agent).
+# This is not part of the merged release tarballs; CI jobs that need a host
+# agent binary must download kata-artifacts-*-agent separately.
+function install_kata_agent() {
+	declare -r tarballdir="${1:-kata-agent-artifacts}"
+
+	install_tarball "/" "${tarballdir}" "kata-static-agent.tar.zst" false
+}
+
 function install_kata() {
 	declare -r katadir="/opt/kata"
 	declare -r tarballdir="kata-artifacts"
 	declare -r local_bin_dir="/usr/local/bin/"
+	local tarball="kata-static.tar.zst"
 
-	install_tarball "${katadir}" "${tarballdir}" "kata-static.tar.zst" true
+	case "${KATA_HYPERVISOR:-qemu-runtime-rs}" in
+		dragonball|*-runtime-rs) ;;
+		*)
+			if [[ -f "${tarballdir}/kata-go-static.tar.zst" ]]; then
+				tarball="kata-go-static.tar.zst"
+			fi
+			;;
+	esac
+
+	install_tarball "${katadir}" "${tarballdir}" "${tarball}" true
 
 	# create symbolic links to kata components
-	for b in "${katadir}"/bin/* ; do
+	for b in "${katadir}"/bin/* "${katadir}"/runtime-rs/bin/* ; do
+		[[ -e "${b}" ]] || continue
 		sudo ln -sf "${b}" "${local_bin_dir}/$(basename "${b}")"
 	done
 

--- a/tests/functional/kata-agent-apis/gha-run.sh
+++ b/tests/functional/kata-agent-apis/gha-run.sh
@@ -45,6 +45,7 @@ function main() {
 	case "${action}" in
 		install-dependencies) install_dependencies ;;
 		install-kata) install_kata ;;
+		install-kata-agent) install_kata_agent "${2:-}" ;;
 		install-kata-tools) install_kata_tools "${2:-}" ;;
 		run) run ;;
 		*) >&2 die "Invalid argument" ;;

--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -36,6 +36,11 @@ function install_dependencies() {
 }
 
 function run() {
+	# Without this the tests run whatever configuration.toml the tarball
+	# happens to ship with, so every entry of the vmm matrix exercises the
+	# same hypervisor instead of the one it is named after.
+	enabling_hypervisor
+
 	# shellcheck disable=SC2154
 	info "Running soak parallel stability tests using ${KATA_HYPERVISOR} hypervisor"
 

--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -57,6 +57,7 @@ function main() {
 	case "${action}" in
 		install-dependencies) install_dependencies ;;
 		install-kata) install_kata ;;
+		install-kata-tools) install_kata_tools "${2:-}" ;;
 		enabling-hypervisor) enabling_hypervisor ;;
 		run) run ;;
 		*) >&2 die "Invalid argument" ;;

--- a/tests/stability/soak_parallel_rm.sh
+++ b/tests/stability/soak_parallel_rm.sh
@@ -30,10 +30,6 @@ MEM_CUTOFF="${MEM_CUTOFF:-(2*1024*1024*1024)}"
 # do we need a command argument for this payload?
 COMMAND="${COMMAND:-tail -f /dev/null}"
 
-# Runtime path
-# shellcheck disable=SC2154
-RUNTIME_PATH=$(command -v "${RUNTIME}")
-
 # The place where virtcontainers keeps its active pod info
 # This is ultimately what 'kata-runtime list' uses to get its info, but
 # we can also check it for sanity directly
@@ -44,16 +40,6 @@ VC_POD_DIR="${VC_POD_DIR:-/run/vc/sbs}"
 MAX_CONTAINERS="${MAX_CONTAINERS:-110}"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu-runtime-rs}"
-
-function check_vsock_active() {
-	vsock_configured=$("${RUNTIME_PATH}" kata-env | awk '/UseVSock/ {print $3}')
-	vsock_supported=$("${RUNTIME_PATH}" kata-env | awk '/SupportVSock/ {print $3}')
-	if [[ "${vsock_configured}" == true ]] && [[ "${vsock_supported}" == true ]]; then
-		return 0
-	else
-		return 1
-	fi
-}
 
 function count_containers() {
 	# shellcheck disable=SC2154
@@ -96,6 +82,7 @@ function check_all_running() {
 		fi
 
 		# if this is kata-runtime, check how many pods virtcontainers thinks we have
+		# shellcheck disable=SC2154
 		if [[ "${RUNTIME}" == "containerd-shim-kata-v2" ]]; then
 			if [[ -d "${VC_POD_DIR}" ]]; then
 				num_vc_pods=$(sudo ls -1 "${VC_POD_DIR}" | wc -l)

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -33,22 +33,16 @@ BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
 	rootfs-image-coco-extension-tarball \
 	rootfs-image-mariner-tarball \
+	rootfs-image-nvidia-gpu-tarball \
+	rootfs-image-nvidia-gpu-confidential-tarball \
+	rootfs-image-nvidia-tarball \
+	rootfs-image-nvidia-gpu-extension-tarball \
 	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-tarball \
 	cloud-hypervisor-tarball
 else ifeq ($(ARCH), s390x)
 BASE_TARBALLS = serial-targets \
-	kernel-debug-tarball \
-	kernel-tarball \
-	qemu-tarball \
-	shim-v2-go-tarball \
-	shim-v2-rust-tarball \
-	virtiofsd-tarball
-BASE_SERIAL_TARBALLS = rootfs-image-tarball \
-	rootfs-image-coco-extension-tarball \
-	rootfs-initrd-tarball
-else ifeq ($(ARCH), aarch64)
-BASE_TARBALLS = serial-targets \
+	boot-image-se-tarball \
 	kernel-debug-tarball \
 	kernel-tarball \
 	qemu-tarball \
@@ -58,7 +52,41 @@ BASE_TARBALLS = serial-targets \
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
 	rootfs-image-coco-extension-tarball \
+	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-tarball
+else ifeq ($(ARCH), aarch64)
+BASE_TARBALLS = serial-targets \
+	firecracker-tarball \
+	kernel-debug-tarball \
+	kernel-dragonball-experimental-tarball \
+	kernel-tarball \
+	nydus-tarball \
+	ovmf-tarball \
+	qemu-tarball \
+	shim-v2-go-tarball \
+	shim-v2-rust-tarball \
+	virtiofsd-tarball
+BASE_SERIAL_TARBALLS = rootfs-image-tarball \
+	rootfs-image-confidential-tarball \
+	rootfs-image-coco-extension-tarball \
+	rootfs-image-nvidia-gpu-tarball \
+	rootfs-image-nvidia-tarball \
+	rootfs-image-nvidia-gpu-extension-tarball \
+	rootfs-initrd-tarball \
+	cloud-hypervisor-tarball
+else ifeq ($(ARCH), ppc64le)
+BASE_TARBALLS = serial-targets \
+	kernel-tarball \
+	qemu-tarball \
+	shim-v2-go-tarball \
+	virtiofsd-tarball
+BASE_SERIAL_TARBALLS = rootfs-initrd-tarball
+endif
+
+ifeq ($(ARCH), ppc64le)
+SHIM_TARBALLS = shim-v2-go-tarball
+else
+SHIM_TARBALLS = shim-v2-go-tarball shim-v2-rust-tarball
 endif
 
 PUBLISH_COMPONENT_TARBALLS = \
@@ -145,7 +173,40 @@ define DUMMY
 	mv $(MK_DIR)/build/kata-static-dummy.tar.zst $(MK_DIR)/build/kata-static-$(patsubst %-tarball,%,$1).tar.zst
 endef
 
+ifneq ($(filter $(ARCH),x86_64 aarch64 s390x ppc64le),)
+ifneq ($(ARCH), ppc64le)
+KATA_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-static $(ARCH) | tr '\n' ' ')
+endif
+KATA_GO_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-go-static $(ARCH) | tr '\n' ' ')
+endif
+
+ifeq ($(ARCH), ppc64le)
+kata-tarball:
+	@echo "kata-tarball: runtime-rs is unsupported on $(ARCH); use kata-go-static-tarball"; exit 1
+else ifneq ($(KATA_STATIC_FINAL_TARBALL_INPUTS),)
+kata-tarball: FINAL_TARBALL_INPUTS=$(KATA_STATIC_FINAL_TARBALL_INPUTS)
+kata-tarball: FINAL_TARBALL_NAME=kata-static.tar.zst
+kata-tarball: | all-parallel
+	$(MAKE) -f $(MK_PATH) merge-builds \
+		FINAL_TARBALL_NAME="$(FINAL_TARBALL_NAME)" \
+		FINAL_TARBALL_INPUTS="$(FINAL_TARBALL_INPUTS)" \
+		FINAL_TARBALL_MERGE_MODE="$(FINAL_TARBALL_MERGE_MODE)"
+else
 kata-tarball: | all-parallel merge-builds
+endif
+
+ifneq ($(KATA_GO_STATIC_FINAL_TARBALL_INPUTS),)
+kata-go-static-tarball: FINAL_TARBALL_INPUTS=$(KATA_GO_STATIC_FINAL_TARBALL_INPUTS)
+kata-go-static-tarball: FINAL_TARBALL_NAME=kata-go-static.tar.zst
+kata-go-static-tarball: | all-parallel
+	$(MAKE) -f $(MK_PATH) merge-builds \
+		FINAL_TARBALL_NAME="$(FINAL_TARBALL_NAME)" \
+		FINAL_TARBALL_INPUTS="$(FINAL_TARBALL_INPUTS)" \
+		FINAL_TARBALL_MERGE_MODE="$(FINAL_TARBALL_MERGE_MODE)"
+else
+kata-go-static-tarball:
+	@echo "kata-go-static-tarball: unsupported on $(ARCH)"; exit 1
+endif
 
 copy-scripts-for-the-agent-build:
 	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh "agent"
@@ -155,7 +216,7 @@ copy-scripts-for-the-tools-build:
 
 all-parallel:
 	${MAKE} -f $(MK_PATH) all -j $(shell nproc) --output-sync=target V=
-	${MAKE} -f $(MK_PATH) shim-v2-go-tarball shim-v2-rust-tarball V=
+	${MAKE} -f $(MK_PATH) $(SHIM_TARBALLS) V=
 
 all: ${BASE_TARBALLS}
 
@@ -164,8 +225,9 @@ serial-targets: $(filter-out serial-targets,$(BASE_TARBALLS))
 	${BASE_SERIAL_TARBALLS}
 
 # Optional explicit allowlist for merge-builds input tarballs.
-# Keep empty for normal targets; set explicitly for NVIDIA flow.
+# Release and NVIDIA targets set this to keep their contents deterministic.
 FINAL_TARBALL_INPUTS ?=
+FINAL_TARBALL_NAME ?= kata-static.tar.zst
 
 %-tarball-build:
 	$(call BUILD,$*)
@@ -320,7 +382,7 @@ merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh \
 		build \
 		"$(MK_DIR)/../../../../versions.yaml" \
-		kata-static.tar.zst \
+		"$(FINAL_TARBALL_NAME)" \
 		"$(FINAL_TARBALL_INPUTS)" \
 		"$(FINAL_TARBALL_MERGE_MODE)"
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright (c) Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Merge component tarballs into kata-static.tar.zst and/or kata-go-static.tar.zst
+# using per-architecture allowlists.
+
+[[ -z "${DEBUG}" ]] || set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
+source "${this_script_dir}/kata-release-tarball-inputs.sh"
+
+kata_build_dir="${1:-kata-artifacts}"
+kata_versions_yaml_file="${2:-versions.yaml}"
+arch="${3:-$(uname -m)}"
+
+merge_with_allowlist() {
+	local output="${1}"
+	local allowlist="${2}"
+
+	"${this_script_dir}/kata-deploy-merge-builds.sh" \
+		"${kata_build_dir}" \
+		"${kata_versions_yaml_file}" \
+		"${output}" \
+		"${allowlist}" \
+		merge
+}
+
+normalized_arch="$(normalize_arch "${arch}")"
+
+if [[ "${normalized_arch}" != "ppc64le" ]]; then
+	allowlist="$(kata_static_tarball_inputs "${arch}" | tr '\n' ' ')"
+	merge_with_allowlist "kata-static.tar.zst" "${allowlist}"
+fi
+
+allowlist="$(kata_go_tarball_inputs "${arch}" | tr '\n' ' ')"
+merge_with_allowlist "kata-go-static.tar.zst" "${allowlist}"

--- a/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Copyright (c) Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Per-architecture allowlists for merged release tarballs:
+#   kata-static.tar.zst  - runtime-rs focused (composable guest images)
+#   kata-go-static.tar.zst - Go runtime focused (monolithic guest images)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+normalize_arch() {
+	case "${1}" in
+		x86_64|amd64) echo "amd64" ;;
+		aarch64|arm64) echo "arm64" ;;
+		s390x) echo "s390x" ;;
+		ppc64le) echo "ppc64le" ;;
+		*) echo "unsupported architecture: ${1}" >&2; return 1 ;;
+	esac
+}
+
+kata_static_tarball_inputs() {
+	local arch
+	arch="$(normalize_arch "${1}")"
+
+	case "${arch}" in
+		amd64)
+			cat <<'EOF'
+kata-static-cloud-hypervisor.tar.zst
+kata-static-kernel-debug.tar.zst
+kata-static-kernel-dragonball-experimental.tar.zst
+kata-static-kernel-nvidia-gpu.tar.zst
+kata-static-kernel.tar.zst
+kata-static-nydus.tar.zst
+kata-static-ovmf-sev.tar.zst
+kata-static-ovmf-tdx.tar.zst
+kata-static-ovmf.tar.zst
+kata-static-qemu-snp-experimental.tar.zst
+kata-static-qemu-tdx-experimental.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-coco-extension.tar.zst
+kata-static-rootfs-image-mariner.tar.zst
+kata-static-rootfs-image-nvidia-gpu-extension.tar.zst
+kata-static-rootfs-image-nvidia.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd-confidential.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-rust.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		arm64)
+			cat <<'EOF'
+kata-static-cloud-hypervisor.tar.zst
+kata-static-kernel-debug.tar.zst
+kata-static-kernel-dragonball-experimental.tar.zst
+kata-static-kernel-nvidia-gpu.tar.zst
+kata-static-kernel.tar.zst
+kata-static-nydus.tar.zst
+kata-static-ovmf.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-coco-extension.tar.zst
+kata-static-rootfs-image-nvidia-gpu-extension.tar.zst
+kata-static-rootfs-image-nvidia.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-rust.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		s390x)
+			cat <<'EOF'
+kata-static-boot-image-se.tar.zst
+kata-static-kernel.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-coco-extension.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd-confidential.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-rust.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		ppc64le)
+			echo "runtime-rs tarball is not produced on ppc64le" >&2
+			return 1
+			;;
+	esac
+}
+
+kata_go_tarball_inputs() {
+	local arch
+	arch="$(normalize_arch "${1}")"
+
+	case "${arch}" in
+		amd64)
+			cat <<'EOF'
+kata-static-cloud-hypervisor.tar.zst
+kata-static-firecracker.tar.zst
+kata-static-kernel-debug.tar.zst
+kata-static-kernel-nvidia-gpu.tar.zst
+kata-static-kernel.tar.zst
+kata-static-nydus.tar.zst
+kata-static-ovmf-sev.tar.zst
+kata-static-ovmf-tdx.tar.zst
+kata-static-ovmf.tar.zst
+kata-static-qemu-snp-experimental.tar.zst
+kata-static-qemu-tdx-experimental.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-confidential.tar.zst
+kata-static-rootfs-image-mariner.tar.zst
+kata-static-rootfs-image-nvidia-gpu-confidential.tar.zst
+kata-static-rootfs-image-nvidia-gpu.tar.zst
+kata-static-rootfs-image-nvidia.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd-confidential.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-go.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		arm64)
+			cat <<'EOF'
+kata-static-cloud-hypervisor.tar.zst
+kata-static-firecracker.tar.zst
+kata-static-kernel-debug.tar.zst
+kata-static-kernel-nvidia-gpu.tar.zst
+kata-static-kernel.tar.zst
+kata-static-nydus.tar.zst
+kata-static-ovmf.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-confidential.tar.zst
+kata-static-rootfs-image-nvidia-gpu.tar.zst
+kata-static-rootfs-image-nvidia.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-go.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		s390x)
+			cat <<'EOF'
+kata-static-boot-image-se.tar.zst
+kata-static-kernel.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-image-confidential.tar.zst
+kata-static-rootfs-image.tar.zst
+kata-static-rootfs-initrd-confidential.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-go.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+		ppc64le)
+			cat <<'EOF'
+kata-static-kernel.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-go.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
+			;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	action="${1:-}"
+	arch="${2:-$(uname -m)}"
+	case "${action}" in
+		kata-static) kata_static_tarball_inputs "${arch}" ;;
+		kata-go-static) kata_go_tarball_inputs "${arch}" ;;
+		*) echo "usage: ${0} {kata-static|kata-go-static} [arch]" >&2; exit 1 ;;
+	esac
+fi

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -27,6 +27,7 @@ IFS=' ' read -r -a JOB_DISPATCHER_REGISTRIES <<< "${KATA_DEPLOY_JOB_DISPATCHER_R
 GH_TOKEN="${GH_TOKEN:-}"
 ARCHITECTURE="${ARCHITECTURE:-}"
 KATA_STATIC_TARBALL="${KATA_STATIC_TARBALL:-}"
+KATA_GO_STATIC_TARBALL="${KATA_GO_STATIC_TARBALL:-}"
 
 function _die()
 {
@@ -44,6 +45,7 @@ function _check_required_env_var()
 		GH_TOKEN) env_var="${GH_TOKEN}" ;;
 		ARCHITECTURE) env_var="${ARCHITECTURE}" ;;
 		KATA_STATIC_TARBALL) env_var="${KATA_STATIC_TARBALL}" ;;
+		KATA_GO_STATIC_TARBALL) env_var="${KATA_GO_STATIC_TARBALL}" ;;
 		KATA_DEPLOY_IMAGE_TAGS) env_var="${KATA_DEPLOY_IMAGE_TAGS}" ;;
 		KATA_DEPLOY_REGISTRIES) env_var="${KATA_DEPLOY_REGISTRIES}" ;;
 		KATA_TOOLS_STATIC_TARBALL) env_var="${KATA_TOOLS_STATIC_TARBALL}" ;;
@@ -202,6 +204,20 @@ function _upload_kata_static_tarball()
 	gh release upload "${RELEASE_VERSION}" "${new_tarball_name}"
 }
 
+function _upload_kata_go_static_tarball()
+{
+	_check_required_env_var "GH_TOKEN"
+	_check_required_env_var "ARCHITECTURE"
+	_check_required_env_var "KATA_GO_STATIC_TARBALL"
+
+	RELEASE_VERSION="$(_release_version)"
+
+	new_tarball_name="kata-go-static-${RELEASE_VERSION}-${ARCHITECTURE}.tar.zst"
+	mv "${KATA_GO_STATIC_TARBALL}" "${new_tarball_name}"
+	echo "uploading asset '${new_tarball_name}' (${ARCHITECTURE}) for tag: ${RELEASE_VERSION}"
+	gh release upload "${RELEASE_VERSION}" "${new_tarball_name}"
+}
+
 function _upload_kata_tools_static_tarball()
 {
 	_check_required_env_var "GH_TOKEN"
@@ -276,6 +292,7 @@ function main()
 		release-version) _release_version;;
 		create-new-release) _create_new_release ;;
 		upload-kata-static-tarball) _upload_kata_static_tarball ;;
+		upload-kata-go-static-tarball) _upload_kata_go_static_tarball ;;
 		upload-kata-tools-static-tarball) _upload_kata_tools_static_tarball ;;
 		upload-versions-yaml-file) _upload_versions_yaml_file ;;
 		upload-vendored-code-tarball) _upload_vendored_code_tarball ;;


### PR DESCRIPTION
`kata-static` currently ships both shims and both flavours of guest image, so
everyone downloads the Go runtime and the monolithic images. This splits the
merged release archive in two, per architecture:

| Tarball | Shim | Guest images |
|---|---|---|
| `kata-static-${VERSION}-${ARCH}.tar.zst` | runtime-rs (`shim-v2-rust`) | composable (`rootfs-image` plus the coco and NVIDIA extensions) |
| `kata-go-static-${VERSION}-${ARCH}.tar.zst` | Go (`shim-v2-go`) | monolithic (`rootfs-image-confidential`, `rootfs-image-nvidia-gpu`, ...) |

Both archives are assembled from the same per-component build artifacts. A new
`kata-release-tarball-inputs.sh` holds a per-architecture allowlist for each
bundle and the merge step simply picks a different set, so this costs no
additional build time. The split also lets each bundle carry only what it can
actually use: Firecracker ships in the Go archive only, and the Dragonball
kernel in the runtime-rs one only.

ppc64le is Go-only, since runtime-rs is not built there. Asking for the
runtime-rs inputs on that architecture is an explicit error rather than a
silently empty archive.

Tests now pull whichever package matches the runtime they exercise: the
Dragonball and `*-runtime-rs` matrix entries take `kata-static`, everything else
takes `kata-go-static`. The agent API tests additionally download the standalone
agent artifact, because neither merged tarball ships a host `kata-agent` binary
any more — the agent only exists inside the guest images.

Two problems that this work exposed, each in its own commit:

- The containerd stability job never called `enabling_hypervisor`, so every
  entry of its `vmm` matrix ran against whichever `configuration.toml` the
  installed tarball happened to ship instead of the hypervisor it is named
  after. Note that this means anything but QEMU will genuinely boot here
for the first time.

- The vsock checks in `soak_parallel_rm.sh` and `common.bash` have been dead
  since `UseVSock` was removed from the runtime env output in 1099a28830
  ("kata 2.0: delete use_vsock option and proxy abstraction"). The awk never
  matched, `check_vsock_active()` had no callers, and `check_processes()`
  computed both variables without reading them.