### PR TITLE
runtime: Allow nvswitch-class devices to be passed through

### DIFF
--- a/src/runtime/pkg/device/drivers/utils.go
+++ b/src/runtime/pkg/device/drivers/utils.go
@@ -156,9 +156,22 @@ func GetAPVFIODevices(sysfsdev string) ([]string, error) {
 	return strings.Split(string(data[:len(data)-1]), "\n"), nil
 }
 
-// Ignore specific PCI devices, supply the pciClass and the bitmask to check
-// against the device class, deviceBDF for meaningfull info message
-func checkIgnorePCIClass(pciClass string, deviceBDF string, bitmask uint64) (bool, error) {
+// pciClassesIgnoredForPassthrough lists the PCI class codes (base+subclass, i.e.
+// the sysfs `class` value with the trailing programming-interface byte removed)
+// that cannot be passed through when they merely share an IOMMU group with a
+// passthrough-capable device: 0x0600 Host Bridge and 0x0604 PCI-to-PCI Bridge.
+// Matched exactly rather than against the PCI base class 0x06 (Bridge) so
+// passthrough-capable bridges like NVSwitches (0x0680, "Bridge: Other") are not
+// filtered out.
+var pciClassesIgnoredForPassthrough = map[uint64]struct{}{
+	0x0600: {},
+	0x0604: {},
+}
+
+// checkIgnorePCIClass reports whether the device with the given sysfs pciClass
+// must be ignored (not passed through) because it is a Host or PCI-to-PCI bridge
+// sharing the IOMMU group. deviceBDF is only used for the info message.
+func checkIgnorePCIClass(pciClass string, deviceBDF string) (bool, error) {
 	if pciClass == "" {
 		return false, nil
 	}
@@ -168,8 +181,8 @@ func checkIgnorePCIClass(pciClass string, deviceBDF string, bitmask uint64) (boo
 	}
 	// ClassID is 16 bits, remove the two trailing zeros
 	pciClassID = pciClassID >> 8
-	if pciClassID&bitmask == bitmask {
-		deviceLogger().Infof("Ignoring PCI (Host) Bridge deviceBDF %v Class %x", deviceBDF, pciClassID)
+	if _, ok := pciClassesIgnoredForPassthrough[pciClassID]; ok {
+		deviceLogger().Infof("Ignoring PCI Host/PCI Bridge deviceBDF %v Class %x", deviceBDF, pciClassID)
 		return true, nil
 	}
 	return false, nil
@@ -296,7 +309,7 @@ func GetAllVFIODevicesFromIOMMUGroup(device config.DeviceInfo) ([]*config.VFIODe
 			// We need to ignore Host or PCI Bridges that are in the same IOMMU group as the
 			// passed-through devices. One CANNOT pass-through a PCI bridge or Host bridge.
 			// Class 0x0604 is PCI bridge, 0x0600 is Host bridge
-			ignorePCIDevice, err := checkIgnorePCIClass(pciClass, deviceBDF, 0x0600)
+			ignorePCIDevice, err := checkIgnorePCIClass(pciClass, deviceBDF)
 			if err != nil {
 				return nil, err
 			}

--- a/src/runtime/pkg/device/drivers/utils_test.go
+++ b/src/runtime/pkg/device/drivers/utils_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIgnorePCIClass(t *testing.T) {
+	type testData struct {
+		pciClass string
+		ignored  bool
+	}
+
+	data := []testData{
+		{"0x060000", true},  // Host Bridge
+		{"0x060400", true},  // PCI-to-PCI Bridge
+		{"0x068000", false}, // NVSwitch ("Bridge: Other"), must be passed through
+		{"0x030200", false}, // 3D controller (GPU)
+		{"0x040300", false}, // Audio device
+		{"", false},
+	}
+
+	for _, d := range data {
+		ignored, err := checkIgnorePCIClass(d.pciClass, "0000:00:00.0")
+		assert.NoError(t, err, "pciClass %q", d.pciClass)
+		assert.Equal(t, d.ignored, ignored, "pciClass %q", d.pciClass)
+	}
+}


### PR DESCRIPTION
The device class ID of nvswitches (0x0680) was being inappropriately rejected because it appears to be a host bridge device. This breaks HGX systems because we need to be able to run fabricmanager as a separate service VM (daemonset) that has access to all of the nvswitches. The logic in this commit creates an allow-list of class IDs.