### PR TITLE
runtime-rs: nvidia: Remove unwanted annotations

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -206,7 +206,9 @@ DEFNETQUEUES := 1
 # Security note: do not enable "virtio_fs_extra_args" by default.
 # Allowing pods to pass arbitrary virtiofsd arguments can be abused for malicious host-side behavior.
 DEFENABLEANNOTATIONS := [\"enable_iommu\", \"kernel_params\", \"kernel_verity_params\", \"default_vcpus\", \"default_memory\"]
+DEFENABLEANNOTATIONS_NVIDIA := []
 DEFENABLEANNOTATIONS_COCO := [\"enable_iommu\", \"kernel_params\", \"kernel_verity_params\", \"default_vcpus\", \"default_memory\", \"cc_init_data\"]
+DEFENABLEANNOTATIONS_COCO_NVIDIA := [\"cc_init_data\"]
 DEFDISABLEGUESTSECCOMP := true
 DEFEMPTYDIRMODE := shared-fs
 DEFEMPTYDIRMODE_COCO := block-encrypted
@@ -781,7 +783,9 @@ USER_VARS += DEFVIRTIOFSCACHE
 USER_VARS += DEFVIRTIOFSQUEUESIZE
 USER_VARS += DEFVIRTIOFSEXTRAARGS
 USER_VARS += DEFENABLEANNOTATIONS
+USER_VARS += DEFENABLEANNOTATIONS_NVIDIA
 USER_VARS += DEFENABLEANNOTATIONS_COCO
+USER_VARS += DEFENABLEANNOTATIONS_COCO_NVIDIA
 USER_VARS += DEFENABLEIOTHREADS
 USER_VARS += DEFINDEPIOTHREADS
 USER_VARS += DEFSECCOMPSANDBOXPARAM

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -38,7 +38,7 @@ rootless = false
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
-enable_annotations = @DEFENABLEANNOTATIONS@
+enable_annotations = @DEFENABLEANNOTATIONS_NVIDIA@
 
 # List of valid annotations values for the hypervisor
 # Each member of the list is a path pattern as described by glob(3).

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -38,7 +38,7 @@ rootless = false
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
-enable_annotations = @DEFENABLEANNOTATIONS@
+enable_annotations = @DEFENABLEANNOTATIONS_NVIDIA@
 
 # List of valid annotations values for the hypervisor
 # Each member of the list is a path pattern as described by glob(3).

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -79,7 +79,7 @@ rootless = false
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
-enable_annotations = @DEFENABLEANNOTATIONS_COCO@
+enable_annotations = @DEFENABLEANNOTATIONS_COCO_NVIDIA@
 
 # List of valid annotations values for the hypervisor
 # Each member of the list is a path pattern as described by glob(3).

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -55,7 +55,7 @@ rootless = false
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
-enable_annotations = @DEFENABLEANNOTATIONS_COCO@
+enable_annotations = @DEFENABLEANNOTATIONS_COCO_NVIDIA@
 
 # List of valid annotations values for the hypervisor
 # Each member of the list is a path pattern as described by glob(3).

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -211,6 +211,18 @@ function deploy_kata() {
 	if [[ "${KATA_HYPERVISOR}" = "qemu" ]]; then
 		ANNOTATIONS="image initrd kernel default_vcpus"
 	fi
+	# The NVIDIA runtime classes ship with the hypervisor annotations disabled,
+	# so the ones a few tests depend on have to be opted into here.
+	if is_nvidia_hypervisor "${KATA_HYPERVISOR}" || is_confidential_gpu_hypervisor "${KATA_HYPERVISOR}"; then
+		if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
+			# k8s-confidential-attestation.bats and the NIM TEE pods pass the
+			# KBS address and the guest components setup on the kernel cmdline.
+			ANNOTATIONS+=" kernel_params"
+		elif is_verity_enabled_runtime_class "${KATA_HYPERVISOR}"; then
+			# k8s-measured-rootfs.bats corrupts the verity root hash.
+			ANNOTATIONS+=" kernel_verity_params"
+		fi
+	fi
 
 	SNAPSHOTTER_HANDLER_MAPPING=""
 	if [[ -n "${SNAPSHOTTER}" ]]; then


### PR DESCRIPTION
For the NVIDIA runtime classes we do not want folks messing up with annotations, at least not by default.