### PR TITLE
agent, runtime: contain blocking guest metrics collection

### DIFF
--- a/src/agent/src/metrics.rs
+++ b/src/agent/src/metrics.rs
@@ -10,7 +10,10 @@ use prometheus::{Encoder, Gauge, GaugeVec, IntCounter, Opts, Registry, TextEncod
 use anyhow::{anyhow, Result};
 use nix::sys::statfs;
 use slog::warn;
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex, OnceLock,
+};
 use tracing::instrument;
 
 const NAMESPACE_KATA_AGENT: &str = "kata_agent";
@@ -21,9 +24,33 @@ fn sl() -> slog::Logger {
     slog_scope::logger().new(o!("subsystem" => "metrics"))
 }
 
+static REGISTERED: OnceLock<Result<(), String>> = OnceLock::new();
+
+#[derive(Default)]
+pub(crate) struct MetricsState {
+    collection_in_progress: AtomicBool,
+    last_successful_metrics: Mutex<Option<String>>,
+}
+
+struct CollectionGuard {
+    state: Arc<MetricsState>,
+}
+
+impl Drop for CollectionGuard {
+    fn drop(&mut self) {
+        self.state
+            .collection_in_progress
+            .store(false, Ordering::Release);
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("guest metrics collection already in progress")]
+struct CollectionInProgress;
+
 lazy_static! {
 
-    static ref REGISTERED: Mutex<bool> = Mutex::new(false);
+    static ref METRICS_STATE: Arc<MetricsState> = Arc::new(MetricsState::default());
 
     // custom registry
     static ref REGISTRY: Registry = Registry::new();
@@ -83,23 +110,78 @@ lazy_static! {
 }
 
 #[instrument]
-pub fn get_metrics(_: &protocols::agent::GetMetricsRequest) -> Result<String> {
-    let mut registered = REGISTERED
-        .lock()
-        .map_err(|e| anyhow!("failed to check agent metrics register status {:?}", e))?;
+pub async fn get_metrics(_: &protocols::agent::GetMetricsRequest) -> Result<String> {
+    get_metrics_with_filesystem_collector(METRICS_STATE.clone(), update_guest_filesystem_metrics)
+        .await
+}
 
-    if !(*registered) {
-        register_metrics()?;
-        *registered = true;
+pub(crate) fn is_collection_in_progress(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<CollectionInProgress>().is_some()
+}
+
+fn ensure_metrics_registered() -> Result<()> {
+    match REGISTERED.get_or_init(|| register_metrics().map_err(|err| format!("{err:#}"))) {
+        Ok(()) => Ok(()),
+        Err(err) => Err(anyhow!("failed to register agent metrics: {err}")),
+    }
+}
+
+pub(crate) async fn get_metrics_with_filesystem_collector<F>(
+    state: Arc<MetricsState>,
+    filesystem_collector: F,
+) -> Result<String>
+where
+    F: FnOnce() + Send + 'static,
+{
+    ensure_metrics_registered()?;
+
+    if state
+        .collection_in_progress
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return state
+            .last_successful_metrics
+            .lock()
+            .map_err(|err| anyhow!("failed to read cached agent metrics: {err}"))?
+            .clone()
+            .ok_or_else(|| CollectionInProgress.into());
     }
 
+    // Move the guard into the blocking task. If the caller goes away, the gate
+    // remains closed until the task actually exits; dropping JoinHandle does not
+    // cancel a blocking syscall.
+    let guard = CollectionGuard {
+        state: state.clone(),
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let _guard = guard;
+        let metrics = collect_metrics(filesystem_collector)?;
+
+        *state
+            .last_successful_metrics
+            .lock()
+            .map_err(|err| anyhow!("failed to cache agent metrics: {err}"))? =
+            Some(metrics.clone());
+
+        Ok(metrics)
+    })
+    .await
+    .map_err(|err| anyhow!("guest metrics collector task failed: {err}"))?
+}
+
+fn collect_metrics<F>(filesystem_collector: F) -> Result<String>
+where
+    F: FnOnce(),
+{
     AGENT_SCRAPE_COUNT.inc();
 
     // update agent process metrics
     update_agent_metrics()?;
 
     // update guest os metrics
-    update_guest_metrics();
+    update_guest_metrics(filesystem_collector);
 
     // gather all metrics and return as a String
     let metric_families = REGISTRY.gather();
@@ -194,8 +276,11 @@ fn update_agent_metrics() -> Result<()> {
     Ok(())
 }
 
-#[instrument]
-fn update_guest_metrics() {
+#[instrument(skip(filesystem_collector))]
+fn update_guest_metrics<F>(filesystem_collector: F)
+where
+    F: FnOnce(),
+{
     // try get load and task info
     match procfs::LoadAverage::new() {
         Err(err) => {
@@ -277,7 +362,7 @@ fn update_guest_metrics() {
     }
 
     // get filesystem space usage via statfs
-    update_guest_filesystem_metrics();
+    filesystem_collector();
 }
 
 #[instrument]
@@ -647,4 +732,109 @@ fn set_gauge_vec_proc_stat(gv: &prometheus::GaugeVec, stat: &procfs::process::St
     gv.with_label_values(&["stime"]).set(stat.stime as f64);
     gv.with_label_values(&["cutime"]).set(stat.cutime as f64);
     gv.with_label_values(&["cstime"]).set(stat.cstime as f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[test]
+    fn registration_is_race_free() {
+        const CALLERS: usize = 32;
+
+        let barrier = Arc::new(std::sync::Barrier::new(CALLERS));
+        let mut callers = Vec::with_capacity(CALLERS);
+
+        for _ in 0..CALLERS {
+            let barrier = barrier.clone();
+            callers.push(std::thread::spawn(move || {
+                barrier.wait();
+                ensure_metrics_registered()
+            }));
+        }
+
+        for caller in callers {
+            caller.join().unwrap().unwrap();
+        }
+
+        let families = REGISTRY.gather();
+        let names = families
+            .iter()
+            .map(|family| family.name())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(names.len(), families.len());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn blocking_filesystem_collection_is_single_flight_and_cached() {
+        let state = Arc::new(MetricsState::default());
+
+        let cached = get_metrics_with_filesystem_collector(state.clone(), || {})
+            .await
+            .unwrap();
+        assert!(cached.contains("kata_agent_scrape_count"));
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let collector_calls = Arc::new(AtomicUsize::new(0));
+
+        let blocked_calls = collector_calls.clone();
+        let blocked = tokio::spawn(get_metrics_with_filesystem_collector(
+            state.clone(),
+            move || {
+                blocked_calls.fetch_add(1, Ordering::SeqCst);
+                let _ = started_tx.send(());
+                let _ = release_rx.recv();
+            },
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("filesystem collector did not start")
+            .expect("filesystem collector dropped its start notification");
+
+        let unexpected_calls = collector_calls.clone();
+        let concurrent = tokio::time::timeout(
+            Duration::from_millis(250),
+            get_metrics_with_filesystem_collector(state.clone(), move || {
+                unexpected_calls.fetch_add(1, Ordering::SeqCst);
+            }),
+        )
+        .await
+        .expect("concurrent metrics request waited for the blocked collector")
+        .unwrap();
+
+        assert_eq!(concurrent, cached);
+        assert_eq!(collector_calls.load(Ordering::SeqCst), 1);
+
+        release_tx.send(()).unwrap();
+
+        let refreshed = tokio::time::timeout(Duration::from_secs(1), blocked)
+            .await
+            .expect("metrics collection did not finish after release")
+            .unwrap()
+            .unwrap();
+        assert!(refreshed.contains("kata_guest_load"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_collection_without_cache_is_transient_error() {
+        let state = Arc::new(MetricsState::default());
+        state.collection_in_progress.store(true, Ordering::Release);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(250),
+            get_metrics_with_filesystem_collector(state.clone(), || {
+                panic!("a second collector must not start");
+            }),
+        )
+        .await
+        .expect("concurrent metrics request did not return promptly")
+        .unwrap_err();
+
+        assert!(is_collection_in_progress(&result));
+    }
 }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -79,7 +79,7 @@ use crate::device::{
     update_env_pci,
 };
 use crate::features::get_build_features;
-use crate::metrics::get_metrics;
+use crate::metrics::{get_metrics, is_collection_in_progress};
 use crate::mount::baremount;
 use crate::namespace::{NSTYPEIPC, NSTYPEPID, NSTYPEUTS};
 use crate::network::setup_guest_dns;
@@ -1703,7 +1703,14 @@ impl agent_ttrpc::AgentService for AgentService {
         trace_rpc_call!(ctx, "get_metrics", req);
         is_allowed(&req).await?;
 
-        let s = get_metrics(&req).map_ttrpc_err(same)?;
+        let s = get_metrics(&req).await.map_err(|err| {
+            let code = if is_collection_in_progress(&err) {
+                ttrpc::Code::UNAVAILABLE
+            } else {
+                ttrpc::Code::INTERNAL
+            };
+            ttrpc_error(code, err)
+        })?;
         let mut metrics = Metrics::new();
         metrics.set_metrics(s);
         Ok(metrics)
@@ -2706,7 +2713,11 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
-    use crate::{namespace::Namespace, protocols::agent_ttrpc_async::AgentService as _};
+    use crate::{
+        metrics::{get_metrics_with_filesystem_collector, MetricsState},
+        namespace::Namespace,
+        protocols::{agent_ttrpc_async::AgentService as _, health_ttrpc_async::Health as _},
+    };
     use anyhow::{bail, ensure};
     use nix::mount;
     use nix::sched::{unshare, CloneFlags};
@@ -2796,6 +2807,59 @@ mod tests {
             .unwrap(),
             dir,
         )
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn blocking_metrics_do_not_block_control_handlers() {
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let sandbox = Sandbox::new(&logger).unwrap();
+        let agent_service = AgentService {
+            sandbox: Arc::new(Mutex::new(sandbox)),
+            init_mode: true,
+            oma: None,
+        };
+
+        let state = Arc::new(MetricsState::default());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let blocked_metrics =
+            tokio::spawn(get_metrics_with_filesystem_collector(state, move || {
+                let _ = started_tx.send(());
+                let _ = release_rx.recv();
+            }));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), started_rx)
+            .await
+            .expect("filesystem collector did not start")
+            .expect("filesystem collector dropped its start notification");
+
+        let ctx = mk_ttrpc_context();
+        let health = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            HealthService.check(&ctx, protocols::health::CheckRequest::default()),
+        )
+        .await
+        .expect("health check was blocked by metrics collection")
+        .unwrap();
+        assert_eq!(health.status(), HealthCheckResponse_ServingStatus::SERVING);
+
+        let signal = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            agent_service.signal_process(&ctx, protocols::agent::SignalProcessRequest::default()),
+        )
+        .await
+        .expect("signal handler was blocked by metrics collection");
+        assert!(signal.is_err(), "the test request has no matching process");
+
+        release_tx.send(()).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), blocked_metrics)
+            .await
+            .expect("metrics collection did not finish after release")
+            .unwrap()
+            .unwrap();
     }
 
     #[test]

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -146,6 +146,10 @@ type service struct {
 	mu          sync.Mutex
 	eventSendMu sync.Mutex
 
+	// agentMetrics bounds guest metrics collection and keeps capability/failure
+	// state local to this sandbox.
+	agentMetrics agentMetricsState
+
 	// teardownWg tracks in-flight sandbox teardown started from wait().
 	// Shutdown() waits on it so the sandbox run directory (watched by
 	// kata-monitor) is removed before the shim exits, without having to

--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -41,12 +43,52 @@ const (
 	PolicyURL             = "/policy"
 	IP6TablesURL          = "/ip6tables"
 	MetricsURL            = "/metrics"
+
+	agentMetricsRetryInterval = 30 * time.Second
 )
 
 var (
-	ifSupportAgentMetricsAPI = true
-	shimMgtLog               = shimLog.WithField("subsystem", "shim-management")
+	shimMgtLog = shimLog.WithField("subsystem", "shim-management")
 )
+
+type agentMetricsState struct {
+	mu sync.Mutex
+
+	inFlight    bool
+	unsupported bool
+	retryAfter  time.Time
+}
+
+func (s *agentMetricsState) tryStart(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.inFlight || s.unsupported || now.Before(s.retryAfter) {
+		return false
+	}
+
+	s.inFlight = true
+	return true
+}
+
+func (s *agentMetricsState) finish(now time.Time, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.inFlight = false
+
+	if err == nil {
+		s.retryAfter = time.Time{}
+		return
+	}
+
+	if isGRPCErrorCode(codes.NotFound, err) {
+		s.unsupported = true
+		return
+	}
+
+	s.retryAfter = now.Add(agentMetricsRetryInterval)
+}
 
 type ResizeRequest struct {
 	VolumePath string
@@ -86,21 +128,22 @@ func (s *service) serveMetrics(w http.ResponseWriter, r *http.Request) {
 		encoder.Encode(mf)
 	}
 
-	// if using an old agent, only collect shim/sandbox metrics.
-	if !ifSupportAgentMetricsAPI {
+	// Allow at most one guest request per sandbox. If a transport ignores
+	// cancellation and remains stuck, the in-flight bit deliberately stays set
+	// so later scrapes cannot accumulate more blocked calls.
+	if !s.agentMetrics.tryStart(time.Now()) {
 		return
 	}
 
 	// get metrics from agent
-	// can not pass context to serveMetrics, so use background context
-	agentMetrics, err := s.sandbox.GetAgentMetrics(context.Background())
+	agentMetrics, err := s.sandbox.GetAgentMetrics(r.Context())
+	s.agentMetrics.finish(time.Now(), err)
 	if err != nil {
 		shimMgtLog.WithError(err).Error("failed GetAgentMetrics")
 		if isGRPCErrorCode(codes.NotFound, err) {
-			shimMgtLog.Warn("metrics API not supportted by this agent.")
-			ifSupportAgentMetricsAPI = false
-			return
+			shimMgtLog.Warn("metrics API not supported by this agent.")
 		}
+		return
 	}
 
 	// decode and parse metrics from agent

--- a/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
@@ -6,58 +6,245 @@
 package containerdshim
 
 import (
-	"fmt"
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func TestServeMetrics(t *testing.T) {
-	assert := assert.New(t)
+const testAgentMetrics = `# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 23
+`
 
-	sandbox := &vcmock.Sandbox{
-		MockID: testSandboxID,
-	}
-
-	s := &service{
+func newMetricsService(sandbox *vcmock.Sandbox) *service {
+	return &service{
 		id:         testSandboxID,
 		sandbox:    sandbox,
 		containers: make(map[string]*container),
 	}
+}
 
+func scrapeMetrics(s *service, ctx context.Context) *httptest.ResponseRecorder {
 	rr := httptest.NewRecorder()
-	r := &http.Request{}
+	r := httptest.NewRequest(http.MethodGet, MetricsURL, nil).WithContext(ctx)
+	s.serveMetrics(rr, r)
+	return rr
+}
 
-	// case 1: normal
-	sandbox.GetAgentMetricsFunc = func() (string, error) {
-		return `# HELP go_threads Number of OS threads created.
-# TYPE go_threads gauge
-go_threads 23
-`, nil
+func TestServeMetricsIncludesAgentMetrics(t *testing.T) {
+	sandbox := &vcmock.Sandbox{MockID: testSandboxID}
+	sandbox.GetAgentMetricsFunc = func(context.Context) (string, error) {
+		return testAgentMetrics, nil
 	}
 
-	defer func() {
-		sandbox.GetAgentMetricsFunc = nil
+	rr := scrapeMetrics(newMetricsService(sandbox), context.Background())
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "kata_agent_go_threads 23\n")
+}
+
+func TestServeMetricsReturnsAfterAgentError(t *testing.T) {
+	sandbox := &vcmock.Sandbox{MockID: testSandboxID}
+	sandbox.GetAgentMetricsFunc = func(context.Context) (string, error) {
+		// A response accompanying an error must never be decoded.
+		return testAgentMetrics, errors.New("some error occurred")
+	}
+
+	rr := scrapeMetrics(newMetricsService(sandbox), context.Background())
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Body.String(), "shim metrics should remain available")
+	assert.NotContains(t, rr.Body.String(), "kata_agent_go_threads")
+}
+
+func TestServeMetricsPropagatesRequestCancellation(t *testing.T) {
+	sandbox := &vcmock.Sandbox{MockID: testSandboxID}
+	seenContext := make(chan context.Context, 1)
+	sandbox.GetAgentMetricsFunc = func(ctx context.Context) (string, error) {
+		seenContext <- ctx
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	s := newMetricsService(sandbox)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		result <- scrapeMetrics(s, ctx)
 	}()
 
-	s.serveMetrics(rr, r)
-	assert.Equal(200, rr.Code, "response code should be 200")
-	body := rr.Body.String()
-
-	assert.Equal(true, strings.Contains(body, "kata_agent_go_threads 23\n"))
-
-	// case 2: GetAgentMetricsFunc return error
-	sandbox.GetAgentMetricsFunc = func() (string, error) {
-		return "", fmt.Errorf("some error occurred")
+	var agentContext context.Context
+	select {
+	case agentContext = <-seenContext:
+	case <-time.After(time.Second):
+		t.Fatal("agent call did not receive the HTTP request context")
 	}
 
-	s.serveMetrics(rr, r)
-	assert.Equal(200, rr.Code, "response code should be 200")
-	body = rr.Body.String()
-	assert.Equal(true, len(strings.Split(body, "\n")) > 0)
+	cancel()
+
+	select {
+	case rr := <-result:
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.NotEmpty(t, rr.Body.String(), "shim metrics should remain available")
+	case <-time.After(time.Second):
+		t.Fatal("metrics handler did not return after request cancellation")
+	}
+	assert.ErrorIs(t, agentContext.Err(), context.Canceled)
+}
+
+func TestServeMetricsDeadlineStartsCooldown(t *testing.T) {
+	sandbox := &vcmock.Sandbox{MockID: testSandboxID}
+	var calls atomic.Int32
+	sandbox.GetAgentMetricsFunc = func(ctx context.Context) (string, error) {
+		calls.Add(1)
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	s := newMetricsService(sandbox)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	rr := scrapeMetrics(s, ctx)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Body.String(), "shim metrics should remain available")
+	require.EqualValues(t, 1, calls.Load())
+
+	// The failure opens a per-sandbox cooldown, so an immediate retry does not
+	// call the guest again.
+	rr = scrapeMetrics(s, context.Background())
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Body.String(), "shim metrics should remain available")
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+func TestServeMetricsBlockedAgentDoesNotAccumulateCalls(t *testing.T) {
+	sandbox := &vcmock.Sandbox{MockID: testSandboxID}
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	sandbox.GetAgentMetricsFunc = func(ctx context.Context) (string, error) {
+		calls.Add(1)
+		current := active.Add(1)
+		defer active.Add(-1)
+
+		for {
+			previous := maxActive.Load()
+			if current <= previous || maxActive.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+
+		select {
+		case <-release:
+			return testAgentMetrics, nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	s := newMetricsService(sandbox)
+
+	firstResult := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		firstResult <- scrapeMetrics(s, context.Background())
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first agent metrics call did not start")
+	}
+
+	const concurrentScrapes = 50
+	results := make(chan *httptest.ResponseRecorder, concurrentScrapes)
+	var scrapes sync.WaitGroup
+	scrapes.Add(concurrentScrapes)
+	for range concurrentScrapes {
+		go func() {
+			defer scrapes.Done()
+			results <- scrapeMetrics(s, context.Background())
+		}()
+	}
+
+	scrapesDone := make(chan struct{})
+	go func() {
+		scrapes.Wait()
+		close(scrapesDone)
+	}()
+
+	select {
+	case <-scrapesDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent scrapes waited behind the blocked guest call")
+	}
+	close(results)
+
+	for rr := range results {
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.NotEmpty(t, rr.Body.String(), "shim metrics should remain available")
+		assert.NotContains(t, rr.Body.String(), "kata_agent_go_threads")
+	}
+	assert.EqualValues(t, 1, calls.Load())
+	assert.EqualValues(t, 1, maxActive.Load())
+
+	close(release)
+	select {
+	case rr := <-firstResult:
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "kata_agent_go_threads 23\n")
+	case <-time.After(time.Second):
+		t.Fatal("first metrics scrape did not finish after releasing the agent")
+	}
+}
+
+func TestServeMetricsCapabilityStateIsPerSandbox(t *testing.T) {
+	unsupportedSandbox := &vcmock.Sandbox{MockID: "unsupported"}
+	var unsupportedCalls atomic.Int32
+	unsupportedSandbox.GetAgentMetricsFunc = func(context.Context) (string, error) {
+		unsupportedCalls.Add(1)
+		return "", status.Error(codes.NotFound, "GetMetrics is unavailable")
+	}
+
+	supportedSandbox := &vcmock.Sandbox{MockID: "supported"}
+	var supportedCalls atomic.Int32
+	supportedSandbox.GetAgentMetricsFunc = func(context.Context) (string, error) {
+		supportedCalls.Add(1)
+		return testAgentMetrics, nil
+	}
+
+	unsupportedService := newMetricsService(unsupportedSandbox)
+	supportedService := newMetricsService(supportedSandbox)
+
+	unsupportedResult := scrapeMetrics(unsupportedService, context.Background())
+	assert.Equal(t, http.StatusOK, unsupportedResult.Code)
+	assert.NotContains(t, unsupportedResult.Body.String(), "kata_agent_go_threads")
+
+	// The old agent is remembered only by its own service.
+	scrapeMetrics(unsupportedService, context.Background())
+	assert.EqualValues(t, 1, unsupportedCalls.Load())
+
+	supportedResult := scrapeMetrics(supportedService, context.Background())
+	assert.Equal(t, http.StatusOK, supportedResult.Code)
+	assert.Contains(t, supportedResult.Body.String(), "kata_agent_go_threads 23\n")
+	assert.EqualValues(t, 1, supportedCalls.Load())
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -231,7 +231,7 @@ func (s *Sandbox) UpdateRuntimeMetrics() error {
 // GetAgentMetrics implements the VCSandbox function of the same name.
 func (s *Sandbox) GetAgentMetrics(ctx context.Context) (string, error) {
 	if s.GetAgentMetricsFunc != nil {
-		return s.GetAgentMetricsFunc()
+		return s.GetAgentMetricsFunc(ctx)
 	}
 	return "", nil
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -65,7 +65,7 @@ type Sandbox struct {
 	UpdateRoutesFunc         func(routes []*pbTypes.Route) ([]*pbTypes.Route, error)
 	ListRoutesFunc           func() ([]*pbTypes.Route, error)
 	UpdateRuntimeMetricsFunc func() error
-	GetAgentMetricsFunc      func() (string, error)
+	GetAgentMetricsFunc      func(context.Context) (string, error)
 	StatsFunc                func() (vc.SandboxStats, error)
 	GetAgentURLFunc          func() (string, error)
 }


### PR DESCRIPTION
  ## Summary

  Prevent blocked guest metrics collection from accumulating workers or disrupting lifecycle RPCs.

  This PR contains two independently buildable and cherry-pickable commits:

  1. Isolate synchronous guest-agent metrics collection.
  2. Bound guest metrics requests in each runtime shim.

  ## Changes

  ### Guest agent

  - Run synchronous metrics collection on Tokio’s blocking pool.
  - Permit only one active collection at a time.
  - Return the last successful cached response to concurrent scrapes.
  - Return a transient `UNAVAILABLE` error when collection is already active and no cache exists.
  - Keep the single-flight gate closed until blocking work actually exits, even if the requesting future is canceled.
  - Replace registration locking with race-safe one-time initialization.
  - Add deterministic tests using a blocked filesystem collector.
  - Verify health and signal handlers remain responsive during blocked collection.

  ### Runtime

  - Pass the HTTP request context to `GetAgentMetrics`.
  - Permit only one in-flight guest metrics request per sandbox.
  - Skip guest collection immediately when another request is active.
  - Add a per-sandbox cooldown after cancellation or agent failure.
  - Keep unsupported-agent state local to each sandbox instead of package-global.
  - Continue returning shim/runtime metrics with HTTP 200 when guest metrics are unavailable.
  - Stop processing the guest response after an agent error.
  - Update the sandbox mock to expose the received context.
