### PR TITLE
dragonball: Restructure interrupt managers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,9 @@ name = "dbs-legacy-devices"
 version = "0.1.1"
 dependencies = [
  "dbs-device",
+ "dbs-interrupt",
  "dbs-utils",
+ "kvm-ioctls",
  "libc",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,9 @@ name = "dbs-legacy-devices"
 version = "0.1.1"
 dependencies = [
  "dbs-device",
+ "dbs-interrupt",
  "dbs-utils",
+ "kvm-ioctls",
  "libc",
  "log",
  "serde",

--- a/src/dragonball/crates/dbs_acpi/src/madt.rs
+++ b/src/dragonball/crates/dbs_acpi/src/madt.rs
@@ -158,7 +158,5 @@ pub fn create_madt_table(max_vcpus: u8, boot_vcpus: u8) -> Sdt {
 
     madt.append_slice(MadtEntryIoapic::new(0, IOAPIC_START, 0).as_slice());
 
-    madt.append_slice(MadtEntryIntrSrcOverride::new(0, 2, 2, 0).as_slice());
-
     madt
 }

--- a/src/dragonball/crates/dbs_interrupt/Cargo.toml
+++ b/src/dragonball/crates/dbs_interrupt/Cargo.toml
@@ -30,9 +30,5 @@ legacy-irq = []
 msi-irq = []
 
 kvm-irq = ["kvm-ioctls", "kvm-bindings"]
-kvm-legacy-irq = ["legacy-irq", "kvm-irq"]
-kvm-msi-generic = ["msi-irq", "kvm-irq"]
-kvm-msi-irq = ["kvm-msi-generic"]
-
-split-irq = ["kvm-ioctls", "kvm-bindings"]
-split-legacy-irq = ["legacy-irq", "split-irq"]
+userspace-irq = ["kvm-ioctls", "kvm-bindings"]
+split-irq = ["kvm-irq", "userspace-irq"]

--- a/src/dragonball/crates/dbs_interrupt/Cargo.toml
+++ b/src/dragonball/crates/dbs_interrupt/Cargo.toml
@@ -34,5 +34,9 @@ kvm-legacy-irq = ["legacy-irq", "kvm-irq"]
 kvm-msi-generic = ["msi-irq", "kvm-irq"]
 kvm-msi-irq = ["kvm-msi-generic"]
 
-split-irq = ["kvm-ioctls", "kvm-bindings"]
-split-legacy-irq = ["legacy-irq", "split-irq"]
+userspace-irq = ["kvm-ioctls", "kvm-bindings"]
+userspace-legacy-irq = ["legacy-irq", "userspace-irq"]
+
+split-irq = ["kvm-irq", "userspace-irq"]
+split-legacy-irq = ["userspace-legacy-irq"]
+split-msi-irq = ["kvm-msi-irq"]

--- a/src/dragonball/crates/dbs_interrupt/src/kvm/legacy_irq.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/kvm/legacy_irq.rs
@@ -270,10 +270,10 @@ mod test {
         let routing = KvmIrqRouting::new(vmfd.clone());
 
         // this would ok on 4.9 kernel
-        assert!(routing.initialize().is_err());
+        assert!(routing.initialize(false).is_err());
 
         vmfd.create_irq_chip().unwrap();
-        routing.initialize().unwrap();
+        routing.initialize(false).unwrap();
 
         let routes = &routing.routes.lock().unwrap();
         assert_eq!(routes.len(), MASTER_PIC + SLAVE_PIC + IOAPIC);
@@ -286,10 +286,10 @@ mod test {
         let routing = KvmIrqRouting::new(vmfd.clone());
 
         // this would ok on 4.9 kernel
-        assert!(routing.initialize().is_err());
+        assert!(routing.initialize(false).is_err());
 
         vmfd.create_irq_chip().unwrap();
-        routing.initialize().unwrap();
+        routing.initialize(false).unwrap();
 
         let mut entry = kvm_irq_routing_entry {
             gsi: 8,
@@ -318,10 +318,10 @@ mod test {
         let routing = KvmIrqRouting::new(vmfd.clone());
 
         // this would ok on 4.9 kernel
-        assert!(routing.initialize().is_err());
+        assert!(routing.initialize(false).is_err());
 
         vmfd.create_irq_chip().unwrap();
-        routing.initialize().unwrap();
+        routing.initialize(false).unwrap();
 
         let mut entry = kvm_irq_routing_entry {
             gsi: 8,

--- a/src/dragonball/crates/dbs_interrupt/src/kvm/mod.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/kvm/mod.rs
@@ -30,16 +30,16 @@ use kvm_ioctls::VmFd;
 
 use super::*;
 
-#[cfg(feature = "kvm-legacy-irq")]
+#[cfg(feature = "legacy-irq")]
 use legacy_irq::LegacyIrq;
-#[cfg(feature = "kvm-msi-irq")]
+#[cfg(feature = "msi-irq")]
 use msi_irq::MsiIrq;
 
-#[cfg(feature = "kvm-legacy-irq")]
+#[cfg(feature = "legacy-irq")]
 mod legacy_irq;
-#[cfg(feature = "kvm-msi-generic")]
+#[cfg(feature = "msi-irq")]
 mod msi_generic;
-#[cfg(feature = "kvm-msi-irq")]
+#[cfg(feature = "msi-irq")]
 mod msi_irq;
 
 /// Maximum number of global interrupt sources.
@@ -71,6 +71,24 @@ impl KvmIrqManager {
                 groups: HashMap::new(),
                 routes: Arc::new(KvmIrqRouting::new(vmfd)),
                 max_msi_irqs: DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+                kvm_legacy_disabled: false,
+            }),
+        }
+    }
+
+    /// Create a new KVM interrupt manager that only handles MSI interrupt, usually
+    /// used for VM with split irqchip
+    ///
+    /// # Arguments
+    /// * `vmfd`: The KVM VM file descriptor, which will be used to access the KVM subsystem.
+    pub fn new_with_kvm_legacy_disabled(vmfd: Arc<VmFd>) -> Self {
+        KvmIrqManager {
+            mgr: Mutex::new(KvmIrqManagerObj {
+                vmfd: vmfd.clone(),
+                groups: HashMap::new(),
+                routes: Arc::new(KvmIrqRouting::new(vmfd)),
+                max_msi_irqs: DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+                kvm_legacy_disabled: true,
             }),
         }
     }
@@ -112,11 +130,12 @@ struct KvmIrqManagerObj {
     routes: Arc<KvmIrqRouting>,
     groups: HashMap<InterruptIndex, Arc<Box<dyn InterruptSourceGroup>>>,
     max_msi_irqs: InterruptIndex,
+    kvm_legacy_disabled: bool,
 }
 
 impl KvmIrqManagerObj {
     fn initialize(&self) -> Result<()> {
-        self.routes.initialize()?;
+        self.routes.initialize(self.kvm_legacy_disabled)?;
         Ok(())
     }
 
@@ -128,14 +147,14 @@ impl KvmIrqManagerObj {
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
         #[allow(unreachable_patterns)]
         let group: Arc<Box<dyn InterruptSourceGroup>> = match ty {
-            #[cfg(feature = "kvm-legacy-irq")]
+            #[cfg(feature = "legacy-irq")]
             InterruptSourceType::LegacyIrq => Arc::new(Box::new(LegacyIrq::new(
                 base,
                 count,
                 self.vmfd.clone(),
                 self.routes.clone(),
             )?)),
-            #[cfg(feature = "kvm-msi-irq")]
+            #[cfg(feature = "msi-irq")]
             InterruptSourceType::MsiIrq => Arc::new(Box::new(MsiIrq::new(
                 base,
                 count,
@@ -161,7 +180,7 @@ impl KvmIrqManagerObj {
 // interrupt source on x86 platforms. The PIC and IOAPIC may share the same GSI on x86 platforms.
 fn hash_key(entry: &kvm_irq_routing_entry) -> u64 {
     let type1 = match entry.type_ {
-        #[cfg(feature = "kvm-legacy-irq")]
+        #[cfg(feature = "legacy-irq")]
         kvm_bindings::KVM_IRQ_ROUTING_IRQCHIP => unsafe { entry.u.irqchip.irqchip },
         _ => 0u32,
     };
@@ -181,13 +200,15 @@ impl KvmIrqRouting {
         }
     }
 
-    pub(super) fn initialize(&self) -> Result<()> {
+    pub(super) fn initialize(&self, kvm_legacy_disabled: bool) -> Result<()> {
         // Safe to unwrap because there's no legal way to break the mutex.
         #[allow(unused_mut)]
         let mut routes = self.routes.lock().unwrap();
 
-        #[cfg(feature = "kvm-legacy-irq")]
-        LegacyIrq::initialize_legacy(&mut routes)?;
+        #[cfg(feature = "legacy-irq")]
+        if !kvm_legacy_disabled {
+            LegacyIrq::initialize_legacy(&mut routes)?;
+        }
 
         self.set_routing(&routes)?;
 
@@ -213,7 +234,7 @@ impl KvmIrqRouting {
     }
 }
 
-#[cfg(feature = "kvm-msi-generic")]
+#[cfg(feature = "msi-irq")]
 impl KvmIrqRouting {
     pub(super) fn add(&self, entries: &[kvm_irq_routing_entry]) -> Result<()> {
         // Safe to unwrap because there's no legal way to break the mutex.

--- a/src/dragonball/crates/dbs_interrupt/src/kvm/mod.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/kvm/mod.rs
@@ -71,6 +71,24 @@ impl KvmIrqManager {
                 groups: HashMap::new(),
                 routes: Arc::new(KvmIrqRouting::new(vmfd)),
                 max_msi_irqs: DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+                kvm_legacy_disabled: false,
+            }),
+        }
+    }
+
+    /// Create a new KVM interrupt manager that only handles MSI interrupt, usually
+    /// used for VM with split irqchip
+    ///
+    /// # Arguments
+    /// * `vmfd`: The KVM VM file descriptor, which will be used to access the KVM subsystem.
+    pub fn new_with_kvm_legacy_disabled(vmfd: Arc<VmFd>) -> Self {
+        KvmIrqManager {
+            mgr: Mutex::new(KvmIrqManagerObj {
+                vmfd: vmfd.clone(),
+                groups: HashMap::new(),
+                routes: Arc::new(KvmIrqRouting::new(vmfd)),
+                max_msi_irqs: DEFAULT_MAX_MSI_IRQS_PER_DEVICE,
+                kvm_legacy_disabled: true,
             }),
         }
     }
@@ -112,11 +130,12 @@ struct KvmIrqManagerObj {
     routes: Arc<KvmIrqRouting>,
     groups: HashMap<InterruptIndex, Arc<Box<dyn InterruptSourceGroup>>>,
     max_msi_irqs: InterruptIndex,
+    kvm_legacy_disabled: bool,
 }
 
 impl KvmIrqManagerObj {
     fn initialize(&self) -> Result<()> {
-        self.routes.initialize()?;
+        self.routes.initialize(self.kvm_legacy_disabled)?;
         Ok(())
     }
 
@@ -181,13 +200,15 @@ impl KvmIrqRouting {
         }
     }
 
-    pub(super) fn initialize(&self) -> Result<()> {
+    pub(super) fn initialize(&self, kvm_legacy_disabled: bool) -> Result<()> {
         // Safe to unwrap because there's no legal way to break the mutex.
         #[allow(unused_mut)]
         let mut routes = self.routes.lock().unwrap();
 
         #[cfg(feature = "kvm-legacy-irq")]
-        LegacyIrq::initialize_legacy(&mut routes)?;
+        if !kvm_legacy_disabled {
+            LegacyIrq::initialize_legacy(&mut routes)?;
+        }
 
         self.set_routing(&routes)?;
 

--- a/src/dragonball/crates/dbs_interrupt/src/kvm/msi_irq.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/kvm/msi_irq.rs
@@ -212,7 +212,7 @@ mod test {
         vmfd.create_irq_chip().unwrap();
 
         let rounting = Arc::new(KvmIrqRouting::new(vmfd.clone()));
-        rounting.initialize().unwrap();
+        rounting.initialize(false).unwrap();
 
         let base = 168;
         let count = 32;

--- a/src/dragonball/crates/dbs_interrupt/src/lib.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/lib.rs
@@ -71,10 +71,15 @@ pub mod kvm;
 #[cfg(feature = "kvm-irq")]
 pub use self::kvm::KvmIrqManager;
 
-#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+#[cfg(all(target_arch = "x86_64", feature = "userspace-irq"))]
 pub mod userspace;
-#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+#[cfg(all(target_arch = "x86_64", feature = "userspace-irq"))]
 pub use self::userspace::{ioapic::*, manager::UserspaceIoapicManager};
+
+#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+pub mod split;
+#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+pub use self::split::SplitIrqManager;
 
 /// Reuse std::io::Result to simplify interoperability among crates.
 pub type Result<T> = std::io::Result<T>;

--- a/src/dragonball/crates/dbs_interrupt/src/manager.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/manager.rs
@@ -461,7 +461,7 @@ impl InterruptStatusRegister32 {
     }
 }
 
-#[cfg(all(test, feature = "kvm-legacy-irq", feature = "kvm-msi-irq"))]
+#[cfg(all(test, feature = "legacy-irq", feature = "msi-irq"))]
 pub(crate) mod tests {
     use std::sync::Arc;
 

--- a/src/dragonball/crates/dbs_interrupt/src/notifier.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/notifier.rs
@@ -248,7 +248,7 @@ mod tests {
         assert!(notifier.notifier().is_none());
     }
 
-    #[cfg(feature = "kvm-legacy-irq")]
+    #[cfg(feature = "legacy-irq")]
     #[test]
     fn test_create_legacy_notifier() {
         skip_if_kvm_unaccessable!();
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(clone.as_any().type_id(), notifier.as_any().type_id());
     }
 
-    #[cfg(feature = "kvm-msi-irq")]
+    #[cfg(feature = "msi-irq")]
     #[test]
     fn test_virtio_msi_notifier() {
         skip_if_kvm_unaccessable!();

--- a/src/dragonball/crates/dbs_interrupt/src/split.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/split.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use kvm_ioctls::VmFd;
+
+use std::io::{Error, ErrorKind};
+use std::sync::Arc;
+
+#[cfg(feature = "msi-irq")]
+use super::KvmIrqManager;
+#[cfg(feature = "legacy-irq")]
+use super::UserspaceIoapicManager;
+use super::{InterruptIndex, InterruptManager, InterruptSourceGroup, InterruptSourceType, Result};
+
+/// Structure to manage interrupt sources for a virtual machine in with both KVM and
+/// userspace IOAPIC.
+///
+/// In case of split irqchip, legacy IRQs are managed with userspace IOAPIC, while
+/// MSI IRQs are managed by KVM.
+pub struct SplitIrqManager {
+    #[cfg(feature = "legacy-irq")]
+    userspace_mgr: UserspaceIoapicManager,
+    #[cfg(feature = "msi-irq")]
+    kvm_mgr: KvmIrqManager,
+}
+
+impl SplitIrqManager {
+    /// Create a new interrupt manager in split mode
+    pub fn new(vmfd: Arc<VmFd>) -> Result<Self> {
+        Ok(Self {
+            #[cfg(feature = "legacy-irq")]
+            userspace_mgr: UserspaceIoapicManager::create_default_ioapic_manager(vmfd.clone())?,
+            #[cfg(feature = "msi-irq")]
+            kvm_mgr: KvmIrqManager::new_with_kvm_legacy_disabled(vmfd.clone()),
+        })
+    }
+
+    #[cfg(feature = "msi-irq")]
+    /// Set maximum supported MSI interrupts per device.
+    pub fn set_max_msi_irqs(&self, max_msi_irqs: InterruptIndex) {
+        self.kvm_mgr.set_max_msi_irqs(max_msi_irqs);
+    }
+}
+
+impl InterruptManager for SplitIrqManager {
+    fn initialize(&self) -> Result<()> {
+        #[cfg(feature = "legacy-irq")]
+        self.userspace_mgr.initialize()?;
+        #[cfg(feature = "msi-irq")]
+        self.kvm_mgr.initialize()?;
+        Ok(())
+    }
+
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        #[allow(unreachable_patterns)]
+        let group = match ty {
+            #[cfg(feature = "legacy-irq")]
+            InterruptSourceType::LegacyIrq => self.userspace_mgr.create_group(ty, base, count)?,
+            #[cfg(feature = "msi-irq")]
+            InterruptSourceType::MsiIrq => self.kvm_mgr.create_group(ty, base, count)?,
+            _ => return Err(Error::from(ErrorKind::InvalidInput)),
+        };
+        Ok(group)
+    }
+
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        #[allow(unreachable_patterns)]
+        match group.interrupt_type() {
+            #[cfg(feature = "legacy-irq")]
+            InterruptSourceType::LegacyIrq => self.userspace_mgr.destroy_group(group)?,
+            #[cfg(feature = "msi-irq")]
+            InterruptSourceType::MsiIrq => self.kvm_mgr.destroy_group(group)?,
+            _ => return Err(Error::from(ErrorKind::InvalidInput)),
+        };
+        Ok(())
+    }
+
+    fn ioapic_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        #[cfg(feature = "legacy-irq")]
+        return self.userspace_mgr.ioapic_read(addr, data);
+        #[cfg(not(feature = "legacy-irq"))]
+        {
+            let _ = (addr, data);
+            Ok(())
+        }
+    }
+
+    fn ioapic_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        #[cfg(feature = "legacy-irq")]
+        return self.userspace_mgr.ioapic_write(addr, data);
+        #[cfg(not(feature = "legacy-irq"))]
+        {
+            let _ = (addr, data);
+            Ok(())
+        }
+    }
+}

--- a/src/dragonball/crates/dbs_interrupt/src/split.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/split.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use kvm_ioctls::VmFd;
+
+use std::io::{Error, ErrorKind};
+use std::sync::Arc;
+
+#[cfg(feature = "split-msi-irq")]
+use super::KvmIrqManager;
+#[cfg(feature = "split-legacy-irq")]
+use super::UserspaceIoapicManager;
+use super::{InterruptIndex, InterruptManager, InterruptSourceGroup, InterruptSourceType, Result};
+
+/// Structure to manage interrupt sources for a virtual machine in with both KVM and
+/// userspace IOAPIC.
+///
+/// In case of split irqchip, legacy IRQs are managed with userspace IOAPIC, while
+/// MSI IRQs are managed by KVM.
+pub struct SplitIrqManager {
+    #[cfg(feature = "split-legacy-irq")]
+    userspace_mgr: UserspaceIoapicManager,
+    #[cfg(feature = "split-msi-irq")]
+    kvm_mgr: KvmIrqManager,
+}
+
+impl SplitIrqManager {
+    /// Create a new interrupt manager in split mode
+    pub fn new(vmfd: Arc<VmFd>) -> Result<Self> {
+        Ok(Self {
+            #[cfg(feature = "split-legacy-irq")]
+            userspace_mgr: UserspaceIoapicManager::create_default_ioapic_manager(vmfd.clone())?,
+            #[cfg(feature = "split-msi-irq")]
+            kvm_mgr: KvmIrqManager::new_with_kvm_legacy_disabled(vmfd.clone()),
+        })
+    }
+
+    #[cfg(feature = "split-msi-irq")]
+    /// Set maximum supported MSI interrupts per device.
+    pub fn set_max_msi_irqs(&self, max_msi_irqs: InterruptIndex) {
+        self.kvm_mgr.set_max_msi_irqs(max_msi_irqs);
+    }
+}
+
+impl InterruptManager for SplitIrqManager {
+    fn initialize(&self) -> Result<()> {
+        #[cfg(feature = "split-legacy-irq")]
+        self.userspace_mgr.initialize()?;
+        #[cfg(feature = "split-msi-irq")]
+        self.kvm_mgr.initialize()?;
+        Ok(())
+    }
+
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        #[allow(unreachable_patterns)]
+        let group = match ty {
+            #[cfg(feature = "split-legacy-irq")]
+            InterruptSourceType::LegacyIrq => self.userspace_mgr.create_group(ty, base, count)?,
+            #[cfg(feature = "split-msi-irq")]
+            InterruptSourceType::MsiIrq => self.kvm_mgr.create_group(ty, base, count)?,
+            _ => return Err(Error::from(ErrorKind::InvalidInput))?,
+        };
+        Ok(group)
+    }
+
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        #[allow(unreachable_patterns)]
+        match group.interrupt_type() {
+            #[cfg(feature = "split-legacy-irq")]
+            InterruptSourceType::LegacyIrq => self.userspace_mgr.destroy_group(group)?,
+            #[cfg(feature = "split-msi-irq")]
+            InterruptSourceType::MsiIrq => self.kvm_mgr.destroy_group(group)?,
+            _ => return Err(Error::from(ErrorKind::InvalidInput))?,
+        };
+        Ok(())
+    }
+
+    fn ioapic_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        #[cfg(feature = "split-legacy-irq")]
+        return self.userspace_mgr.ioapic_read(addr, data);
+    }
+
+    fn ioapic_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        #[cfg(feature = "split-legacy-irq")]
+        return self.userspace_mgr.ioapic_write(addr, data);
+    }
+}

--- a/src/dragonball/crates/dbs_interrupt/src/userspace/manager.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/userspace/manager.rs
@@ -8,7 +8,7 @@ use kvm_ioctls::VmFd;
 use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
 
-#[cfg(feature = "split-legacy-irq")]
+#[cfg(feature = "legacy-irq")]
 use super::legacy_irq::*;
 use super::{
     ioapic::*, InterruptIndex, InterruptManager, InterruptSourceGroup, InterruptSourceType, Result,
@@ -25,7 +25,7 @@ pub struct UserspaceIoapicManager {
     // IoapicVer register is read-only
     ioapicver: IoapicVer,
     ioapicarb: RwLock<IoapicArb>,
-    #[cfg(feature = "split-legacy-irq")]
+    #[cfg(feature = "legacy-irq")]
     irqs: Vec<Arc<UserspaceLegacyIrqObj>>,
 }
 
@@ -44,7 +44,7 @@ impl UserspaceIoapicManager {
         ioapicver.set_version(version);
         ioapicver.set_entries(nr_redir_entries as u8 - 1);
 
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "legacy-irq")]
         let irqs = {
             let mut irqs = Vec::with_capacity(nr_redir_entries as usize);
             for i in 0..nr_redir_entries {
@@ -58,7 +58,7 @@ impl UserspaceIoapicManager {
             ioapicid: RwLock::new(IoapicId::default()),
             ioapicver,
             ioapicarb: RwLock::new(IoapicArb::default()),
-            #[cfg(feature = "split-legacy-irq")]
+            #[cfg(feature = "legacy-irq")]
             irqs,
         })
     }
@@ -101,7 +101,7 @@ impl UserspaceIoapicManager {
             // We have checked the validity of ioregsel while setting, therefore all values beyond the
             // special IOAPIC registers above would become a valid redirection entry
             index => {
-                #[cfg(feature = "split-legacy-irq")]
+                #[cfg(feature = "legacy-irq")]
                 {
                     let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
                     let is_low = (offset & 0x1) == 0;
@@ -113,7 +113,7 @@ impl UserspaceIoapicManager {
                         self.irqs[irq_base].redir_entry_high().into()
                     }
                 }
-                #[cfg(not(feature = "split-legacy-irq"))]
+                #[cfg(not(feature = "legacy-irq"))]
                 0
             }
         }
@@ -136,7 +136,7 @@ impl UserspaceIoapicManager {
             // We have checked the validity of ioregsel while setting, therefore all values beyond the four
             // special IOAPIC registers above would become a valid redirection entry
             index => {
-                #[cfg(feature = "split-legacy-irq")]
+                #[cfg(feature = "legacy-irq")]
                 {
                     let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
                     let is_low = (offset & 0x1) == 0;
@@ -167,7 +167,7 @@ impl InterruptManager for UserspaceIoapicManager {
         count: u32,
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
         let group = match ty {
-            #[cfg(feature = "split-legacy-irq")]
+            #[cfg(feature = "legacy-irq")]
             InterruptSourceType::LegacyIrq => {
                 if count != 1 {
                     return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
@@ -265,7 +265,7 @@ pub(crate) mod test {
             u4::from_u8(0)
         );
 
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "legacy-irq")]
         {
             assert_eq!(manager.irqs.len(), 12);
             for irq in manager.irqs.iter() {
@@ -313,7 +313,7 @@ pub(crate) mod test {
         manager.set_ioregsel(0x12).unwrap();
         manager.set_iowin(0xcccccccc).unwrap();
         assert_eq!(manager.iowin(), 0xcccccccc);
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "legacy-irq")]
         {
             assert_eq!(u32::from(manager.irqs[1].redir_entry_low()), 0xcccccccc);
         }
@@ -321,7 +321,7 @@ pub(crate) mod test {
         manager.set_ioregsel(0x15).unwrap();
         manager.set_iowin(0xbbbbbbbb).unwrap();
         assert_eq!(manager.iowin(), 0xbbbbbbbb);
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "legacy-irq")]
         {
             assert_eq!(u32::from(manager.irqs[2].redir_entry_high()), 0xbbbbbbbb);
         }

--- a/src/dragonball/crates/dbs_interrupt/src/userspace/manager.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/userspace/manager.rs
@@ -8,7 +8,7 @@ use kvm_ioctls::VmFd;
 use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
 
-#[cfg(feature = "split-legacy-irq")]
+#[cfg(feature = "userspace-legacy-irq")]
 use super::legacy_irq::*;
 use super::{
     ioapic::*, InterruptIndex, InterruptManager, InterruptSourceGroup, InterruptSourceType, Result,
@@ -25,7 +25,7 @@ pub struct UserspaceIoapicManager {
     // IoapicVer register is read-only
     ioapicver: IoapicVer,
     ioapicarb: RwLock<IoapicArb>,
-    #[cfg(feature = "split-legacy-irq")]
+    #[cfg(feature = "userspace-legacy-irq")]
     irqs: Vec<Arc<UserspaceLegacyIrqObj>>,
 }
 
@@ -44,7 +44,7 @@ impl UserspaceIoapicManager {
         ioapicver.set_version(version);
         ioapicver.set_entries(nr_redir_entries as u8 - 1);
 
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "userspace-legacy-irq")]
         let irqs = {
             let mut irqs = Vec::with_capacity(nr_redir_entries as usize);
             for i in 0..nr_redir_entries {
@@ -58,7 +58,7 @@ impl UserspaceIoapicManager {
             ioapicid: RwLock::new(IoapicId::default()),
             ioapicver,
             ioapicarb: RwLock::new(IoapicArb::default()),
-            #[cfg(feature = "split-legacy-irq")]
+            #[cfg(feature = "userspace-legacy-irq")]
             irqs,
         })
     }
@@ -101,7 +101,7 @@ impl UserspaceIoapicManager {
             // We have checked the validity of ioregsel while setting, therefore all values beyond the
             // special IOAPIC registers above would become a valid redirection entry
             index => {
-                #[cfg(feature = "split-legacy-irq")]
+                #[cfg(feature = "userspace-legacy-irq")]
                 {
                     let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
                     let is_low = (offset & 0x1) == 0;
@@ -113,7 +113,7 @@ impl UserspaceIoapicManager {
                         self.irqs[irq_base].redir_entry_high().into()
                     }
                 }
-                #[cfg(not(feature = "split-legacy-irq"))]
+                #[cfg(not(feature = "userspace-legacy-irq"))]
                 0
             }
         }
@@ -136,7 +136,7 @@ impl UserspaceIoapicManager {
             // We have checked the validity of ioregsel while setting, therefore all values beyond the four
             // special IOAPIC registers above would become a valid redirection entry
             index => {
-                #[cfg(feature = "split-legacy-irq")]
+                #[cfg(feature = "userspace-legacy-irq")]
                 {
                     let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
                     let is_low = (offset & 0x1) == 0;
@@ -167,7 +167,7 @@ impl InterruptManager for UserspaceIoapicManager {
         count: u32,
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
         let group = match ty {
-            #[cfg(feature = "split-legacy-irq")]
+            #[cfg(feature = "userspace-legacy-irq")]
             InterruptSourceType::LegacyIrq => {
                 if count != 1 {
                     return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
@@ -265,7 +265,7 @@ pub(crate) mod test {
             u4::from_u8(0)
         );
 
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "userspace-legacy-irq")]
         {
             assert_eq!(manager.irqs.len(), 12);
             for irq in manager.irqs.iter() {
@@ -313,7 +313,7 @@ pub(crate) mod test {
         manager.set_ioregsel(0x12).unwrap();
         manager.set_iowin(0xcccccccc).unwrap();
         assert_eq!(manager.iowin(), 0xcccccccc);
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "userspace-legacy-irq")]
         {
             assert_eq!(u32::from(manager.irqs[1].redir_entry_low()), 0xcccccccc);
         }
@@ -321,7 +321,7 @@ pub(crate) mod test {
         manager.set_ioregsel(0x15).unwrap();
         manager.set_iowin(0xbbbbbbbb).unwrap();
         assert_eq!(manager.iowin(), 0xbbbbbbbb);
-        #[cfg(feature = "split-legacy-irq")]
+        #[cfg(feature = "userspace-legacy-irq")]
         {
             assert_eq!(u32::from(manager.irqs[2].redir_entry_high()), 0xbbbbbbbb);
         }

--- a/src/dragonball/crates/dbs_interrupt/src/userspace/mod.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/userspace/mod.rs
@@ -4,7 +4,7 @@
 //
 
 pub mod ioapic;
-#[cfg(feature = "split-legacy-irq")]
+#[cfg(feature = "legacy-irq")]
 pub mod legacy_irq;
 pub mod manager;
 

--- a/src/dragonball/crates/dbs_interrupt/src/userspace/mod.rs
+++ b/src/dragonball/crates/dbs_interrupt/src/userspace/mod.rs
@@ -4,7 +4,7 @@
 //
 
 pub mod ioapic;
-#[cfg(feature = "split-legacy-irq")]
+#[cfg(feature = "userspace-legacy-irq")]
 pub mod legacy_irq;
 pub mod manager;
 

--- a/src/dragonball/crates/dbs_legacy_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_legacy_devices/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 dbs-device = { workspace = true }
+dbs-interrupt = { workspace = true, features = ["legacy-irq", "kvm-irq"] }
 dbs-utils = { workspace = true }
 libc = "0.2.39"
 log = "0.4.14"
@@ -20,4 +21,5 @@ vm-superio = {workspace = true}
 vmm-sys-util = {workspace = true}
 
 [dev-dependencies]
+kvm-ioctls = { workspace = true }
 libc = "0.2.39"

--- a/src/dragonball/crates/dbs_legacy_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_legacy_devices/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 
 [dependencies]
 dbs-device = { workspace = true }
+dbs-interrupt = { workspace = true, features = ["legacy-irq"] }
 dbs-utils = { workspace = true }
+kvm-ioctls = { workspace = true }
 libc = "0.2.39"
 log = "0.4.14"
 serde = { version = "1.0.27", features = ["derive", "rc"] }

--- a/src/dragonball/crates/dbs_legacy_devices/src/lib.rs
+++ b/src/dragonball/crates/dbs_legacy_devices/src/lib.rs
@@ -24,8 +24,12 @@ mod rtc_pl031;
 #[cfg(target_arch = "aarch64")]
 pub use self::rtc_pl031::*;
 
+use dbs_interrupt::{InterruptSourceGroup, InterruptSourceType};
 use vm_superio::Trigger;
 use vmm_sys_util::eventfd::EventFd;
+
+use std::sync::Arc;
+
 /// Newtype for implementing the trigger functionality for `EventFd`.
 ///
 /// The trigger is used for handling events in the legacy devices.
@@ -54,6 +58,26 @@ impl EventFdTrigger {
 
     pub fn get_event(&self) -> EventFd {
         self.0.try_clone().unwrap()
+    }
+}
+
+pub struct IrqTrigger(Arc<Box<dyn InterruptSourceGroup>>);
+
+impl Trigger for IrqTrigger {
+    type E = std::io::Error;
+
+    fn trigger(&self) -> std::io::Result<()> {
+        #[allow(unreachable_patterns)]
+        match self.0.interrupt_type() {
+            InterruptSourceType::LegacyIrq => self.0.trigger(0),
+            _ => Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
+        }
+    }
+}
+
+impl IrqTrigger {
+    pub fn new(irq: Arc<Box<dyn InterruptSourceGroup>>) -> Self {
+        Self(irq)
     }
 }
 

--- a/src/dragonball/crates/dbs_legacy_devices/src/serial.rs
+++ b/src/dragonball/crates/dbs_legacy_devices/src/serial.rs
@@ -9,13 +9,13 @@ use std::io::Write;
 use std::sync::{Arc, Mutex};
 
 use dbs_device::{DeviceIoMut, IoAddress, PioAddress};
+use dbs_interrupt::InterruptSourceGroup;
 use dbs_utils::metric::{IncMetric, SharedIncMetric};
 use log::error;
 use serde::Serialize;
 use vm_superio::{serial::SerialEvents, Serial, Trigger};
-use vmm_sys_util::eventfd::EventFd;
 
-use crate::EventFdTrigger;
+use crate::{EventFdTrigger, IrqTrigger};
 
 /// Trait for devices that handle raw non-blocking I/O requests.
 pub trait ConsoleHandler {
@@ -75,15 +75,15 @@ impl SerialEvents for SerialEventsWrapper {
     }
 }
 
-pub type SerialDevice = SerialWrapper<EventFdTrigger, SerialEventsWrapper>;
+pub type SerialDevice = SerialWrapper<IrqTrigger, SerialEventsWrapper>;
 
 impl SerialDevice {
     /// Creates a new SerialDevice instance.
-    pub fn new(event: EventFd) -> Self {
+    pub fn new(irq: Arc<Box<dyn InterruptSourceGroup>>) -> Self {
         let out = Arc::new(Mutex::new(None));
         Self {
             serial: Serial::with_events(
-                EventFdTrigger::new(event),
+                IrqTrigger::new(irq),
                 SerialEventsWrapper {
                     metrics: Arc::new(SerialDeviceMetrics::default()),
                     buffer_ready_event_fd: None,
@@ -104,7 +104,7 @@ pub struct SerialWrapper<T: Trigger, EV: SerialEvents> {
     pub out: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
 }
 
-impl ConsoleHandler for SerialWrapper<EventFdTrigger, SerialEventsWrapper> {
+impl ConsoleHandler for SerialDevice {
     fn raw_input(&mut self, data: &[u8]) -> std::io::Result<usize> {
         self.serial
             .enqueue_raw_bytes(data)
@@ -116,7 +116,7 @@ impl ConsoleHandler for SerialWrapper<EventFdTrigger, SerialEventsWrapper> {
     }
 }
 
-impl DeviceIoMut for SerialWrapper<EventFdTrigger, SerialEventsWrapper> {
+impl DeviceIoMut for SerialDevice {
     fn pio_read(&mut self, _base: PioAddress, offset: PioAddress, data: &mut [u8]) {
         if data.len() != 1 {
             self.serial.events().metrics.missed_read_count.inc();
@@ -176,9 +176,21 @@ impl Write for AdapterWriter {
 
 #[cfg(test)]
 mod tests {
+    use dbs_interrupt::{InterruptManager, InterruptSourceType, KvmIrqManager};
+    use kvm_ioctls::Kvm;
+
     use super::*;
     use std::io;
     use std::sync::{Arc, Mutex};
+
+    fn create_irq() -> Arc<Box<dyn InterruptSourceGroup>> {
+        let kvm = Kvm::new().unwrap();
+        let vmfd = kvm.create_vm().unwrap();
+        let irq_manager = KvmIrqManager::new(Arc::new(vmfd));
+        irq_manager
+            .create_group(InterruptSourceType::LegacyIrq, 0, 1)
+            .unwrap()
+    }
 
     #[derive(Clone)]
     struct SharedBuffer {
@@ -200,9 +212,9 @@ mod tests {
         let serial_out = Box::new(SharedBuffer {
             buf: serial_out_buf.clone(),
         });
-        let intr_evt = EventFd::new(libc::EFD_NONBLOCK).unwrap();
+        let irq = create_irq();
 
-        let mut serial = SerialDevice::new(intr_evt);
+        let mut serial = SerialDevice::new(irq);
         let metrics = serial.serial.events().metrics.clone();
 
         serial.set_output_stream(Some(serial_out));
@@ -238,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_serial_bus_read() {
-        let intr_evt = EventFdTrigger::new(EventFd::new(libc::EFD_NONBLOCK).unwrap());
+        let irq = create_irq();
 
         let metrics = Arc::new(SerialDeviceMetrics::default());
 
@@ -246,7 +258,7 @@ mod tests {
             Arc::new(Mutex::new(Some(Box::new(std::io::sink()))));
         let mut serial = SerialDevice {
             serial: Serial::with_events(
-                intr_evt,
+                IrqTrigger::new(irq),
                 SerialEventsWrapper {
                     metrics: metrics.clone(),
                     buffer_ready_event_fd: None,

--- a/src/dragonball/crates/dbs_pci/Cargo.toml
+++ b/src/dragonball/crates/dbs_pci/Cargo.toml
@@ -20,8 +20,8 @@ dbs-address-space = { workspace = true }
 dbs-virtio-devices = { workspace = true }
 dbs-interrupt = { workspace = true, features = [
     "kvm-irq",
-    "kvm-legacy-irq",
-    "kvm-msi-irq",
+    "legacy-irq",
+    "msi-irq",
 ] }
 byteorder = "1.4.3"
 serde = "1.0.27"

--- a/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
@@ -16,9 +16,10 @@ byteorder = "1.4.3"
 caps = "0.5.3"
 dbs-device = { workspace = true }
 dbs-interrupt = { workspace = true, features = [
-    "kvm-legacy-irq",
-    "kvm-msi-irq",
-    "split-legacy-irq",
+    "kvm-irq",
+    "split-irq",
+    "legacy-irq",
+    "msi-irq",
 ] }
 dbs-utils = { workspace = true }
 dbs-address-space = { workspace = true }

--- a/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/crates/dbs_virtio_devices/Cargo.toml
@@ -18,6 +18,7 @@ dbs-interrupt = { workspace = true, features = [
     "kvm-legacy-irq",
     "kvm-msi-irq",
     "split-legacy-irq",
+    "split-msi-irq",
 ] }
 dbs-utils = { workspace = true }
 dbs-address-space = { workspace = true }

--- a/src/dragonball/src/device_manager/legacy.rs
+++ b/src/dragonball/src/device_manager/legacy.rs
@@ -9,9 +9,13 @@
 //! Device Manager for Legacy Devices.
 
 use std::io;
+
 use std::sync::{Arc, Mutex};
 
 use dbs_device::device_manager::Error as IoManagerError;
+use dbs_interrupt::{
+    InterruptManager, InterruptSourceConfig, InterruptSourceType, LegacyIrqSourceConfig,
+};
 #[cfg(target_arch = "aarch64")]
 use dbs_legacy_devices::RTCDevice;
 use dbs_legacy_devices::SerialDevice;
@@ -35,7 +39,7 @@ pub enum Error {
 
     /// Failed to register/deregister interrupt.
     #[error("failure while managing interrupt for legacy device")]
-    IrqManager(#[source] vmm_sys_util::errno::Error),
+    IrqManager(#[source] std::io::Error),
 }
 
 /// The `LegacyDeviceManager` is a wrapper that is used for registering legacy devices
@@ -49,11 +53,11 @@ pub struct LegacyDeviceManager {
     #[cfg(target_arch = "aarch64")]
     pub(crate) _rtc_device: Arc<Mutex<RTCDevice>>,
     #[cfg(target_arch = "aarch64")]
-    _rtc_eventfd: EventFd,
+    _rtc_eventfd: Option<EventFd>,
     pub(crate) com1_device: Arc<Mutex<SerialDevice>>,
-    _com1_eventfd: EventFd,
+    _com1_eventfd: Option<EventFd>,
     pub(crate) com2_device: Arc<Mutex<SerialDevice>>,
-    _com2_eventfd: EventFd,
+    _com2_eventfd: Option<EventFd>,
 }
 
 impl LegacyDeviceManager {
@@ -74,7 +78,6 @@ pub(crate) mod x86_64 {
     use dbs_device::device_manager::IoManager;
     use dbs_device::resources::Resource;
     use dbs_legacy_devices::{EventFdTrigger, I8042Device};
-    use kvm_ioctls::VmFd;
 
     pub(crate) const COM1_NAME: &str = "com1";
     pub(crate) const COM1_IRQ: u32 = 4;
@@ -87,15 +90,18 @@ pub(crate) mod x86_64 {
 
     impl LegacyDeviceManager {
         /// Create a LegacyDeviceManager instance handling legacy devices (uart, i8042).
-        pub fn create_manager(bus: &mut IoManager, vm_fd: Option<Arc<VmFd>>) -> Result<Self> {
+        pub fn create_manager(
+            bus: &mut IoManager,
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<Self> {
             let (com1_device, com1_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), COM1_IRQ, COM1_PORT1)?;
+                Self::create_com_device(bus, COM1_IRQ, COM1_PORT1, irq_manager.clone())?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM1_NAME),
                 com1_device.lock().unwrap().metrics(),
             );
             let (com2_device, com2_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), COM2_IRQ, COM2_PORT1)?;
+                Self::create_com_device(bus, COM2_IRQ, COM2_PORT1, irq_manager.clone())?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM2_NAME),
                 com2_device.lock().unwrap().metrics(),
@@ -131,14 +137,20 @@ pub(crate) mod x86_64 {
 
         fn create_com_device(
             bus: &mut IoManager,
-            vm_fd: Option<&Arc<VmFd>>,
-            irq: u32,
+            irq_base: u32,
             port_base: u16,
-        ) -> Result<(Arc<Mutex<SerialDevice>>, EventFd)> {
-            let eventfd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-            let device = Arc::new(Mutex::new(SerialDevice::new(
-                eventfd.try_clone().map_err(Error::EventFd)?,
-            )));
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<(Arc<Mutex<SerialDevice>>, Option<EventFd>)> {
+            let irq = irq_manager
+                .create_group(InterruptSourceType::LegacyIrq, irq_base, 1)
+                .map_err(Error::IrqManager)?;
+            let irq_config = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+            irq.enable(&irq_config).map_err(Error::IrqManager)?;
+            let eventfd = match irq.notifier(0) {
+                Some(fd) => Some(fd.try_clone().map_err(Error::EventFd)?),
+                None => None,
+            };
+            let device = Arc::new(Mutex::new(SerialDevice::new(irq)));
             // port_base defines the base port address for the COM devices.
             // Since every COM device has 8 data registers so we register the pio address range as size 0x8.
             let resources = [Resource::PioAddressRange {
@@ -147,11 +159,6 @@ pub(crate) mod x86_64 {
             }];
             bus.register_device_io(device.clone(), &resources)
                 .map_err(Error::BusError)?;
-
-            if let Some(fd) = vm_fd {
-                fd.register_irqfd(&eventfd, irq)
-                    .map_err(Error::IrqManager)?;
-            }
 
             Ok((device, eventfd))
         }
@@ -163,7 +170,6 @@ pub(crate) mod aarch64 {
     use super::*;
     use dbs_device::device_manager::IoManager;
     use dbs_device::resources::DeviceResources;
-    use kvm_ioctls::VmFd;
     use std::collections::HashMap;
 
     type Result<T> = ::std::result::Result<T, Error>;
@@ -179,23 +185,32 @@ pub(crate) mod aarch64 {
         /// Create a LegacyDeviceManager instance handling legacy devices.
         pub fn create_manager(
             bus: &mut IoManager,
-            vm_fd: Option<Arc<VmFd>>,
             resources: &HashMap<String, DeviceResources>,
+            irq_manager: Arc<Box<dyn InterruptManager>>,
         ) -> Result<Self> {
-            let (com1_device, com1_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), resources.get(COM1_NAME).unwrap())?;
+            let (com1_device, com1_eventfd) = Self::create_com_device(
+                bus,
+                resources.get(COM1_NAME).unwrap(),
+                irq_manager.clone(),
+            )?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM1_NAME),
                 com1_device.lock().unwrap().metrics(),
             );
-            let (com2_device, com2_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), resources.get(COM2_NAME).unwrap())?;
+            let (com2_device, com2_eventfd) = Self::create_com_device(
+                bus,
+                resources.get(COM2_NAME).unwrap(),
+                irq_manager.clone(),
+            )?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM2_NAME),
                 com2_device.lock().unwrap().metrics(),
             );
-            let (rtc_device, rtc_eventfd) =
-                Self::create_rtc_device(bus, vm_fd.as_ref(), resources.get(RTC_NAME).unwrap())?;
+            let (rtc_device, rtc_eventfd) = Self::create_rtc_device(
+                bus,
+                resources.get(RTC_NAME).unwrap(),
+                irq_manager.clone(),
+            )?;
             METRICS.write().unwrap().rtc = rtc_device.lock().unwrap().metrics();
 
             Ok(LegacyDeviceManager {
@@ -210,42 +225,46 @@ pub(crate) mod aarch64 {
 
         fn create_com_device(
             bus: &mut IoManager,
-            vm_fd: Option<&Arc<VmFd>>,
             resources: &DeviceResources,
-        ) -> Result<(Arc<Mutex<SerialDevice>>, EventFd)> {
-            let eventfd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-            let device = Arc::new(Mutex::new(SerialDevice::new(
-                eventfd.try_clone().map_err(Error::EventFd)?,
-            )));
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<(Arc<Mutex<SerialDevice>>, Option<EventFd>)> {
+            let irq_base = resources.get_legacy_irq().unwrap();
+            let irq = irq_manager
+                .create_group(InterruptSourceType::LegacyIrq, irq_base, 1)
+                .map_err(Error::IrqManager)?;
+            let irq_config = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+            irq.enable(&irq_config).map_err(Error::IrqManager)?;
+            let eventfd = match irq.notifier(0) {
+                Some(fd) => Some(fd.try_clone().map_err(Error::EventFd)?),
+                None => None,
+            };
+            let device = Arc::new(Mutex::new(SerialDevice::new(irq)));
 
             bus.register_device_io(device.clone(), resources.get_all_resources())
                 .map_err(Error::BusError)?;
-
-            if let Some(fd) = vm_fd {
-                let irq = resources.get_legacy_irq().unwrap();
-                fd.register_irqfd(&eventfd, irq)
-                    .map_err(Error::IrqManager)?;
-            }
 
             Ok((device, eventfd))
         }
 
         fn create_rtc_device(
             bus: &mut IoManager,
-            vm_fd: Option<&Arc<VmFd>>,
             resources: &DeviceResources,
-        ) -> Result<(Arc<Mutex<RTCDevice>>, EventFd)> {
-            let eventfd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<(Arc<Mutex<RTCDevice>>, Option<EventFd>)> {
+            let irq_base = resources.get_legacy_irq().unwrap();
+            let irq = irq_manager
+                .create_group(InterruptSourceType::LegacyIrq, irq_base, 1)
+                .map_err(Error::IrqManager)?;
+            let irq_config = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+            irq.enable(&irq_config).map_err(Error::IrqManager)?;
+            let eventfd = match irq.notifier(0) {
+                Some(fd) => Some(fd.try_clone().map_err(Error::EventFd)?),
+                None => None,
+            };
             let device = Arc::new(Mutex::new(RTCDevice::new()));
 
             bus.register_device_io(device.clone(), resources.get_all_resources())
                 .map_err(Error::BusError)?;
-
-            if let Some(fd) = vm_fd {
-                let irq = resources.get_legacy_irq().unwrap();
-                fd.register_irqfd(&eventfd, irq)
-                    .map_err(Error::IrqManager)?;
-            }
 
             Ok((device, eventfd))
         }
@@ -256,12 +275,23 @@ pub(crate) mod aarch64 {
 mod tests {
     #[cfg(target_arch = "x86_64")]
     use super::*;
+    #[cfg(target_arch = "x86_64")]
+    use dbs_interrupt::KvmIrqManager;
+    #[cfg(target_arch = "x86_64")]
+    use kvm_ioctls::Kvm;
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_create_legacy_device_manager() {
+        let kvm = Kvm::new().unwrap();
+        let vmfd = Arc::new(kvm.create_vm().unwrap());
+        let irq_manager = KvmIrqManager::new(vmfd.clone());
+        vmfd.create_irq_chip().unwrap();
+        irq_manager.initialize().unwrap();
+
         let mut bus = dbs_device::device_manager::IoManager::new();
-        let mgr = LegacyDeviceManager::create_manager(&mut bus, None).unwrap();
+        let mgr =
+            LegacyDeviceManager::create_manager(&mut bus, Arc::new(Box::new(irq_manager))).unwrap();
         let _exit_fd = mgr.get_reset_eventfd().unwrap();
     }
 }

--- a/src/dragonball/src/device_manager/legacy.rs
+++ b/src/dragonball/src/device_manager/legacy.rs
@@ -9,9 +9,13 @@
 //! Device Manager for Legacy Devices.
 
 use std::io;
+
 use std::sync::{Arc, Mutex};
 
 use dbs_device::device_manager::Error as IoManagerError;
+use dbs_interrupt::{
+    InterruptManager, InterruptSourceConfig, InterruptSourceType, LegacyIrqSourceConfig,
+};
 #[cfg(target_arch = "aarch64")]
 use dbs_legacy_devices::RTCDevice;
 use dbs_legacy_devices::SerialDevice;
@@ -35,7 +39,7 @@ pub enum Error {
 
     /// Failed to register/deregister interrupt.
     #[error("failure while managing interrupt for legacy device")]
-    IrqManager(#[source] vmm_sys_util::errno::Error),
+    IrqManager(#[source] std::io::Error),
 }
 
 /// The `LegacyDeviceManager` is a wrapper that is used for registering legacy devices
@@ -51,9 +55,9 @@ pub struct LegacyDeviceManager {
     #[cfg(target_arch = "aarch64")]
     _rtc_eventfd: EventFd,
     pub(crate) com1_device: Arc<Mutex<SerialDevice>>,
-    _com1_eventfd: EventFd,
+    _com1_eventfd: Option<EventFd>,
     pub(crate) com2_device: Arc<Mutex<SerialDevice>>,
-    _com2_eventfd: EventFd,
+    _com2_eventfd: Option<EventFd>,
 }
 
 impl LegacyDeviceManager {
@@ -74,7 +78,6 @@ pub(crate) mod x86_64 {
     use dbs_device::device_manager::IoManager;
     use dbs_device::resources::Resource;
     use dbs_legacy_devices::{EventFdTrigger, I8042Device};
-    use kvm_ioctls::VmFd;
 
     pub(crate) const COM1_NAME: &str = "com1";
     pub(crate) const COM1_IRQ: u32 = 4;
@@ -87,15 +90,18 @@ pub(crate) mod x86_64 {
 
     impl LegacyDeviceManager {
         /// Create a LegacyDeviceManager instance handling legacy devices (uart, i8042).
-        pub fn create_manager(bus: &mut IoManager, vm_fd: Option<Arc<VmFd>>) -> Result<Self> {
+        pub fn create_manager(
+            bus: &mut IoManager,
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<Self> {
             let (com1_device, com1_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), COM1_IRQ, COM1_PORT1)?;
+                Self::create_com_device(bus, COM1_IRQ, COM1_PORT1, irq_manager.clone())?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM1_NAME),
                 com1_device.lock().unwrap().metrics(),
             );
             let (com2_device, com2_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), COM2_IRQ, COM2_PORT1)?;
+                Self::create_com_device(bus, COM2_IRQ, COM2_PORT1, irq_manager.clone())?;
             METRICS.write().unwrap().serial.insert(
                 String::from(COM2_NAME),
                 com2_device.lock().unwrap().metrics(),
@@ -131,14 +137,20 @@ pub(crate) mod x86_64 {
 
         fn create_com_device(
             bus: &mut IoManager,
-            vm_fd: Option<&Arc<VmFd>>,
-            irq: u32,
+            irq_base: u32,
             port_base: u16,
-        ) -> Result<(Arc<Mutex<SerialDevice>>, EventFd)> {
-            let eventfd = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::EventFd)?;
-            let device = Arc::new(Mutex::new(SerialDevice::new(
-                eventfd.try_clone().map_err(Error::EventFd)?,
-            )));
+            irq_manager: Arc<Box<dyn InterruptManager>>,
+        ) -> Result<(Arc<Mutex<SerialDevice>>, Option<EventFd>)> {
+            let irq = irq_manager
+                .create_group(InterruptSourceType::LegacyIrq, irq_base, 1)
+                .map_err(Error::IrqManager)?;
+            let irq_config = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+            irq.enable(&irq_config).map_err(Error::IrqManager)?;
+            let eventfd = match irq.notifier(0) {
+                Some(fd) => Some(fd.try_clone().map_err(Error::EventFd)?),
+                None => None,
+            };
+            let device = Arc::new(Mutex::new(SerialDevice::new(irq)));
             // port_base defines the base port address for the COM devices.
             // Since every COM device has 8 data registers so we register the pio address range as size 0x8.
             let resources = [Resource::PioAddressRange {
@@ -147,11 +159,6 @@ pub(crate) mod x86_64 {
             }];
             bus.register_device_io(device.clone(), &resources)
                 .map_err(Error::BusError)?;
-
-            if let Some(fd) = vm_fd {
-                fd.register_irqfd(&eventfd, irq)
-                    .map_err(Error::IrqManager)?;
-            }
 
             Ok((device, eventfd))
         }
@@ -256,12 +263,19 @@ pub(crate) mod aarch64 {
 mod tests {
     #[cfg(target_arch = "x86_64")]
     use super::*;
+    use dbs_interrupt::KvmIrqManager;
+    use kvm_ioctls::Kvm;
 
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_create_legacy_device_manager() {
+        let kvm = Kvm::new().unwrap();
+        let vmfd = kvm.create_vm().unwrap();
+        let irq_manager = KvmIrqManager::new(Arc::new(vmfd));
+
         let mut bus = dbs_device::device_manager::IoManager::new();
-        let mgr = LegacyDeviceManager::create_manager(&mut bus, None).unwrap();
+        let mgr =
+            LegacyDeviceManager::create_manager(&mut bus, Arc::new(Box::new(irq_manager))).unwrap();
         let _exit_fd = mgr.get_reset_eventfd().unwrap();
     }
 }

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -21,7 +21,7 @@ use dbs_device::resources::DeviceResources;
 use dbs_device::resources::Resource;
 use dbs_device::DeviceIo;
 #[cfg(target_arch = "x86_64")]
-use dbs_interrupt::UserspaceIoapicManager;
+use dbs_interrupt::SplitIrqManager;
 use dbs_interrupt::{InterruptManager, KvmIrqManager};
 use dbs_legacy_devices::ConsoleHandler;
 #[cfg(feature = "dbs-virtio-devices")]
@@ -210,9 +210,9 @@ pub enum DeviceMgrError {
     #[error("unsupported pci device type")]
     InvalidPciDeviceType,
     #[cfg(target_arch = "x86_64")]
-    /// Error from Userspace IOAPIC
-    #[error("Userspace IOAPIC error: {0}")]
-    UserspaceIoapicError(#[source] std::io::Error),
+    /// Error from split IRQ manager
+    #[error("Split IRQ manager error: {0}")]
+    SplitIrqManagerError(#[source] std::io::Error),
 }
 
 /// Specialized version of `std::result::Result` for device manager operations.
@@ -698,8 +698,8 @@ impl DeviceManager {
         let irq_manager: Arc<Box<dyn InterruptManager>> =
             if shared_info.read().unwrap().split_irqchip() {
                 Arc::new(Box::new(
-                    UserspaceIoapicManager::create_default_ioapic_manager(vm_fd.clone())
-                        .map_err(DeviceMgrError::UserspaceIoapicError)?,
+                    SplitIrqManager::new(vm_fd.clone())
+                        .map_err(DeviceMgrError::SplitIrqManagerError)?,
                 ))
             } else {
                 Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())))
@@ -803,7 +803,7 @@ impl DeviceManager {
             {
                 legacy_manager = LegacyDeviceManager::create_manager(
                     &mut tx.io_manager,
-                    Some(self.vm_fd.clone()),
+                    self.irq_manager.clone(),
                 );
             }
 
@@ -813,8 +813,8 @@ impl DeviceManager {
                 let resources = self.get_legacy_resources()?;
                 legacy_manager = LegacyDeviceManager::create_manager(
                     &mut tx.io_manager,
-                    Some(self.vm_fd.clone()),
                     &resources,
+                    self.irq_manager.clone(),
                 );
             }
 

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -21,7 +21,7 @@ use dbs_device::resources::DeviceResources;
 use dbs_device::resources::Resource;
 use dbs_device::DeviceIo;
 #[cfg(target_arch = "x86_64")]
-use dbs_interrupt::UserspaceIoapicManager;
+use dbs_interrupt::SplitIrqManager;
 use dbs_interrupt::{InterruptManager, KvmIrqManager};
 use dbs_legacy_devices::ConsoleHandler;
 #[cfg(feature = "dbs-virtio-devices")]
@@ -210,9 +210,9 @@ pub enum DeviceMgrError {
     #[error("unsupported pci device type")]
     InvalidPciDeviceType,
     #[cfg(target_arch = "x86_64")]
-    /// Error from Userspace IOAPIC
-    #[error("Userspace IOAPIC error: {0}")]
-    UserspaceIoapicError(#[source] std::io::Error),
+    /// Error from spit IRQ manager
+    #[error("Split IRQ manager error: {0}")]
+    SplitIrqManagerError(#[source] std::io::Error),
 }
 
 /// Specialized version of `std::result::Result` for device manager operations.
@@ -690,8 +690,8 @@ impl DeviceManager {
         let irq_manager: Arc<Box<dyn InterruptManager>> =
             if shared_info.read().unwrap().split_irqchip() {
                 Arc::new(Box::new(
-                    UserspaceIoapicManager::create_default_ioapic_manager(vm_fd.clone())
-                        .map_err(DeviceMgrError::UserspaceIoapicError)?,
+                    SplitIrqManager::new(vm_fd.clone())
+                        .map_err(DeviceMgrError::SplitIrqManagerError)?,
                 ))
             } else {
                 Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())))
@@ -795,7 +795,7 @@ impl DeviceManager {
             {
                 legacy_manager = LegacyDeviceManager::create_manager(
                     &mut tx.io_manager,
-                    Some(self.vm_fd.clone()),
+                    self.irq_manager.clone(),
                 );
             }
 


### PR DESCRIPTION
Add SplitIrqHandler to dbs_interrupt, which manages legacy interrupts with userspace IOAPIC while manages MSI interrupts via KVM. VMs are able to switch between all-KVM, all-userspace or a mixed interrupt manager based on specific requirements. In TDX case, since split irqchip is necessary to start a VM, SplitIrqManager should be used.

Though legacy devices including COM are also using irqfd to trigger interrupts, they are using a different trait from virtio devices attached to the VM, which is hard to manage. This commit also unifies the interface used to manage interrupts from these two types of devices. In case of split irqchip, interrupts from legacy devices are going to be managed by userspace IOAPIC.