### PR TITLE
runtime(-rs): fix rootless path handling

### DIFF
--- a/src/libs/kata-types/src/lib.rs
+++ b/src/libs/kata-types/src/lib.rs
@@ -114,8 +114,10 @@ macro_rules! validate_path {
     }};
 }
 
-/// Helper function that builds paths based on the vmm's rootless state.
-pub fn build_path(path: &str) -> String {
+/// Prefix a path with the VMM's rootless runtime directory.
+///
+/// The path is returned unchanged when the VMM is not running rootless.
+pub fn prefix_with_rootless_dir(path: &str) -> String {
     if is_rootless() {
         let path = Path::new(path);
         let path = if path.is_absolute() {

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -9,8 +9,8 @@ use base64::Engine as _;
 use std::convert::TryFrom;
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::build_path;
 use crate::handler::HandlerManager;
+use crate::prefix_with_rootless_dir;
 
 /// Prefix to mark a volume as Kata special.
 pub const KATA_VOLUME_TYPE_PREFIX: &str = "kata:";
@@ -86,12 +86,12 @@ pub type StorageHandlerManager<H> = HandlerManager<H>;
 
 /// Get the root path used for concatenating with the direct-volume mount info file path.
 pub fn kata_direct_volume_root_path() -> String {
-    build_path(DEFAULT_KATA_DIRECT_VOLUME_ROOT_PATH)
+    prefix_with_rootless_dir(DEFAULT_KATA_DIRECT_VOLUME_ROOT_PATH)
 }
 
 /// Get the sandbox bind mounts directory.
 pub fn kata_guest_sandbox_dir() -> String {
-    build_path(DEFAULT_KATA_GUEST_SANDBOX_DIR)
+    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_SANDBOX_DIR)
 }
 
 /// Information about a mount.

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -91,7 +91,7 @@ pub fn kata_direct_volume_root_path() -> String {
 
 /// Get the sandbox bind mounts directory.
 pub fn kata_guest_sandbox_dir() -> String {
-    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_SANDBOX_DIR)
+    DEFAULT_KATA_GUEST_SANDBOX_DIR.to_string()
 }
 
 /// Information about a mount.
@@ -635,6 +635,12 @@ pub fn adjust_rootfs_mounts() -> Result<Vec<Mount>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_kata_guest_sandbox_dir() {
+        assert_eq!(kata_guest_sandbox_dir(), DEFAULT_KATA_GUEST_SANDBOX_DIR);
+    }
+
     #[test]
     fn test_is_kata_special_volume() {
         assert!(is_kata_special_volume("kata:guest-mount:nfs"));

--- a/src/runtime-rs/crates/hypervisor/src/ch/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/utils.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use anyhow::{Ok, Result};
-use kata_types::build_path;
+use kata_types::prefix_with_rootless_dir;
 
 use crate::{utils::get_sandbox_path, JAILER_ROOT};
 
@@ -40,7 +40,7 @@ pub fn get_vsock_path(id: &str) -> Result<String> {
 
 /// Returns the symlink path of the sandbox for the virtio-fs socket in rootless mode.
 pub fn get_rootless_symlink_sandbox_path(id: &str) -> String {
-    Path::new(build_path(id).as_str())
+    Path::new(prefix_with_rootless_dir(id).as_str())
         .to_string_lossy()
         .to_string()
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -23,7 +23,7 @@ use crate::utils::{
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use kata_sys_util::netns::NetnsGuard;
-use kata_types::build_path;
+use kata_types::prefix_with_rootless_dir;
 use kata_types::config::hypervisor::{RootlessUser, VIRTIO_BLK_CCW, VIRTIO_BLK_PCI};
 use kata_types::rootless::is_rootless;
 use kata_types::{
@@ -100,7 +100,8 @@ impl QemuInner {
             }
         }
 
-        let vm_path = Path::new(build_path(KATA_PATH).as_str()).join(self.id.as_str());
+        let vm_path =
+            Path::new(prefix_with_rootless_dir(KATA_PATH).as_str()).join(self.id.as_str());
         create_dir_all_with_inherit_owner(vm_path, 0o750)?;
 
         Ok(())
@@ -696,7 +697,11 @@ impl QemuInner {
 
     pub(crate) async fn cleanup(&self) -> Result<()> {
         info!(sl!(), "QemuInner::cleanup()");
-        let vm_path = [build_path(KATA_PATH).as_str(), self.id.as_str()].join("/");
+        let vm_path = [
+            prefix_with_rootless_dir(KATA_PATH).as_str(),
+            self.id.as_str(),
+        ]
+        .join("/");
         vm_cleanup(&self.config, vm_path.as_str())
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Context, Result};
 use kata_types::{
-    build_path,
+    prefix_with_rootless_dir,
     config::{Hypervisor, KATA_PATH},
 };
 use lazy_static::lazy_static;
@@ -70,7 +70,7 @@ pub fn get_child_threads(pid: u32) -> HashSet<u32> {
 // Return the path for a _hypothetical_ sandbox: the path does *not* exist
 // yet, and for this reason safe-path cannot be used.
 pub fn get_sandbox_path(sid: &str) -> String {
-    Path::new(build_path(KATA_PATH).as_str())
+    Path::new(prefix_with_rootless_dir(KATA_PATH).as_str())
         .join(sid)
         .to_string_lossy()
         .to_string()

--- a/src/runtime-rs/crates/persist/src/lib.rs
+++ b/src/runtime-rs/crates/persist/src/lib.rs
@@ -6,7 +6,7 @@
 
 pub mod sandbox_persist;
 use anyhow::{anyhow, Context, Ok, Result};
-use kata_types::{build_path, config::KATA_PATH};
+use kata_types::{prefix_with_rootless_dir, config::KATA_PATH};
 use serde::de;
 use std::{fs::File, io::BufReader};
 
@@ -18,7 +18,7 @@ pub fn to_disk<T: serde::Serialize>(value: &T, sid: &str, jailer_path: &str) -> 
     verify_id(sid).context("failed to verify sid")?;
     // FIXME: handle jailed case
     let mut path = match jailer_path {
-        "" => scoped_join(build_path(KATA_PATH), sid)?,
+        "" => scoped_join(prefix_with_rootless_dir(KATA_PATH), sid)?,
         _ => scoped_join(jailer_path, "root")?,
     };
     //let mut path = scoped_join(KATA_PATH, sid)?;
@@ -39,7 +39,7 @@ where
     T: de::DeserializeOwned,
 {
     verify_id(sid).context("failed to verify sid")?;
-    let mut path = scoped_join(build_path(KATA_PATH), sid)?;
+    let mut path = scoped_join(prefix_with_rootless_dir(KATA_PATH), sid)?;
     if path.exists() {
         path.push(PERSIST_FILE);
         let file = File::open(path).context("failed to open the file")?;

--- a/src/runtime-rs/crates/resource/src/coco_data/initdata.rs
+++ b/src/runtime-rs/crates/resource/src/coco_data/initdata.rs
@@ -4,7 +4,7 @@
 //
 
 use hypervisor::BlockConfigModern;
-use kata_types::build_path;
+use kata_types::prefix_with_rootless_dir;
 
 /// The path /run/kata-containers/shared/initdata, combined with the sandbox ID,
 /// will form the default directory for storing the initdata image.
@@ -22,5 +22,5 @@ pub struct InitDataConfig(pub BlockConfigModern, pub String);
 /// will form the directory for storing the initdata image.
 /// The directory will be prefixed with the rootless directory when running in rootless mode
 pub fn kata_shared_init_data_path() -> String {
-    build_path(DEFAULT_KATA_SHARED_INIT_DATA_PATH)
+    prefix_with_rootless_dir(DEFAULT_KATA_SHARED_INIT_DATA_PATH)
 }

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -72,7 +72,9 @@ const X_KATA_MKDIR_PATH: &str = "X-kata.mkdir.path=";
 
 /// Create the per-container directory under the shared filesystem root.
 pub(crate) fn ensure_container_dir(sid: &str, cid: &str) -> Result<PathBuf> {
-    let dir = PathBuf::from(kata_types::build_path(DEFAULT_KATA_GUEST_ROOT_SHARED_FS))
+    let dir = PathBuf::from(kata_types::prefix_with_rootless_dir(
+        DEFAULT_KATA_GUEST_ROOT_SHARED_FS,
+    ))
         .join(sid)
         .join(cid);
     fs::create_dir_all(&dir).context(format!(
@@ -987,7 +989,7 @@ impl ErofsMultiLayerRootfs {
             erofs_storages,
             vmdk_path,
             gpt_metadata_paths,
-            generated_artifacts_dir: PathBuf::from(kata_types::build_path(
+            generated_artifacts_dir: PathBuf::from(kata_types::prefix_with_rootless_dir(
                 DEFAULT_KATA_GUEST_ROOT_SHARED_FS,
             ))
             .join(sid)

--- a/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
@@ -9,7 +9,6 @@ use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use kata_types::prefix_with_rootless_dir;
 use kata_types::mount::ImagePullVolume;
 use oci_spec::runtime as oci;
 use serde_json;
@@ -27,7 +26,7 @@ use kata_types::{
 const KUBERNETES_CRI_IMAGE_NAME: &str = "io.kubernetes.cri.image-name";
 const KUBERNETES_CRIO_IMAGE_NAME: &str = "io.kubernetes.cri-o.ImageName";
 const KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS: &str = "overlay";
-const DEFAULT_KATA_GUEST_ROOT_SHARED_FS: &str = "/run/kata-containers/";
+const KATA_GUEST_ROOT_SHARED_FS: &str = "/run/kata-containers/";
 
 const CRI_CONTAINER_TYPE_KEY_LIST: &[&str] = &[
     // cri containerd
@@ -35,11 +34,6 @@ const CRI_CONTAINER_TYPE_KEY_LIST: &[&str] = &[
     // cri-o
     annotations::crio::CONTAINER_TYPE_LABEL_KEY,
 ];
-
-/// Get Kata guest root shared filesystem path.
-fn kata_guest_root_shared_fs() -> String {
-    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_ROOT_SHARED_FS)
-}
 
 /// Retrieves the image reference from OCI spec annotations.
 ///
@@ -140,7 +134,7 @@ fn handle_virtual_volume_storage(
                 KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL, image_pull_info
             )],
             fs_type: KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS.to_string(),
-            mount_point: Path::new(kata_guest_root_shared_fs().as_str())
+            mount_point: Path::new(KATA_GUEST_ROOT_SHARED_FS)
                 .join(cid)
                 .join("rootfs")
                 .display()
@@ -188,7 +182,7 @@ impl VirtualVolume {
             }
         }
 
-        let guest_path = Path::new(kata_guest_root_shared_fs().as_str())
+        let guest_path = Path::new(KATA_GUEST_ROOT_SHARED_FS)
             .join(cid)
             .join("rootfs")
             .to_path_buf();
@@ -232,9 +226,9 @@ pub fn is_kata_virtual_volume(m: &kata_types::mount::Mount) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::rootfs::virtual_volume::kata_guest_root_shared_fs;
     use crate::rootfs::virtual_volume::{
-        KATA_VIRTUAL_VOLUME_PREFIX, KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS,
+        KATA_GUEST_ROOT_SHARED_FS, KATA_VIRTUAL_VOLUME_PREFIX,
+        KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS,
     };
 
     use super::get_image_reference;
@@ -331,7 +325,7 @@ mod tests {
         let virt_vol_obj = result.unwrap();
 
         // 1. Verify guest_path
-        let expected_guest_path = Path::new(kata_guest_root_shared_fs().as_str())
+        let expected_guest_path = Path::new(KATA_GUEST_ROOT_SHARED_FS)
             .join(cid)
             .join("rootfs");
         assert_eq!(virt_vol_obj.guest_path, expected_guest_path);
@@ -346,7 +340,7 @@ mod tests {
         assert_eq!(storage.driver, KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL);
         assert_eq!(storage.fs_type, KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS);
 
-        let expected_mount_point = Path::new(kata_guest_root_shared_fs().as_str())
+        let expected_mount_point = Path::new(KATA_GUEST_ROOT_SHARED_FS)
             .join(cid)
             .join("rootfs")
             .display()

--- a/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use kata_types::build_path;
+use kata_types::prefix_with_rootless_dir;
 use kata_types::mount::ImagePullVolume;
 use oci_spec::runtime as oci;
 use serde_json;
@@ -38,7 +38,7 @@ const CRI_CONTAINER_TYPE_KEY_LIST: &[&str] = &[
 
 /// Get Kata guest root shared filesystem path.
 fn kata_guest_root_shared_fs() -> String {
-    build_path(DEFAULT_KATA_GUEST_ROOT_SHARED_FS)
+    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_ROOT_SHARED_FS)
 }
 
 /// Retrieves the image reference from OCI spec annotations.

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -31,7 +31,7 @@ use std::{collections::HashMap, fmt::Debug, path::PathBuf, sync::Arc};
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use kata_types::{build_path, config::hypervisor::SharedFsInfo};
+use kata_types::{prefix_with_rootless_dir, config::hypervisor::SharedFsInfo};
 use oci_spec::runtime as oci;
 use tokio::sync::RwLock;
 
@@ -56,16 +56,16 @@ pub const PASSTHROUGH_FS_DIR: &str = "passthrough";
 const RAFS_DIR: &str = "rafs";
 
 pub fn kata_host_shared_dir() -> String {
-    build_path(DEFAULT_KATA_HOST_SHARED_DIR)
+    prefix_with_rootless_dir(DEFAULT_KATA_HOST_SHARED_DIR)
 }
 
 pub fn kata_guest_share_dir() -> String {
-    build_path(DEFAULT_KATA_GUEST_SHARE_DIR)
+    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_SHARE_DIR)
 }
 
 /// The virtiofs mount point in the guest for nydusd mode.
 pub fn kata_guest_nydus_root_dir() -> String {
-    build_path(DEFAULT_KATA_GUEST_ROOT_DIR)
+    prefix_with_rootless_dir(DEFAULT_KATA_GUEST_ROOT_DIR)
 }
 
 #[async_trait]

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -8,7 +8,7 @@ use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use kata_sys_util::mount::{bind_remount, umount_all, umount_timeout};
-use kata_types::{build_path, k8s::is_watchable_mount};
+use kata_types::{prefix_with_rootless_dir, k8s::is_watchable_mount};
 use std::fs;
 use std::path::Path;
 
@@ -28,7 +28,7 @@ use super::{
 };
 
 pub fn ephemeral_path() -> String {
-    build_path(DEFAULT_EPHEMERAL_PATH)
+    prefix_with_rootless_dir(DEFAULT_EPHEMERAL_PATH)
 }
 
 #[derive(Debug)]

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -8,7 +8,7 @@ use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use kata_sys_util::mount::{bind_remount, umount_all, umount_timeout};
-use kata_types::{prefix_with_rootless_dir, k8s::is_watchable_mount};
+use kata_types::k8s::is_watchable_mount;
 use std::fs;
 use std::path::Path;
 
@@ -28,7 +28,7 @@ use super::{
 };
 
 pub fn ephemeral_path() -> String {
-    prefix_with_rootless_dir(DEFAULT_EPHEMERAL_PATH)
+    DEFAULT_EPHEMERAL_PATH.to_string()
 }
 
 #[derive(Debug)]
@@ -196,5 +196,15 @@ impl ShareFsMount for VirtiofsShareMount {
         let host_path = get_host_shared_path(sid);
         fs::remove_dir_all(host_path).context("failed to remove host shared path")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ephemeral_path() {
+        assert_eq!(ephemeral_path(), DEFAULT_EPHEMERAL_PATH);
     }
 }

--- a/src/runtime-rs/crates/resource/src/volume/ephemeral_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/ephemeral_volume.rs
@@ -112,3 +112,27 @@ impl Volume for EphemeralVolume {
 pub(crate) fn is_ephemeral_volume(m: &oci::Mount) -> bool {
     get_mount_type(m).as_str() == KATA_EPHEMERAL_VOLUME_TYPE
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kata_types::mount::DEFAULT_KATA_GUEST_SANDBOX_DIR;
+
+    #[test]
+    fn test_ephemeral_volume_uses_guest_sandbox_path() {
+        let source = tempfile::tempdir().unwrap();
+        let mut mount = oci::Mount::default();
+        mount.set_source(Some(source.path().to_path_buf()));
+
+        let volume = EphemeralVolume::new(&mount).unwrap();
+        let expected = Path::new(DEFAULT_KATA_GUEST_SANDBOX_DIR)
+            .join(KATA_EPHEMERAL_VOLUME_TYPE)
+            .join(source.path().file_name().unwrap());
+
+        let mounts = volume.get_volume_mount().unwrap();
+        assert_eq!(mounts[0].source(), &Some(expected.clone()));
+
+        let storages = volume.get_storage().unwrap();
+        assert_eq!(storages[0].mount_point, expected.to_string_lossy().into_owned());
+    }
+}

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -57,3 +57,23 @@ pub(crate) fn is_shm_volume(m: &oci::Mount) -> bool {
     get_mount_path(&Some(m.destination().clone())).as_str() == SHM_DEVICE
         && get_mount_type(m).as_str() != KATA_EPHEMERAL_VOLUME_TYPE
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kata_types::mount::DEFAULT_KATA_GUEST_SANDBOX_DIR;
+
+    #[test]
+    fn test_shm_volume_uses_guest_sandbox_path() {
+        let mut mount = oci::Mount::default();
+        mount.set_destination(PathBuf::from(SHM_DEVICE));
+
+        let volume = ShmVolume::new(&mount).unwrap();
+        let mounts = volume.get_volume_mount().unwrap();
+
+        assert_eq!(
+            mounts[0].source(),
+            &Some(PathBuf::from(DEFAULT_KATA_GUEST_SANDBOX_DIR).join(SHM_DIR))
+        );
+    }
+}

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -26,7 +26,7 @@ use hypervisor::{
 use kata_sys_util::{mount::get_mount_path, spec::load_oci_spec};
 use kata_types::{
     annotations::Annotation,
-    build_path,
+    prefix_with_rootless_dir,
     config::{default::DEFAULT_GUEST_DNS_FILE, hypervisor::RootlessUser, Hypervisor, TomlConfig},
     mount::SHM_DEVICE,
     rootless::{is_rootless, rootless_dir, set_rootless},
@@ -1052,7 +1052,8 @@ fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<RootlessSetu
     env::set_var("XDG_RUNTIME_DIR", user_tmp_dir);
 
     // Update the rootless dir prefix for guest_swap_path
-    config.memory_info.guest_swap_path = build_path("/run/kata-containers/swap");
+    config.memory_info.guest_swap_path =
+        prefix_with_rootless_dir("/run/kata-containers/swap");
 
     let kvm_path = PathBuf::from("/dev/kvm");
     let metadata = std::fs::metadata(&kvm_path)?;

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -279,10 +279,6 @@ var kataGuestSharedDir = func() string {
 
 // The function is declared this way for mocking in unit tests
 var kataGuestSandboxDir = func() string {
-	if rootless.IsRootless() {
-		// filepath.Join removes trailing slashes, but it is necessary for mounting
-		return filepath.Join(rootless.GetRootlessDir(), defaultKataGuestSandboxDir) + "/"
-	}
 	return defaultKataGuestSandboxDir
 }
 
@@ -291,9 +287,6 @@ var kataGuestSandboxStorageDir = func() string {
 }
 
 func ephemeralPath() string {
-	if rootless.IsRootless() {
-		return filepath.Join(kataGuestSandboxDir(), kataEphemeralDevType)
-	}
 	return defaultEphemeralPath
 }
 

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -205,7 +205,7 @@ func TestHandleEphemeralStorage(t *testing.T) {
 	assert.Nil(t, err)
 
 	epheMountPoint := epheStorages[0].MountPoint
-	expected := filepath.Join(ephemeralPath(), filepath.Base(mountSource))
+	expected := filepath.Join(defaultEphemeralPath, filepath.Base(mountSource))
 	assert.Equal(t, epheMountPoint, expected,
 		"Ephemeral mount point didn't match: got %s, expecting %s", epheMountPoint, expected)
 }
@@ -727,7 +727,7 @@ func TestHandleShm(t *testing.T) {
 	assert.NotEmpty(ociMounts[0].Destination)
 	assert.Equal(ociMounts[0].Destination, "/dev/shm")
 	assert.Equal(ociMounts[0].Type, "bind")
-	assert.NotEmpty(ociMounts[0].Source, filepath.Join(kataGuestSharedDir(), shmDir))
+	assert.Equal(filepath.Join(defaultKataGuestSandboxDir, shmDir), ociMounts[0].Source)
 	assert.Equal(ociMounts[0].Options, []string{"rbind"})
 
 	sandbox.shmSize = 0
@@ -755,7 +755,7 @@ func TestHandleShm(t *testing.T) {
 	assert.Nil(err)
 
 	epheMountPoint := epheStorages[0].MountPoint
-	expected := filepath.Join(ephemeralPath(), filepath.Base(mountSource))
+	expected := filepath.Join(defaultEphemeralPath, filepath.Base(mountSource))
 	assert.Equal(epheMountPoint, expected,
 		"Ephemeral mount point didn't match: got %s, expecting %s", epheMountPoint, expected)
 
@@ -1235,19 +1235,17 @@ func TestKataAgentDirs(t *testing.T) {
 	uidmap := strings.Fields(string(line))
 	expectedRootless := (uidmap[0] == "0" && uidmap[1] != "0")
 	assert.Equal(expectedRootless, rootless.IsRootless())
+	assert.Equal(defaultKataGuestSandboxDir, kataGuestSandboxDir())
+	assert.Equal(defaultEphemeralPath, ephemeralPath())
 	if expectedRootless {
 		assert.Equal(kataHostSharedDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataHostSharedDir)
 		assert.Equal(kataGuestSharedDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataGuestSharedDir)
-		assert.Equal(kataGuestSandboxDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataGuestSandboxDir)
-		assert.Equal(ephemeralPath(), os.Getenv("XDG_RUNTIME_DIR")+defaultEphemeralPath)
 		assert.Equal(kataGuestNydusRootDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataGuestNydusRootDir)
 		assert.Equal(kataGuestNydusImageDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataGuestNydusRootDir+"images"+"/")
 		assert.Equal(kataGuestSharedDir(), os.Getenv("XDG_RUNTIME_DIR")+defaultKataGuestNydusRootDir+"containers"+"/")
 	} else {
 		assert.Equal(kataHostSharedDir(), defaultKataHostSharedDir)
 		assert.Equal(kataGuestSharedDir(), defaultKataGuestSharedDir)
-		assert.Equal(kataGuestSandboxDir(), defaultKataGuestSandboxDir)
-		assert.Equal(ephemeralPath(), defaultEphemeralPath)
 		assert.Equal(kataGuestNydusRootDir(), defaultKataGuestNydusRootDir)
 		assert.Equal(kataGuestNydusImageDir(), defaultKataGuestNydusRootDir+"rafs"+"/")
 		assert.Equal(kataGuestSharedDir(), defaultKataGuestNydusRootDir+"containers"+"/")

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -228,7 +228,7 @@ func TestPrepareEphemeralMounts(t *testing.T) {
 		assert.Equal(t, s.Driver, KataEphemeralDevType)
 		assert.Equal(t, s.Source, "tmpfs")
 		assert.Equal(t, s.Fstype, "tmpfs")
-		assert.Equal(t, s.MountPoint, filepath.Join(ephemeralPath(), "tmp"))
+		assert.Equal(t, s.MountPoint, filepath.Join(defaultEphemeralPath, "tmp"))
 		assert.Equal(t, len(s.Options), 2) // remount, size=1024M
 
 		validSet := map[string]struct{}{


### PR DESCRIPTION
This PR continues the staged work tracked by #13424.

The goal of this change is to clearly distinguish guest-local paths from host-dependent rootless paths in the runtimes: Runtime-go and runtime-rs applied the temporary VMM user's `/run/user/<uid>` prefix to paths consumed exclusively inside the guest. This affected sandbox shm, memory-backed volumes, hugepage mounts, and runtime-rs guest-pull rootfs paths.

Instead, we keep these guest-local resources beneath `/run/kata-containers` in the guest. There is no reason, these paths in the guest would need to follow the rootless-dependent host-convention.

With this, the shim no longer sends the affected guest-local resources with the host-only /run/user/<uid> prefix. As a result, this PR prepares for exercising rootless mode in combination with the agent security policy (see below for relevant, exercised testing).

### Non-goal: Host-dependent shared-filesystem paths remain out of scope

We do not change the rootless prefix to host paths and guest mount points whose layout is coupled to host-side filesystem sharing. A separate commit with more explanation can be found here: https://github.com/kata-containers/kata-containers/compare/main...manuelh-dev:mahuber/rootless-shared-fs-genpolicy-reference?expand=1

### Validation

Combined-stack validation was performed through [ci-devel run 31443666681](https://github.com/kata-containers/kata-containers/actions/runs/31443666681), exercising the rootless and seccomp-sandbox BATS coverage with  generated-policy configurations. The branch used for that CI run contains the set of all pull requests from #13424 and thus runs against relevant handlers using policy annotations. The PR which will actually enable policy testing against a rootless configuration is #13546

Remaining rootless and seccomp-sandbox work is tracked in #13424.
