### PR TITLE
runtime/QEMU: roll back rootless setup on sandbox error

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -50,6 +50,8 @@ var defaultStartManagementServerFunc startManagementServerFunc = func(s *service
 	shimLog.Info("management server started")
 }
 
+var configureNonRootHypervisorFunc = configureNonRootHypervisor
+
 func copyLayersToMounts(rootFs *virtcontainers.RootFs, spec *specs.Spec) error {
 	for _, o := range rootFs.Options {
 		if !strings.HasPrefix(o, annotations.FileSystemLayer) {
@@ -169,10 +171,17 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 
 		katautils.HandleFactory(ctx, vci, s.config)
 		rootless.SetRootless(s.config.HypervisorConfig.Rootless)
+		var rollbackRootlessSetup func()
 		if rootless.IsRootless() {
-			if err := configureNonRootHypervisor(s.config, r.ID); err != nil {
+			rollbackRootlessSetup, err = configureNonRootHypervisorFunc(s.config, r.ID)
+			if err != nil {
 				return nil, err
 			}
+			defer func() {
+				if rollbackRootlessSetup != nil {
+					rollbackRootlessSetup()
+				}
+			}()
 		}
 
 		// config.WithCDI() has used the CDI annotations to inject
@@ -191,6 +200,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			return nil, err
 		}
 		s.sandbox = sandbox
+		rollbackRootlessSetup = nil
 		pid, err := s.sandbox.GetHypervisorPid()
 		if err != nil {
 			return nil, err
@@ -385,39 +395,53 @@ func doMount(mounts []*containerd_types.Mount, rootfs string) error {
 	return nil
 }
 
-func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID string) error {
+func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID string) (rollback func(), err error) {
 	userName, err := utils.CreateVmmUser()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer func() {
-		if err != nil {
+	var runtimeUID *uint32
+	rollback = func() {
+		if runtimeUID != nil {
+			if err := rootless.RemoveVmmUserRuntimeDir(*runtimeUID); err != nil {
+				shimLog.WithFields(logrus.Fields{
+					"path":       rootless.VmmUserRuntimeDir(*runtimeUID),
+					"sandbox_id": sandboxID,
+				}).WithError(err).Warn("failed to remove rootless runtime directory")
+			}
+		}
+
+		if err := utils.RemoveVmmUser(userName); err != nil {
 			shimLog.WithFields(logrus.Fields{
 				"user_name":  userName,
 				"sandbox_id": sandboxID,
-			}).WithError(err).Warn("configure non root hypervisor failed, delete the user")
-			if err2 := utils.RemoveVmmUser(userName); err2 != nil {
-				shimLog.WithField("userName", userName).WithError(err).Warn("failed to remove user")
-			}
+			}).WithError(err).Warn("failed to remove rootless VMM user")
+		}
+	}
+	defer func() {
+		if err != nil {
+			rollback()
 		}
 	}()
 
 	u, err := user.Lookup(userName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	gid, err := strconv.Atoi(u.Gid)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	runtimeConfig.HypervisorConfig.Uid = uint32(uid)
 	runtimeConfig.HypervisorConfig.User = userName
 	runtimeConfig.HypervisorConfig.Gid = uint32(gid)
+	uidValue := uint32(uid)
+	runtimeUID = &uidValue
 	shimLog.WithFields(logrus.Fields{
 		"user_name":  userName,
 		"uid":        uid,
@@ -430,38 +454,31 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID stri
 	// Clean up the directory created by the previous run
 	if !os.IsNotExist(err) {
 		if err = os.RemoveAll(userTmpDir); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if err = os.Mkdir(userTmpDir, virtcontainers.DirMode); err != nil {
-		return err
+		return nil, err
 	}
-	defer func() {
-		if err != nil {
-			if err = os.RemoveAll(userTmpDir); err != nil {
-				shimLog.WithField("userTmpDir", userTmpDir).WithError(err).Warn("failed to remove userTmpDir")
-			}
-		}
-	}()
 	if err = syscall.Chown(userTmpDir, uid, gid); err != nil {
-		return err
+		return nil, err
 	}
 
-	if err := os.Setenv("XDG_RUNTIME_DIR", userTmpDir); err != nil {
-		return err
+	if err = os.Setenv("XDG_RUNTIME_DIR", userTmpDir); err != nil {
+		return nil, err
 	}
 
 	info, err := os.Stat("/dev/kvm")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		// Add the kvm group to the hypervisor supplemental group so that the hypervisor process can access /dev/kvm
 		runtimeConfig.HypervisorConfig.Groups = append(runtimeConfig.HypervisorConfig.Groups, stat.Gid)
-		return nil
+		return rollback, nil
 	}
-	return fmt.Errorf("failed to get the gid of /dev/kvm")
+	return nil, fmt.Errorf("failed to get the gid of /dev/kvm")
 }
 
 func removeCDIAnnotations(annotations map[string]string) {

--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -11,6 +11,7 @@ package containerdshim
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -429,23 +430,38 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID stri
 		return nil, err
 	}
 
-	uid, err := strconv.Atoi(u.Uid)
+	parsedUID, err := strconv.ParseInt(u.Uid, 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	gid, err := strconv.Atoi(u.Gid)
+	if parsedUID < 0 || parsedUID > math.MaxUint32 {
+		return nil, fmt.Errorf("rootless UID %q is outside the uint32 range", u.Uid)
+	}
+	if parsedUID > math.MaxInt {
+		return nil, fmt.Errorf("rootless UID %q exceeds the platform int range", u.Uid)
+	}
+	parsedGID, err := strconv.ParseInt(u.Gid, 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	runtimeConfig.HypervisorConfig.Uid = uint32(uid)
+	if parsedGID < 0 || parsedGID > math.MaxUint32 {
+		return nil, fmt.Errorf("rootless GID %q is outside the uint32 range", u.Gid)
+	}
+	if parsedGID > math.MaxInt {
+		return nil, fmt.Errorf("rootless GID %q exceeds the platform int range", u.Gid)
+	}
+	runtimeUIDValue := uint32(parsedUID)
+	runtimeGIDValue := uint32(parsedGID)
+	chownUID := int(parsedUID)
+	chownGID := int(parsedGID)
+	runtimeConfig.HypervisorConfig.Uid = runtimeUIDValue
 	runtimeConfig.HypervisorConfig.User = userName
-	runtimeConfig.HypervisorConfig.Gid = uint32(gid)
-	uidValue := uint32(uid)
-	runtimeUID = &uidValue
+	runtimeConfig.HypervisorConfig.Gid = runtimeGIDValue
+	runtimeUID = &runtimeUIDValue
 	shimLog.WithFields(logrus.Fields{
 		"user_name":  userName,
-		"uid":        uid,
-		"gid":        gid,
+		"uid":        runtimeUIDValue,
+		"gid":        runtimeGIDValue,
 		"sandbox_id": sandboxID,
 	}).Debug("successfully created a non root user for the hypervisor")
 
@@ -461,7 +477,7 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxID stri
 	if err = os.Mkdir(userTmpDir, virtcontainers.DirMode); err != nil {
 		return nil, err
 	}
-	if err = syscall.Chown(userTmpDir, uid, gid); err != nil {
+	if err = syscall.Chown(userTmpDir, chownUID, chownGID); err != nil {
 		return nil, err
 	}
 

--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -24,8 +24,10 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
 )
 
@@ -127,6 +129,67 @@ func TestCreateSandboxFail(t *testing.T) {
 	_, err = s.Create(ctx, req)
 	assert.Error(err)
 	assert.True(vcmock.IsMockError(err))
+}
+
+// TestCreateSandboxFailRollsBackRootlessSetup verifies that rootless resources
+// remain provisional until sandbox construction succeeds.
+func TestCreateSandboxFailRollsBackRootlessSetup(t *testing.T) {
+	assert := assert.New(t)
+	expectedErr := fmt.Errorf("sandbox construction failed")
+
+	// Use vcmock's existing injection point to fail after rootless setup and
+	// before a sandbox is returned.
+	testingImpl.CreateSandboxFunc = func(ctx context.Context, sandboxConfig vc.SandboxConfig, hookFunc func(context.Context) error) (vc.VCSandbox, error) {
+		return nil, expectedErr
+	}
+	defer func() {
+		testingImpl.CreateSandboxFunc = nil
+	}()
+
+	rolledBack := false
+	originalConfigureNonRootHypervisor := configureNonRootHypervisorFunc
+	// Replace privileged user and directory setup with a rollback marker. This
+	// tests create()'s ownership handoff without modifying users or /run/user.
+	configureNonRootHypervisorFunc = func(runtimeConfig *oci.RuntimeConfig, sandboxID string) (func(), error) {
+		return func() {
+			rolledBack = true
+		}, nil
+	}
+	defer func() {
+		configureNonRootHypervisorFunc = originalConfigureNonRootHypervisor
+		rootless.SetRootless(false)
+	}()
+
+	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
+
+	runtimeConfig, err := newTestRuntimeConfig(tmpdir, true)
+	assert.NoError(err)
+	runtimeConfig.HypervisorConfig.Rootless = true
+	runtimeConfig.DisableNewNetNs = true
+
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
+	assert.NoError(err)
+
+	err = ktu.WriteOCIConfigFile(spec, ociConfigFile)
+	assert.NoError(err)
+
+	s := &service{
+		id:         testSandboxID,
+		containers: make(map[string]*container),
+		config:     &runtimeConfig,
+		ctx:        context.Background(),
+	}
+
+	req := &taskAPI.CreateTaskRequest{
+		ID:       testSandboxID,
+		Bundle:   bundlePath,
+		Terminal: true,
+	}
+
+	ctx := namespaces.WithNamespace(context.Background(), "UnitTest")
+	_, err = s.Create(ctx, req)
+	assert.ErrorIs(err, expectedErr)
+	assert.True(rolledBack)
 }
 
 func TestCreateSandboxConfigFail(t *testing.T) {

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -11,6 +11,36 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 readonly QEMU_SANDBOX_PARAM="on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny"
+readonly QEMU_SANDBOX_CLEANUP_TIMEOUT_SECONDS="${QEMU_SANDBOX_CLEANUP_TIMEOUT_SECONDS:-30}"
+
+get_rootless_host_resources() {
+	local query="{ getent passwd | "
+	query+="awk -F: '\$1 ~ /^kata-[0-9]+$/ "
+	query+="&& \$5 ~ /Kata Containers temporary hypervisor user/ "
+	query+="{ print \"user:\" \$1 \":\" \$3 }'; "
+	query+="find /run/user -mindepth 1 -maxdepth 1 -type d "
+	query+="-printf 'dir:%f\\n' 2>/dev/null; } | sort"
+
+	exec_host "${node}" "${query}"
+}
+
+wait_for_rootless_host_resources() {
+	local actual_resources
+	local attempt
+	local expected_resources="$1"
+
+	for ((attempt = 0; attempt < QEMU_SANDBOX_CLEANUP_TIMEOUT_SECONDS; attempt++)); do
+		actual_resources="$(get_rootless_host_resources)"
+		[[ "${actual_resources}" == "${expected_resources}" ]] && return 0
+		sleep 1
+	done
+
+	echo "Rootless host resources before the sandbox:"
+	echo "${expected_resources}"
+	echo "Rootless host resources after sandbox teardown:"
+	echo "${actual_resources}"
+	return 1
+}
 
 qemu_rootless_sandbox_supported() {
 	[[ "${KATA_HYPERVISOR}" == qemu* ]] || return 1
@@ -60,10 +90,12 @@ EOF
 
 @test "QEMU runs rootless with its seccomp sandbox enabled" {
 	local cmdline
+	local host_resources
 	local qemu_pid
 	local qemu_status
 	local qemu_gid
 	local qemu_uid
+	host_resources="$(get_rootless_host_resources)"
 
 	retry_kubectl_apply "${pod_config}"
 	kubectl wait --for=condition=Ready --timeout="${timeout}" "pod/${pod_name}"
@@ -83,6 +115,9 @@ EOF
 
 	cmdline="$(exec_host "${node}" "tr '\\0' ' ' < /proc/${qemu_pid}/cmdline")"
 	[[ " ${cmdline} " == *" -sandbox ${QEMU_SANDBOX_PARAM} "* ]]
+
+	kubectl delete -f "${pod_config}" --ignore-not-found=true
+	wait_for_rootless_host_resources "${host_resources}"
 }
 
 teardown() {


### PR DESCRIPTION
The PR improves the rootless lifecycle handling and the QEMU rootless and seccomp-sandbox BATS baseline.

**ATTENTION:** This targets the go runtime. This is a smaller size fix for an *existing* feature. Proper clean-up should work for both runtimes (also allowing to add a unified bats logic validating resource cleanup).

#### Problem: Lacking resource cleanup when sandbox creation fails
Today `configureNonRootHypervisor()` removes the temporary VMM user and runtime directory if rootless setup itself returns an error. After `katautils.CreateSandbox()` succeeds, normal sandbox teardown owns those resources. However, if rootless setup succeeds but `CreateSandbox()` subsequently returns an error, neither path owns the resources. The temporary user and `/run/user/<uid>` directory are therefore leaked.

Return a rollback closure from `configureNonRootHypervisor()` and defer it across `CreateSandbox()`. Disarm it only after storing the created sandbox, when normal teardown has taken ownership.

Add focused unit coverage that injects a `CreateSandbox()` error and verifies that rollback runs. Also strengthen the successful QEMU BATS test by recording the temporary users and runtime directories before sandbox creation, deleting the pod explicitly, and requiring the host state to return to its original baseline.

Further QEMU rootless and seccomp-sandbox work is tracked in #13424.
