### PR TITLE
docs: Update containerd installation link

### DIFF
--- a/docs/how-to/containerd-kata.md
+++ b/docs/how-to/containerd-kata.md
@@ -62,7 +62,7 @@ Follow the instructions to [install Kata Containers](../install/README.md).
 > You do not need to install `cri` if you have containerd 1.1 or above. Just remove the `cri` plugin from the list of
 > `disabled_plugins` in the containerd configuration file (`/etc/containerd/config.toml`).
 
-Follow the instructions from the [CRI installation guide](https://github.com/containerd/containerd/blob/main/docs/cri/crictl.md#install-crictl).
+Follow the instructions from the [containerd getting started guide](https://github.com/containerd/containerd/blob/main/docs/getting-started.md).
 
 Then, check if `containerd` is now available:
 


### PR DESCRIPTION
Replace the CRI tooling link in the containerd setup instructions with the current containerd getting started guide.

The destination link was verified to return successfully.

Fixes #6370