### PR TITLE
static-checks: Add agent features check

### DIFF
--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -90,6 +90,7 @@ skip_paths(){
 
 
 long_options=(
+    [agent-features]="Check agent features consistency"
 	[all]="Force checking of all changes, including files in the base branch"
 	[branch]="Specify upstream branch to compare against (default '${branch}')"
 	[docs]="Check document files"
@@ -1099,6 +1100,69 @@ static_check_rego()
 	fi
 }
 
+# Check that agent features defined in src/agent/src/features.rs match
+# the features defined in src/agent/Cargo.toml [features] section.
+static_check_agent_features()
+{
+	local features_file="src/agent/src/features.rs"
+	local cargo_file="src/agent/Cargo.toml"
+
+	pushd "${repo_path}" >/dev/null
+
+	# Check if files exist
+	if [[ ! -f "${features_file}" ]] || [[ ! -f "${cargo_file}" ]]; then
+    	popd 
+		die "Agent feature files not found. Expected to find: ${features_file} and ${cargo_file}"
+	fi
+
+	info "Checking agent features consistency"
+
+	# Extract features from features.rs by matching #[cfg(feature = "...")] attributes
+	local features_from_rs
+	features_from_rs=$(sed -n 's/^[[:space:]]*#\[cfg(feature = "\([^"]*\)".*/\1/p' "${features_file}" | sort -u)
+
+	# Extract features from Cargo.toml [features] section using Python's tomllib
+	local features_from_cargo
+	if ! features_from_cargo=$(python3 -c 'import tomllib, sys; print("\n".join(sorted(tomllib.load(open(sys.argv[1], "rb")).get("features", {}).keys())))' "${cargo_file}"); then
+		die "Failed to parse Cargo.toml using built-in Python tomllib."
+	fi
+
+	# Create temp files for comparison
+	local rs_file
+	local cargo_file_tmp
+	rs_file=$(mktemp)
+	cargo_file_tmp=$(mktemp)
+
+	files_to_remove+=("${rs_file}" "${cargo_file_tmp}")
+
+	echo "${features_from_rs}" > "${rs_file}"
+	echo "${features_from_cargo}" > "${cargo_file_tmp}"
+
+	# Compare the two lists
+	local diff_output
+	diff_output=$(diff "${rs_file}" "${cargo_file_tmp}" || true)
+
+	if [[ -n "${diff_output}" ]]; then
+		cat >&2 <<EOF
+ERROR: Agent features mismatch between src/agent/src/features.rs and src/agent/Cargo.toml
+
+Features in features.rs:
+$(cat "${rs_file}")
+
+Features in Cargo.toml:
+$(cat "${cargo_file_tmp}")
+
+Differences:
+${diff_output}
+
+EOF
+		die "Please ensure the feature list in src/agent/src/features.rs matches the [features] section in src/agent/Cargo.toml"
+	fi
+
+	info "Agent features are consistent"
+	popd
+}
+
 # Run the specified function (after first checking it is compatible with the
 # users architectural preferences), or simply list the function name if list
 # mode is active.
@@ -1230,6 +1294,7 @@ main()
 	while [[ $# -gt 1 ]]
 	do
 		case "$1" in
+            --agent-features) func=static_check_agent_features ;;
 			--all) specific_branch="true" ;;
 			--branch) branch="$2"; shift ;;
 			--commits) func=static_check_commits ;;

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -109,6 +109,7 @@ long_options=(
 	[scripts]="Check script files"
 	[versions]="Check versions files"
 	[xml]="Check XML files"
+  [agent-features]="Check agent features consistency"
 )
 
 yamllint_cmd="yamllint"
@@ -1099,6 +1100,68 @@ static_check_rego()
 	fi
 }
 
+# Check that agent features defined in src/agent/src/features.rs match
+# the features defined in src/agent/Cargo.toml [features] section.
+static_check_agent_features()
+{
+	local features_file="src/agent/src/features.rs"
+	local cargo_file="src/agent/Cargo.toml"
+
+	pushd "${repo_path}"
+
+	# Check if files exist
+	if [[ ! -f "${features_file}" ]] || [[ ! -f "${cargo_file}" ]]; then
+		die "Agent feature files not found. Expected to find: ${features_file} and ${cargo_file}"
+	fi
+
+	info "Checking agent features consistency"
+
+	# Extract features from features.rs by matching #[cfg(feature = "...")] attributes
+	local features_from_rs
+	features_from_rs=$(sed -n 's/^[[:space:]]*#\[cfg(feature = "\([^"]*\)".*/\1/p' "${features_file}" | sort -u)
+
+	# Extract features from Cargo.toml [features] section using Python's tomllib
+	local features_from_cargo
+	if ! features_from_cargo=$(python3 -c 'import tomllib, sys; print("\n".join(sorted(tomllib.load(open(sys.argv[1], "rb")).get("features", {}).keys())))' "${cargo_file}"); then
+		die "Failed to parse Cargo.toml using built-in Python tomllib."
+	fi
+
+	# Create temp files for comparison
+	local rs_file
+	local cargo_file_tmp
+	rs_file=$(mktemp)
+	cargo_file_tmp=$(mktemp)
+
+	files_to_remove+=("${rs_file}" "${cargo_file_tmp}")
+
+	echo "${features_from_rs}" > "${rs_file}"
+	echo "${features_from_cargo}" > "${cargo_file_tmp}"
+
+	# Compare the two lists
+	local diff_output
+	diff_output=$(diff "${rs_file}" "${cargo_file_tmp}" || true)
+
+	if [[ -n "${diff_output}" ]]; then
+		cat >&2 <<-EOF
+    ERROR: Agent features mismatch between src/agent/src/features.rs and src/agent/Cargo.toml
+
+    Features in features.rs:
+    $(cat "${rs_file}")
+
+    Features in Cargo.toml:
+    $(cat "${cargo_file_tmp}")
+
+    Differences:
+    ${diff_output}
+
+EOF
+		die "Please ensure the feature list in src/agent/src/features.rs matches the [features] section in src/agent/Cargo.toml"
+	fi
+
+	info "Agent features are consistent"
+	popd
+}
+
 # Run the specified function (after first checking it is compatible with the
 # users architectural preferences), or simply list the function name if list
 # mode is active.
@@ -1250,6 +1313,7 @@ main()
 			--scripts) func=static_check_shell ;;
 			--versions) func=static_check_versions ;;
 			--xml) func=static_check_xml ;;
+      --agent-features) func=static_check_agent_features ;;
 			--) shift; break ;;
 		esac
 


### PR DESCRIPTION
## Description

This PR implements a static check to validate feature parity between the agent's 
feature definition files, addressing issue #9319.

### Problem

When adding optional build-time features to the agent, developers must update 
two separate files:
- `src/agent/src/features.rs` - The Rust code that reports enabled features
- `src/agent/Cargo.toml` - The cargo manifest that defines available features

Without automated validation, it's easy to forget to update one file when 
modifying the other, leading to inconsistencies between what features are 
defined and what features are actually reported.

### Solution

This PR adds a new static check function `static_check_agent_features()` that:

1. Extracts the list of features from `src/agent/Cargo.toml`'s `[features]` section
2. Extracts the list of features from `src/agent/src/features.rs`
3. Compares both lists for consistency
4. Fails the CI check with a detailed error message if they don't match

The check integrates seamlessly with the existing static-checks framework and 
runs automatically as part of the regular static check suite.

### Example Error Output

When features are out of sync, developers see:
```bash
ubuntu@kc:/tmp/kata-containers$ bash tests/static-checks.sh --all --repo-path="$(pwd)" 2>&1 
[static-checks.sh:1344] INFO: Auto-detected repo as github.com/kata-containers/kata-containers
[static-checks.sh:1272] INFO: Running static checks:
[static-checks.sh:1272] INFO:   script: static-checks.sh
[static-checks.sh:1272] INFO:   architecture: ppc64le ('POWER10(architected),altivecsupported')
[static-checks.sh:1272] INFO:   kernel: 6.8.0-83-generic
[static-checks.sh:1272] INFO:   distro:
[static-checks.sh:1272] INFO:     name: Ubuntu
[static-checks.sh:1272] INFO:     version: 24.04.4 LTS (Noble Numbat)
[static-checks.sh:1215] INFO: Running 'static_check_agent_features' function
/tmp/kata-containers /tmp/kata-containers
[static-checks.sh:1116] INFO: Checking agent features consistency
ERROR: Agent features mismatch between src/agent/src/features.rs and src/agent/Cargo.toml

Features in features.rs:
agent-policy
seccomp

Features in Cargo.toml:
agent-policy
devicemapper
init-data
seccomp

Differences:
1a2,3
> devicemapper
> init-data

Please ensure the feature list in src/agent/src/features.rs matches the [features] section in src/agent/Cargo.toml

/tmp/kata-containers

```