### PR TITLE
runtime/clh: don't declare the VMM dead while it is busy

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1659,6 +1659,25 @@ func (clh *cloudHypervisor) Check() error {
 	// longer than usual specially if there is a hot-plug request in progress.
 	running, err := clh.isClhRunning(10)
 	if !running {
+		// An unanswered ping does not on its own mean the VMM is gone. CLH
+		// serves its API from a single-threaded micro_http server, so one
+		// long-running request stops it answering anything else.
+		// vm.send-migration is the clearest case: it holds the server for the
+		// whole migration while the VMM event loop streams the guest state
+		// out, and vmm.ping queues behind it until it times out. Reporting the
+		// VMM dead there makes the monitor tear down a sandbox whose
+		// hypervisor is working normally.
+		//
+		// Ask the kernel instead, using the same kill(pid, 0) probe that
+		// isClhRunning already performs before it pings. A process that is
+		// still there is busy rather than dead; only its absence is
+		// conclusive.
+		if pid := clh.state.PID; pid > 0 {
+			if killErr := syscall.Kill(pid, syscall.Signal(0)); killErr == nil {
+				clh.Logger().WithField("pid", pid).WithError(err).Warn("clh API ping failed but the VMM process is alive, treating it as running")
+				return nil
+			}
+		}
 		return fmt.Errorf("clh is not running: %s", err)
 	}
 	return err


### PR DESCRIPTION
### Problem

`cloudHypervisor.Check()` decides whether the VMM is alive by sending `vmm.ping` over the HTTP API with a 10 second timeout, and reports "not running" if that call does not return.

Cloud Hypervisor's micro_http server is single-threaded. `/api/v1/vm.send-migration` occupies it for the entire duration of a migration, because the VMM event loop is busy streaming guest state to the destination. Every other API call, `vmm.ping` included, queues behind it and times out.

So during any live migration long enough to exceed 10 seconds, the monitor thread concludes the hypervisor has died and notifies its watcher; the shim's `watchSandbox` then calls `Sandbox.Stop`, which kills a healthy VMM in the middle of transferring its own guest.

The observable failure is confusing, because the first thing that surfaces is the migration call dying rather than the cause:

```
Put "http://localhost/api/v1/vm.send-migration": EOF
```

The destination then waits out its full receive timeout with nothing arriving, and the migration is recorded as failed even though it was progressing normally and would have completed.

### Fix

Treat an unanswered ping as inconclusive rather than fatal. Before reporting the VMM dead, probe the process directly:

```go
if pid := clh.state.PID; pid > 0 {
    if killErr := syscall.Kill(pid, syscall.Signal(0)); killErr == nil {
        return nil   // alive, just busy
    }
}
```

Only when the process itself is gone does `Check()` report not-running. This narrows the check to what it is actually asking, does the VMM exist, instead of conflating it with whether the VMM is currently free to answer HTTP.

This is the same `kill(pid, 0)` probe `isClhRunning` already performs before it pings, so no new mechanism is introduced.

### On testing

No test is included, and I would rather say so plainly than pretend otherwise. Reproducing this needs an API call that blocks the server past the ping timeout, which is awkward to arrange in a unit test without either a real migration or reshaping how the client is injected. If there is a preferred place or pattern for this, I am happy to add one.
