### PR TITLE
genpolicy: derive pause identity from image and restore Azure CLH policy coverage

### DIFF
--- a/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-cbl-mariner-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-cbl-mariner-drop-in.json
@@ -11,11 +11,6 @@
   },
   {
     "op": "replace",
-    "path": "/cluster_config/pause_container_id_policy",
-    "value": "v2"
-  },
-  {
-    "op": "replace",
     "path": "/cluster_config/pause_container_image",
     "value": "mcr.microsoft.com/oss/v2/kubernetes/pause:3.6"
   },
@@ -28,16 +23,6 @@
     "op": "replace",
     "path": "/kata_config/enable_configmap_secret_storages",
     "value": true
-  },
-  {
-    "op": "replace",
-    "path": "/pause_container/Process/User/UID",
-    "value": 0
-  },
-  {
-    "op": "replace",
-    "path": "/pause_container/Process/User/GID",
-    "value": 0
   },
   {
     "op": "replace",

--- a/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-drop-in.json
@@ -11,11 +11,6 @@
   },
   {
     "op": "replace",
-    "path": "/cluster_config/pause_container_id_policy",
-    "value": "v2"
-  },
-  {
-    "op": "replace",
     "path": "/cluster_config/pause_container_image",
     "value": "mcr.microsoft.com/oss/v2/kubernetes/pause:3.6"
   },
@@ -28,16 +23,6 @@
     "op": "replace",
     "path": "/kata_config/enable_configmap_secret_storages",
     "value": true
-  },
-  {
-    "op": "replace",
-    "path": "/pause_container/Process/User/UID",
-    "value": 0
-  },
-  {
-    "op": "replace",
-    "path": "/pause_container/Process/User/GID",
-    "value": 0
   },
   {
     "op": "replace",

--- a/src/tools/genpolicy/drop-in-examples/README.md
+++ b/src/tools/genpolicy/drop-in-examples/README.md
@@ -24,8 +24,8 @@ Drop-ins are layered: `10-*` files set the platform base, `20-*` files overlay O
 | `10-non-coco-aks-drop-in.json` | Non-confidential guest on AKS |
 | `10-non-coco-aks-cbl-mariner-drop-in.json` | Non-confidential guest on AKS with CBL-Mariner host |
 | `20-oci-1.2.0-drop-in.json` | OCI bundle version 1.2.0 |
-| `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU, CBL-Mariner) |
-| `20-oci-1.3.0-drop-in.json` | OCI bundle version 1.3.0 (e.g. containerd 2.2.x) |
+| `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU) |
+| `20-oci-1.3.0-drop-in.json` | OCI bundle version 1.3.0 (e.g. containerd 2.2.x, CBL-Mariner) |
 | `20-experimental-force-guest-pull-drop-in.json` | Disable guest pull |
 
 Request/exec overrides (e.g. allowing `kubectl exec` or specific ttRPC requests) are not shipped as drop-in examples; build your own drop-in or merge the needed `request_defaults` into a local file in `genpolicy-settings.d/`.

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -35,12 +35,6 @@
         },
         "Process": {
             "NoNewPrivileges": true,
-            "User": {
-                "UID": 65535,
-                "GID": 65535,
-                "AdditionalGids": [],
-                "Username": ""
-            },
             "Args": [
                 "/pause"
             ]
@@ -350,7 +344,6 @@
     "cluster_config": {
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
         "guest_pull": true,
-        "pause_container_id_policy": "v1",
         "emptydir_type": "block-encrypted",
         "cgroup_mount_extras_allowed": [
             "nsdelegate",

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -455,25 +455,16 @@ pub struct CommonData {
 /// Configuration from "kubectl config".
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClusterConfig {
-    /// Pause container image reference.
+    /// Pause container image used by the target cluster.
+    ///
+    /// Policy may be generated on a system whose local runtime uses a different
+    /// pause image. This setting identifies the cluster's image so that
+    /// genpolicy can inspect its configuration and layers and derive the OCI
+    /// fields needed to generate the `CreateContainerRequest` policy.
     pub pause_container_image: String,
 
     /// Whether or not the cluster uses the guest pull mechanism.
     pub guest_pull: bool,
-
-    /// Supported values:
-    ///
-    /// "v1" - Pause container UID/GID/AdditionalGids handled as in AKS pre-October 2025:
-    ///         - Example container image reference: mcr.microsoft.com/oss/kubernetes/pause:3.6
-    ///         - Defaults: UID=65535, GID=65535, AdditionalGids=[65535].
-    ///         - When changing the GID via runAsUser or runAsGroup, the new GID value *replaces*
-    ///           the default value from AdditionalGids.
-    /// "v2" - Pause container UID/GID/AdditionalGids handled as in AKS post-October 2025:
-    ///         - Example container image reference: mcr.microsoft.com/oss/v2/kubernetes/pause:3.6
-    ///         - Defaults: UID=0, GID=0, AdditionalGids=[].
-    ///         - When changing the GID via runAsUser or runAsGroup, the new GID value *gets added
-    ///           as the only value* in AdditionalGids.
-    pub pause_container_id_policy: String,
 
     /// How emptyDirs are represented in the policy.
     /// Supported values are "shared-fs", "block-encrypted", and "block-plain".
@@ -980,13 +971,23 @@ impl AgentPolicy {
 
         ///////////////////////////////////////////////////////////////////////////////////////
         // Container image settings.
-        yaml_container
-            .registry
-            .get_process(&mut process, yaml_has_command, yaml_has_args);
+        yaml_container.registry.get_process(
+            &mut process,
+            yaml_has_command,
+            yaml_has_args,
+            is_pause_container,
+        );
         debug!(
             "get_container_process: after registry.get_processs: process = {:?}",
             &process
         );
+
+        // containerd applies WithAdditionalGIDs to workload containers even
+        // when no user is configured. That always includes the process's
+        // primary GID, including GID 0 for the default root user.
+        if !is_pause_container {
+            process.User.AdditionalGids.insert(process.User.GID);
+        }
 
         if let Some(tty) = yaml_container.tty {
             process.Terminal = tty;
@@ -1032,31 +1033,10 @@ impl AgentPolicy {
 
         ///////////////////////////////////////////////////////////////////////////////////////
         // genpolicy-settings.json information.
-        let v1_policy = self
-            .config
-            .settings
-            .cluster_config
-            .pause_container_id_policy
-            == "v1";
-        if !v1_policy {
-            let v2_policy = self
-                .config
-                .settings
-                .cluster_config
-                .pause_container_id_policy
-                == "v2";
-            if !v2_policy {
-                panic!(
-                    "Unsupported pause_container_id_policy = {} - must be v1 or v2 in the settings file",
-                    self.config.settings.cluster_config.pause_container_id_policy
-                );
-            }
-        }
-        let update_additional_gids = !is_pause_container || v1_policy;
-        c_settings.get_process_fields(&mut process, update_additional_gids);
+        c_settings.apply_process_defaults(&mut process);
         debug!(
-            "get_container_process: after c_settings.get_process_fields: User = {:?}",
-            &process.User
+            "get_container_process: after c_settings.apply_process_defaults: Args = {:?}, Env = {:?}",
+            &process.Args, &process.Env
         );
 
         ///////////////////////////////////////////////////////////////////////////////////////
@@ -1098,10 +1078,11 @@ impl AgentPolicy {
             );
         }
 
-        yaml::apply_pod_fs_group_and_supplemental_groups(
+        apply_pod_groups_to_process(
             &mut process,
             resource.get_pod_security_context(),
             is_pause_container,
+            yaml_container.registry.has_configured_user(),
         );
         debug!(
             "get_container_process: after apply_pod_fs_group_and_supplemental_groups: User = {:?}",
@@ -1130,6 +1111,24 @@ impl AgentPolicy {
     }
 }
 
+fn apply_pod_groups_to_process(
+    process: &mut KataProcess,
+    security_context: Option<&pod::PodSecurityContext>,
+    is_pause_container: bool,
+    image_has_configured_user: bool,
+) {
+    let pause_user_is_overridden = is_pause_container
+        && security_context
+            .is_some_and(|context| context.runAsUser.is_some() || context.runAsGroup.is_some());
+
+    // Resolving either the pause image user or an explicit sandbox user
+    // replaces AdditionalGids with that user's primary GID. If neither
+    // supplies a user, the pod's fsGroup and supplementalGroups remain.
+    if !is_pause_container || (!image_has_configured_user && !pause_user_is_overridden) {
+        yaml::apply_pod_fs_group_and_supplemental_groups(process, security_context);
+    }
+}
+
 impl KataSpec {
     fn add_annotations(&self, annotations: &mut BTreeMap<String, String>) {
         for a in &self.Annotations {
@@ -1137,31 +1136,7 @@ impl KataSpec {
         }
     }
 
-    fn get_process_fields(&self, process: &mut KataProcess, update_additional_gids: bool) {
-        if process.User.UID == 0 {
-            process.User.UID = self.Process.User.UID;
-            debug!(
-                "get_process_fields: set UID = {}: User = {:?}",
-                process.User.UID, &process.User
-            );
-        }
-        if process.User.GID == 0 {
-            process.User.GID = self.Process.User.GID;
-            debug!(
-                "get_process_fields: set GID = {}: User = {:?}",
-                process.User.GID, &process.User
-            );
-
-            if update_additional_gids {
-                process.User.AdditionalGids.insert(process.User.GID);
-                debug!(
-                    "get_process_fields: inserted process.User.GID = {} into AdditionalGids: User = {:?}",
-                    process.User.GID, &process.User
-                );
-            }
-        }
-
-        process.User.Username = String::from(&self.Process.User.Username);
+    fn apply_process_defaults(&self, process: &mut KataProcess) {
         add_missing_strings(&self.Process.Args, &mut process.Args);
 
         add_missing_strings(&self.Process.Env, &mut process.Env);
@@ -1408,4 +1383,81 @@ pub fn get_kata_namespaces(
     });
 
     namespaces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pod_security_context(yaml: &str) -> pod::PodSecurityContext {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    fn additional_gids(process: &KataProcess) -> Vec<u32> {
+        process.User.AdditionalGids.iter().copied().collect()
+    }
+
+    #[test]
+    fn pause_without_image_or_pod_user_keeps_pod_groups() {
+        let context = pod_security_context(
+            "fsGroup: 997\n\
+             supplementalGroups: [998, 999]\n",
+        );
+        let mut process = KataProcess::default();
+
+        apply_pod_groups_to_process(&mut process, Some(&context), true, false);
+
+        assert_eq!(additional_gids(&process), vec![997, 998, 999]);
+    }
+
+    #[test]
+    fn pause_with_pod_user_keeps_only_resolved_primary_gid() {
+        for user_override in ["runAsUser: 2000", "runAsGroup: 2000"] {
+            let context = pod_security_context(&format!(
+                "{user_override}\n\
+                 fsGroup: 997\n\
+                 supplementalGroups: [998, 999]\n"
+            ));
+            let mut process = KataProcess::default();
+            process.User.AdditionalGids.insert(2000);
+
+            apply_pod_groups_to_process(&mut process, Some(&context), true, false);
+
+            assert_eq!(
+                additional_gids(&process),
+                vec![2000],
+                "override: {user_override}"
+            );
+        }
+    }
+
+    #[test]
+    fn pause_with_image_user_keeps_only_image_primary_gid() {
+        let context = pod_security_context(
+            "fsGroup: 997\n\
+             supplementalGroups: [998, 999]\n",
+        );
+        let mut process = KataProcess::default();
+        process.User.AdditionalGids.insert(65535);
+
+        apply_pod_groups_to_process(&mut process, Some(&context), true, true);
+
+        assert_eq!(additional_gids(&process), vec![65535]);
+    }
+
+    #[test]
+    fn workload_process_still_receives_pod_groups() {
+        let context = pod_security_context(
+            "runAsUser: 2000\n\
+             runAsGroup: 2000\n\
+             fsGroup: 997\n\
+             supplementalGroups: [998, 999]\n",
+        );
+        let mut process = KataProcess::default();
+        process.User.AdditionalGids.insert(2000);
+
+        apply_pod_groups_to_process(&mut process, Some(&context), false, true);
+
+        assert_eq!(additional_gids(&process), vec![997, 998, 999, 2000]);
+    }
 }

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -229,6 +229,15 @@ impl Container {
         }
     }
 
+    /// Whether the image configuration explicitly selects a process user.
+    pub fn has_configured_user(&self) -> bool {
+        self.config_layer
+            .config
+            .User
+            .as_ref()
+            .is_some_and(|user| !user.is_empty())
+    }
+
     pub fn get_uid_gid_from_passwd_user(&self, user: String) -> Result<(u32, u32)> {
         if user.is_empty() {
             return Err(anyhow!("User is empty"));
@@ -326,12 +335,35 @@ impl Container {
         }
     }
 
+    /// Parses the group component of an image's `Config.User`.
+    ///
+    /// Numeric groups are used directly and named groups are resolved through
+    /// the image's `/etc/group`. An empty or unresolvable group returns `None`,
+    /// leaving the caller to resolve the user's primary GID through
+    /// `/etc/passwd`.
+    fn parse_group_string(&self, group: &str) -> Option<u32> {
+        if group.is_empty() {
+            return None;
+        }
+
+        if let Ok(gid) = group.parse::<u32>() {
+            return Some(gid);
+        }
+
+        parse_group_file(&self.group)
+            .ok()?
+            .iter()
+            .find(|record| record.name == group)
+            .map(|record| record.gid)
+    }
+
     // Convert Docker image config to policy data.
     pub fn get_process(
         &self,
         process: &mut policy::KataProcess,
         yaml_has_command: bool,
         yaml_has_args: bool,
+        is_pause_container: bool,
     ) {
         let docker_config = &self.config_layer.config;
         debug!(
@@ -349,14 +381,36 @@ impl Container {
          * 5. Contain a user name:group name pair
          * 6. Be erroneous, somehow
          *
-         * For Kubernetes, containerd CRI ImageStatus strips any group component
-         * before kubelet maps the image user into a CRI security context. Keep
-         * genpolicy aligned with that path: USER user:group behaves like USER
-         * user, and USER uid:gid behaves like USER uid. Direct ctr/crictl paths
-         * can resolve the group component differently because they bypass kubelet.
+         * Kubernetes constructs workload and pause container users through
+         * different paths:
+         *
+         * For a workload container, kubelet's getImageUser calls CRI
+         * ImageStatus, which exposes only a UID or user name. Kubelet copies
+         * that value into the container's CRI security context. containerd
+         * prioritizes this CRI value over the original imageConfig.User, so an
+         * image group component is no longer available. Keep genpolicy aligned
+         * with this path: USER user:group behaves like USER user, and USER
+         * uid:gid behaves like USER uid.
+         *
+         * Kubelet does not resolve the pause image user. In
+         * sandboxContainerSpecOpts, containerd falls back directly to the full
+         * imageConfig.User and passes it to oci.WithUser. oci.WithUser parses
+         * and applies both user and group components, so genpolicy must retain
+         * the image group for a pause container.
+         *
+         * The presence of Config.User matters even when the resulting IDs are
+         * the same. With no pod-level user, an absent Config.User and
+         * Config.User="0:0" both produce UID=0 and GID=0, but only the explicit
+         * value invokes oci.WithUser and replaces the pod's supplemental groups
+         * with the primary GID.
+         *
+         * Relevant upstream functions:
+         * - Kubernetes: getImageUser and determineEffectiveSecurityContext
+         * - containerd: sandboxContainerSpecOpts and oci.WithUser
          */
         if let Some(image_user) = &docker_config.User {
             if !image_user.is_empty() {
+                let mut image_gid = None;
                 if image_user.contains(':') {
                     debug!(
                         "Container::get_process: splitting Docker config user = {:?}",
@@ -376,9 +430,17 @@ impl Container {
                         );
                         process.User.UID = self.parse_user_string(user[0]);
 
-                        debug!(
-                            "Container::get_process: overriding OCI container GID with UID:GID mapping from /etc/passwd"
-                        );
+                        if is_pause_container {
+                            image_gid = self.parse_group_string(user[1]);
+                            debug!(
+                                "Container::get_process: parsed pause GID = {:?} from image user",
+                                image_gid
+                            );
+                        } else {
+                            debug!(
+                                "Container::get_process: overriding OCI container GID with UID:GID mapping from /etc/passwd"
+                            );
+                        }
                     }
                 } else {
                     debug!(
@@ -390,7 +452,10 @@ impl Container {
                     debug!("Container::get_process: Using UID:GID mapping from /etc/passwd");
                 }
 
-                match self.get_gid_from_passwd_uid(process.User.UID) {
+                let gid = image_gid
+                    .map(Ok)
+                    .unwrap_or_else(|| self.get_gid_from_passwd_uid(process.User.UID));
+                match gid {
                     Ok(gid) => {
                         process.User.GID = gid;
                         debug!(
@@ -839,7 +904,7 @@ mod tests {
             let container = container_with_image_user(image_user);
             let mut process = policy::KataProcess::default();
 
-            container.get_process(&mut process, false, false);
+            container.get_process(&mut process, false, false, false);
 
             assert_eq!(process.User.UID, 33, "image user: {image_user}");
             assert_eq!(process.User.GID, 33, "image user: {image_user}");
@@ -854,6 +919,37 @@ mod tests {
                 "image user: {image_user}"
             );
         }
+    }
+
+    #[test]
+    fn pause_image_user_retains_group_component() {
+        for (image_user, expected_gid) in [("33:10", 10), ("www-data:staff", 50)] {
+            let container = container_with_image_user(image_user);
+            let mut process = policy::KataProcess::default();
+
+            container.get_process(&mut process, false, false, true);
+
+            assert_eq!(process.User.UID, 33, "image user: {image_user}");
+            assert_eq!(process.User.GID, expected_gid, "image user: {image_user}");
+            assert_eq!(
+                process
+                    .User
+                    .AdditionalGids
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                vec![expected_gid],
+                "image user: {image_user}"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_whether_image_config_selects_a_user() {
+        assert!(!Container::default().has_configured_user());
+        assert!(!container_with_image_user("").has_configured_user());
+        assert!(container_with_image_user("0").has_configured_user());
+        assert!(container_with_image_user("65535:65535").has_configured_user());
     }
 
     #[test]

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -398,11 +398,7 @@ fn handle_unused_field(path: &str, silent_unsupported_fields: bool) {
 pub fn apply_pod_fs_group_and_supplemental_groups(
     process: &mut policy::KataProcess,
     security_context: Option<&pod::PodSecurityContext>,
-    is_pause_container: bool,
 ) {
-    if is_pause_container {
-        return;
-    }
     let Some(context) = security_context else {
         return;
     };
@@ -452,7 +448,6 @@ pub fn get_process_fields(
             // 1. The securityContext runAsGroup field - applied below.
             // 2. /etc/passwd - parsed in policy::get_container_process().
             // 3. From the container image configuration - read from registry::get_process().
-            // 4. From genpolicy-settings.json.
             //
             // This behavior comes from the containerd runtime implementation:
             // WithUser https://github.com/containerd/containerd/blob/main/pkg/oci/spec_opts.go#L592

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -484,7 +484,7 @@ function main() {
 	if [[ -z "${AUTO_GENERATE_POLICY}" ]]; then
 		# https://github.com/kata-containers/kata-containers/issues/12839
 		if [[ "${KATA_HOST_OS}" = "cbl-mariner" && \
-			  "${KATA_HYPERVISOR}" = "clh" ]]; then
+			  "${KATA_HYPERVISOR}" =~ ^clh(-azure)?$ ]]; then
 			AUTO_GENERATE_POLICY="yes"
 		elif [[ "${KATA_HYPERVISOR}" = qemu-coco-dev* && \
 		        ( "${TARGET_ARCH}" = "x86_64" || "${TARGET_ARCH}" = "aarch64" ) && \

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -91,7 +91,7 @@ spec:
   resources:
     limits:
       memory: "1Gi"
-      cpu: "1"
+      cpu: "500m"
     requests:
       memory: "1Gi"
-      cpu: "1"
+      cpu: "500m"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -376,7 +376,7 @@ install_genpolicy_drop_ins() {
 
 	# 20-* OCI version overlay
 	if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-		cp "${examples_dir}/20-oci-1.2.1-drop-in.json" "${settings_d}/"
+		cp "${examples_dir}/20-oci-1.3.0-drop-in.json" "${settings_d}/"
 	elif is_k3s_or_rke2 || is_nvidia_gpu_platform || is_snp_hypervisor "${KATA_HYPERVISOR}" || is_tdx_hypervisor "${KATA_HYPERVISOR}" || [[ -n "${CONTAINER_ENGINE_VERSION:-}" ]] || is_arm64_host; then
 		cp "${examples_dir}/20-oci-1.3.0-drop-in.json" "${settings_d}/"
 	fi
@@ -601,7 +601,7 @@ hard_coded_policy_tests_enabled() {
 
 	# https://github.com/kata-containers/kata-containers/issues/12720
 	if [[ "${enabled}" == "no" && "${KATA_HOST_OS}" == "cbl-mariner" && \
-	 	  "${KATA_HYPERVISOR}" == "clh" ]]; then
+		  "${KATA_HYPERVISOR}" =~ ^clh(-azure)?$ ]]; then
 		enabled="yes"
 	fi
 


### PR DESCRIPTION
## Background

Kubernetes and containerd construct workload and pause identities through different paths.

For workload containers, kubelet obtains only the image UID or user name from CRI `ImageStatus` and puts it in the CRI security context. Any group in `Config.User` is therefore lost, and containerd resolves the primary GID through `passwd`.

For pause containers, kubelet does not resolve the image user. Containerd passes the complete `Config.User`, including an explicit group, to `oci.WithUser`.

For example, `mcr.microsoft.com/oss/kubernetes/pause:3.6` has `Config.User=65535:65535`. With pod `supplementalGroups: [10]`, containerd creates its pause process with:

```text
UID=65535, GID=65535, AdditionalGids=[65535]
```

`oci.WithUser` replaces the pod group with the image user’s primary GID.

The newer `mcr.microsoft.com/oss/v2/kubernetes/pause:3.6` has no `Config.User`. With the same pod context, `oci.WithUser` is not called, producing:

```text
UID=0, GID=0, AdditionalGids=[10]
```

## Existing genpolicy behavior

genpolicy did not model this workload-versus-pause distinction. It treated every `Config.User` like a workload image user and supplemented that result with hard-coded pause UID and GID values in `genpolicy-settings.json`.

The `pause_container_id_policy` setting selected between “v1” and “v2” identity rules and also participated in the guest-pull workaround. Commit `73ad83e1c` made parsing the newer pause image conditional on the “v2” value and warned that further identity tests could require additional changes.

This worked with the cases exercised for a long time. For the legacy image, `passwd` happens to map UID 65535 to the explicit GID 65535 that genpolicy discarded. For the newer image, tested pods did not set `fsGroup` or `supplementalGroups` without also setting `runAsUser` or `runAsGroup`.

The mismatch was therefore present but not exercised.

## How CI exposed the problem

PR #13126 switched Azure Linux AKS jobs from `clh` to `clh-azure` in commit `81ce51a9a`. The policy test gates still recognized only `clh`, silently disabling generated and hard-coded policy testing for the runtime-go handler.

While that testing was disabled, commit `b38ca059d` added pod-level contexts like this to many Kubernetes test manifests:

```yaml
spec:
  securityContext:
    supplementalGroups: [10]
```

These select a pod group without selecting a pod-level `runAsUser` or `runAsGroup`.

Non-AKS policy jobs exercised these manifests with the legacy pause image, where genpolicy and containerd both produced `AdditionalGids=[65535]`. Restoring policy testing for `clh-azure` combined these manifests with the v2 pause image under policy for the first time.

For v2, genpolicy allowed:

```text
UID=0, GID=0, AdditionalGids=[]
```

Containerd requested:

```text
UID=0, GID=0, AdditionalGids=[10]
```

The policy consequently rejected `CreateContainerRequest`.

## Changes

This PR changes genpolicy code, configuration and documentation as follows:

- Models the Kubernetes and containerd identity paths explicitly.
- Retains the complete `Config.User` group for pause containers while preserving existing workload image-user handling.
- Applies pod `fsGroup` and `supplementalGroups` to the pause process when neither the image nor pod-level `runAsUser` or `runAsGroup` selects a sandbox user.
- Makes `pause_container_image` the sole source of pause image identity.
- Removes `pause_container_id_policy` and the hard-coded pause UID/GID defaults from the shipped settings and AKS drop-ins.
- Preserves the workload primary GID in `AdditionalGids`, including GID 0 for the default root user, to match containerd.
- Documents the image-derived behavior and adds regression coverage for both pause image forms, explicit pod users, and workload containers.

Commit `493ecccc4` already made genpolicy inspect image layers under guest pull. The configured pause image therefore provides the required identity metadata directly, making separate image-version identity rules unnecessary.

The PR then restores Azure CLH policy coverage by:

- Recognizing both `clh` and `clh-azure` runtime-go handler names (while continuing to exclude runtime-rs variants, tracked by #12720 and #12839).
- Updating the CBL-Mariner overlay from OCI 1.2.1 to OCI 1.3.0, matching requests produced by the current containerd version.
- Making a minor change to the `k8s-policy-pod.bats` file

`k8s-policy-pod.bats` is selected by the small-host suite. On AKS, that suite uses a single `Standard_D2s_v5` node with two vCPUs. A 1 CPU pod request plus the Kata `RuntimeClass` 250m overhead cannot fit after accounting for AKS system pod requests and node reservations. The manifest was not previously submitted on these hosts because policy testing was disabled. Set both its CPU request and limit to 500m. This remains sufficient to exercise pod-level resource handling while allowing the pod to coexist with Kata overhead and AKS system workloads.

## Compatibility

This intentionally drops compatibility with custom settings that supply `Process.User`. A fresh genpolicy binary and fresh settings file must be deployed together.