### PR TITLE
Helm chart: pass user provided node affinity to kata-monitor DaemonSet

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -1077,3 +1077,8 @@ are still rendered, and delete the chart's rule if it duplicates yours.
     `env.multiInstallSuffix` when that is set. A rule called `amd64-tee-keys`
     belongs to a release that has not been upgraded yet, and can be deleted once
     every release has been.
+
+## kata-monitor
+
+When `monitor.enabled=true` is set, the Helm chart also deploys [`kata-monitor`](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/cmd/kata-monitor/README.md) DaemonSet.
+Note that a number of top level Helm chart values, such as tolerations and affinity, are applied to both `kata-deploy` and `kata-monitor`. See [Helm chart values](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml) for full configuration.

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -24,13 +24,6 @@ CHART_PATH="$(get_chart_path)"
 RENDERED="/tmp/kata-deploy-scheduling-rendered.yaml"
 RENDERED_JOBS="/tmp/kata-deploy-scheduling-rendered-jobs.yaml"
 
-render_chart() {
-	helm template kata-deploy "${CHART_PATH}" \
-		--set image.reference=quay.io/kata-containers/kata-deploy \
-		--set image.tag=latest \
-		"$@" > "${RENDERED}"
-}
-
 # Render only the per-node Job templates ConfigMap (deploymentMode: job).
 render_job_templates() {
 	helm template kata-deploy "${CHART_PATH}" \
@@ -82,31 +75,7 @@ extract_pernode_job() {
 
 # Extract the kata-deploy DaemonSet manifest (not kata-monitor or NFD subchart).
 extract_kata_deploy_ds() {
-	awk '
-		/^kind: DaemonSet$/ { buf = $0 "\n"; in_ds = 1; has_name = 0; next }
-		in_ds {
-			buf = buf $0 "\n"
-			if ($0 ~ /^  name: kata-deploy$/) { has_name = 1 }
-			if ($0 ~ /^---$/) {
-				if (has_name) { printf "%s", buf; exit }
-				in_ds = 0; buf = ""; has_name = 0
-				next
-			}
-		}
-		END { if (has_name && in_ds) { printf "%s", buf } }
-	' "${RENDERED}"
-}
-
-# Count nodeSelectorTerms under requiredDuringSchedulingIgnoredDuringExecution in a manifest.
-count_required_node_selector_terms() {
-	local manifest="${1}"
-	echo "${manifest}" | awk '
-		/requiredDuringSchedulingIgnoredDuringExecution:/ { in_req = 1; next }
-		in_req && /preferredDuringSchedulingIgnoredDuringExecution:/ { exit }
-		in_req && /^        [a-zA-Z]/ { exit }
-		in_req && /- match(Expressions|Fields):/ { count++ }
-		END { print count + 0 }
-	'
+	extract_daemonset "kata-deploy"
 }
 
 # =============================================================================

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -159,6 +159,50 @@ deploy_kata() {
 	return 0
 }
 
+# Render the kata-deploy helm chart to the file named by the caller-set
+# ${RENDERED} variable.
+# Arguments:
+#   $@ - Additional helm template arguments
+render_chart() {
+	helm template kata-deploy "$(get_chart_path)" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@" > "${RENDERED}"
+}
+
+# Extract a DaemonSet manifest by name from the ${RENDERED} chart output.
+# Arguments:
+#   $1 - DaemonSet name (e.g. kata-deploy, kata-monitor)
+extract_daemonset() {
+	local name_line="  name: $1"
+	awk -v name_line="${name_line}" '
+		/^kind: DaemonSet$/ { buf = $0 "\n"; in_ds = 1; has_name = 0; next }
+		in_ds {
+			buf = buf $0 "\n"
+			if ($0 == name_line) { has_name = 1 }
+			if ($0 ~ /^---$/) {
+				if (has_name) { printf "%s", buf; exit }
+				in_ds = 0; buf = ""; has_name = 0
+				next
+			}
+		}
+		END { if (has_name && in_ds) { printf "%s", buf } }
+	' "${RENDERED}"
+}
+
+# Count nodeSelectorTerms under requiredDuringSchedulingIgnoredDuringExecution
+# in a manifest.
+count_required_node_selector_terms() {
+	local manifest="${1}"
+	echo "${manifest}" | awk '
+		/requiredDuringSchedulingIgnoredDuringExecution:/ { in_req = 1; next }
+		in_req && /preferredDuringSchedulingIgnoredDuringExecution:/ { exit }
+		in_req && /^        [a-zA-Z]/ { exit }
+		in_req && /- match(Expressions|Fields):/ { count++ }
+		END { print count + 0 }
+	'
+}
+
 # Uninstall kata-deploy
 uninstall_kata() {
 	helm uninstall "${HELM_RELEASE_NAME}" -n "${HELM_NAMESPACE}" \

--- a/tests/functional/kata-monitor/kata-monitor-scheduling.bats
+++ b/tests/functional/kata-monitor/kata-monitor-scheduling.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 The Kata Containers Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for kata-monitor DaemonSet scheduling options (affinity).
+# No cluster required.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/../kata-deploy/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+RENDERED="/tmp/kata-monitor-scheduling-rendered.yaml"
+
+render_chart() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@" > "${RENDERED}"
+}
+
+# Extract the kata-monitor DaemonSet manifest.
+extract_kata_monitor_ds() {
+	awk '
+		/^kind: DaemonSet$/ { buf = $0 "\n"; in_ds = 1; has_name = 0; next }
+		in_ds {
+			buf = buf $0 "\n"
+			if ($0 ~ /^  name: kata-monitor$/) { has_name = 1 }
+			if ($0 ~ /^---$/) {
+				if (has_name) { printf "%s", buf; exit }
+				in_ds = 0; buf = ""; has_name = 0
+				next
+			}
+		}
+		END { if (has_name && in_ds) { printf "%s", buf } }
+	' "${RENDERED}"
+}
+
+# Count nodeSelectorTerms under requiredDuringSchedulingIgnoredDuringExecution in a manifest.
+count_required_node_selector_terms() {
+	local manifest="${1}"
+	echo "${manifest}" | awk '
+		/requiredDuringSchedulingIgnoredDuringExecution:/ { in_req = 1; next }
+		in_req && /preferredDuringSchedulingIgnoredDuringExecution:/ { exit }
+		in_req && /^        [a-zA-Z]/ { exit }
+		in_req && /- match(Expressions|Fields):/ { count++ }
+		END { print count + 0 }
+	'
+}
+
+# =============================================================================
+# Template Rendering Tests (no cluster required)
+# =============================================================================
+
+@test "Helm template: kata-monitor default values have no affinity" {
+	render_chart --set monitor.enabled=true
+
+	local ds
+	ds=$(extract_kata_monitor_ds)
+
+	[[ -n "${ds}" ]]
+	echo "${ds}" | grep -q "name: kata-monitor"
+	! echo "${ds}" | grep -q "affinity:"
+}
+
+@test "Helm template: kata-monitor user affinity is applied to pod spec" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node.cloud/reserved
+              operator: In
+              values:
+                - platform-team
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - gpu-operator
+        topologyKey: kubernetes.io/hostname
+EOF
+
+	render_chart -f "${values_file}" --set monitor.enabled=true
+	rm -f "${values_file}"
+
+	local ds
+	ds=$(extract_kata_monitor_ds)
+
+	echo "${ds}" | grep -q "affinity:"
+	echo "${ds}" | grep -q "node.cloud/reserved"
+	echo "${ds}" | grep -q "platform-team"
+	echo "${ds}" | grep -q "podAntiAffinity:"
+	echo "${ds}" | grep -q "gpu-operator"
+}
+
+@test "Helm template: kata-monitor NFD enabled merges virtualization nodeAffinity" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node.cloud/reserved
+              operator: In
+              values:
+                - platform-team
+EOF
+
+	render_chart -f "${values_file}" --set monitor.enabled=true --set node-feature-discovery.enabled=true
+	rm -f "${values_file}"
+
+	local ds term_count
+	ds=$(extract_kata_monitor_ds)
+	term_count=$(count_required_node_selector_terms "${ds}")
+
+	[[ "${term_count}" -eq 6 ]]
+	echo "${ds}" | grep -q "node.cloud/reserved"
+	echo "${ds}" | grep -q "platform-team"
+	echo "${ds}" | grep -q "feature.node.kubernetes.io/cpu-cpuid.VMX"
+	echo "${ds}" | grep -q "feature.node.kubernetes.io/cpu-cpuid.SVM"
+}

--- a/tests/functional/kata-monitor/kata-monitor-scheduling.bats
+++ b/tests/functional/kata-monitor/kata-monitor-scheduling.bats
@@ -10,43 +10,11 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 
 source "${BATS_TEST_DIRNAME}/../kata-deploy/lib/helm-deploy.bash"
 
-CHART_PATH="$(get_chart_path)"
 RENDERED="/tmp/kata-monitor-scheduling-rendered.yaml"
-
-render_chart() {
-	helm template kata-deploy "${CHART_PATH}" \
-		--set image.reference=quay.io/kata-containers/kata-deploy \
-		--set image.tag=latest \
-		"$@" > "${RENDERED}"
-}
 
 # Extract the kata-monitor DaemonSet manifest.
 extract_kata_monitor_ds() {
-	awk '
-		/^kind: DaemonSet$/ { buf = $0 "\n"; in_ds = 1; has_name = 0; next }
-		in_ds {
-			buf = buf $0 "\n"
-			if ($0 ~ /^  name: kata-monitor$/) { has_name = 1 }
-			if ($0 ~ /^---$/) {
-				if (has_name) { printf "%s", buf; exit }
-				in_ds = 0; buf = ""; has_name = 0
-				next
-			}
-		}
-		END { if (has_name && in_ds) { printf "%s", buf } }
-	' "${RENDERED}"
-}
-
-# Count nodeSelectorTerms under requiredDuringSchedulingIgnoredDuringExecution in a manifest.
-count_required_node_selector_terms() {
-	local manifest="${1}"
-	echo "${manifest}" | awk '
-		/requiredDuringSchedulingIgnoredDuringExecution:/ { in_req = 1; next }
-		in_req && /preferredDuringSchedulingIgnoredDuringExecution:/ { exit }
-		in_req && /^        [a-zA-Z]/ { exit }
-		in_req && /- match(Expressions|Fields):/ { count++ }
-		END { print count + 0 }
-	'
+	extract_daemonset "kata-monitor"
 }
 
 # =============================================================================

--- a/tests/functional/kata-monitor/run-kata-monitor-helm-tests.sh
+++ b/tests/functional/kata-monitor/run-kata-monitor-helm-tests.sh
@@ -20,6 +20,7 @@ if [[ -n "${KATA_MONITOR_HELM_TEST_UNION:-}" ]]; then
 else
 	KATA_MONITOR_HELM_TEST_UNION=( \
 		"kata-monitor.bats" \
+		"kata-monitor-scheduling.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -32,6 +32,11 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- $dsAffinity := include "kata-deploy.daemonsetAffinity" . | trim -}}
+{{- if $dsAffinity }}
+      affinity:
+{{- $dsAffinity | nindent 8 }}
+{{- end }}
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -179,6 +179,10 @@ kubectlImage:
   reference: quay.io/kata-containers/kubectl
   tag: latest
 
+# monitor configures kata-monitor DaemonSet.
+# https://github.com/kata-containers/kata-containers/blob/main/src/runtime/cmd/kata-monitor/README.md
+# Note that some of the top level chart values outside this block, such as
+# node selectors and affinity get applied to this DaemonSet.
 monitor:
   enabled: false
   image:
@@ -246,7 +250,7 @@ containerd:
   #     default_size = "20G"
   userDropIn: ""
 
-# Which nodes Kata is installed on, and which taints that installation tolerates.
+# Which nodes kata-deploy and, if enabled, kata-monitor is installed on, and which taints that installation tolerates.
 #
 # These apply to BOTH deployment modes. In daemonset mode they are set on the
 # kata-deploy DaemonSet pods and the scheduler decides where those land; in job
@@ -261,6 +265,7 @@ containerd:
 # An empty nodeSelector does NOT mean "every node": nodes whose taints are not
 # tolerated are still excluded, which is what keeps Kata off control-plane nodes
 # by default.
+#
 #
 # Examples:
 # nodeSelector:
@@ -328,7 +333,7 @@ podLabels: {}
 #   prometheus.io/scrape: "false"
 podAnnotations: {}
 
-# Affinity rules for kata-deploy.
+# Affinity rules for the kata-deploy and, if enabled, kata-monitor.
 # nodeSelector matches exact key/value pairs; affinity supports matchExpressions
 # and rules about other pods on the same node (e.g. podAntiAffinity).
 #
@@ -373,7 +378,7 @@ podAnnotations: {}
 #         topologyKey: kubernetes.io/hostname
 affinity: {}
 
-# Priority class name for the kata-deploy DaemonSet pods.
+# Priority class name for the kata-deploy and, if enabled, kata-monitor DaemonSet pods.
 #
 # kata-deploy is an infrastructure DaemonSet that installs Kata runtime
 # artifacts on every node. If it gets evicted under node pressure, the


### PR DESCRIPTION
This change makes the kata-deploy Helm chart pass the top level user provided node affinity to the kata-monitor DaemonSet, if one is configured, same as it is already done with the top level user provided node selector.

## Context

We would like to take advantage of the node affinity Helm chart option added in https://github.com/kata-containers/kata-containers/pull/13212 to deploy Kata to our cluster, which has a mix of nodes where not all nodes need Kata and the ones that do, don't have a single shared label. We would also love to be able to replace our kata-monitor manifests and instead deploy it via the kata-deploy Helm chart, which is possible since https://github.com/kata-containers/kata-containers/pull/13107. The chart currently [propagates the top level node selector](https://github.com/kata-containers/kata-containers/blob/aec75d9f4575d354521520378e04cb69812a7927/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml#L27) to kata-monitor, but not affinity.

The kata-deploy affinity behavior where [NFD affinity is merged with any user explicitly provided affinity](https://github.com/kata-containers/kata-containers/blob/aec75d9f4575d354521520378e04cb69812a7927/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl#L1075) is preserved in kata-monitor too (so this change will now make NFD affinity apply to kata-monitor Pods that was previously not the case- I think that makes sense since users would always want to run kata-monitor on the same nodes as kata-deploy, so it should make sense to pass the same node selection rules to both DaemonSets.)


## Tests


I've tested that the chart renders as expected (with and without NFD):
<details>
// without NFD
<code>
$ helm template kata-deploy tools/packaging/kata-deploy/helm-chart/kata-deploy \
  --set image.reference=quay.io/kata-containers/kata-deploy \
  --set image.tag=latest \
  --set monitor.enabled=true \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=node.cloud/reserved' \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=platform-team'
...
# Source: kata-deploy/templates/kata-monitor.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app.kubernetes.io/name: kata-monitor
    app.kubernetes.io/instance: kata-deploy
  name: kata-monitor
  namespace: default
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: kata-monitor
      app.kubernetes.io/instance: kata-deploy
  template:
    metadata:
      labels:
        app.kubernetes.io/name: kata-monitor
        app.kubernetes.io/instance: kata-deploy
      annotations:
        prometheus.io/scrape: "true"
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
 ...
</code>
// with NFD
<code>
$ helm template kata-deploy tools/packaging/kata-deploy/helm-chart/kata-deploy \
  --set image.reference=quay.io/kata-containers/kata-deploy \                                                                                                                                 --set image.tag=latest \
  --set monitor.enabled=true \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=node.cloud/reserved' \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
  --set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=platform-team' --set node-feature-discovery.enabled=true
....
# Source: kata-deploy/templates/kata-monitor.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app.kubernetes.io/name: kata-monitor
    app.kubernetes.io/instance: kata-deploy
  name: kata-monitor
  namespace: default
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: kata-monitor
      app.kubernetes.io/instance: kata-deploy
  template:
    metadata:
      labels:
        app.kubernetes.io/name: kata-monitor
        app.kubernetes.io/instance: kata-deploy
      annotations:
        prometheus.io/scrape: "true"
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: feature.node.kubernetes.io/cpu-cpuid.VMX
                operator: In
                values:
                - "true"
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
            - matchExpressions:
              - key: feature.node.kubernetes.io/cpu-cpuid.SVM
                operator: In
                values:
                - "true"
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - arm64
                - aarch64
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - s390x
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - ppc64le
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - riscv64
              - key: node.cloud/reserved
                operator: In
                values:
                - platform-team
              ....
</code>
</details>

I've also added a new test file with Helm template tests for the new affinity behavior for kata-monitor DaemonSet. The tests are like the [kata-deploy DS scheduling ones](https://github.com/kata-containers/kata-containers/blob/main/tests/functional/kata-deploy/kata-deploy-scheduling.bats). I've put them in a new file under /kata-monitor to match the existing structure.

Fixes #13507