### PR TITLE
Static runtime default

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -849,20 +849,44 @@ QUIET_TEST     = $(Q:@=@echo    '     TEST     '$@;)
 
 BUILDTAGS :=
 
-# go build common flags
-BUILDFLAGS := -buildmode=pie ${BUILDTAGS}
-
-# Static build profile.
+# Static build profile (default on amd64, arm64 and riscv64; opt-in on
+# s390x and ppc64le).
 #
-# When STATIC=yes the Go host binaries (kata-runtime, containerd-shim-kata-v2
-# and kata-monitor) are built with cgo disabled and without PIE, producing
-# fully static, libc-agnostic executables. This lets the kata-deploy payload
-# run on musl-only hosts that have no glibc dynamic loader. It relies on the
-# runtime being cgo-free; the default (non-static) build is left unchanged.
+# The Go host binaries (kata-runtime, containerd-shim-kata-v2 and kata-monitor)
+# are built with cgo disabled and without PIE by default, producing fully
+# static, libc-agnostic executables. This lets the kata-deploy payload run on
+# musl-only hosts that have no glibc dynamic loader (e.g. Alpine, Kairos'
+# Hadron), in addition to the traditional glibc hosts. It relies on the runtime
+# being cgo-free.
+#
+# On s390x the profile stays opt-in because the KVM host process must be
+# marked with a PT_S390_PGSTE program header, which is emitted by ld's
+# --s390-pgste. Go only honours -extldflags when linkmode=external, and
+# linkmode=external requires cgo, so a cgo-free s390x build cannot carry the
+# marker with today's tooling. The default on s390x therefore stays cgo + PIE
+# until we have a way to produce a cgo-free static binary that still carries
+# the PGSTE program header.
+#
+# On ppc64le the profile also stays opt-in for now. The rest of the
+# kata-deploy payload on ppc64le is glibc-linked (musl is not well supported
+# on the arch, and upstream nydus-snapshotter publishes only per-arch glibc
+# release assets), so shipping a static Go runtime alone does not unlock
+# musl-only hosts. Keep the cgo + PIE build as the default until the ppc64le
+# payload story catches up and ppc64le maintainers confirm the flip.
+#
+# Set STATIC=no to opt out (on s390x and ppc64le this is the default).
+ifneq (,$(filter $(ARCH),s390x ppc64le))
+    STATIC ?= no
+else
+    STATIC ?= yes
+endif
+
 ifeq ($(STATIC),yes)
        export CGO_ENABLED := 0
        # PIE requires a dynamic loader, so it cannot be used for static binaries.
        BUILDFLAGS := ${BUILDTAGS}
+else
+       BUILDFLAGS := -buildmode=pie ${BUILDTAGS}
 endif
 
 # whether stipping the binary
@@ -870,6 +894,11 @@ ifeq ($(STRIP),yes)
        KATA_LDFLAGS = -w -s
 endif
 
+# On s390x the KVM host process must be marked with a PT_S390_PGSTE program
+# header so the kernel allocates PGSTE tables (required by KVM_CREATE_VM). The
+# marker is emitted by the external linker's --s390-pgste flag, which the
+# default cgo + PIE build (STATIC=no on s390x) drives through Go's external
+# linker path.
 ifeq ($(ARCH),s390x)
     KATA_LDFLAGS += -extldflags=-Wl,--s390-pgste
 endif

--- a/src/runtime/go-test.sh
+++ b/src/runtime/go-test.sh
@@ -23,8 +23,17 @@ if [[ -z "${go_test_flags}" ]]; then
     # "go test -timeout X"
     go_test_flags="-timeout ${KATA_GO_TEST_TIMEOUT:-30s}"
 
-    # -race flag is not supported on s390x and riscv64
-    [[ "$(go env GOARCH)" != "s390x" ]] && [[ "$(go env GOARCH)" != "riscv64" ]] && go_test_flags+=" -race"
+    # Enable -race only when the arch supports it (Go does not offer it on
+    # s390x or riscv64) and when cgo is on (Go's race detector requires
+    # cgo). Under the default STATIC=yes build CGO_ENABLED=0, so this leg
+    # is off and `make test` runs the same toolchain as the shipped
+    # binary. Run `make test STATIC=no` locally if you need the race
+    # detector for concurrency-bug hunting.
+    if [[ "$(go env GOARCH)" != "s390x" ]] \
+        && [[ "$(go env GOARCH)" != "riscv64" ]] \
+        && [[ "$(go env CGO_ENABLED)" != "0" ]]; then
+        go_test_flags+=" -race"
+    fi
 
     # s390x requires special linker flags
     # shellcheck disable=SC2089

--- a/tools/packaging/kata-deploy/Dockerfile.components
+++ b/tools/packaging/kata-deploy/Dockerfile.components
@@ -7,11 +7,11 @@
 
 FROM alpine:3.22 AS nydus-binary-downloader
 
-# When STATIC_NYDUS_SNAPSHOTTER is set to a non-empty value, download the
-# statically linked release asset (nydus-snapshotter-<ver>-linux-static.tar.gz)
-# instead of the per-arch (dynamically, glibc-linked) one. The static binaries
-# run on musl-only hosts that have no glibc dynamic loader. The static asset is
-# currently published for x86_64/amd64 only.
+# When STATIC_NYDUS_SNAPSHOTTER=yes, download the statically linked release
+# asset (nydus-snapshotter-<ver>-linux-static.tar.gz) instead of the per-arch
+# (dynamically, glibc-linked) one. The static binaries run on musl-only hosts
+# that have no glibc dynamic loader. The static asset is currently published
+# for x86_64/amd64 only.
 ARG STATIC_NYDUS_SNAPSHOTTER=""
 
 COPY versions.yaml /tmp/versions.yaml
@@ -25,7 +25,7 @@ RUN \
 	ARCH="$(uname -m)" && \
 	if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64 ; fi && \
 	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
-	if [ -n "${STATIC_NYDUS_SNAPSHOTTER}" ]; then \
+	if [ "${STATIC_NYDUS_SNAPSHOTTER}" = "yes" ]; then \
 		if [ "${ARCH}" != "amd64" ]; then \
 			echo "STATIC_NYDUS_SNAPSHOTTER is only supported on amd64 (no static asset is published for ${ARCH})" >&2; \
 			exit 1; \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
@@ -84,10 +84,11 @@ build_kata_deploy_job_dispatcher() {
 }
 
 build_nydus_snapshotter_for_coco_guest_pull() {
-	# STATIC_RUNTIME=yes is the umbrella flag for a musl-compatible payload: it
-	# builds the kata Go host binaries static (see static-build/shim-v2) and here
-	# pulls the statically linked nydus-snapshotter binaries instead of the
-	# glibc-linked per-arch ones.
+	# The kata Go host binaries are built static by default (see
+	# static-build/shim-v2). STATIC_RUNTIME=yes additionally pulls the
+	# statically linked nydus-snapshotter binaries instead of the glibc-linked
+	# per-arch ones, producing a fully musl-compatible payload. The static
+	# nydus asset is published for amd64 only.
 	local static_nydus_snapshotter="${STATIC_RUNTIME:-}"
 
 	docker buildx build \

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -7,14 +7,20 @@
 # Expected file in context:
 #   ./opt/kata/bin/kata-monitor
 #
-# The kata-monitor binary is built inside an Ubuntu (glibc) toolchain
-# as part of the shim-v2-go static build, so it is dynamically linked
-# against glibc. We assemble its runtime dependencies via `ldd` from
-# a glibc base image and copy them into a distroless/static runtime
-# image, matching the same pattern used by
-# tools/packaging/kata-deploy/Dockerfile.
+# The kata-monitor binary can be either statically or dynamically linked
+# depending on the arch it was built for (see src/runtime/Makefile):
+#
+#   * amd64, arm64, riscv64: fully static, cgo-free (STATIC=yes default).
+#   * s390x, ppc64le:        cgo + PIE, glibc-linked (STATIC=no default).
+#
+# For the static case there are no runtime dependencies to assemble, and
+# distroless/static already provides everything the binary needs. For the
+# glibc case we use `ldd` to discover the required shared libraries and
+# the dynamic linker, and copy them into the runtime image, matching the
+# pattern used by tools/packaging/kata-deploy/Dockerfile.
 
-# Stage 1: discover and copy the glibc libraries the binary needs.
+# Stage 1: discover and copy the glibc libraries the binary needs
+# (skipped when the binary is statically linked).
 # hadolint ignore=DL3007
 FROM debian:trixie-slim AS runtime-assembler
 
@@ -25,6 +31,16 @@ COPY opt/kata/bin/kata-monitor /tmp/kata-monitor
 RUN \
 	set -eux; \
 	mkdir -p /output/lib /output/lib64; \
+	# `ldd` on a static ELF prints "not a dynamic executable" to stderr and
+	# exits 1. Capture both streams into a variable so the detection does
+	# not go through a pipeline (with `set -o pipefail` a failing ldd would
+	# otherwise mask a matching grep and the check would silently miss the
+	# static case).
+	ldd_output="$(ldd /tmp/kata-monitor 2>&1 || true)"; \
+	if [[ "${ldd_output}" == *"not a dynamic executable"* ]]; then \
+		echo "kata-monitor is statically linked on $(uname -m); no glibc libraries or dynamic linker to copy"; \
+		exit 0; \
+	fi; \
 	echo "Libraries needed by kata-monitor on $(uname -m):"; \
 	ldd /tmp/kata-monitor || true; \
 	# Copy each shared library reported by ldd ("=>" lines).
@@ -38,7 +54,9 @@ RUN \
 		fi; \
 	done; \
 	# Copy the dynamic linker too: ldd does not include it in the "=>"
-	# lines. Cover all four target architectures:
+	# lines. Cover all glibc target architectures: s390x and ppc64le
+	# under the default settings, plus amd64/arm64 for opt-out
+	# STATIC=no builds.
 	#   x86_64  -> /lib64/ld-linux-x86-64.so.2
 	#   aarch64 -> /lib/ld-linux-aarch64.so.1
 	#   s390x   -> /lib/ld64.so.1

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -131,12 +131,12 @@ case "${RUNTIME_CHOICE}" in
 		;;
 esac
 
-# When STATIC_RUNTIME=yes the Go host binaries (kata-runtime,
-# containerd-shim-kata-v2 and kata-monitor) are built as fully static,
-# cgo-free executables so the payload runs on musl-only hosts that have no
-# glibc dynamic loader. Default builds are unchanged.
-if [[ "${STATIC_RUNTIME:-}" == "yes" ]]; then
-	GO_EXTRA_OPTS+=" STATIC=yes"
+# The Go host binaries (kata-runtime, containerd-shim-kata-v2 and kata-monitor)
+# are built as fully static, cgo-free executables by default so the payload
+# runs on musl-only hosts that have no glibc dynamic loader. Set
+# STATIC_RUNTIME=no to opt out and restore the previous cgo + PIE build.
+if [[ "${STATIC_RUNTIME:-}" == "no" ]]; then
+	GO_EXTRA_OPTS+=" STATIC=no"
 fi
 
 case "${RUNTIME_CHOICE}" in


### PR DESCRIPTION
This is the follow-up I promised in #13243: flip the STATIC profile to be the default so `kata-runtime`, `containerd-shim-kata-v2` and `kata-monitor` build cgo-free and without PIE out of the box. Payload now runs on musl-only hosts (Alpine, Hadron, ...) with no downstream rebuild.

Opt-out is still there: `STATIC=no` at the runtime Makefile, or `STATIC_RUNTIME=no` at the packaging layer, restores the old cgo + PIE build.

## s390x

According to Claude:

```
s390x needs a `PT_S390_PGSTE` program header on the KVM host process or `KVM_CREATE_VM` fails. That marker comes from ld's `--s390-pgste`, which Go only honours when `linkmode=external`. Under the new default (cgo off, internal linker) it would be silently dropped, so on s390x `STATIC=yes` forces `linkmode=external` and passes `-static` through `-extldflags`. Result: still fully static, still carries PGSTE.  `STATIC=no` on s390x is unchanged (cgo already drives the external linker there).
```

I guess the only way to tell is to let CI run on s390x. The other option is to let s390x builds out of this (dynamic) but it's worth a try.

## Nydus and non-amd64

The `STATIC_RUNTIME=yes` umbrella flag is unchanged: it also selects the static nydus-snapshotter asset, which upstream only publishes for amd64, so it still fails fast on other arches. Default builds on arm64/s390x/ppc64le/riscv64 keep pulling the per-arch dynamic-glibc nydus they always did. Only the Go host binaries flipped.

## Not in this PR (deliberately)

- Defaulting amd64 nydus to the static asset too. The static asset runs on glibc hosts as well, so there is no functional cost, but it would leave `STATIC_RUNTIME=yes` a no-op on amd64 and change the umbrella flag's role to "fail loud on non-amd64". Worth its own PR and its own discussion. In my opinion it would make sense to consume static nydus on static builds whenever possible.
- Dropping the Ubuntu 22.04 glibc-compat deps, per @fidencio's suggestion in #13243. Also its own PR.


Assisted-By: Claude Opus 4.7 noreply@anthropic.com