### PR TITLE
genpolicy: invalidate incompatible layer caches and persist them across NVIDIA CI runs

### DIFF
--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -115,7 +115,14 @@ jobs:
 
       - name: Run tests ${{ matrix.environment.vmm }}
         timeout-minutes: 60
-        run: bash tests/integration/kubernetes/gha-run.sh run-nv-tests
+        run: |
+          if [[ "${KBS}" == "true" ]]; then
+            cache_dir="${HOME}/.cache/kata-containers/genpolicy"
+            mkdir -p "${cache_dir}"
+            export GENPOLICY_LAYERS_CACHE_FILE_PATH="${cache_dir}/layers-cache.json"
+          fi
+
+          bash tests/integration/kubernetes/gha-run.sh run-nv-tests
         env:
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
           ENABLE_NVRC_TRACE: ${{ inputs.enable-nvrc-trace }}

--- a/src/tools/genpolicy/genpolicy-advanced-command-line-parameters.md
+++ b/src/tools/genpolicy/genpolicy-advanced-command-line-parameters.md
@@ -51,6 +51,9 @@ Depending on the size of the container images and the speed of the network conne
 
 **Warning** Using cached image layers can lead to undesirable results. For example, if one or more locally cached layers have been modified (e.g., by an attacker) then the auto-generated Policy will allow those modified container images to be executed on the Guest VM.
 
+The cache file format is internal to `genpolicy`. If a cache file is incompatible
+with the current `genpolicy` version, the tool deletes it and rebuilds the cache.
+
 To enable caching, use the `-u` command line parameter - e.g.,
 
 ```bash

--- a/src/tools/genpolicy/src/layers_cache.rs
+++ b/src/tools/genpolicy/src/layers_cache.rs
@@ -7,7 +7,9 @@ use crate::registry::ImageLayer;
 
 use fs2::FileExt;
 use log::{debug, warn};
-use std::fs::OpenOptions;
+use serde::de::DeserializeOwned;
+use std::fs::{File, OpenOptions};
+use std::io::{Error, ErrorKind};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
@@ -32,6 +34,13 @@ impl ImageLayersCache {
     }
 
     fn try_new(layers_cache_file_path: &Option<String>) -> std::io::Result<Vec<ImageLayer>> {
+        Self::try_new_with_schema(layers_cache_file_path)
+    }
+
+    fn try_new_with_schema<T>(layers_cache_file_path: &Option<String>) -> std::io::Result<Vec<T>>
+    where
+        T: DeserializeOwned,
+    {
         match &layers_cache_file_path {
             Some(filename) => {
                 let file = OpenOptions::new()
@@ -44,19 +53,33 @@ impl ImageLayersCache {
                 // In this case, the cache will simply not be used for this instance.
                 FileExt::try_lock_shared(&file)?;
 
-                let initial_state: Vec<ImageLayer> = match serde_json::from_reader(&file) {
+                let initial_state: Vec<T> = match serde_json::from_reader(&file) {
                     Ok(data) => data,
                     Err(e) if e.is_eof() => Vec::new(), // empty file
                     Err(e) => {
-                        FileExt::unlock(&file)?;
-                        return Err(e.into());
+                        return Self::delete_incompatible_cache(filename, file, e.to_string());
                     }
                 };
+
                 FileExt::unlock(&file)?;
                 Ok(initial_state)
             }
             None => Ok(Vec::new()),
         }
+    }
+
+    fn delete_incompatible_cache<T>(
+        filename: &str,
+        file: File,
+        reason: String,
+    ) -> std::io::Result<Vec<T>> {
+        FileExt::unlock(&file)?;
+        drop(file);
+        std::fs::remove_file(filename)?;
+        Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("deleted incompatible image layers cache: {reason}"),
+        ))
     }
 
     pub fn get_layer(&self, diff_id: &str) -> Option<ImageLayer> {
@@ -93,5 +116,114 @@ impl ImageLayersCache {
         serde_json::to_writer_pretty(&file, &*layers)?;
         FileExt::unlock(&file)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    const DIFF_ID: &str = "sha256:0123456789abcdef";
+
+    #[test]
+    fn persists_and_loads_current_schema() {
+        let temp_dir = tempdir().unwrap();
+        let cache_path = temp_dir.path().join("layers-cache.json");
+        let filename = Some(cache_path.to_string_lossy().into_owned());
+        let cache = ImageLayersCache::new(&filename);
+        cache.insert_layer(&ImageLayer {
+            diff_id: DIFF_ID.to_string(),
+            passwd: "root:x:0:0:root:/root:/bin/sh".to_string(),
+            group: "root:x:0:".to_string(),
+        });
+
+        cache.persist();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cache_path).unwrap()).unwrap();
+        assert_eq!(json[0].as_object().unwrap().len(), 3);
+        assert!(json[0].get("unknown").is_none());
+
+        let reloaded = ImageLayersCache::new(&filename);
+        let layer = reloaded.get_layer(DIFF_ID).unwrap();
+        assert_eq!(layer.diff_id, DIFF_ID);
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    #[allow(dead_code)]
+    struct ImageLayerWithUnknownField {
+        diff_id: String,
+        passwd: String,
+        group: String,
+        unknown: String,
+    }
+
+    #[test]
+    fn deletes_current_cache_when_future_field_is_required() {
+        let temp_dir = tempdir().unwrap();
+        let cache_path = temp_dir.path().join("layers-cache.json");
+        let current_cache = serde_json::json!([{
+            "diff_id": DIFF_ID,
+            "passwd": "root:x:0:0:root:/root:/bin/sh",
+            "group": "root:x:0:"
+        }]);
+        fs::write(
+            &cache_path,
+            serde_json::to_vec_pretty(&current_cache).unwrap(),
+        )
+        .unwrap();
+
+        let filename = Some(cache_path.to_string_lossy().into_owned());
+        let result = ImageLayersCache::try_new_with_schema::<ImageLayerWithUnknownField>(&filename);
+
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidData);
+        assert!(!cache_path.exists());
+    }
+
+    #[test]
+    fn deletes_future_cache_with_unexpected_field() {
+        let temp_dir = tempdir().unwrap();
+        let cache_path = temp_dir.path().join("layers-cache.json");
+        let future_cache = serde_json::json!([{
+            "diff_id": DIFF_ID,
+            "passwd": "root:x:0:0:root:/root:/bin/sh",
+            "group": "root:x:0:",
+            "unknown": "future-value"
+        }]);
+        fs::write(
+            &cache_path,
+            serde_json::to_vec_pretty(&future_cache).unwrap(),
+        )
+        .unwrap();
+
+        let filename = Some(cache_path.to_string_lossy().into_owned());
+        let cache = ImageLayersCache::new(&filename);
+
+        assert!(!cache_path.exists());
+        assert!(cache.get_layer(DIFF_ID).is_none());
+    }
+
+    #[test]
+    fn deletes_cache_when_expected_field_is_renamed() {
+        let temp_dir = tempdir().unwrap();
+        let cache_path = temp_dir.path().join("layers-cache.json");
+        let changed_cache = serde_json::json!([{
+            "diff_id": DIFF_ID,
+            "passwd": "root:x:0:0:root:/root:/bin/sh",
+            "unknown": "root:x:0:"
+        }]);
+        fs::write(
+            &cache_path,
+            serde_json::to_vec_pretty(&changed_cache).unwrap(),
+        )
+        .unwrap();
+
+        let filename = Some(cache_path.to_string_lossy().into_owned());
+        let cache = ImageLayersCache::new(&filename);
+
+        assert!(!cache_path.exists());
+        assert!(cache.get_layer(DIFF_ID).is_none());
     }
 }

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -68,6 +68,7 @@ pub struct DockerRootfs {
 
 /// This application's image layer properties.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImageLayer {
     pub diff_id: String,
     pub passwd: String,

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -122,8 +122,8 @@ create_and_wait_for_pod_ready() {
 @test "Successful pod with auto-generated policy and custom layers cache path" {
 	tmp_path=$(mktemp -d)
 
-	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
-		"--layers-cache-file-path=${tmp_path}/cache.json"
+	GENPOLICY_LAYERS_CACHE_FILE_PATH="${tmp_path}/cache.json" \
+		auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}"
 
 	[ -f "${tmp_path}/cache.json" ]
 	rm -r "${tmp_path}"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -43,6 +43,7 @@ AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-}"
 GENPOLICY_PULL_METHOD="${GENPOLICY_PULL_METHOD:-}"
 GENPOLICY_BINARY="${GENPOLICY_BINARY:-"/opt/kata/bin/genpolicy"}"
 GENPOLICY_SETTINGS_DIR="${GENPOLICY_SETTINGS_DIR:-"/opt/kata/share/defaults/kata-containers"}"
+GENPOLICY_LAYERS_CACHE_FILE_PATH="${GENPOLICY_LAYERS_CACHE_FILE_PATH:-}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
 KATA_HOST_OS="${KATA_HOST_OS:-}"
 RUNS_ON_AKS="${RUNS_ON_AKS:-false}"
@@ -386,8 +387,14 @@ auto_generate_policy_no_added_flags() {
 
 	auto_generate_policy_enabled || return 0
 	local genpolicy_command="RUST_LOG=info ${GENPOLICY_BINARY} -u -y ${yaml_file}"
+	local quoted_layers_cache_file_path
 	genpolicy_command+=" -p ${settings_dir}/rules.rego"
 	genpolicy_command+=" -j ${settings_dir}"
+
+	if [[ -n "${GENPOLICY_LAYERS_CACHE_FILE_PATH}" ]]; then
+		printf -v quoted_layers_cache_file_path "%q" "${GENPOLICY_LAYERS_CACHE_FILE_PATH}"
+		genpolicy_command+=" --layers-cache-file-path=${quoted_layers_cache_file_path}"
+	fi
 
 	if [[ -n "${config_map_yaml_file}" ]]; then
 		genpolicy_command+=" -c ${config_map_yaml_file}"


### PR DESCRIPTION
Kubernetes integration tests invoke `genpolicy` repeatedly with `-u`, but the default `layers-cache.json` is stored inside the repository checkout. Persistent CI runners thus receive a clean checkout for each job, so this cache is discarded between runs. As a result, genpolicy repeatedly downloads the same container image layers.

This changeset allows persisting the cache. Persisting the cache, however, means it can outlive the genpolicy binary that created it. Cache format changes therefore need to be handled safely.

The changes at a glance:
- Delete incompatible layer cache files when deserialization fails, reject unknown fields in cached image-layer entries.
- Add tests covering: a) the current three-field cache format, b) a hypothetical future required field is introduced, c) an unexpected additional field is present, d) a renamed expected field is present.
- Add `GENPOLICY_LAYERS_CACHE_FILE_PATH` support to the Kubernetes test harness.
- Store the cache for NVIDIA CoCo jobs under the persistent runner home directory.

The automated CI run tests this change without using `GENPOLICY_LAYERS_CACHE_FILE_PATH` from `.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml`, i.e., without requesting a persistent cache.

The manual CI run requests a persistent cache, run link: https://github.com/kata-containers/kata-containers/actions/runs/30574447617
A second manual CI run would re-use a persistent cache and should thus reduce test time: https://github.com/kata-containers/kata-containers/actions/runs/30655958926