### PR TITLE
runtime-rs: Allow listxattr in dragonball seccomp

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/seccomp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/seccomp.rs
@@ -111,6 +111,7 @@ pub fn get_process_seccomp_rules() -> Vec<(i64, Vec<seccompiler::SeccompRule>)> 
         (libc::SYS_umount2, vec![]),
         (libc::SYS_gettid, vec![]),
         (libc::SYS_getxattr, vec![]),
+        (libc::SYS_listxattr, vec![]),
         (libc::SYS_tkill, vec![]),
         (libc::SYS_futex, vec![]),
         (libc::SYS_sched_setaffinity, vec![]),

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/seccomp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/seccomp.rs
@@ -112,6 +112,7 @@ pub fn get_process_seccomp_rules() -> Vec<(i64, Vec<seccompiler::SeccompRule>)> 
         (libc::SYS_gettid, vec![]),
         (libc::SYS_getxattr, vec![]),
         (libc::SYS_listxattr, vec![]),
+        (libc::SYS_name_to_handle_at, vec![]),
         (libc::SYS_tkill, vec![]),
         (libc::SYS_futex, vec![]),
         (libc::SYS_sched_setaffinity, vec![]),


### PR DESCRIPTION
The inline virtio-fs backend calls listxattr when handling FUSE LISTXATTR requests. Since listxattr is missing from the Dragonball seccomp allowlist, the virtiofs thread receives SIGSYS and the shim exits.

Allow listxattr so xattr-aware operations on shared paths can complete with Dragonball seccomp enabled.

Keep the allowlist as small as possible. Other commonly used xattr syscalls can be considered when concrete use cases require them.

Fixes: #13136