### PR TITLE
packaging: disable AGENT_INIT for s390x vanilla initrd

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -924,8 +924,11 @@ install_initrd() {
 			export COCO_GUEST_COMPONENTS_TARBALL
 		fi
 	else
-		# Vanilla initrd uses kata-agent as /sbin/init (no systemd).
-		export AGENT_INIT=yes
+		# Vanilla initrd uses kata-agent as /sbin/init (no systemd), except on s390x.
+		unset AGENT_INIT
+		if [[ "${ARCH}" != "s390x" ]]; then
+			export AGENT_INIT=yes
+		fi
 	fi
 
 	AGENT_TARBALL=$(get_agent_tarball_path)


### PR DESCRIPTION
In order for qemu-se-* to work with the composable VM extension, the s390x initrd must be built with systemd instead of using kata-agent as /sbin/init.

Stop exporting AGENT_INIT=yes for s390x in the vanilla initrd build path so the guest image build keeps the default AGENT_INIT=no behavior and includes the systemd-based boot flow required by the extension mount units.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>