### PR TITLE
ci: Get s390x CI back

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,19 +153,19 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  #build-kata-static-tarball-s390x:
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #    id-token: write # needed to sign images and generate attestations
-  #    attestations: write # needed to generate artifact attestations
-  #  uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
-  #  with:
-  #    tarball-suffix: -${{ inputs.tag }}
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    target-branch: ${{ inputs.target-branch }}
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  build-kata-static-tarball-s390x:
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
+    uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   build-kata-static-tarball-ppc64le:
     permissions:
@@ -179,42 +179,42 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  #publish-kata-deploy-image-s390x:
-  #  needs: build-kata-static-tarball-s390x
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #  uses: ./.github/workflows/publish-kata-images.yaml
-  #  with:
-  #    tarball-suffix: -${{ inputs.tag }}
-  #    registry: ghcr.io
-  #    repo: ${{ github.repository_owner }}/kata-deploy-ci
-  #    tag: ${{ inputs.tag }}-s390x
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    target-branch: ${{ inputs.target-branch }}
-  #    runner: ubuntu-24.04-s390x
-  #    arch: s390x
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  publish-kata-deploy-image-s390x:
+    needs: build-kata-static-tarball-s390x
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+    uses: ./.github/workflows/publish-kata-images.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-s390x
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+      runner: ubuntu-24.04-s390x
+      arch: s390x
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  #publish-kata-monitor-image-s390x:
-  #  needs: build-kata-static-tarball-s390x
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #  uses: ./.github/workflows/publish-kata-images.yaml
-  #  with:
-  #    tarball-suffix: -${{ inputs.tag }}
-  #    registry: ghcr.io
-  #    repo: ${{ github.repository_owner }}/kata-monitor-ci
-  #    tag: ${{ inputs.tag }}-s390x
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    target-branch: ${{ inputs.target-branch }}
-  #    runner: ubuntu-24.04-s390x
-  #    arch: s390x
-  #    image-kind: monitor
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  publish-kata-monitor-image-s390x:
+    needs: build-kata-static-tarball-s390x
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+    uses: ./.github/workflows/publish-kata-images.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-monitor-ci
+      tag: ${{ inputs.tag }}-s390x
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+      runner: ubuntu-24.04-s390x
+      arch: s390x
+      image-kind: monitor
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   publish-kata-deploy-image-ppc64le:
     needs: build-kata-static-tarball-ppc64le
@@ -292,7 +292,7 @@ jobs:
           tags: ghcr.io/kata-containers/test-images:unencrypted-${{ inputs.pr-number }}
           push: true
           context: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/s390x
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
   run-kata-monitor-tests:
@@ -429,20 +429,20 @@ jobs:
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
-  #run-k8s-tests-on-zvsi:
-  #  if: ${{ inputs.skip-test != 'yes' }}
-  #  needs: [publish-kata-deploy-image-s390x, build-and-publish-tee-confidential-unencrypted-image]
-  #  uses: ./.github/workflows/run-k8s-tests-on-zvsi.yaml
-  #  with:
-  #    registry: ghcr.io
-  #    repo: ${{ github.repository_owner }}/kata-deploy-ci
-  #    tag: ${{ inputs.tag }}-s390x
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    pr-number: ${{ inputs.pr-number }}
-  #    target-branch: ${{ inputs.target-branch }}
-  #    vmm: ${{ (inputs.pr-number == 'nightly' || inputs.pr-number == 'dev') && '["qemu", "qemu-runtime-rs", "qemu-coco-dev", "qemu-coco-dev-runtime-rs"]' || '["qemu", "qemu-runtime-rs", "qemu-coco-dev"]' }}
-  #  secrets:
-  #    AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
+  run-k8s-tests-on-zvsi:
+    if: ${{ inputs.skip-test != 'yes' }}
+    needs: [publish-kata-deploy-image-s390x, build-and-publish-tee-confidential-unencrypted-image]
+    uses: ./.github/workflows/run-k8s-tests-on-zvsi.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-s390x
+      commit-hash: ${{ inputs.commit-hash }}
+      pr-number: ${{ inputs.pr-number }}
+      target-branch: ${{ inputs.target-branch }}
+      vmm: ${{ (inputs.pr-number == 'nightly' || inputs.pr-number == 'dev') && '["qemu", "qemu-runtime-rs", "qemu-coco-dev", "qemu-coco-dev-runtime-rs"]' || '["qemu", "qemu-runtime-rs", "qemu-coco-dev"]' }}
+    secrets:
+      AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
 
   run-k8s-tests-on-ppc64le:
     if: ${{ inputs.skip-test != 'yes' }}
@@ -477,14 +477,14 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
 
-  #run-basic-s390x-tests:
-  #  if: ${{ inputs.skip-test != 'yes' }}
-  #  needs: build-kata-static-tarball-s390x
-  #  uses: ./.github/workflows/basic-ci-s390x.yaml
-  #  with:
-  #    tarball-suffix: -${{ inputs.tag }}
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    target-branch: ${{ inputs.target-branch }}
+  run-basic-s390x-tests:
+    if: ${{ inputs.skip-test != 'yes' }}
+    needs: build-kata-static-tarball-s390x
+    uses: ./.github/workflows/basic-ci-s390x.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
 
   run-cri-containerd-tests-amd64:
     if: ${{ inputs.skip-test != 'yes' }}
@@ -517,28 +517,28 @@ jobs:
       containerd_version: ${{ matrix.params.containerd_version }}
       vmm: ${{ matrix.params.vmm }}
 
-  #run-cri-containerd-tests-s390x:
-  #  if: ${{ inputs.skip-test != 'yes' }}
-  #  needs: build-kata-static-tarball-s390x
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      params: [
-  #        {containerd_version: latest, vmm: qemu},
-  #        {containerd_version: latest, vmm: qemu-runtime-rs},
-  #      ]
-  #  concurrency:
-  #    group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
-  #    cancel-in-progress: true
-  #  uses: ./.github/workflows/run-cri-containerd-tests.yaml
-  #  with:
-  #    tarball-suffix: -${{ inputs.tag }}
-  #    commit-hash: ${{ inputs.commit-hash }}
-  #    target-branch: ${{ inputs.target-branch }}
-  #    runner: s390x-large
-  #    arch: s390x
-  #    containerd_version: ${{ matrix.params.containerd_version }}
-  #    vmm: ${{ matrix.params.vmm }}
+  run-cri-containerd-tests-s390x:
+    if: ${{ inputs.skip-test != 'yes' }}
+    needs: build-kata-static-tarball-s390x
+    strategy:
+      fail-fast: false
+      matrix:
+        params: [
+          {containerd_version: latest, vmm: qemu},
+          {containerd_version: latest, vmm: qemu-runtime-rs},
+        ]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/run-cri-containerd-tests.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+      runner: s390x-large
+      arch: s390x
+      containerd_version: ${{ matrix.params.containerd_version }}
+      vmm: ${{ matrix.params.vmm }}
 
   run-cri-containerd-tests-ppc64le:
     if: ${{ inputs.skip-test != 'yes' }}

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -41,19 +41,19 @@ jobs:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}
 
-  #build-assets-s390x:
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #    id-token: write # needed to sign images and generate attestations
-  #    attestations: write # needed to generate artifact attestations
-  #  uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
-  #  with:
-  #    commit-hash: ${{ github.sha }}
-  #    push-to-registry: yes
-  #    target-branch: ${{ github.ref_name }}
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  build-assets-s390x:
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
+    uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      push-to-registry: yes
+      target-branch: ${{ github.ref_name }}
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   build-assets-ppc64le:
     permissions:
@@ -103,23 +103,23 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  #publish-kata-deploy-image-s390x:
-  #  needs: build-assets-s390x
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #  uses: ./.github/workflows/publish-kata-images.yaml
-  #  with:
-  #    commit-hash: ${{ github.sha }}
-  #    registry: quay.io
-  #    repo: kata-containers/kata-deploy-ci
-  #    tag: kata-containers-latest-s390x
-  #    target-branch: ${{ github.ref_name }}
-  #    runner: ubuntu-24.04-s390x
-  #    arch: s390x
-  #    image-kind: deploy
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  publish-kata-deploy-image-s390x:
+    needs: build-assets-s390x
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+    uses: ./.github/workflows/publish-kata-images.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      registry: quay.io
+      repo: kata-containers/kata-deploy-ci
+      tag: kata-containers-latest-s390x
+      target-branch: ${{ github.ref_name }}
+      runner: ubuntu-24.04-s390x
+      arch: s390x
+      image-kind: deploy
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   publish-kata-deploy-image-ppc64le:
     needs: build-assets-ppc64le
@@ -175,23 +175,23 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  #publish-kata-monitor-image-s390x:
-  #  needs: build-assets-s390x
-  #  permissions:
-  #    contents: read
-  #    packages: write # needed to push build artifacts to ghcr.io
-  #  uses: ./.github/workflows/publish-kata-images.yaml
-  #  with:
-  #    commit-hash: ${{ github.sha }}
-  #    registry: quay.io
-  #    repo: kata-containers/kata-monitor-ci
-  #    tag: kata-monitor-latest-s390x
-  #    target-branch: ${{ github.ref_name }}
-  #    runner: ubuntu-24.04-s390x
-  #    arch: s390x
-  #    image-kind: monitor
-  #  secrets:
-  #    QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+  publish-kata-monitor-image-s390x:
+    needs: build-assets-s390x
+    permissions:
+      contents: read
+      packages: write # needed to push build artifacts to ghcr.io
+    uses: ./.github/workflows/publish-kata-images.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      registry: quay.io
+      repo: kata-containers/kata-monitor-ci
+      tag: kata-monitor-latest-s390x
+      target-branch: ${{ github.ref_name }}
+      runner: ubuntu-24.04-s390x
+      arch: s390x
+      image-kind: monitor
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   publish-kata-monitor-image-ppc64le:
     needs: build-assets-ppc64le
@@ -217,7 +217,7 @@ jobs:
     permissions:
       contents: read
       packages: write # needed to push manifest images to ghcr.io
-    needs: [publish-kata-deploy-image-amd64, publish-kata-deploy-image-arm64, publish-kata-deploy-image-ppc64le]
+    needs: [publish-kata-deploy-image-amd64, publish-kata-deploy-image-arm64, publish-kata-deploy-image-s390x, publish-kata-deploy-image-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -244,7 +244,7 @@ jobs:
     permissions:
       contents: read
       packages: write # needed to push manifest images to ghcr.io
-    needs: [publish-kata-monitor-image-amd64, publish-kata-monitor-image-arm64, publish-kata-monitor-image-ppc64le]
+    needs: [publish-kata-monitor-image-amd64, publish-kata-monitor-image-arm64, publish-kata-monitor-image-s390x, publish-kata-monitor-image-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -182,6 +182,7 @@ function _publish_multiarch_manifest()
 			docker buildx imagetools create --tag "${registry}:${tag}" \
 				"${registry}:${tag}-amd64" \
 				"${registry}:${tag}-arm64" \
+				"${registry}:${tag}-s390x" \
 				"${registry}:${tag}-ppc64le"
 		done
 	done

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -76,7 +76,7 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-amd64 (minimum, dragonball) / run-cri-containerd-amd64 (minimum, dragonball)
       - Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-amd64 (minimum, qemu-runtime-rs) / run-cri-containerd-amd64 (minimum, qemu-runtime-rs)
       - Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-amd64 (minimum, qemu) / run-cri-containerd-amd64 (minimum, qemu)
-      #- Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-s390x (latest, qemu) / run-cri-containerd-s390x (latest, qemu)
+      - Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-s390x (latest, qemu) / run-cri-containerd-s390x (latest, qemu)
       #- Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-arm64 / run-k8s-tests-on-arm64 (qemu, kubeadm)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh-azure, normal)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh-azure, small, containerd)
@@ -93,8 +93,8 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (qemu-runtime-rs, latest)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (clh-runtime-rs, minimum)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (clh-runtime-rs, latest)
-      #- Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (devmapper, qemu, kubeadm)
-      #- Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (nydus, qemu-coco-dev, kubeadm)
+      - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (devmapper, qemu, kubeadm)
+      - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (nydus, qemu-coco-dev, kubeadm)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-on-tee (sev-snp, qemu-snp)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev, nydus, guest-pull)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev-runtime-rs, nydus, guest-pull)
@@ -145,27 +145,27 @@ mapping:
       - Static checks / static-checks (make static-checks)
       - Spelling check / check-spelling
       # static-checks-self-hosted.yaml
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, agent, src/agent, rust, libdevmapper, libseccomp, protobuf-compiler, clang, ub...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, agent-ctl, src/tools/agent-ctl, rust, protobuf-compiler, clang, ubuntu-24.04-s...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, agent, src/agent, rust, libdevmapper, libseccomp, protobuf-compiler, clang, ubu...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, agent-ctl, src/tools/agent-ctl, rust, protobuf-compiler, c...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, u...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubu...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubunt...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.0...
-      #- Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-2...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, agent, src/agent, rust, libdevmapper, libseccomp, protobuf-compiler, clang, ub...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make check, agent-ctl, src/tools/agent-ctl, rust, protobuf-compiler, clang, ubuntu-24.04-s...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, agent, src/agent, rust, libdevmapper, libseccomp, protobuf-compiler, clang, ubu...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (make test, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, agent-ctl, src/tools/agent-ctl, rust, protobuf-compiler, c...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, dragonball, src/dragonball, rust, ubuntu-24.04-s390x)
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, genpolicy, src/tools/genpolicy, rust, protobuf-compiler, u...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, kata-ctl, src/tools/kata-ctl, rust, protobuf-compiler, ubu...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, runtime-rs, src/runtime-rs, rust, protobuf-compiler, ubunt...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, runtime, src/runtime, golang, XDG_RUNTIME_DIR, ubuntu-24.0...
+      - Static checks self-hosted / build-checks (ubuntu-24.04-s390x) / check (sudo -E PATH="$PATH" make test, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-2...
     required-labels:
       - ok-to-test


### PR DESCRIPTION
A root cause for the issue where all s390x runners were down is identified at https://github.com/kata-containers/kata-containers/pull/13446#issuecomment-5089990423. By the PR:

```
Building content inside a container, but docker bind mounts /etc/resolv.conf into the container
the config file is modified during the workflow.
```

As the PR is closed and the runners are re-registered, this PR reverts https://github.com/kata-containers/kata-containers/pull/13489. 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>