### PR TITLE
build: pause-image must be a dep of the monolith confidential images

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -57,6 +57,7 @@ jobs:
           - ovmf
           - ovmf-sev
           - ovmf-tdx
+          - pause-image
           - qemu
           - qemu-snp-experimental
           - qemu-tdx-experimental

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -55,6 +55,7 @@ jobs:
           - kernel-nvidia-gpu
           - nydus
           - ovmf
+          - pause-image
           - qemu
           - virtiofsd
     concurrency:
@@ -277,6 +278,7 @@ jobs:
         asset:
           - busybox
           - coco-guest-components
+          - pause-image
           - kernel-nvidia-gpu-modules
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm-${{ toJSON(matrix) }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -47,6 +47,7 @@ jobs:
           - coco-guest-components
           - fake-boot-image-se
           - kernel
+          - pause-image
           - qemu
           - virtiofsd
     concurrency:

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -105,6 +105,7 @@ NVGPU_BASE_TARBALLS = \
 	ovmf-sev-tarball \
 	ovmf-tdx-tarball \
 	ovmf-tarball \
+	pause-image \
 	qemu-snp-experimental-tarball \
 	qemu-tdx-experimental-tarball \
 	qemu-tarball \
@@ -118,6 +119,7 @@ NVGPU_BASE_TARBALLS = \
 	$(PUBLISH_COMPONENT_TARBALLS) \
 	kernel-nvidia-gpu-tarball \
 	ovmf-tarball \
+	pause-image \
 	qemu-tarball \
 	virtiofsd-tarball \
 	serial-targets
@@ -314,7 +316,7 @@ DEPS := agent-tarball
 rootfs-image-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball pause-image coco-guest-components-tarball kernel-tarball
 rootfs-image-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -325,7 +327,7 @@ DEPS := agent-tarball
 rootfs-image-mariner-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball pause-image coco-guest-components-tarball kernel-tarball
 rootfs-initrd-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -337,7 +339,7 @@ DEPS := agent-tarball busybox-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball busybox-tarball coco-guest-components-tarball kernel-nvidia-gpu-tarball
+DEPS := agent-tarball busybox-tarball pause-image coco-guest-components-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 


### PR DESCRIPTION
As the guest-components docker image does not include the pause image, only the guest-components extension image does.