### PR TITLE
runtime/clh: match the 429 retry on status code, not error text

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1474,16 +1474,24 @@ func (clh *cloudHypervisor) ResizeVCPUs(ctx context.Context, reqVCPUs uint32) (c
 	// several retries can be performed to avoid this error.
 	ret := retry.Do(func() error {
 
-		if _, err = cl.VmResizePut(ctx, resize); err != nil {
-			errMsg := err.Error()
+		resp, err := cl.VmResizePut(ctx, resize)
+		if err != nil {
+			// CLH replies 429 while a previous vCPU hot-unplug is still
+			// pending (CpuManager::VcpuPendingRemovedVcpu), a transient
+			// condition that clears once the guest completes the removal,
+			// so it has to be retried. Key that decision off the HTTP status
+			// code rather than off the error text: the reason phrase is
+			// optional in a status line (RFC 9112 4.1) and micro_http emits
+			// it empty ("HTTP/1.1 429 "), so the generated client stringifies
+			// the error as a bare "429" and a check for "Too Many Requests"
+			// never matches.
 			// see https://github.com/cloud-hypervisor/cloud-hypervisor/commit/d0225fe68fd14146bacc3be26f0b7e548ce9c239
-			if !strings.Contains(errMsg, "Too Many Requests") {
+			if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
 				return retry.Unrecoverable(err)
 			}
 			return errors.Wrap(err, "[clh] VmResizePut failed")
-		} else {
-			return nil
 		}
+		return nil
 	},
 		retry.Attempts(20),
 		retry.LastErrorOnly(true),

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -77,6 +77,18 @@ type clhClientMock struct {
 	vmInfo          chclient.VmInfo
 	restoreRequest  *chclient.RestoreConfig
 	snapshotRequest *chclient.VmSnapshotConfig
+
+	// resizeVCPUsResponses drives VmResizePut for the retry tests: every call
+	// pops the next queued response, and once the queue is drained the call
+	// succeeds. resizeVCPUsCalls counts the invocations so a test can assert
+	// that an unrecoverable error is not retried.
+	resizeVCPUsResponses []resizeVCPUsResp
+	resizeVCPUsCalls     int
+}
+
+type resizeVCPUsResp struct {
+	statusCode int
+	err        error
 }
 
 func (c *clhClientMock) VmmPingGet(ctx context.Context) (chclient.VmmPingResponse, *http.Response, error) {
@@ -104,7 +116,20 @@ func (c *clhClientMock) BootVM(ctx context.Context) (*http.Response, error) {
 
 //nolint:golint
 func (c *clhClientMock) VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error) {
-	return nil, nil
+	c.resizeVCPUsCalls++
+	if len(c.resizeVCPUsResponses) == 0 {
+		return nil, nil
+	}
+	r := c.resizeVCPUsResponses[0]
+	c.resizeVCPUsResponses = c.resizeVCPUsResponses[1:]
+	if r.err == nil {
+		return nil, nil
+	}
+	var resp *http.Response
+	if r.statusCode != 0 {
+		resp = &http.Response{StatusCode: r.statusCode}
+	}
+	return resp, r.err
 }
 
 //nolint:golint
@@ -738,6 +763,59 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCloudHypervisorResizeVCPUs429Retry guards the retry classification in
+// ResizeVCPUs. CLH answers 429 while a previous vCPU hot-unplug is still
+// pending (CpuManager::VcpuPendingRemovedVcpu), a transient condition the
+// retry loop exists to absorb. Since micro_http emits a status line with an
+// empty reason phrase ("HTTP/1.1 429 "), the generated client stringifies the
+// error as a bare "429", so a strings.Contains(err, "Too Many Requests") guard
+// never matched and the 429 escaped as an unrecoverable error. The guard has
+// to key off the HTTP status code.
+func TestCloudHypervisorResizeVCPUs429Retry(t *testing.T) {
+	clhConfig, err := newClhConfig()
+	assert.NoError(t, err)
+
+	newVCPUsMock := func() *clhClientMock {
+		m := &clhClientMock{}
+		m.vmInfo.Config = *chclient.NewVmConfig(*chclient.NewPayloadConfig())
+		m.vmInfo.Config.Cpus = chclient.NewCpusConfig(1, 8)
+		return m
+	}
+
+	t.Run("429 without a reason phrase is retried", func(t *testing.T) {
+		assert := assert.New(t)
+		clh := cloudHypervisor{config: clhConfig}
+		mock := newVCPUsMock()
+		// The error stringifies to "429", not to "Too Many Requests", just
+		// like the real CLH response does.
+		mock.resizeVCPUsResponses = []resizeVCPUsResp{
+			{statusCode: http.StatusTooManyRequests, err: errors.New("429")},
+			{statusCode: http.StatusTooManyRequests, err: errors.New("429")},
+		}
+		clh.APIClient = mock
+
+		_, newVCPUs, err := clh.ResizeVCPUs(context.Background(), 4)
+		assert.NoError(err)
+		assert.Equal(uint32(4), newVCPUs)
+		assert.Equal(3, mock.resizeVCPUsCalls) // two 429s plus one success
+	})
+
+	t.Run("non-429 error is unrecoverable", func(t *testing.T) {
+		assert := assert.New(t)
+		clh := cloudHypervisor{config: clhConfig}
+		mock := newVCPUsMock()
+		mock.resizeVCPUsResponses = []resizeVCPUsResp{
+			{statusCode: http.StatusInternalServerError, err: errors.New("500")},
+			{statusCode: http.StatusInternalServerError, err: errors.New("500")},
+		}
+		clh.APIClient = mock
+
+		_, _, err := clh.ResizeVCPUs(context.Background(), 4)
+		assert.Error(err)
+		assert.Equal(1, mock.resizeVCPUsCalls) // a single attempt, no retry
+	})
 }
 
 func TestCloudHypervisorHotplugAddBlockDevice(t *testing.T) {


### PR DESCRIPTION
### Problem

`cloudHypervisor.ResizeVCPUs` wraps `VmResizePut` in a 20-attempt retry loop specifically to absorb HTTP 429, which Cloud Hypervisor returns while a previous vCPU hot-unplug is still pending (`CpuManager::VcpuPendingRemovedVcpu`). That is a transient, asynchronous condition - it clears once the guest completes the removal - so retrying is exactly right.

The guard that decides whether to retry keys on the error text:

```go
if !strings.Contains(errMsg, "Too Many Requests") {
    return retry.Unrecoverable(err)
}
```

This never matches. A reason phrase is optional in an HTTP status line (RFC 9112 4.1), and micro_http emits it empty - the response line is literally `HTTP/1.1 429 `. The generated OpenAPI client therefore stringifies the error as `429`, with no `Too Many Requests` anywhere in it.

The consequence is that the retry loop is dead code for the one condition it was written for. Every 429 is classified `retry.Unrecoverable` on the first attempt and propagates out, surfacing to the user as:

```
failed to start containerd task: 429
```

This reproduces reliably when several sandboxes start concurrently on one host and their vCPU resizes overlap.

### Fix

Match on the status code instead of the message:

```go
if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
    return retry.Unrecoverable(err)
}
```

`VmResizePut` already returns the `*http.Response`; it was being discarded. With this, the existing 20 x 20 ms retry does what it was always meant to do.

Includes a regression test covering both directions: a 429 with an empty reason phrase is retried, and a non-429 error is still unrecoverable.

### Why this matters beyond one deployment

Nothing here is specific to a particular setup. Any deployment whose Cloud Hypervisor build omits the reason phrase has this retry silently disabled, and the failure appears as an unexplained container start error rather than as a transient resize.
