### PR TITLE
local-build: fix pause-image dep to use pause-image-tarball

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -105,7 +105,7 @@ NVGPU_BASE_TARBALLS = \
 	ovmf-sev-tarball \
 	ovmf-tdx-tarball \
 	ovmf-tarball \
-	pause-image \
+	pause-image-tarball \
 	qemu-snp-experimental-tarball \
 	qemu-tdx-experimental-tarball \
 	qemu-tarball \
@@ -119,7 +119,7 @@ NVGPU_BASE_TARBALLS = \
 	$(PUBLISH_COMPONENT_TARBALLS) \
 	kernel-nvidia-gpu-tarball \
 	ovmf-tarball \
-	pause-image \
+	pause-image-tarball \
 	qemu-tarball \
 	virtiofsd-tarball \
 	serial-targets
@@ -316,7 +316,7 @@ DEPS := agent-tarball
 rootfs-image-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball pause-image coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball pause-image-tarball coco-guest-components-tarball kernel-tarball
 rootfs-image-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -327,7 +327,7 @@ DEPS := agent-tarball
 rootfs-image-mariner-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball pause-image coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball pause-image-tarball coco-guest-components-tarball kernel-tarball
 rootfs-initrd-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -339,7 +339,7 @@ DEPS := agent-tarball busybox-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball busybox-tarball pause-image coco-guest-components-tarball kernel-nvidia-gpu-tarball
+DEPS := agent-tarball busybox-tarball pause-image-tarball coco-guest-components-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 


### PR DESCRIPTION
The previous commit added `pause-image` as a dependency for the monolith confidential images, but `pause-image` is not a defined Make target. The correct target is `pause-image-tarball`, which follows the same naming convention as all other components and delegates to `${MAKE} $@-build`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>