### PR TITLE
tests/k8s: run plain first, triage failures on -debug

### DIFF
--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -20,13 +20,6 @@ check_and_skip() {
 	if [[ "$(uname -m)" == "s390x" ]]; then
 		skip "measured rootfs tests not implemented for s390x"
 	fi
-
-	# The dm-verity failure is reported on the guest console, which the
-	# hypervisor only forwards to the host journal when it runs with
-	# enable_debug, and that is exclusive to the kata-<shim>-debug RuntimeClass.
-	if ! test_runtime_class_has_guest_debug; then
-		skip "kata-${KATA_HYPERVISOR}-debug RuntimeClass not deployed (kata-deploy debug disabled)"
-	fi
 }
 
 setup() {

--- a/tests/integration/kubernetes/k8s_bats_runner.sh
+++ b/tests/integration/kubernetes/k8s_bats_runner.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Kata Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kubernetes bats runner: plain RuntimeClass by default, with an optional
+# triage-only re-run on kata-<shim>-debug for each failed test case.
+#
+
+# The suites that cannot produce a verdict on the plain RuntimeClass, because
+# they assert on guest output that only reaches the host journal when the
+# hypervisor runs with enable_debug. Each entry is "<runtime>:<bats-file>",
+# where runtime is "go", "runtime-rs", or "both".
+#
+# Keep this list short: needing it means the failure the test looks for is
+# invisible to a user running without debug enabled.
+K8S_TESTS_REQUIRING_GUEST_DEBUG=(
+	# Both runtimes only forward the dm-verity guest-console message in debug.
+	"both:k8s-measured-rootfs.bats"
+
+	# runtime-rs only forwards these image-rs agent errors over agent.log_vport
+	# when the hypervisor has debug enabled. The Go runtime exposes them without
+	# needing the -debug RuntimeClass.
+	"runtime-rs:k8s-guest-pull-image.bats"
+	"runtime-rs:k8s-guest-pull-image-authenticated.bats"
+	"runtime-rs:k8s-guest-pull-image-encrypted.bats"
+	"runtime-rs:k8s-guest-pull-image-signature.bats"
+)
+
+# Whether a bats file requires guest debug for the current runtime.
+bats_file_requires_guest_debug() {
+	local bats_file="$1"
+	local entry
+	local runtime
+	local listed_file
+
+	for entry in "${K8S_TESTS_REQUIRING_GUEST_DEBUG[@]}"; do
+		runtime="${entry%%:*}"
+		listed_file="${entry#*:}"
+		[[ "${listed_file}" == "${bats_file}" ]] || continue
+
+		case "${runtime}" in
+			both) return 0 ;;
+			go)
+				is_runtime_rs && return 1
+				return 0
+				;;
+			runtime-rs)
+				is_runtime_rs && return 0
+				return 1
+				;;
+			*) die "Invalid runtime '${runtime}' in K8S_TESTS_REQUIRING_GUEST_DEBUG" ;;
+		esac
+	done
+
+	return 1
+}
+
+# Escape a string for use as an extended-regex (bats --filter).
+escape_bats_filter_regex() {
+	# The bracket expression leads with ']' so that it is taken literally.
+	printf '%s' "$1" | sed -E 's/[]\\.[^$*+?(){}|]/\\&/g'
+}
+
+# Extract failed bats test names from TAP output.
+failed_bats_tests_from_tap() {
+	local tap_file="$1"
+
+	# TAP from bats --timing may use either:
+	#   not ok N - test name in Xms
+	#   not ok N test name in Xms
+	awk '
+		/^not ok / {
+			sub(/^not ok [0-9]+ - /, "")
+			sub(/^not ok [0-9]+ /, "")
+			sub(/ in [0-9]+(\.[0-9]+)?(ms|s)$/, "")
+			print
+		}
+	' "${tap_file}"
+}
+
+# Whether the debug RuntimeClass for the current shim is deployed.
+debug_runtime_class_available() {
+	# KATA_HYPERVISOR / MULTI_INSTALL_SUFFIX come from the k8s test environment.
+	# shellcheck disable=SC2154
+	local base="kata-${KATA_HYPERVISOR}${MULTI_INSTALL_SUFFIX:+-${MULTI_INSTALL_SUFFIX}}"
+
+	kubectl get runtimeclass "${base}-debug" &>/dev/null
+}
+
+# Run one bats file under KATA_TEST_RUNTIME_CLASS_MODE, writing TAP to out_file.
+# Returns the bats exit status.
+run_bats_file_with_mode() {
+	local test_entry="$1"
+	local mode="$2"
+	local out_file="$3"
+	shift 3
+	local -a extra_args=("$@")
+
+	apply_test_runtime_class_mode "${mode}"
+
+	# Prefer TAP so failed case names are machine-parseable; keep timing and
+	# passing-test output for humans reading the CI log.
+	bats --tap --timing --show-output-of-passing-tests \
+		"${extra_args[@]}" "${test_entry}" | tee "${out_file}"
+	return "${PIPESTATUS[0]}"
+}
+
+# Triage-only re-run of failed cases on the debug RuntimeClass.
+#
+# Never changes the caller's idea of pass/fail: triage exit codes are ignored.
+triage_failed_tests_with_debug() {
+	local test_entry="$1"
+	local tap_file="$2"
+	local report_dir="$3"
+	local -a failed=()
+	local name
+	local safe_name
+	local triage_out
+	local filter
+
+	mapfile -t failed < <(failed_bats_tests_from_tap "${tap_file}")
+	[[ ${#failed[@]} -eq 0 ]] && return 0
+
+	if ! debug_runtime_class_available; then
+		info "Skipping debug triage retry: ${KATA_HYPERVISOR} debug RuntimeClass not deployed"
+		return 0
+	fi
+
+	for name in "${failed[@]}"; do
+		[[ -z "${name}" ]] && continue
+		info "RETRY (triage only) on kata-${KATA_HYPERVISOR}-debug: ${name}; verdict remains FAIL"
+		safe_name=$(echo "${name}" | tr -c 'A-Za-z0-9._-' '_')
+		triage_out="${report_dir}/triage-debug-${test_entry}-${safe_name}.out"
+		filter="^$(escape_bats_filter_regex "${name}")$"
+
+		# Ignore triage status: the plain (or hard-require) run is the verdict.
+		run_bats_file_with_mode "${test_entry}" "debug" "${triage_out}" \
+			-f "${filter}" || true
+	done
+
+	# Restore plain fixtures for subsequent files in the union.
+	apply_test_runtime_class_mode "plain"
+}
+
+# Run the k8s bats union with non-debug-first semantics.
+#
+# Parameters:
+#	$1 - Test directory
+#	$2 - Name of the array variable holding bats filenames
+#
+# Environment:
+#	BATS_TEST_FAIL_FAST - "yes" to stop after the first failed file
+#	K8S_TEST_DEBUG_RETRY - "true" (default) to re-run failed cases on -debug
+run_kubernetes_bats_tests() {
+	local test_dir="$1"
+	local -n test_array=$2
+	local fail_fast="${BATS_TEST_FAIL_FAST:-no}"
+	local debug_retry="${K8S_TEST_DEBUG_RETRY:-true}"
+	local required
+	local required_runtime
+	local required_file
+
+	# An invalid scope or stale filename would silently downgrade a suite to
+	# the plain class.
+	for required in "${K8S_TESTS_REQUIRING_GUEST_DEBUG[@]}"; do
+		required_runtime="${required%%:*}"
+		required_file="${required#*:}"
+		case "${required_runtime}" in
+			go | runtime-rs | both) ;;
+			*) die "Invalid runtime '${required_runtime}' in K8S_TESTS_REQUIRING_GUEST_DEBUG" ;;
+		esac
+		[[ -f "${test_dir}/${required_file}" ]] ||
+			die "K8S_TESTS_REQUIRING_GUEST_DEBUG lists ${required_file}, which does not exist"
+	done
+
+	local report_dir
+	report_dir="${test_dir}/reports/$(date +'%F-%T')"
+	mkdir -p "${report_dir}"
+
+	export K8S_TEST_DIR="${test_dir}"
+
+	info "Running k8s tests with bats version: $(bats --version). Save outputs to ${report_dir}"
+	info "RuntimeClass mode default=plain; debug triage retry=${debug_retry}"
+
+	local tests_fail=()
+	local test_entry
+	local out_file
+	local verdict=0
+	local mode
+
+	for test_entry in "${test_array[@]}"; do
+		test_entry=$(echo "${test_entry}" | tr -d '[:space:][:cntrl:]')
+		[[ -z "${test_entry}" ]] && continue
+
+		info "Executing ${test_entry}"
+		out_file="${report_dir}/${test_entry}.out"
+
+		if [[ -n "${K8S_BATS_BEFORE_FILE:-}" ]] && declare -F "${K8S_BATS_BEFORE_FILE}" >/dev/null; then
+			"${K8S_BATS_BEFORE_FILE}" || true
+		fi
+
+		pushd "${test_dir}" > /dev/null || return 1
+
+		if bats_file_requires_guest_debug "${test_entry}"; then
+			if ! debug_runtime_class_available; then
+				popd > /dev/null || true
+				die "${test_entry} requires kata-${KATA_HYPERVISOR}-debug RuntimeClass, but it is not deployed"
+			fi
+			mode="debug"
+			info "${test_entry} requires guest debug; running on -debug only"
+		else
+			mode="plain"
+		fi
+
+		verdict=0
+		run_bats_file_with_mode "${test_entry}" "${mode}" "${out_file}" || verdict=$?
+
+		if [[ ${verdict} -ne 0 ]]; then
+			tests_fail+=("${test_entry}")
+			mv "${out_file}" "$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
+			local not_ok_file
+			not_ok_file="$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
+
+			# Triage retry only for plain verdict failures (hard-require already ran debug).
+			if [[ "${debug_retry}" == "true" ]] && [[ "${mode}" == "plain" ]]; then
+				triage_failed_tests_with_debug "${test_entry}" "${not_ok_file}" "${report_dir}"
+			fi
+
+			popd > /dev/null || return 1
+			[[ "${fail_fast}" == "yes" ]] && break
+		else
+			mv "${out_file}" "$(dirname "${out_file}")/ok-$(basename "${out_file}")"
+			popd > /dev/null || return 1
+		fi
+	done
+
+	# Leave workloads on plain for anything that inspects them after the suite.
+	apply_test_runtime_class_mode "plain" || true
+
+	if [[ ${#tests_fail[@]} -ne 0 ]]; then
+		die "Tests FAILED from suites: ${tests_fail[*]}"
+	fi
+
+	info "All tests SUCCEEDED"
+}

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -11,6 +11,10 @@ set -o pipefail
 kubernetes_dir="${kubernetes_dir:-$(dirname "$(readlink -f "$0")")}"
 # shellcheck disable=SC1091 # import based on variable
 source "${kubernetes_dir}/../../common.bash"
+# shellcheck disable=SC1091
+source "${kubernetes_dir}/tests_common.sh"
+# shellcheck disable=SC1091
+source "${kubernetes_dir}/k8s_bats_runner.sh"
 
 # Enable NVRC trace logging for NVIDIA GPU runtime via drop-in config
 enable_nvrc_trace() {
@@ -151,35 +155,8 @@ fi
 setup_genpolicy_registry_auth "nvcr.io" "\$oauthtoken" "${NGC_API_KEY:-}" "${kubernetes_dir}/.docker-genpolicy"
 
 # Clean before each bats file so a previous file's leaked resources cannot
-# starve later tests of GPUs on shared runners.
+# starve later tests of GPUs on shared runners. Use the shared k8s bats runner
+# (plain RuntimeClass by default, triage -debug re-run on failure).
 export BATS_TEST_FAIL_FAST="${K8S_TEST_FAIL_FAST}"
-report_dir="${kubernetes_dir}/reports/$(date +'%F-%T')"
-mkdir -p "${report_dir}"
-info "Running NVIDIA GPU tests with bats version: $(bats --version). Save outputs to ${report_dir}"
-
-tests_fail=()
-for test_entry in "${K8S_TEST_NV[@]}"; do
-	test_entry=$(echo "${test_entry}" | tr -d '[:space:][:cntrl:]')
-	[[ -z "${test_entry}" ]] && continue
-
-	cleanup_leaked_nvidia_gpu_test_resources || true
-
-	info "Executing ${test_entry}"
-	out_file="${report_dir}/${test_entry}.out"
-
-	pushd "${kubernetes_dir}" > /dev/null || exit 1
-	if ! bats --timing --show-output-of-passing-tests "${test_entry}" | tee "${out_file}"; then
-		tests_fail+=("${test_entry}")
-		mv "${out_file}" "$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
-		[[ "${K8S_TEST_FAIL_FAST}" == "yes" ]] && break
-	else
-		mv "${out_file}" "$(dirname "${out_file}")/ok-$(basename "${out_file}")"
-	fi
-	popd > /dev/null || exit 1
-done
-
-if [[ ${#tests_fail[@]} -ne 0 ]]; then
-	die "Tests FAILED from suites: ${tests_fail[*]}"
-fi
-
-info "All tests SUCCEEDED"
+export K8S_BATS_BEFORE_FILE="cleanup_leaked_nvidia_gpu_test_resources"
+run_kubernetes_bats_tests "${kubernetes_dir}" K8S_TEST_NV

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -11,6 +11,10 @@ set -o pipefail
 kubernetes_dir="${kubernetes_dir:-$(dirname "$(readlink -f "$0")")}"
 # shellcheck source=/dev/null
 source "${kubernetes_dir}/../../common.bash"
+# shellcheck source=/dev/null
+source "${kubernetes_dir}/tests_common.sh"
+# shellcheck source=/dev/null
+source "${kubernetes_dir}/k8s_bats_runner.sh"
 
 cleanup() {
 	# Clean up all node debugger pods whose name starts with `custom-node-debugger` if pods exist
@@ -155,6 +159,7 @@ fi
 
 ensure_yq
 
-# Use common bats test runner with proper reporting
+# Use common bats test runner with proper reporting, plain RuntimeClass by
+# default, and triage-only -debug re-runs for failed cases.
 export BATS_TEST_FAIL_FAST="${K8S_TEST_FAIL_FAST}"
-run_bats_tests "${kubernetes_dir}" K8S_TEST_UNION
+run_kubernetes_bats_tests "${kubernetes_dir}" K8S_TEST_UNION

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -104,29 +104,6 @@ add_annotations_to_yaml() {
 	esac
 }
 
-# Point the workloads at the RuntimeClass the tests are meant to run on.
-#
-# They ship with the `kata` RuntimeClass, an alias for the deployment's default
-# shim. Rewrite it whenever the guest debug settings live on a class of their
-# own (see get_test_runtime_class), so that a failing test still comes with the
-# guest logs needed to triage it.
-set_workloads_runtime_class() {
-	local runtime_class
-
-	if ! test_runtime_class_has_guest_debug; then
-		info "Keeping the default RuntimeClass in the test workloads"
-		return
-	fi
-
-	runtime_class="$(get_test_runtime_class)"
-	info "Running the test workloads with the ${runtime_class} RuntimeClass"
-
-	find "${runtimeclass_workloads_work_dir}" -type f \
-		\( -name '*.yaml' -o -name '*.yaml.in' \) -print0 |
-		xargs -0 --no-run-if-empty sed -i -E \
-			"s/^([[:space:]]*runtimeClassName:[[:space:]]+)kata[[:space:]]*$/\1${runtime_class}/"
-}
-
 add_runtime_handler_annotation_to_yaml() {
 	local -r yaml_file="$1"
 	if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
@@ -157,7 +134,9 @@ add_runtime_handler_annotations() {
 main() {
 	ensure_yq
 	reset_workloads_work_dir
-	set_workloads_runtime_class
+	# Default to the plain RuntimeClass; triage retries flip to debug on failure.
+	export KATA_TEST_RUNTIME_CLASS_MODE="${KATA_TEST_RUNTIME_CLASS_MODE:-plain}"
+	set_workloads_runtime_class "${runtimeclass_workloads_work_dir}"
 	add_runtime_handler_annotations
 }
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -78,9 +78,12 @@ get_pod_config_dir() {
 # agent.log=debug and initcall_debug on the kernel cmdline) solely to the extra
 # kata-<shim>-debug RuntimeClass it creates when deployed with debug enabled, so
 # that the plain kata-<shim> class keeps the kernel cmdline, and therefore the
-# guest measurements, of a non-debug installation. The tests depend on those
-# guest logs to triage failures, hence they run on the debug class whenever it
-# is deployed.
+# guest measurements, of a non-debug installation.
+#
+# By default the suites run on the plain class (KATA_TEST_RUNTIME_CLASS_MODE=plain).
+# Set KATA_TEST_RUNTIME_CLASS_MODE=debug to target the debug class — used for
+# tests that hard-require guest console forwarding, and for triage re-runs after
+# a plain failure (see run_kubernetes_bats_tests).
 #
 # A multi-install names every class after its own suffix (kata-<shim>-<suffix>,
 # and kata-<shim>-<suffix>-debug for the variant), so build the name from the
@@ -88,19 +91,87 @@ get_pod_config_dir() {
 # one, which is not deployed at all in that case.
 get_test_runtime_class() {
 	if [[ -z "${test_runtime_class:-}" ]]; then
-		test_runtime_class="kata-${KATA_HYPERVISOR}${MULTI_INSTALL_SUFFIX:+-${MULTI_INSTALL_SUFFIX}}"
-		if kubectl get runtimeclass "${test_runtime_class}-debug" &>/dev/null; then
-			test_runtime_class="${test_runtime_class}-debug"
-		fi
+		local base="kata-${KATA_HYPERVISOR}${MULTI_INSTALL_SUFFIX:+-${MULTI_INSTALL_SUFFIX}}"
+		local mode="${KATA_TEST_RUNTIME_CLASS_MODE:-plain}"
+
+		case "${mode}" in
+			debug)
+				if kubectl get runtimeclass "${base}-debug" &>/dev/null; then
+					test_runtime_class="${base}-debug"
+				else
+					test_runtime_class="${base}"
+				fi
+				;;
+			plain | *)
+				test_runtime_class="${base}"
+				;;
+		esac
 		export test_runtime_class
 	fi
 
 	echo "${test_runtime_class}"
 }
 
+# Drop the cached RuntimeClass so the next get_test_runtime_class() call
+# re-reads KATA_TEST_RUNTIME_CLASS_MODE.
+clear_test_runtime_class_cache() {
+	unset test_runtime_class
+}
+
 # Whether the tests run on a RuntimeClass that carries the guest debug settings.
 test_runtime_class_has_guest_debug() {
 	[[ "$(get_test_runtime_class)" == *-debug ]]
+}
+
+# Point the workloads at the RuntimeClass the tests are meant to run on.
+#
+# Fixtures ship with `runtimeClassName: kata` (alias for the deployment default
+# shim). Rewrite them to the explicit class from get_test_runtime_class so plain
+# and debug modes both land on the right handler. Idempotent: also matches an
+# already-rewritten kata-<shim>[-debug] name so triage retries can flip modes.
+#
+# Optional $1 overrides the workloads work directory; defaults to the k8s test
+# suite's runtimeclass_workloads_work.
+set_workloads_runtime_class() {
+	local workloads_dir="${1:-${K8S_TEST_DIR}/runtimeclass_workloads_work}"
+	local runtime_class
+
+	clear_test_runtime_class_cache
+	runtime_class="$(get_test_runtime_class)"
+	info "Running the test workloads with the ${runtime_class} RuntimeClass (mode=${KATA_TEST_RUNTIME_CLASS_MODE:-plain})"
+
+	find "${workloads_dir}" -type f \
+		\( -name '*.yaml' -o -name '*.yaml.in' \) -print0 |
+		xargs -0 --no-run-if-empty sed -i -E \
+			"s/^([[:space:]]*runtimeClassName:[[:space:]]+)kata(-[^[:space:]]*)?[[:space:]]*$/\1${runtime_class}/"
+}
+
+# Re-apply RuntimeClass and (when present) the matching containerd
+# runtime-handler annotation after KATA_TEST_RUNTIME_CLASS_MODE changes.
+apply_test_runtime_class_mode() {
+	local mode="${1:-${KATA_TEST_RUNTIME_CLASS_MODE:-plain}}"
+	local workloads_dir="${2:-${K8S_TEST_DIR}/runtimeclass_workloads_work}"
+	local runtime_class
+
+	export KATA_TEST_RUNTIME_CLASS_MODE="${mode}"
+	clear_test_runtime_class_cache
+	set_workloads_runtime_class "${workloads_dir}"
+
+	runtime_class="$(get_test_runtime_class)"
+
+	# Keep guest-pull handler annotations in sync when setup.sh already added them.
+	local -a annotated_yamls=()
+	mapfile -t annotated_yamls < <(
+		find "${workloads_dir}" -type f -name '*.yaml' -print0 2>/dev/null |
+			xargs -0 --no-run-if-empty grep -l 'io\.containerd\.cri\.runtime-handler' 2>/dev/null || true
+	)
+	local yaml_file
+	for yaml_file in "${annotated_yamls[@]}"; do
+		[[ -z "${yaml_file}" ]] && continue
+		sed -i -E \
+			"s|^([[:space:]]*io\.containerd\.cri\.runtime-handler:[[:space:]]*).*$|\1\"${runtime_class}\"|" \
+			"${yaml_file}"
+	done
 }
 
 # Return the first worker found that is kata-runtime labeled.


### PR DESCRIPTION
Keep guest measurements on the non-debug class for the verdict run, and only re-run failed cases on kata-<shim>-debug for journal triage. Hard-require guest debug via a bats file tag (measured-rootfs) so those tests never take the plain path.

Generated-by: Cursor <cursoragent@cursor.com>