### PR TITLE
runtime: avoid holding service lock during agent RPCs

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/kill_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/kill_test.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package containerdshim
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/types/task"
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
+	"github.com/stretchr/testify/require"
+	otelTrace "go.opentelemetry.io/otel/trace"
+)
+
+const killTestTimeout = 5 * time.Second
+
+type signalProcessCall struct {
+	containerID string
+	processID   string
+	signal      syscall.Signal
+	all         bool
+}
+
+func newKillTestService(t *testing.T, signalProcessFunc func(context.Context, string, string, syscall.Signal, bool) error) (*service, *container) {
+	t.Helper()
+
+	s := &service{
+		id: testSandboxID,
+		sandbox: &vcmock.Sandbox{
+			MockID:            testSandboxID,
+			SignalProcessFunc: signalProcessFunc,
+		},
+		rootCtx:    context.Background(),
+		containers: make(map[string]*container),
+	}
+
+	c, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testContainerID}, vc.PodContainer, nil, false)
+	require.NoError(t, err)
+	c.status = task.Status_RUNNING
+	s.containers[c.id] = c
+
+	return s, c
+}
+
+func addKillTestExec(c *container, execID, processID string, status task.Status) {
+	c.setExec(execID, &exec{
+		container: c,
+		id:        processID,
+		status:    status,
+		tty:       &tty{},
+	})
+}
+
+func TestKillDoesNotHoldServiceLockDuringSignalProcess(t *testing.T) {
+	const otherContainerID = "other-container"
+
+	signalCalls := make(chan signalProcessCall, 2)
+	releaseSignal := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseSignal)
+		}
+	}()
+
+	s, target := newKillTestService(t, func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+		signalCalls <- signalProcessCall{
+			containerID: containerID,
+			processID:   processID,
+			signal:      signal,
+			all:         all,
+		}
+		<-releaseSignal
+		return nil
+	})
+
+	// Treat the target as the sandbox container so Delete only removes the
+	// shim-side state and cannot itself block in a mock agent operation.
+	target.cType = vc.PodSandbox
+
+	other, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: otherContainerID}, vc.PodContainer, nil, false)
+	require.NoError(t, err)
+	other.status = task.Status_RUNNING
+	s.containers[other.id] = other
+
+	killDone := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := s.Kill(context.Background(), &taskAPI.KillRequest{
+				ID:     target.id,
+				Signal: uint32(syscall.SIGTERM),
+			})
+			killDone <- err
+		}()
+	}
+
+	for range 2 {
+		select {
+		case call := <-signalCalls:
+			require.Equal(t, target.id, call.containerID)
+			require.Equal(t, target.id, call.processID)
+			require.Equal(t, syscall.SIGTERM, call.signal)
+			require.True(t, call.all)
+		case <-time.After(killTestTimeout):
+			t.Fatal("concurrent Kill calls did not reach SignalProcess")
+		}
+	}
+
+	stateDone := make(chan error, 1)
+	go func() {
+		_, err := s.State(context.Background(), &taskAPI.StateRequest{ID: otherContainerID})
+		stateDone <- err
+	}()
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, err := s.Delete(context.Background(), &taskAPI.DeleteRequest{ID: target.id})
+		deleteDone <- err
+	}()
+
+	select {
+	case err := <-stateDone:
+		require.NoError(t, err)
+	case <-time.After(killTestTimeout):
+		t.Fatal("State remained blocked behind SignalProcess")
+	}
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err)
+	case <-time.After(killTestTimeout):
+		t.Fatal("Delete remained blocked behind SignalProcess")
+	}
+
+	close(releaseSignal)
+	released = true
+
+	for range 2 {
+		select {
+		case err := <-killDone:
+			require.NoError(t, err)
+		case <-time.After(killTestTimeout):
+			t.Fatal("Kill did not return after SignalProcess completed")
+		}
+	}
+}
+
+func TestKillPropagatesRequestContextAndPreservesRootTrace(t *testing.T) {
+	signalContext := make(chan context.Context, 1)
+	releaseSignal := make(chan struct{})
+	defer close(releaseSignal)
+
+	rootSpanContext := otelTrace.NewSpanContext(otelTrace.SpanContextConfig{
+		TraceID:    otelTrace.TraceID{1},
+		SpanID:     otelTrace.SpanID{1},
+		TraceFlags: otelTrace.FlagsSampled,
+	})
+	rootCtx := otelTrace.ContextWithRemoteSpanContext(context.Background(), rootSpanContext)
+
+	s, _ := newKillTestService(t, func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+		signalContext <- ctx
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-releaseSignal:
+			return nil
+		}
+	})
+	s.rootCtx = rootCtx
+
+	ctx, cancel := context.WithCancel(context.Background())
+	killDone := make(chan error, 1)
+	go func() {
+		_, err := s.Kill(ctx, &taskAPI.KillRequest{
+			ID:     testContainerID,
+			Signal: uint32(syscall.SIGTERM),
+		})
+		killDone <- err
+	}()
+
+	var receivedCtx context.Context
+	select {
+	case receivedCtx = <-signalContext:
+	case <-time.After(killTestTimeout):
+		t.Fatal("Kill did not call SignalProcess")
+	}
+
+	require.Equal(t, rootSpanContext.TraceID(), otelTrace.SpanContextFromContext(receivedCtx).TraceID())
+
+	cancel()
+
+	select {
+	case <-receivedCtx.Done():
+		require.ErrorIs(t, receivedCtx.Err(), context.Canceled)
+	case <-time.After(killTestTimeout):
+		t.Fatal("SignalProcess context was not canceled")
+	}
+
+	select {
+	case err := <-killDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(killTestTimeout):
+		t.Fatal("Kill did not return after its context was canceled")
+	}
+}
+
+func TestKillProcessTargeting(t *testing.T) {
+	const (
+		execID        = "exec-id"
+		execProcessID = "guest-exec-id"
+	)
+
+	tests := []struct {
+		name          string
+		execID        string
+		requestAll    bool
+		wantProcessID string
+		wantAll       bool
+	}{
+		{
+			name:          "init process forces all",
+			wantProcessID: testContainerID,
+			wantAll:       true,
+		},
+		{
+			name:          "exec process",
+			execID:        execID,
+			wantProcessID: execProcessID,
+		},
+		{
+			name:          "exec process preserves all",
+			execID:        execID,
+			requestAll:    true,
+			wantProcessID: execProcessID,
+			wantAll:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signalCalls := make(chan signalProcessCall, 1)
+			s, c := newKillTestService(t, func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+				signalCalls <- signalProcessCall{
+					containerID: containerID,
+					processID:   processID,
+					signal:      signal,
+					all:         all,
+				}
+				return nil
+			})
+			addKillTestExec(c, execID, execProcessID, task.Status_RUNNING)
+
+			request := &taskAPI.KillRequest{
+				ID:     testContainerID,
+				ExecID: test.execID,
+				Signal: uint32(syscall.SIGUSR1),
+				All:    test.requestAll,
+			}
+
+			_, err := s.Kill(context.Background(), request)
+			require.NoError(t, err)
+
+			call := <-signalCalls
+			require.Equal(t, testContainerID, call.containerID)
+			require.Equal(t, test.wantProcessID, call.processID)
+			require.Equal(t, syscall.SIGUSR1, call.signal)
+			require.Equal(t, test.wantAll, call.all)
+			require.Equal(t, test.requestAll, request.All, "Kill mutated its request")
+		})
+	}
+}
+
+func TestKillStoppedProcessIsIdempotent(t *testing.T) {
+	const (
+		execID        = "exec-id"
+		execProcessID = "guest-exec-id"
+	)
+
+	tests := []struct {
+		name       string
+		execID     string
+		signal     syscall.Signal
+		wantCalled bool
+	}{
+		{name: "init SIGTERM", signal: syscall.SIGTERM},
+		{name: "init SIGKILL", signal: syscall.SIGKILL},
+		{name: "exec SIGTERM", execID: execID, signal: syscall.SIGTERM},
+		{name: "exec SIGKILL", execID: execID, signal: syscall.SIGKILL},
+		{name: "other signal is forwarded", execID: execID, signal: syscall.SIGUSR1, wantCalled: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			s, c := newKillTestService(t, func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+				called = true
+				return nil
+			})
+			c.status = task.Status_STOPPED
+			addKillTestExec(c, execID, execProcessID, task.Status_STOPPED)
+
+			_, err := s.Kill(context.Background(), &taskAPI.KillRequest{
+				ID:     testContainerID,
+				ExecID: test.execID,
+				Signal: uint32(test.signal),
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.wantCalled, called)
+		})
+	}
+}

--- a/src/runtime/pkg/containerd-shim-v2/metrics.go
+++ b/src/runtime/pkg/containerd-shim-v2/metrics.go
@@ -16,8 +16,8 @@ import (
 	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
-func marshalMetrics(ctx context.Context, s *service, containerID string) (*anypb.Any, error) {
-	stats, err := s.sandbox.StatsContainer(ctx, containerID)
+func marshalMetrics(ctx context.Context, sandbox vc.VCSandbox, containerID string) (*anypb.Any, error) {
+	stats, err := sandbox.StatsContainer(ctx, containerID)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/pkg/containerd-shim-v2/metrics_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/metrics_test.go
@@ -40,7 +40,7 @@ func TestStatNetworkMetric(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	sandbox.StatsContainerFunc = func(contID string) (vc.ContainerStats, error) {
+	sandbox.StatsContainerFunc = func(_ context.Context, contID string) (vc.ContainerStats, error) {
 		return vc.ContainerStats{
 			NetworkStats: mockNetwork,
 		}, nil

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -1049,7 +1049,17 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *
 func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (_ *taskAPI.StatsResponse, err error) {
 	shimLog.WithField("container", r.ID).Debug("Stats() start")
 	defer shimLog.WithField("container", r.ID).Debug("Stats() end")
-	span, spanCtx := katatrace.Trace(s.rootCtx, shimLog, "Stats", shimTracingTags)
+
+	// Preserve the sandbox-lifetime trace parent while deriving cancellation,
+	// deadlines, and request values from the incoming RPC context.
+	traceCtx := ctx
+	if s.rootCtx != nil {
+		rootSpan := otelTrace.SpanFromContext(s.rootCtx)
+		if rootSpan.SpanContext().IsValid() {
+			traceCtx = otelTrace.ContextWithSpan(ctx, rootSpan)
+		}
+	}
+	span, spanCtx := katatrace.Trace(traceCtx, shimLog, "Stats", shimTracingTags)
 	defer span.End()
 
 	start := time.Now()
@@ -1059,14 +1069,21 @@ func (s *service) Stats(ctx context.Context, r *taskAPI.StatsRequest) (_ *taskAP
 	}()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	c, err := s.getContainer(r.ID)
 	if err != nil {
+		s.mu.Unlock()
 		return nil, err
 	}
 
-	data, err := marshalMetrics(spanCtx, s, c.id)
+	// StatsContainer can block on an agent or cgroup read. Retain only immutable
+	// values after unlocking so a slow stats request cannot starve lifecycle
+	// operations that also need the service mutex.
+	sandbox := s.sandbox
+	containerID := c.id
+	s.mu.Unlock()
+
+	data, err := marshalMetrics(spanCtx, sandbox, containerID)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -804,7 +804,17 @@ func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (_ *empt
 func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *emptypb.Empty, err error) {
 	shimLog.WithField("container", r.ID).Debug("Kill() start")
 	defer shimLog.WithField("container", r.ID).Debug("Kill() end")
-	span, spanCtx := katatrace.Trace(s.rootCtx, shimLog, "Kill", shimTracingTags)
+
+	// Preserve the sandbox-lifetime trace parent while deriving cancellation,
+	// deadlines, and request values from the incoming RPC context.
+	traceCtx := ctx
+	if s.rootCtx != nil {
+		rootSpan := otelTrace.SpanFromContext(s.rootCtx)
+		if rootSpan.SpanContext().IsValid() {
+			traceCtx = otelTrace.ContextWithSpan(ctx, rootSpan)
+		}
+	}
+	span, spanCtx := katatrace.Trace(traceCtx, shimLog, "Kill", shimTracingTags)
 	defer span.End()
 
 	start := time.Now()
@@ -814,34 +824,39 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *emptypb.
 	}()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	signum := syscall.Signal(r.Signal)
+	all := r.All
 
 	c, err := s.getContainer(r.ID)
 	if err != nil {
+		s.mu.Unlock()
 		return nil, err
 	}
 
+	sandbox := s.sandbox
+	containerID := c.id
 	processStatus := c.status
-	processID := c.id
+	processID := containerID
 	if r.ExecID != "" {
 		execs, err := c.getExec(r.ExecID)
 		if err != nil {
+			s.mu.Unlock()
 			return nil, err
 		}
 		processID = execs.id
 		if processID == "" {
 			shimLog.WithFields(logrus.Fields{
-				"sandbox":   s.sandbox.ID(),
-				"container": c.id,
+				"sandbox":   sandbox.ID(),
+				"container": containerID,
 				"exec-id":   r.ExecID,
 			}).Debug("Id of exec process to be signalled is empty")
+			s.mu.Unlock()
 			return empty, errors.New("The exec process does not exist")
 		}
 		processStatus = execs.status
 	} else {
-		r.All = true
+		all = true
 	}
 
 	// According to CRI specs, kubelet will call StopPodSandbox()
@@ -853,14 +868,20 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *emptypb.
 	// and return directly.
 	if (signum == syscall.SIGKILL || signum == syscall.SIGTERM) && processStatus == task.Status_STOPPED {
 		shimLog.WithFields(logrus.Fields{
-			"sandbox":   s.sandbox.ID(),
-			"container": c.id,
+			"sandbox":   sandbox.ID(),
+			"container": containerID,
 			"exec-id":   r.ExecID,
 		}).Debug("process has already stopped")
+		s.mu.Unlock()
 		return empty, nil
 	}
 
-	return empty, s.sandbox.SignalProcess(spanCtx, c.id, processID, signum, r.All)
+	// Only immutable values from the container and exec are retained after
+	// unlocking. They may be stopped or removed while the agent RPC is in
+	// flight.
+	s.mu.Unlock()
+
+	return empty, sandbox.SignalProcess(spanCtx, containerID, processID, signum, all)
 }
 
 // Pids returns all pids inside the container

--- a/src/runtime/pkg/containerd-shim-v2/shim_metrics_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_metrics_test.go
@@ -35,8 +35,8 @@ func getSandboxCPUFunc(c, m uint64) func() (vc.SandboxStats, error) {
 	}
 }
 
-func getStatsContainerCPUFunc(fooCPU, barCPU, fooMem, barMem uint64) func(contID string) (vc.ContainerStats, error) {
-	return func(contID string) (vc.ContainerStats, error) {
+func getStatsContainerCPUFunc(fooCPU, barCPU, fooMem, barMem uint64) func(context.Context, string) (vc.ContainerStats, error) {
+	return func(_ context.Context, contID string) (vc.ContainerStats, error) {
 		vCPU := fooCPU
 		vMem := fooMem
 		if contID == "bar" {

--- a/src/runtime/pkg/containerd-shim-v2/stats_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/stats_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package containerdshim
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+
+	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/types/task"
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
+	"github.com/stretchr/testify/require"
+	otelTrace "go.opentelemetry.io/otel/trace"
+)
+
+const statsTestTimeout = 5 * time.Second
+
+func newStatsTestService(
+	t *testing.T,
+	statsContainerFunc func(context.Context, string) (vc.ContainerStats, error),
+	signalProcessFunc func(context.Context, string, string, syscall.Signal, bool) error,
+) (*service, *container) {
+	t.Helper()
+
+	s := &service{
+		id: testSandboxID,
+		sandbox: &vcmock.Sandbox{
+			MockID:             testSandboxID,
+			StatsContainerFunc: statsContainerFunc,
+			SignalProcessFunc:  signalProcessFunc,
+		},
+		rootCtx:    context.Background(),
+		containers: make(map[string]*container),
+	}
+
+	c, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testContainerID}, vc.PodContainer, nil, false)
+	require.NoError(t, err)
+	c.status = task.Status_RUNNING
+	s.containers[c.id] = c
+
+	return s, c
+}
+
+func TestStatsDoesNotHoldServiceLockDuringStatsContainer(t *testing.T) {
+	statsStarted := make(chan string, 1)
+	releaseStats := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseStats)
+		}
+	}()
+
+	statsErr := errors.New("stats released")
+	signalCalls := make(chan signalProcessCall, 1)
+	s, target := newStatsTestService(
+		t,
+		func(ctx context.Context, containerID string) (vc.ContainerStats, error) {
+			statsStarted <- containerID
+			select {
+			case <-releaseStats:
+				return vc.ContainerStats{}, statsErr
+			case <-ctx.Done():
+				return vc.ContainerStats{}, ctx.Err()
+			}
+		},
+		func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+			signalCalls <- signalProcessCall{
+				containerID: containerID,
+				processID:   processID,
+				signal:      signal,
+				all:         all,
+			}
+			return nil
+		},
+	)
+
+	// Deleting a sandbox container only removes shim-side state, keeping this
+	// regression focused on whether Stats monopolizes the service mutex.
+	target.cType = vc.PodSandbox
+
+	statsDone := make(chan error, 1)
+	go func() {
+		_, err := s.Stats(context.Background(), &taskAPI.StatsRequest{ID: target.id})
+		statsDone <- err
+	}()
+
+	select {
+	case containerID := <-statsStarted:
+		require.Equal(t, target.id, containerID)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Stats did not reach StatsContainer")
+	}
+
+	stateDone := make(chan error, 1)
+	go func() {
+		_, err := s.State(context.Background(), &taskAPI.StateRequest{ID: target.id})
+		stateDone <- err
+	}()
+
+	select {
+	case err := <-stateDone:
+		require.NoError(t, err)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("State remained blocked behind StatsContainer")
+	}
+
+	killDone := make(chan error, 1)
+	go func() {
+		_, err := s.Kill(context.Background(), &taskAPI.KillRequest{
+			ID:     target.id,
+			Signal: uint32(syscall.SIGTERM),
+		})
+		killDone <- err
+	}()
+
+	select {
+	case call := <-signalCalls:
+		require.Equal(t, target.id, call.containerID)
+		require.Equal(t, target.id, call.processID)
+		require.Equal(t, syscall.SIGTERM, call.signal)
+		require.True(t, call.all)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Kill did not reach SignalProcess while StatsContainer was blocked")
+	}
+
+	select {
+	case err := <-killDone:
+		require.NoError(t, err)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Kill remained blocked behind StatsContainer")
+	}
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, err := s.Delete(context.Background(), &taskAPI.DeleteRequest{ID: target.id})
+		deleteDone <- err
+	}()
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Delete remained blocked behind StatsContainer")
+	}
+
+	close(releaseStats)
+	released = true
+
+	select {
+	case err := <-statsDone:
+		require.ErrorIs(t, err, statsErr)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Stats did not return after StatsContainer completed")
+	}
+}
+
+func TestStatsPropagatesRequestContextAndPreservesRootTrace(t *testing.T) {
+	statsContext := make(chan context.Context, 1)
+
+	rootSpanContext := otelTrace.NewSpanContext(otelTrace.SpanContextConfig{
+		TraceID:    otelTrace.TraceID{1},
+		SpanID:     otelTrace.SpanID{1},
+		TraceFlags: otelTrace.FlagsSampled,
+	})
+	rootCtx := otelTrace.ContextWithRemoteSpanContext(context.Background(), rootSpanContext)
+
+	s, _ := newStatsTestService(
+		t,
+		func(ctx context.Context, containerID string) (vc.ContainerStats, error) {
+			statsContext <- ctx
+			<-ctx.Done()
+			return vc.ContainerStats{}, ctx.Err()
+		},
+		nil,
+	)
+	s.rootCtx = rootCtx
+
+	ctx, cancel := context.WithCancel(context.Background())
+	statsDone := make(chan error, 1)
+	go func() {
+		_, err := s.Stats(ctx, &taskAPI.StatsRequest{ID: testContainerID})
+		statsDone <- err
+	}()
+
+	var receivedCtx context.Context
+	select {
+	case receivedCtx = <-statsContext:
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Stats did not call StatsContainer")
+	}
+
+	require.Equal(t, rootSpanContext.TraceID(), otelTrace.SpanContextFromContext(receivedCtx).TraceID())
+
+	cancel()
+
+	select {
+	case <-receivedCtx.Done():
+		require.ErrorIs(t, receivedCtx.Err(), context.Canceled)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("StatsContainer context was not canceled")
+	}
+
+	select {
+	case err := <-statsDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(statsTestTimeout):
+		t.Fatal("Stats did not return after its context was canceled")
+	}
+}

--- a/src/runtime/virtcontainers/agent.go
+++ b/src/runtime/virtcontainers/agent.go
@@ -131,7 +131,7 @@ type agent interface {
 	memHotplugByProbe(ctx context.Context, addr uint64, sizeMB uint32, memorySectionSizeMB uint32) error
 
 	// statsContainer will tell the agent to get stats from a container related to a Sandbox
-	statsContainer(ctx context.Context, sandbox *Sandbox, c Container) (*ContainerStats, error)
+	statsContainer(ctx context.Context, containerID string) (*ContainerStats, error)
 
 	// pauseContainer will pause a container
 	pauseContainer(ctx context.Context, sandbox *Sandbox, c Container) error

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1801,7 +1801,7 @@ func (c *Container) stats(ctx context.Context) (*ContainerStats, error) {
 	if err := c.checkSandboxRunning("stats"); err != nil {
 		return nil, err
 	}
-	return c.sandbox.agent.statsContainer(ctx, c.sandbox, *c)
+	return c.sandbox.agent.statsContainer(ctx, c.id)
 }
 
 func (c *Container) update(ctx context.Context, resources specs.LinuxResources) error {

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1811,7 +1811,7 @@ func (c *Container) stats(ctx context.Context) (*ContainerStats, error) {
 	if err := c.checkSandboxRunning("stats"); err != nil {
 		return nil, err
 	}
-	return c.sandbox.agent.statsContainer(ctx, c.sandbox, *c)
+	return c.sandbox.agent.statsContainer(ctx, c.id)
 }
 
 func (c *Container) update(ctx context.Context, resources specs.LinuxResources) error {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2334,9 +2334,9 @@ func (k *kataAgent) onlineCPUMem(ctx context.Context, cpus uint32, cpuOnly bool)
 	return err
 }
 
-func (k *kataAgent) statsContainer(ctx context.Context, sandbox *Sandbox, c Container) (*ContainerStats, error) {
+func (k *kataAgent) statsContainer(ctx context.Context, containerID string) (*ContainerStats, error) {
 	req := &grpc.StatsContainerRequest{
-		ContainerId: c.id,
+		ContainerId: containerID,
 	}
 
 	returnStats, err := k.sendReq(ctx, req)

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2341,9 +2341,9 @@ func (k *kataAgent) onlineCPUMem(ctx context.Context, cpus uint32, cpuOnly bool)
 	return err
 }
 
-func (k *kataAgent) statsContainer(ctx context.Context, sandbox *Sandbox, c Container) (*ContainerStats, error) {
+func (k *kataAgent) statsContainer(ctx context.Context, containerID string) (*ContainerStats, error) {
 	req := &grpc.StatsContainerRequest{
-		ContainerId: c.id,
+		ContainerId: containerID,
 	}
 
 	returnStats, err := k.sendReq(ctx, req)

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -161,7 +161,7 @@ func TestKataAgentSendReq(t *testing.T) {
 	err = k.onlineCPUMem(ctx, 1, true)
 	assert.Nil(err)
 
-	_, err = k.statsContainer(ctx, sandbox, Container{})
+	_, err = k.statsContainer(ctx, "")
 	assert.Nil(err)
 
 	err = k.check(ctx)

--- a/src/runtime/virtcontainers/mock_agent.go
+++ b/src/runtime/virtcontainers/mock_agent.go
@@ -133,7 +133,7 @@ func (n *mockAgent) check(ctx context.Context) error {
 }
 
 // statsContainer is the Noop agent Container stats implementation. It does nothing.
-func (n *mockAgent) statsContainer(ctx context.Context, sandbox *Sandbox, c Container) (*ContainerStats, error) {
+func (n *mockAgent) statsContainer(_ context.Context, _ string) (*ContainerStats, error) {
 	return &ContainerStats{}, nil
 }
 

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -131,7 +131,7 @@ func (s *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
 // StatsContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) StatsContainer(ctx context.Context, contID string) (vc.ContainerStats, error) {
 	if s.StatsContainerFunc != nil {
-		return s.StatsContainerFunc(contID)
+		return s.StatsContainerFunc(ctx, contID)
 	}
 	return vc.ContainerStats{}, nil
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -173,6 +173,9 @@ func (s *Sandbox) WaitProcess(ctx context.Context, containerID, processID string
 
 // SignalProcess implements the VCSandbox function of the same name.
 func (s *Sandbox) SignalProcess(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error {
+	if s.SignalProcessFunc != nil {
+		return s.SignalProcessFunc(ctx, containerID, processID, signal, all)
+	}
 	return nil
 }
 

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -55,7 +55,7 @@ type Sandbox struct {
 	MonitorFunc              func() (chan error, error)
 	UpdateContainerFunc      func(containerID string, resources specs.LinuxResources) error
 	WaitProcessFunc          func(containerID, processID string) (int32, error)
-	SignalProcessFunc        func(containerID, processID string, signal syscall.Signal, all bool) error
+	SignalProcessFunc        func(ctx context.Context, containerID, processID string, signal syscall.Signal, all bool) error
 	WinsizeProcessFunc       func(containerID, processID string, height, width uint32) error
 	IOStreamFunc             func(containerID, processID string) (io.WriteCloser, io.Reader, io.Reader, error)
 	AddDeviceFunc            func(info config.DeviceInfo) (api.Device, error)

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -47,7 +47,7 @@ type Sandbox struct {
 	StopContainerFunc        func(contID string, force bool) (vc.VCContainer, error)
 	KillContainerFunc        func(contID string, signal syscall.Signal, all bool) error
 	StatusContainerFunc      func(contID string) (vc.ContainerStatus, error)
-	StatsContainerFunc       func(contID string) (vc.ContainerStats, error)
+	StatsContainerFunc       func(ctx context.Context, contID string) (vc.ContainerStats, error)
 	PauseContainerFunc       func(contID string) error
 	ResumeContainerFunc      func(contID string) error
 	StatusFunc               func() vc.SandboxStatus

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -247,7 +247,10 @@ type Sandbox struct {
 	sandboxController  resCtrl.ResourceController
 	overheadController resCtrl.ResourceController
 
-	containers map[string]*Container
+	// containersLock protects container lookups that may overlap with lifecycle
+	// updates while a blocking operation runs without the shim service mutex.
+	containersLock sync.RWMutex
+	containers     map[string]*Container
 
 	id string
 
@@ -404,6 +407,9 @@ func (s *Sandbox) configureGuestNetwork(ctx context.Context) error {
 
 // GetAllContainers returns all containers.
 func (s *Sandbox) GetAllContainers() []VCContainer {
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	ifa := make([]VCContainer, len(s.containers))
 
 	i := 0
@@ -417,6 +423,9 @@ func (s *Sandbox) GetAllContainers() []VCContainer {
 
 // GetContainer returns the container named by the containerID.
 func (s *Sandbox) GetContainer(containerID string) VCContainer {
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	if c, ok := s.containers[containerID]; ok {
 		return c
 	}
@@ -1054,6 +1063,9 @@ func (s *Sandbox) findContainer(containerID string) (*Container, error) {
 		return nil, types.ErrNeedContainerID
 	}
 
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	if c, ok := s.containers[containerID]; ok {
 		return c, nil
 	}
@@ -1072,6 +1084,9 @@ func (s *Sandbox) removeContainer(containerID string) error {
 	if containerID == "" {
 		return types.ErrNeedContainerID
 	}
+
+	s.containersLock.Lock()
+	defer s.containersLock.Unlock()
 
 	if _, ok := s.containers[containerID]; !ok {
 		return errors.Wrapf(types.ErrNoSuchContainer, "Could not remove the container %q from the sandbox %q containers list",
@@ -1673,6 +1688,9 @@ func (s *Sandbox) stopVM(ctx context.Context) error {
 }
 
 func (s *Sandbox) addContainer(c *Container) error {
+	s.containersLock.Lock()
+	defer s.containersLock.Unlock()
+
 	if _, ok := s.containers[c.id]; ok {
 		return fmt.Errorf("Duplicated container: %s", c.id)
 	}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -247,7 +247,10 @@ type Sandbox struct {
 	sandboxController  resCtrl.ResourceController
 	overheadController resCtrl.ResourceController
 
-	containers map[string]*Container
+	// containersLock protects container lookups that may overlap with lifecycle
+	// updates while a blocking operation runs without the shim service mutex.
+	containersLock sync.RWMutex
+	containers     map[string]*Container
 
 	id string
 
@@ -404,6 +407,9 @@ func (s *Sandbox) configureGuestNetwork(ctx context.Context) error {
 
 // GetAllContainers returns all containers.
 func (s *Sandbox) GetAllContainers() []VCContainer {
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	ifa := make([]VCContainer, len(s.containers))
 
 	i := 0
@@ -417,6 +423,9 @@ func (s *Sandbox) GetAllContainers() []VCContainer {
 
 // GetContainer returns the container named by the containerID.
 func (s *Sandbox) GetContainer(containerID string) VCContainer {
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	if c, ok := s.containers[containerID]; ok {
 		return c
 	}
@@ -1054,6 +1063,9 @@ func (s *Sandbox) findContainer(containerID string) (*Container, error) {
 		return nil, types.ErrNeedContainerID
 	}
 
+	s.containersLock.RLock()
+	defer s.containersLock.RUnlock()
+
 	if c, ok := s.containers[containerID]; ok {
 		return c, nil
 	}
@@ -1072,6 +1084,9 @@ func (s *Sandbox) removeContainer(containerID string) error {
 	if containerID == "" {
 		return types.ErrNeedContainerID
 	}
+
+	s.containersLock.Lock()
+	defer s.containersLock.Unlock()
 
 	if _, ok := s.containers[containerID]; !ok {
 		return errors.Wrapf(types.ErrNoSuchContainer, "Could not remove the container %q from the sandbox %q containers list",
@@ -1665,6 +1680,9 @@ func (s *Sandbox) stopVM(ctx context.Context) error {
 }
 
 func (s *Sandbox) addContainer(c *Container) error {
+	s.containersLock.Lock()
+	defer s.containersLock.Unlock()
+
 	if _, ok := s.containers[c.id]; ok {
 		return fmt.Errorf("Duplicated container: %s", c.id)
 	}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -473,6 +473,45 @@ func TestGetAllContainers(t *testing.T) {
 	}
 }
 
+func TestContainerLookupsConcurrentWithMutation(t *testing.T) {
+	const (
+		containerID = "container"
+		iterations  = 1000
+		readers     = 3
+	)
+
+	sandbox := Sandbox{
+		containers: map[string]*Container{
+			containerID: {id: containerID},
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(readers + 1)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			assert.NoError(t, sandbox.removeContainer(containerID))
+			assert.NoError(t, sandbox.addContainer(&Container{id: containerID}))
+		}
+	}()
+
+	for range readers {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				sandbox.GetContainer(containerID)
+				sandbox.GetAllContainers()
+				_, _ = sandbox.findContainer(containerID)
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.NotNil(t, sandbox.GetContainer(containerID))
+}
+
 func TestSetAnnotations(t *testing.T) {
 	assert := assert.New(t)
 	sandbox := Sandbox{


### PR DESCRIPTION
   ## Description

  A slow or blocked agent RPC could hold the shim-wide `service.mu`, preventing unrelated task operations from making progress.

  In particular, a blocked `StatsContainer` request could prevent `Kill` from delivering `SIGTERM`. If `SignalProcess` then stalled, it could similarly block `State`, `Delete`, and other lifecycle operations.

  This PR limits the service mutex to validating state and snapshotting immutable request data. The mutex is released before calling either `StatsContainer` or `SignalProcess`.

  It also:

  - propagates request cancellation and deadlines while preserving the sandbox root trace parent;
  - preserves init/exec targeting and stopped-process idempotency;
  - avoids mutating the incoming `KillRequest`;
  - passes only the immutable container ID through the agent stats path;
  - protects concurrent sandbox container-map lookups and mutations with an `RWMutex`.

  This does not force a blocked agent operation to complete; it contains its impact so unrelated shim operations remain responsive.
