### PR TITLE
runtime-rs: completes the cleanup lifecycle for hotplugged block and VFIO devices

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -185,33 +185,39 @@ impl DeviceManager {
     pub async fn try_remove_device(&mut self, device_id: &str) -> Result<()> {
         if let Some(dev) = self.devices.get(device_id) {
             let mut device_guard = dev.lock().await;
-            let result = match device_guard
+            let index = device_guard
                 .detach(&mut self.pcie_topology.as_mut(), self.hypervisor.as_ref())
-                .await
-            {
-                Ok(index) => {
-                    if let Some(i) = index {
-                        // release the declared device index
-                        let is_pmem = match device_guard.get_device_info().await {
-                            DeviceType::BlockModern(dev) => {
-                                dev.lock().await.config.driver_option == *KATA_NVDIMM_DEV_TYPE
-                            }
-                            _ => false,
-                        };
-                        self.shared_info.release_device_index(i, is_pmem);
-                    }
-                    Ok(())
-                }
-                Err(e) => Err(e),
+                .await?;
+
+            // A shared block/VFIO device returns successfully without doing the
+            // physical hot-unplug while its attach count is still non-zero. Do
+            // not discard the manager entry in that case: the last container
+            // reference still needs it to perform the real detach later.
+            let device_info = device_guard.get_device_info().await;
+            let still_in_use = match &device_info {
+                DeviceType::VhostUserBlk(device) => device.attach_count != 0,
+                DeviceType::BlockModern(device) => device.lock().await.attach_count != 0,
+                DeviceType::VfioModern(device) => device.lock().await.attach_count != 0,
+                _ => false,
             };
 
-            // if detach success, remove it from device manager
-            if result.is_ok() {
-                drop(device_guard);
-                self.devices.remove(device_id);
+            if still_in_use {
+                return Ok(());
             }
 
-            return result;
+            if let Some(i) = index {
+                let is_pmem = matches!(
+                    &device_info,
+                    DeviceType::BlockModern(block)
+                        if block.lock().await.config.driver_option == *KATA_NVDIMM_DEV_TYPE
+                );
+                self.shared_info.release_device_index(i, is_pmem);
+            }
+
+            drop(device_guard);
+            self.devices.remove(device_id);
+
+            return Ok(());
         }
 
         Err(anyhow!(
@@ -746,5 +752,27 @@ mod tests {
         } else {
             assert_eq!(1, 0)
         }
+    }
+
+    #[actix_rt::test]
+    async fn test_shared_block_device_is_retained_until_last_detach() {
+        let d = new_device_manager().await.unwrap();
+        let block_driver = get_block_device_info(&d).await.block_device_driver;
+        let dev_info = DeviceConfig::BlockCfgModern(BlockConfigModern {
+            path_on_host: "/dev/shared-test-device".to_string(),
+            driver_option: block_driver,
+            ..Default::default()
+        });
+
+        let device_id = d.write().await.new_device(&dev_info).await.unwrap();
+        d.write().await.try_add_device(&device_id).await.unwrap();
+        let matched_id = d.write().await.new_device(&dev_info).await.unwrap();
+        assert_eq!(device_id, matched_id);
+        d.write().await.try_add_device(&matched_id).await.unwrap();
+
+        d.write().await.try_remove_device(&device_id).await.unwrap();
+
+        let device_info = d.read().await.get_device_info(&device_id).await.unwrap();
+        assert!(matches!(device_info, DeviceType::BlockModern(device) if device.lock().await.attach_count == 1));
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1011,6 +1011,8 @@ impl QemuInner {
             (DeviceType::BlockModern(a), DeviceType::BlockModern(b)) => {
                 !std::sync::Arc::ptr_eq(a, b)
             }
+            (DeviceType::Vfio(a), DeviceType::Vfio(b)) => a.device_id != b.device_id,
+            (DeviceType::VfioModern(a), DeviceType::VfioModern(b)) => !std::sync::Arc::ptr_eq(a, b),
             _ => true,
         });
 
@@ -1035,9 +1037,21 @@ impl QemuInner {
                 qmp.hotunplug_block_device(&driver, index)
                     .context("hotunplug block device")?;
             }
+            DeviceType::Vfio(ref vfio_device) => {
+                let hostdev_id = vfio_device
+                    .devices
+                    .first()
+                    .map(|device| device.hostdev_id.as_str())
+                    .ok_or_else(|| anyhow!("VFIO device has no host device to hotunplug"))?;
+                qmp.hotunplug_vfio_device(hostdev_id)
+                    .context("hotunplug VFIO device")?;
+            }
+            DeviceType::VfioModern(ref vfio_device) => {
+                let hostdev_id = vfio_device.lock().await.device_id.clone();
+                qmp.hotunplug_vfio_device(&hostdev_id)
+                    .context("hotunplug VFIO device")?;
+            }
             DeviceType::Network(_)
-            | DeviceType::Vfio(_)
-            | DeviceType::VfioModern(_)
             | DeviceType::VhostUserBlk(_)
             | DeviceType::VhostUserNetwork(_)
             | DeviceType::ShareFs(_)

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1008,6 +1008,8 @@ impl QemuInner {
             (DeviceType::BlockModern(a), DeviceType::BlockModern(b)) => {
                 !std::sync::Arc::ptr_eq(a, b)
             }
+            (DeviceType::Vfio(a), DeviceType::Vfio(b)) => a.device_id != b.device_id,
+            (DeviceType::VfioModern(a), DeviceType::VfioModern(b)) => !std::sync::Arc::ptr_eq(a, b),
             _ => true,
         });
 
@@ -1032,9 +1034,21 @@ impl QemuInner {
                 qmp.hotunplug_block_device(&driver, index)
                     .context("hotunplug block device")?;
             }
+            DeviceType::Vfio(ref vfio_device) => {
+                let hostdev_id = vfio_device
+                    .devices
+                    .first()
+                    .map(|device| device.hostdev_id.as_str())
+                    .ok_or_else(|| anyhow!("VFIO device has no host device to hotunplug"))?;
+                qmp.hotunplug_vfio_device(hostdev_id)
+                    .context("hotunplug VFIO device")?;
+            }
+            DeviceType::VfioModern(ref vfio_device) => {
+                let hostdev_id = vfio_device.lock().await.device_id.clone();
+                qmp.hotunplug_vfio_device(&hostdev_id)
+                    .context("hotunplug VFIO device")?;
+            }
             DeviceType::Network(_)
-            | DeviceType::Vfio(_)
-            | DeviceType::VfioModern(_)
             | DeviceType::VhostUserBlk(_)
             | DeviceType::VhostUserNetwork(_)
             | DeviceType::ShareFs(_)

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -1534,6 +1534,71 @@ impl Qmp {
         Ok(Some(pci_path))
     }
 
+    /// Hotunplug a VFIO device.
+    pub fn hotunplug_vfio_device(&mut self, hostdev_id: &str) -> Result<()> {
+        if !self
+            .device_exists(hostdev_id)
+            .context("query VFIO device before hotunplug")?
+        {
+            info!(
+                sl!(),
+                "hotunplug_vfio_device(): {} is already absent", hostdev_id
+            );
+            return Ok(());
+        }
+
+        if let Err(delete_err) = self.qmp.execute(&qmp::device_del {
+            id: hostdev_id.to_owned(),
+        }) {
+            return match self.device_exists(hostdev_id) {
+                Ok(false) => Ok(()),
+                Ok(true) => Err(anyhow!(
+                    "device_del for VFIO device {}: {:?}",
+                    hostdev_id,
+                    delete_err
+                )),
+                Err(query_err) => Err(anyhow!(
+                    "device_del for VFIO device {} failed: {:?}; state reconciliation failed: {:#}",
+                    hostdev_id,
+                    delete_err,
+                    query_err
+                )),
+            };
+        }
+
+        if let Err(wait_err) = self.wait_for_device_deleted(hostdev_id, DEVICE_DELETED_TIMEOUT) {
+            return match self.device_exists(hostdev_id) {
+                Ok(false) => Ok(()),
+                Ok(true) => Err(wait_err).context(
+                    format!(
+                        "hotunplug_vfio_device(): waiting for DEVICE_DELETED for {}",
+                        hostdev_id
+                    )
+                ),
+                Err(query_err) => Err(anyhow!(
+                    "waiting for DEVICE_DELETED for {} failed: {:#}; state reconciliation failed: {:#}",
+                    hostdev_id,
+                    wait_err,
+                    query_err
+                )),
+            };
+        }
+
+        info!(
+            sl!(),
+            "hotunplug_vfio_device(): successfully removed {}", hostdev_id
+        );
+
+        Ok(())
+    }
+
+    pub fn device_exists(&mut self, device_name: &str) -> Result<bool> {
+        let devices = self.qmp.execute(&qapi_qmp::qom_list {
+            path: "/machine/peripheral".to_owned(),
+        })?;
+        Ok(devices.iter().any(|device| device.name == device_name))
+    }
+
     pub fn qmp_stop(&mut self) -> Result<()> {
         self.qmp
             .execute(&qmp::stop {})

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -199,9 +199,14 @@ impl ResourceManager {
         inner.handler_volumes(cid, spec).await
     }
 
-    pub async fn handler_devices(&self, cid: &str, linux: &Linux) -> Result<Vec<ContainerDevice>> {
+    pub async fn handler_devices(
+        &self,
+        cid: &str,
+        linux: &Linux,
+        device_ids: &mut Vec<String>,
+    ) -> Result<Vec<ContainerDevice>> {
         let inner = self.inner.read().await;
-        inner.handler_devices(cid, linux).await
+        inner.handler_devices(cid, linux, device_ids).await
     }
 
     pub async fn dump(&self) {

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -505,7 +505,12 @@ impl ResourceManagerInner {
         self.volume_resource.handler_volumes(&ctx, cid, spec).await
     }
 
-    pub async fn handler_devices(&self, _cid: &str, linux: &Linux) -> Result<Vec<ContainerDevice>> {
+    pub async fn handler_devices(
+        &self,
+        _cid: &str,
+        linux: &Linux,
+        device_ids: &mut Vec<String>,
+    ) -> Result<Vec<ContainerDevice>> {
         let mut devices = vec![];
 
         // Build a map of host_bdf -> Option<guest_pci_path> for cold-plugged
@@ -575,6 +580,7 @@ impl ResourceManagerInner {
                     // CCW, or virtual path, depending on the driver and configuration.
                     if let DeviceType::BlockModern(device_mod) = device_info {
                         let device = device_mod.lock().await.clone();
+                        device_ids.push(device.device_id.clone());
                         let id = if let Some(pci_path) = device.config.pci_path {
                             pci_path.to_string()
                         } else if let Some(scsi_address) = device.config.scsi_addr {
@@ -725,6 +731,7 @@ impl ResourceManagerInner {
                     if let DeviceType::VfioModern(vfio_dev) = device_info.clone() {
                         info!(sl!(), "device info: {:?}", vfio_dev.lock().await);
                         let vfio_device = vfio_dev.lock().await;
+                        device_ids.push(vfio_device.device_id.clone());
 
                         let group_num = d
                             .path()
@@ -811,6 +818,7 @@ impl ResourceManagerInner {
 
                         // create agent device
                         if let DeviceType::Vfio(device) = device_info {
+                            device_ids.push(device.device_id.clone());
                             let device_options = sort_options_by_pcipath(device.device_options);
                             let group_num = d
                                 .path()

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -206,7 +206,7 @@ impl Container {
 
         let container_devices = self
             .resource_manager
-            .handler_devices(&config.container_id, linux)
+            .handler_devices(&config.container_id, linux, &mut inner.devices)
             .await?;
         let devices_agent = annotate_container_devices(&mut spec, container_devices)
             .context("annotate container devices failed")?;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -33,6 +33,7 @@ pub struct ContainerInner {
     pub(crate) exec_processes: HashMap<String, Exec>,
     pub(crate) rootfs: Vec<Arc<dyn Rootfs>>,
     pub(crate) volumes: Vec<Arc<dyn Volume>>,
+    pub(crate) devices: Vec<String>, // device ids of devices hotplugged to the container
     pub(crate) linux_resources: Option<LinuxResources>,
 }
 
@@ -50,6 +51,7 @@ impl ContainerInner {
             exec_processes: HashMap::new(),
             rootfs: vec![],
             volumes: vec![],
+            devices: vec![],
             linux_resources,
         }
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -342,10 +342,12 @@ impl ContainerInner {
                 );
             }
         }
-        if !unhandled.is_empty() {
-            self.volumes = unhandled;
+        self.volumes = unhandled;
+        if self.volumes.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!("failed to clean {} volume(s)", self.volumes.len()))
         }
-        Ok(())
     }
 
     async fn clean_rootfs(&mut self, device_manager: &RwLock<DeviceManager>) -> Result<()> {
@@ -361,9 +363,11 @@ impl ContainerInner {
                 );
             }
         }
-        if !unhandled.is_empty() {
-            self.rootfs = unhandled;
+        self.rootfs = unhandled;
+        if self.rootfs.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!("failed to clean {} rootfs(s)", self.rootfs.len()))
         }
-        Ok(())
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -214,6 +214,9 @@ impl ContainerInner {
         // send to notify watchers who are waiting for the process exit
         self.init_process.stop().await;
 
+        self.clean_devices(device_manager)
+        .await
+        .context("clean devices")?;
         self.clean_volumes(device_manager)
             .await
             .context("clean volumes")?;
@@ -368,6 +371,33 @@ impl ContainerInner {
             Ok(())
         } else {
             Err(anyhow!("failed to clean {} rootfs(s)", self.rootfs.len()))
+        }
+    }
+
+    async fn clean_devices(&mut self, device_manager: &RwLock<DeviceManager>) -> Result<()> {
+        let mut unhandled = Vec::new();
+        for device_id in &self.devices {
+            if let Err(err) = device_manager
+                .write()
+                .await
+                .try_remove_device(device_id)
+                .await
+            {
+                unhandled.push(device_id.clone());
+                warn!(
+                    self.logger,
+                    "failed to hotunplug container device {}: {:?}", device_id, err
+                );
+            }
+        }
+        self.devices = unhandled;
+        if self.devices.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "failed to hotunplug {} container device(s)",
+                self.devices.len()
+            ))
         }
     }
 }


### PR DESCRIPTION
### Description

runtime-rs does not completely clean up dynamically hotplugged block and VFIO devices when a Pod is deleted.
One practical case looks like as below:

```
Error: failed to create containerd task: failed to create shim task: Others("failed to handle
  message create container\n\nCaused by:\n    0: do handle device\n    1: failed to add device\n    2: device_add vfio device failed Qapi(Error { class: GenericError,
  desc: \"vfio 0000:5a:00.0: error getting device from group 7: Resource temporarily unavailable\", id: None })\n\nStack backtrace:\n   0: anyhow::kind::Adhoc::new\n   1:
  hypervisor::qemu::qmp::Qmp::hotplug_vfio_device::{{closure}}\n   2: <hypervisor::qemu::Qemu as hypervisor::Hypervisor>::add_device::{{closure}}\n   3:
  <hypervisor::device::driver::vfio::VfioDevice as hypervisor::device::Device>::attach::{{closure}}\n   4: hypervisor::device::device_manager::do_handle_device::
  {{closure}}\n   5: virt_container::container_manager::container::Container::create::{{closure}}\n   6: <virt_container::container_manager::manager::VirtContainerManager
  as common::container_manager::ContainerManager>::create_container::{{closure}}::{{closure}}\n   7: <virt_container::container_manager::manager::VirtContainerManager as
  common::container_manager::ContainerManager>::create_container::{{closure}}\n   8: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}::
  {{closure}}\n   9: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}\n  10: <service::task_service::TaskService as
  containerd_shim_protos::shim::shim_ttrpc_async::Task>::create::{{closure}}\n  11: <containerd_shim_protos::shim::shim_ttrpc_async::CreateMethod as
  ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}\n  12: ttrpc::asynchronous::server::HandlerContext::handle_request::{{closure}}\n  13:
  <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}\n  14:
  tokio::runtime::task::raw::poll\n  15: tokio::runtime::scheduler::multi_thread::worker::Context::run_task\n  16: tokio::runtime::task::raw::poll\n  17:
  std::sys::backtrace::__rust_begin_short_backtrace\n  18: core::ops::function::FnOnce::call_once{{vtable.shim}}\n  19: std::sys::thread::unix::Thread::new::thread_start\n
  20: start_thread\n  21: __clone3")
```

The root cause is that the container cleanup path releases volumes and root filesystems, but device IDs attached during container creation are not tracked and detached reliably. As a result, QEMU or DeviceManager may continue holding the device after the Pod has been removed.


This PR completes the runtime-rs cleanup lifecycle for dynamically hotplugged block and VFIO devices.