### PR TITLE
tests: avoid apt install of curl in GPU attestation pod

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -83,23 +83,23 @@ setup() {
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout="$timeout" pod "${pod_name}"
 
-	# pod-attestable-gpu becomes Ready once curl is installed; CDH fetch and GPU
-	# attestation (e.g. remote NRAS) run afterward and routinely exceed a short
-	# fixed sleep. Poll logs until the resource appears (or timeout).
+	# On confidential GPU, CDH fetch and GPU attestation (e.g. remote NRAS)
+	# routinely exceed a short fixed sleep after Ready. Poll until both
+	# containers have produced the expected output (or timeout).
 	if is_confidential_gpu_hardware; then
-		waitForProcess "180" "5" "kubectl logs ${pod_name} 2>/dev/null | grep -q \"${test_key}\""
-		waitForProcess "120" "5" "kubectl logs ${pod_name} 2>/dev/null | grep -iq 'Confidential Compute GPUs Ready state:[[:space:]]*ready'"
+		waitForProcess "180" "5" "kubectl logs --all-containers=true ${pod_name} 2>/dev/null | grep -q \"${test_key}\""
+		waitForProcess "120" "5" "kubectl logs --all-containers=true ${pod_name} 2>/dev/null | grep -iq 'Confidential Compute GPUs Ready state:[[:space:]]*ready'"
 	else
 		sleep 5
 	fi
 
-	kubectl logs "${pod_name}"
-	cmd="kubectl logs ${pod_name} | grep -q ${test_key}"
+	kubectl logs --all-containers=true "${pod_name}"
+	cmd="kubectl logs --all-containers=true ${pod_name} | grep -q ${test_key}"
 	run bash -c "$cmd"
 	[ "$status" -eq 0 ]
 
 	if is_confidential_gpu_hardware; then
-		cmd="kubectl logs ${pod_name} | grep -iq 'Confidential Compute GPUs Ready state:[[:space:]]*ready'"
+		cmd="kubectl logs --all-containers=true ${pod_name} | grep -iq 'Confidential Compute GPUs Ready state:[[:space:]]*ready'"
 		run bash -c "$cmd"
 		[ "$status" -eq 0 ]
 	fi
@@ -117,8 +117,8 @@ setup() {
 
 	sleep 5
 
-	kubectl logs aa-test-cc
-	cmd="kubectl logs aa-test-cc | grep -q ${test_key}"
+	kubectl logs --all-containers=true "${pod_name}"
+	cmd="kubectl logs --all-containers=true ${pod_name} | grep -q ${test_key}"
 	run bash -c "$cmd"
 	[ "$status" -eq 1 ]
 }
@@ -151,8 +151,8 @@ setup() {
 
 	sleep 5
 
-	kubectl logs aa-test-cc
-	cmd="kubectl logs aa-test-cc | grep -q ${test_key}"
+	kubectl logs --all-containers=true "${pod_name}"
+	cmd="kubectl logs --all-containers=true ${pod_name} | grep -q ${test_key}"
 	run bash -c "$cmd"
 	[ "$status" -eq 1 ]
 }
@@ -222,10 +222,17 @@ setup() {
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout="$timeout" pod "${pod_name}"
 
-	sleep 5
+	# Same as "Get CDH resource": on confidential GPU, CDH fetch and GPU attestation
+	# can exceed a short fixed sleep after Ready.
+	if is_confidential_gpu_hardware; then
+		waitForProcess "180" "5" "kubectl logs --all-containers=true ${pod_name} 2>/dev/null | grep -q \"${test_key}\""
+		waitForProcess "120" "5" "kubectl logs --all-containers=true ${pod_name} 2>/dev/null | grep -iq 'Confidential Compute GPUs Ready state:[[:space:]]*ready'"
+	else
+		sleep 5
+	fi
 
-	kubectl logs aa-test-cc
-	cmd="kubectl logs aa-test-cc | grep -q ${test_key}"
+	kubectl logs --all-containers=true "${pod_name}"
+	cmd="kubectl logs --all-containers=true ${pod_name} | grep -q ${test_key}"
 	run bash -c "$cmd"
 	result=$status
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable-gpu.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable-gpu.yaml.in
@@ -10,27 +10,39 @@ metadata:
 spec:
   runtimeClassName: ${RUNTIME_CLASS_NAME}
   containers:
+    # Same image as pod-attestable.yaml.in. Kept separate from the CUDA
+    # container so Ready does not depend on apt-installing curl inside the
+    # guest (which routinely blows the 90s wait on 1-vCPU SNP sandboxes).
     - name: bash-curl
-      image: nvcr.io/nvidia/cuda:12.2.0-base-ubuntu22.04
+      image: quay.io/kata-containers/alpine-bash-curl:latest
       imagePullPolicy: Always
       command:
         - sh
         - -c
         - |
           set -e
-          apt update && apt install -y curl
-          curl http://127.0.0.1:8006/cdh/resource/default/aa/key
-          nvidia-smi conf-compute -grs
+          attempts=60
+          while ! curl -fsS http://127.0.0.1:8006/cdh/resource/default/aa/key; do
+            attempts=$((attempts-1))
+            [ "$attempts" -gt 0 ] || exit 1
+            sleep 1
+          done
           sleep 1000
-      readinessProbe:
-        exec:
-          command:
-            - sh
-            - -c
-            - test -x /usr/bin/curl
-        initialDelaySeconds: 10
-        periodSeconds: 5
       resources:
         limits:
+          cpu: "1"
+          memory: 512Mi
+    - name: nvidia-smi
+      image: nvcr.io/nvidia/cuda:12.2.0-base-ubuntu22.04
+      imagePullPolicy: Always
+      command:
+        - sh
+        - -c
+        - |
+          nvidia-smi conf-compute -grs
+          sleep 1000
+      resources:
+        limits:
+          cpu: "2"
           nvidia.com/pgpu: "1"
           memory: 16Gi


### PR DESCRIPTION
Fetching package indexes inside the SNP guest routinely consumes most of the 90s Ready timeout and flakes the affirming-policy CDH test. Split the pod into alpine-bash-curl (CDH fetch) and CUDA (nvidia-smi) containers, and collect logs with --all-containers.