### PR TITLE
build: add pcilibs-rs workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "nix 0.31.3",
  "once_cell",
  "path-clean",
+ "pcilibs-rs",
  "persist",
  "protobuf",
  "protocols",
@@ -5287,8 +5288,7 @@ dependencies = [
 [[package]]
 name = "pcilibs-rs"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a881b7e99a9f8a84ce775878838e5ad206e142d2213cc3868efea6bdac24590"
+source = "git+https://github.com/zvonkok/pcilibs-rs?rev=ce6486db#ce6486db79ade33028583a9e81245db5f4de2079"
 dependencies = [
  "nix 0.31.3",
  "pci-ids",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ wasm_container = { path = "src/runtime-rs/crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/lib`
 kata-sys-util = { path = "src/libs/kata-sys-util" }
-pcilibs-rs = "0.1.0"
+pcilibs-rs = { git = "https://github.com/zvonkok/pcilibs-rs", rev = "ce6486db" }
 pod-resources-rs = { path = "src/libs/pod-resources-rs" }
 kata-types = { path = "src/libs/kata-types", features = ["safe-path"] }
 logging = { path = "src/libs/logging" }

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -40,6 +40,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 regex = "1"
 once_cell = "1.21.3"
+pcilibs-rs = { workspace = true }
 # Local dependencies
 kata-sys-util = { workspace = true }
 kata-types = { workspace = true }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -4,6 +4,7 @@
 //
 
 use anyhow::{anyhow, Context, Result};
+use pcilibs_rs::{IOMMUFD_SYSFS_CLASS, IOMMUFD_VFIO_DIR};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -12,13 +13,10 @@ use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 
-/// Path constants for VFIO and IOMMU sysfs/dev interfaces
-const DEV_VFIO: &str = "/dev/vfio";
 const SYS_IOMMU_GROUPS: &str = "/sys/kernel/iommu_groups";
 const SYS_PCI_DEVS: &str = "/sys/bus/pci/devices";
 const DEV_IOMMU: &str = "/dev/iommu";
 const DEV_VFIO_DEVICES: &str = "/dev/vfio/devices";
-const SYS_CLASS_VFIO_DEV: &str = "/sys/class/vfio-dev";
 const SYS_VFIO_AP: &str = "/sys/devices/vfio_ap";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -499,7 +497,7 @@ fn discover_vfio_cdev_by_name(
         } else {
             Some(minor)
         },
-        sysfs_path: Path::new(SYS_CLASS_VFIO_DEV).join(vfio_name),
+        sysfs_path: Path::new(IOMMUFD_SYSFS_CLASS).join(vfio_name),
         bdf,
         group_id: gid,
     })
@@ -523,7 +521,7 @@ pub fn discover_vfio_device(vfio_device: &Path) -> Result<VfioDevice> {
 
     // /sys/class/vfio-dev/<name>/device -> .../0000:01:00.0
     let dev_link = fs::read_link(
-        Path::new(SYS_CLASS_VFIO_DEV)
+        Path::new(IOMMUFD_SYSFS_CLASS)
             .join(&vfio_name)
             .join("device"),
     )
@@ -634,7 +632,7 @@ pub fn discover_vfio_group_device(host_path: PathBuf) -> Result<VfioDevice> {
 /// `group_devnode` is the char device used to represent the group for metadata/health:
 /// typically `/dev/vfio/<gid>` (legacy) or `/dev/vfio/devices/vfioX` when legacy nodes are absent.
 fn discover_vfio_device_for_iommu_group(gid: u32, group_devnode: PathBuf) -> Result<VfioDevice> {
-    let vfio_ctl = Path::new(DEV_VFIO).join("vfio");
+    let vfio_ctl = Path::new(IOMMUFD_VFIO_DIR).join("vfio");
     if !vfio_ctl.exists() {
         return Err(anyhow!("VFIO control node missing: {}", vfio_ctl.display()));
     }


### PR DESCRIPTION
`pcilibs-rs` provides PCI device enumeration, IOMMUFD cdev discovery, and VFIO driver-type helpers that were extracted from Kata Containers for reuse across tools that need PCI/VFIO primitives without pulling in the full hypervisor crate.

Wire it up at three points:

**Workspace `Cargo.toml`**: git-pinned to `ce6486db` which includes the `iommufd` module with `IOMMUFD_VFIO_DIR` and `IOMMUFD_SYSFS_CLASS` constants. Switch to a semver version once pcilibs-rs cuts a v0.2.0 release.

**hypervisor crate**: imports `IOMMUFD_VFIO_DIR` / `IOMMUFD_SYSFS_CLASS` from pcilibs-rs in `vfio_device/core.rs`, replacing the duplicate local constants.

**kata-deploy binary**: wired up so future PRs can use `PCIDevice`, `PCIDeviceManager` and `enumerate_iommufd` directly without adding a new dep per crate.