### PR TITLE
runtime: never place two vCPU threads on the same host CPU 

### DIFF
--- a/docs/design/vcpu-threads-pinning.md
+++ b/docs/design/vcpu-threads-pinning.md
@@ -44,9 +44,13 @@ Inside that node, the placement depends on what the sandbox owns:
 
 | Condition | Placement |
 |-----------|-----------|
-| The sandbox owns its CPU set and it holds at least one CPU per vCPU | each vCPU thread is pinned to a host CPU of its own, taken from its node and borrowed from the rest of the CPU set only once its node runs out |
-| Otherwise | each vCPU thread gets the CPUs of its node as an affinity mask |
+| The sandbox owns its CPU set and a CPU of it is still unclaimed | the vCPU thread is pinned to a host CPU of its own, taken from its node, or borrowed from the CPUs no node claimed once every node has served its own vCPUs |
+| Otherwise | the vCPU thread gets the CPUs of its node as an affinity mask |
 
-The fallback exists because a CPU set the sandbox does not own — no cpuset was assigned to it, so the CPUs are derived from the NUMA topology and shared with every other sandbox on the host — gives no basis for claiming individual CPUs: each sandbox would claim the same ones and its vCPU threads would then time-share CPUs with the vCPU threads of the others. The `num(vCPU threads) == num(CPUs in CPU set)` equality of the non-NUMA path does not apply here: a CPU set larger than the vCPU count is fine, the surplus CPUs simply stay unused by this sandbox.
+The two conditions are evaluated per vCPU, so a CPU set that cannot back the whole guest pins the vCPUs it can and leaves the surplus threads to the host scheduler within their node. That is the common case under static sizing, which boots the guest with `default_vcpus` on top of the pod's CPU limit while the kubelet reserves only the limit. Sharing a node beats the alternative of pinning two vCPU threads to one CPU, which would make them time-share it for good; the scheduler can instead move such a thread to whichever CPU of the node has slack.
+
+The mask is also all a sandbox that does not own its CPU set can get — no cpuset was assigned to it, so the CPUs are derived from the NUMA topology and shared with every other sandbox on the host, which gives no basis for claiming individual CPUs: each sandbox would claim the same ones and its vCPU threads would then time-share CPUs with the vCPU threads of the others. The `num(vCPU threads) == num(CPUs in CPU set)` equality of the non-NUMA path does not apply here: a CPU set larger than the vCPU count is fine, the surplus CPUs simply stay unused by this sandbox.
+
+Ownership is read off the sandbox's own cpuset: a sandbox that has one is taken to hold it alone. That is what a cpuset means under Kubernetes, where the kubelet assigns one only to a Guaranteed pod under `cpuManagerPolicy=static` and removes those CPUs from the shared pool; a pod under `cpuManagerPolicy=none` has no cpuset of its own at all. Outside Kubernetes it is the caller's to uphold: a cpuset given on the command line (`--cpuset-cpus`) restricts a container to those CPUs without reserving them, so two sandboxes started that way can pin their vCPU threads onto the same host CPUs. Enable the feature where the CPU sets it places from are exclusive.
 
 See [How to use NUMA with Kata](../how-to/how-to-use-numa-with-kata.md) for the configuration and verification steps.

--- a/docs/design/vcpu-threads-pinning.md
+++ b/docs/design/vcpu-threads-pinning.md
@@ -35,3 +35,18 @@ So when may `num(CPUs in CPU set)` change? There are 5 possible scenes:
 
 We can split the whole process into the following steps. Related methods are `checkVCPUsPinning` and `resetVCPUsPinning`, in file Sandbox.go.
 ![](arch-images/vcpus-pinning-process.png)
+
+### NUMA-Aware Placement
+
+When the sandbox has a guest NUMA topology (`enable_numa`), `checkVCPUsPinning` hands the work to `checkVCPUsPinningNUMA`, which keeps every vCPU thread on the host NUMA node that the vCPU's guest node maps to, so that a vCPU and the memory of its node stay local to each other.
+
+Inside that node, the placement depends on what the sandbox owns:
+
+| Condition | Placement |
+|-----------|-----------|
+| The sandbox owns its CPU set and it holds at least one CPU per vCPU | each vCPU thread is pinned to a host CPU of its own, taken from its node and borrowed from the rest of the CPU set only once its node runs out |
+| Otherwise | each vCPU thread gets the CPUs of its node as an affinity mask |
+
+The fallback exists because a CPU set the sandbox does not own — no cpuset was assigned to it, so the CPUs are derived from the NUMA topology and shared with every other sandbox on the host — gives no basis for claiming individual CPUs: each sandbox would claim the same ones and its vCPU threads would then time-share CPUs with the vCPU threads of the others. The `num(vCPU threads) == num(CPUs in CPU set)` equality of the non-NUMA path does not apply here: a CPU set larger than the vCPU count is fine, the surplus CPUs simply stay unused by this sandbox.
+
+See [How to use NUMA with Kata](../how-to/how-to-use-numa-with-kata.md) for the configuration and verification steps.

--- a/docs/how-to/how-to-use-numa-with-kata.md
+++ b/docs/how-to/how-to-use-numa-with-kata.md
@@ -17,11 +17,11 @@ This guide walks through the full setup end-to-end: host inspection,
 Kubernetes configuration, Kata configuration, pod deployment, and
 verification.
 
-> **Note:**
->
-> NUMA support is currently available only for the **Go runtime** with the
-> **QEMU hypervisor** on **amd64** and **arm64** architectures. The Rust
-> runtime (`runtime-rs`) does not yet support NUMA topology.
+!!! note
+
+    NUMA support is currently available only for the **Go runtime** with the
+    **QEMU hypervisor** on **amd64** and **arm64** architectures. The Rust
+    runtime (`runtime-rs`) does not yet support NUMA topology.
 
 ## Step 1: Inspect the Host NUMA Topology
 
@@ -65,26 +65,37 @@ the runtime detects one node and skips multi-NUMA topology.
 
 ## Step 2: Kubernetes CPU Manager Policy
 
-Kata's NUMA-aware vCPU pinning works **without** `cpuManagerPolicy: static`.
-The recommended policy is the default (`none`):
+The kubelet CPU manager policy decides whether a pod owns host CPUs, and that
+in turn decides how tightly Kata can place the sandbox's vCPU threads:
 
-```yaml
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-cpuManagerPolicy: "none"
-```
+| `cpuManagerPolicy` | Sandbox CPUSet | vCPU thread placement |
+|--------------------|----------------|-----------------------|
+| `none` (default) | none — the pod shares the node's CPUs | each vCPU thread is confined to the host CPUs of its guest NUMA node |
+| `static` (Guaranteed pods) | an exclusive set of host CPUs | each vCPU thread is pinned to a host CPU of its own within that set |
 
-> **Why not `static`?**
->
-> With `cpuManagerPolicy: static`, Kubernetes assigns dedicated CPUs to
-> Guaranteed QoS pods. On a multi-NUMA host, those CPUs are often all from
-> a **single** NUMA node (depending on the topology manager policy). This
-> causes the sandbox CPUSet to cover only one NUMA node, which defeats the
-> purpose of multi-NUMA guest topology.
->
-> With `cpuManagerPolicy: none` (the default), the pod inherits the full
-> node CPUSet spanning all NUMA nodes, and Kata's NUMA-aware pinning
-> distributes vCPU threads proportionally across host NUMA nodes.
+Either way the guest's vCPUs and memory stay on the right host NUMA node,
+which is what NUMA support is about. What differs is the placement *within*
+the node: under `none` the host scheduler may move a vCPU thread between the
+CPUs of its node, under `static` each vCPU thread keeps one CPU to itself.
+
+!!! warning "Why one thread per CPU needs `static`"
+
+    A sandbox cannot see which host CPUs the other sandboxes are using. If
+    Kata pinned vCPUs to individual CPUs of a shared pool, every sandbox on
+    the node would pick the same ones and stack its vCPU threads on top of
+    theirs, and each of them would get a fraction of a CPU while other CPUs
+    stayed idle. Kata therefore pins one thread per CPU only when Kubernetes
+    has reserved those CPUs for the pod, and confines the threads to their
+    NUMA node otherwise.
+
+!!! note "What `static` costs"
+
+    On a multi-NUMA host, the CPUs the static CPU manager hands out often
+    come from a single host NUMA node (depending on the topology manager
+    policy), so the sandbox CPUSet covers one node and the guest topology
+    right-sizes to it. Choose `static` when per-vCPU pinning matters more
+    than a multi-node guest, and `none` when you want the guest to span
+    several host nodes.
 
 ### 2.1 Check the current policy
 
@@ -92,23 +103,30 @@ cpuManagerPolicy: "none"
 $ grep cpuManagerPolicy /var/lib/kubelet/config.yaml
 ```
 
-If it shows `static`, switch to `none`:
+To change it, edit the kubelet configuration, drop the stale CPU manager
+state and restart the kubelet. For example, to opt into per-vCPU pinning:
 
 ```bash
-$ sudo sed -i 's/cpuManagerPolicy:.*/cpuManagerPolicy: "none"/' /var/lib/kubelet/config.yaml
+$ sudo sed -i 's/cpuManagerPolicy:.*/cpuManagerPolicy: "static"/' /var/lib/kubelet/config.yaml
 $ sudo rm -f /var/lib/kubelet/cpu_manager_state
 $ sudo systemctl restart kubelet
 ```
 
+!!! note
+
+    The `static` policy requires a non-zero `kubeReserved` or
+    `systemReserved` CPU quantity in the kubelet configuration; without it
+    the kubelet refuses to start.
+
 ## Step 3: Configure Kata Containers for NUMA
 
-> **Note:**
->
-> If you are using the NVIDIA GPU runtime classes
-> (`kata-qemu-nvidia-gpu`, `kata-qemu-nvidia-gpu-snp`,
-> `kata-qemu-nvidia-gpu-tdx`), NUMA is already enabled by default in their
-> configuration templates. You only need the steps below for the base
-> `kata-qemu` runtime class or custom configurations.
+!!! note
+
+    If you are using the NVIDIA GPU runtime classes
+    (`kata-qemu-nvidia-gpu`, `kata-qemu-nvidia-gpu-snp`,
+    `kata-qemu-nvidia-gpu-tdx`), NUMA is already enabled by default in their
+    configuration templates. You only need the steps below for the base
+    `kata-qemu` runtime class or custom configurations.
 
 Never edit the base `configuration-qemu.toml` directly — use a
 **configuration drop-in** so your customizations survive upgrades.
@@ -195,11 +213,11 @@ The drop-in is merged on top of the base `configuration-qemu.toml`
 automatically. No restart is needed — the shim reads the configuration
 at pod creation time.
 
-> **Note:**
->
-> For details on the drop-in mechanism, reserved prefix ranges, and
-> additional Helm examples, see the
-> [Helm configuration guide](../../docs/helm-configuration.md).
+!!! note
+
+    For details on the drop-in mechanism, reserved prefix ranges, and
+    additional Helm examples, see the
+    [Helm configuration guide](../../docs/helm-configuration.md).
 
 ### 3.3 Verify the effective configuration
 
@@ -242,13 +260,17 @@ spec:
 EOF
 ```
 
-> **Note:**
->
-> Kata sizes the VM based on `limits` (not `requests`). Using different
-> values for `requests` and `limits` makes the pod **Burstable** QoS,
-> which avoids Kubernetes CPU manager interference with NUMA-aware
-> pinning. The large `limits.cpu` value tells Kata to create a VM with
-> that many vCPUs distributed across NUMA nodes.
+!!! note
+
+    Kata sizes the VM based on `limits`, not `requests`: the `limits.cpu`
+    value above tells Kata to create a VM with that many vCPUs distributed
+    across NUMA nodes.
+
+    QoS class only matters under `cpuManagerPolicy: static`, where a pod
+    needs Guaranteed QoS — integer `cpu`, with `requests` equal to `limits`
+    for both CPU and memory — to be given host CPUs of its own and thus get
+    one host CPU per vCPU thread. Under `cpuManagerPolicy: none` no pod gets
+    an exclusive CPUSet, so every QoS class ends up with per-node affinity.
 
 ### 4.2 GPU passthrough pod with NUMA
 
@@ -351,27 +373,42 @@ Node 1 MemTotal:     2097152 kB
 
 ## Step 6: Verify NUMA on the Host
 
-### 6.1 Check vCPU pinning
+### 6.1 Check vCPU placement
 
-From the host, find the QEMU process and check its thread affinities:
+From the host, list the CPUs each vCPU thread of the QEMU process may run
+on:
 
 ```bash
 $ QEMU_PID=$(pgrep -f "qemu.*numa-test")
-$ ls /proc/${QEMU_PID}/task/ | while read tid; do
-    echo "TID ${tid}: $(taskset -p ${tid} 2>/dev/null)"
+$ for task in /proc/${QEMU_PID}/task/*; do
+    grep -q '^CPU .*/KVM' "${task}/comm" || continue
+    echo "$(cat "${task}/comm"): $(grep Cpus_allowed_list "${task}/status" | cut -f2)"
   done
 ```
 
-With NUMA pinning enabled, you should see vCPU threads pinned to specific
-CPUs (not the full CPU mask). For example, on a 2-NUMA-node host with
-CPUs 0-7 on node 0 and CPUs 8-15 on node 1:
+On a 2-NUMA-node host with CPUs 0-7 on node 0 and 8-15 on node 1, a sandbox
+holding an exclusive CPUSet shows one CPU per thread:
 
 ```
-TID 12345: pid 12345's current affinity mask: 1    # CPU 0
-TID 12346: pid 12346's current affinity mask: 2    # CPU 1
-TID 12347: pid 12347's current affinity mask: 100  # CPU 8
-TID 12348: pid 12348's current affinity mask: 200  # CPU 9
+CPU 0/KVM: 0
+CPU 1/KVM: 1
+CPU 2/KVM: 8
+CPU 3/KVM: 9
 ```
+
+Without an exclusive CPUSet, the threads show the CPU list of their guest
+node instead:
+
+```
+CPU 0/KVM: 0-7
+CPU 1/KVM: 0-7
+CPU 2/KVM: 8-15
+CPU 3/KVM: 8-15
+```
+
+Both are correct placements (see [Step 2](#step-2-kubernetes-cpu-manager-policy)).
+What should never appear is a thread whose list spans both host nodes, or two
+threads pinned to the same single CPU.
 
 ### 6.2 Check the shim logs for NUMA configuration
 
@@ -490,10 +527,12 @@ When a VM is created with NUMA enabled, the runtime:
    `cores = ceil(maxvcpus / num_NUMA_nodes)` so QEMU groups vCPUs by socket
    per NUMA node.
 
-5. **Pins vCPUs** (when enabled): Each vCPU thread is pinned to a host CPU
-   belonging to the same NUMA node. Right-sized single-node sandboxes
-   also go through this NUMA-aware path, so all vCPUs land on the chosen
-   host NUMA node's CPUs.
+5. **Places vCPU threads** (when enabled): Each vCPU thread is bound to host
+   CPUs of the NUMA node its guest node maps to — to one host CPU of its own
+   when the sandbox holds an exclusive CPUSet with at least one CPU per vCPU,
+   to the node's CPU list otherwise. Right-sized single-node sandboxes also
+   go through this NUMA-aware path, so all vCPUs land on the chosen host NUMA
+   node's CPUs.
 
 6. **Validates VFIO devices**: Checks each cold-plugged device's host NUMA
    node against the guest topology and logs placement status.
@@ -550,34 +589,61 @@ EOF
 
 ### vCPU pinning is skipped (empty CPUSet)
 
-**Symptom:** The shim logs show:
+**Symptom:** The shim logs show one of:
 
 ```
 sandbox CPUSet is empty; skipping vCPU pinning
+sandbox CPUSet is empty and cannot derive from NUMA HostCPUs; skipping vCPU pinning
 ```
 
-**Cause:** The runtime could not determine a CPUSet for pinning. With
-`cpuManagerPolicy: none` and multi-NUMA enabled, the runtime derives the
-CPUSet from the guest NUMA nodes' `HostCPUs`. This message indicates no
-NUMA topology was built (e.g., the host has only one NUMA node).
+**Cause:** The sandbox has no CPUSet of its own, and no guest NUMA topology
+to fall back on either — the first message means no guest NUMA nodes were
+built at all, the second that the nodes carry no usable host CPUs. There is
+nothing left to constrain the vCPU threads to, so they keep the affinity they
+started with.
 
 **Fix:** Verify:
 
-1. The host has multiple NUMA nodes (`numactl --hardware`)
-2. `enable_numa = true` is set in the Kata configuration
-3. `enable_vcpus_pinning = true` is set in the Kata configuration
-4. `static_sandbox_resource_mgmt = true` is set (so all vCPUs boot at start)
+1. `enable_numa = true` is set in the Kata configuration
+2. `enable_vcpus_pinning = true` is set in the Kata configuration
+3. `static_sandbox_resource_mgmt = true` is set (so all vCPUs boot at start)
+4. The guest topology was actually built — see
+   [Step 6.2](#62-check-the-shim-logs-for-numa-configuration)
 
-### NUMA pinning fallback warning
+### vCPU threads share their NUMA node instead of a CPU each
 
 **Symptom:** The shim logs show:
 
 ```
-NUMA node HostCPUs do not intersect sandbox CPUSet; falling back to full cpuset
+cannot give every vCPU a host CPU of its own; constraining vCPU threads to their NUMA node instead
+```
+
+and each vCPU thread's `Cpus_allowed_list` is a range rather than a single
+CPU.
+
+**Cause:** Either the sandbox has no exclusive CPUSet (`exclusive-cpuset` is
+`false` in the log fields, meaning `cpuManagerPolicy` is not `static` or the
+pod is not Guaranteed), or its CPUSet holds fewer CPUs than the VM has vCPUs.
+Pinning several vCPU threads to one host CPU would make them time-share it,
+so the runtime keeps them on their node and lets the host scheduler spread
+them.
+
+**Fix:** If you want one host CPU per vCPU, run the pod as Guaranteed QoS
+under `cpuManagerPolicy: static` (see
+[Step 2](#step-2-kubernetes-cpu-manager-policy)) and make sure its
+`limits.cpu` is at least the VM's vCPU count. Otherwise no action is needed —
+NUMA locality is preserved either way.
+
+### NUMA node lost its host locality
+
+**Symptom:** The shim logs show:
+
+```
+NUMA node HostCPUs do not intersect sandbox CPUSet; its vCPUs lose host NUMA locality
 ```
 
 **Cause:** The CPUs Kubernetes assigned to the pod do not overlap with the
-host CPUs on the NUMA node. This means NUMA locality is lost for that node.
+host CPUs of that NUMA node, so its vCPUs have to run on CPUs of other nodes.
 
 **Fix:** Verify that your `numa_mapping` matches the actual host topology:
 
@@ -612,7 +678,7 @@ EOF
 | `enable_numa` | `[hypervisor.qemu]` | `false` | Enable guest NUMA topology |
 | `numa_mapping` | `[hypervisor.qemu]` | `[]` | Map guest NUMA nodes to host nodes. Empty = auto-discover with right-sizing (small sandboxes collapse to one node); non-empty = honored verbatim |
 | `static_sandbox_resource_mgmt` | `[runtime]` | varies | Size VM at boot (required for NUMA) |
-| `enable_vcpus_pinning` | `[runtime]` | `false` | Pin vCPU threads to host CPUs (NUMA-aware when NUMA enabled) |
+| `enable_vcpus_pinning` | `[runtime]` | `false` | Bind vCPU threads to host CPUs (NUMA-aware when NUMA enabled) |
 
 ## Limitations
 
@@ -622,9 +688,12 @@ EOF
   CPU/memory hotplug).
 - The VM needs at least as many vCPUs as NUMA nodes. If fewer vCPUs are
   available, multi-NUMA is silently skipped.
-- vCPU pinning with NUMA works best with `cpuManagerPolicy: none` (the
-  default). Using `static` may restrict the pod's CPUSet to a single NUMA
-  node, preventing balanced pinning across nodes.
+- One host CPU per vCPU thread requires the pod to hold an exclusive CPUSet
+  with at least one CPU per vCPU, that is Guaranteed QoS under
+  `cpuManagerPolicy: static`. With any other combination the vCPU threads are
+  confined to their host NUMA node and share its CPUs. `static` in turn tends
+  to restrict the CPUSet to a single host NUMA node, so a multi-node guest
+  and per-vCPU pinning rarely come together.
 - Confidential guests (SEV-SNP, TDX) with NUMA require a QEMU patch
   ([accel/kvm: Fix kvm_convert_memory calls crossing memory regions](https://github.com/AMDESE/qemu/commit/6b0eaa20))
   to handle page conversions that span multiple NUMA memory backends.

--- a/docs/how-to/how-to-use-numa-with-kata.md
+++ b/docs/how-to/how-to-use-numa-with-kata.md
@@ -71,12 +71,14 @@ in turn decides how tightly Kata can place the sandbox's vCPU threads:
 | `cpuManagerPolicy` | Sandbox CPUSet | vCPU thread placement |
 |--------------------|----------------|-----------------------|
 | `none` (default) | none — the pod shares the node's CPUs | each vCPU thread is confined to the host CPUs of its guest NUMA node |
-| `static` (Guaranteed pods) | an exclusive set of host CPUs | each vCPU thread is pinned to a host CPU of its own within that set |
+| `static` (Guaranteed pods) | an exclusive set of host CPUs | each vCPU thread is pinned to a host CPU of its own within that set, and any vCPU beyond the set's size is confined to its node |
 
 Either way the guest's vCPUs and memory stay on the right host NUMA node,
 which is what NUMA support is about. What differs is the placement *within*
 the node: under `none` the host scheduler may move a vCPU thread between the
-CPUs of its node, under `static` each vCPU thread keeps one CPU to itself.
+CPUs of its node, under `static` the vCPU threads the reserved set can back
+keep a CPU each and the few left over — see the note on `default_vcpus`
+below — stay spread over their node.
 
 !!! warning "Why one thread per CPU needs `static`"
 
@@ -268,9 +270,21 @@ EOF
 
     QoS class only matters under `cpuManagerPolicy: static`, where a pod
     needs Guaranteed QoS — integer `cpu`, with `requests` equal to `limits`
-    for both CPU and memory — to be given host CPUs of its own and thus get
-    one host CPU per vCPU thread. Under `cpuManagerPolicy: none` no pod gets
-    an exclusive CPUSet, so every QoS class ends up with per-node affinity.
+    for both CPU and memory — to be given host CPUs of its own, and with them
+    a host CPU each for as many vCPU threads as those CPUs can back. Under
+    `cpuManagerPolicy: none` no pod gets an exclusive CPUSet, so every QoS
+    class ends up with per-node affinity.
+
+!!! note "`default_vcpus` and the pod's CPU limit"
+
+    Static sizing boots the guest with `default_vcpus` *on top of* the pod's
+    `limits.cpu`, while the kubelet reserves only the limit, so the guest
+    always holds a few more vCPUs than the pod holds host CPUs. There is no
+    CPU left for those extra vCPU threads to own, so they are confined to
+    their NUMA node and share its CPUs with the pinned ones. With
+    `default_vcpus = 1`, the pod above runs an 81 vCPU guest on the 80 CPUs
+    it owns: 80 threads with a CPU each, one floating over its node. Raising
+    `limits.cpu` does not change that, as it raises the vCPU count with it.
 
 ### 4.2 GPU passthrough pod with NUMA
 
@@ -387,16 +401,20 @@ $ for task in /proc/${QEMU_PID}/task/*; do
 ```
 
 On a 2-NUMA-node host with CPUs 0-7 on node 0 and 8-15 on node 1, a sandbox
-holding an exclusive CPUSet shows one CPU per thread:
+holding an exclusive CPUSet of CPUs 0,1,8,9 shows one CPU per thread for as
+many threads as that set can back, and the CPUs its own node holds in the set
+for whatever is left over — here the fifth vCPU that static sizing adds on top
+of the pod's CPU limit:
 
 ```
 CPU 0/KVM: 0
 CPU 1/KVM: 1
 CPU 2/KVM: 8
 CPU 3/KVM: 9
+CPU 4/KVM: 0,1
 ```
 
-Without an exclusive CPUSet, the threads show the CPU list of their guest
+Without an exclusive CPUSet, every thread shows the CPU list of its guest
 node instead:
 
 ```
@@ -407,8 +425,11 @@ CPU 3/KVM: 8-15
 ```
 
 Both are correct placements (see [Step 2](#step-2-kubernetes-cpu-manager-policy)).
-What should never appear is a thread whose list spans both host nodes, or two
-threads pinned to the same single CPU.
+What should never appear is two threads pinned to the same single CPU. A thread
+whose list spans both host nodes means its guest node maps to host CPUs the
+sandbox was not given: the runtime warns about that node
+(`its vCPUs lose host NUMA locality`) and leaves its threads on the whole
+CPUSet, which is all such a node has left.
 
 ### 6.2 Check the shim logs for NUMA configuration
 
@@ -528,11 +549,13 @@ When a VM is created with NUMA enabled, the runtime:
    per NUMA node.
 
 5. **Places vCPU threads** (when enabled): Each vCPU thread is bound to host
-   CPUs of the NUMA node its guest node maps to — to one host CPU of its own
-   when the sandbox holds an exclusive CPUSet with at least one CPU per vCPU,
-   to the node's CPU list otherwise. Right-sized single-node sandboxes also
-   go through this NUMA-aware path, so all vCPUs land on the chosen host NUMA
-   node's CPUs.
+   CPUs of the NUMA node its guest node maps to. When the sandbox holds a
+   CPUSet of its own, the vCPUs that CPUSet can back get a host CPU each,
+   their own node's first, and whichever vCPUs are left over get their node's
+   CPU list instead — so a guest with more vCPUs than the pod reserved CPUs
+   comes out part pinned, part masked. Without a CPUSet of its own every vCPU
+   gets its node's CPU list. Right-sized single-node sandboxes also go through
+   this NUMA-aware path, so all vCPUs land on the chosen host NUMA node's CPUs.
 
 6. **Validates VFIO devices**: Checks each cold-plugged device's host NUMA
    node against the guest topology and logs placement status.
@@ -615,23 +638,31 @@ started with.
 **Symptom:** The shim logs show:
 
 ```
-cannot give every vCPU a host CPU of its own; constraining vCPU threads to their NUMA node instead
+cannot give every vCPU a host CPU of its own; constraining the remaining vCPU threads to their NUMA node instead
 ```
 
-and each vCPU thread's `Cpus_allowed_list` is a range rather than a single
-CPU.
+and some vCPU threads' `Cpus_allowed_list` is a range rather than a single
+CPU. The `dedicated-cpus` log field says how many threads did get a CPU of
+their own.
 
 **Cause:** Either the sandbox has no exclusive CPUSet (`exclusive-cpuset` is
 `false` in the log fields, meaning `cpuManagerPolicy` is not `static` or the
-pod is not Guaranteed), or its CPUSet holds fewer CPUs than the VM has vCPUs.
-Pinning several vCPU threads to one host CPU would make them time-share it,
-so the runtime keeps them on their node and lets the host scheduler spread
-them.
+pod is not Guaranteed), in which case `dedicated-cpus` is `0`, or its CPUSet
+holds fewer CPUs than the VM has vCPUs, in which case the vCPUs the CPUSet
+can back keep a CPU each and the rest are confined to their node. Pinning
+two vCPU threads to one host CPU would make them time-share it for good, so
+the surplus threads are left to the host scheduler, which can move them to
+whichever CPU of the node has slack.
 
-**Fix:** If you want one host CPU per vCPU, run the pod as Guaranteed QoS
-under `cpuManagerPolicy: static` (see
-[Step 2](#step-2-kubernetes-cpu-manager-policy)) and make sure its
-`limits.cpu` is at least the VM's vCPU count. Otherwise no action is needed —
+**Fix:** For most sandboxes there is nothing to fix. A Guaranteed pod under
+`cpuManagerPolicy: static` is normally short by exactly `default_vcpus`,
+which static sizing adds on top of `limits.cpu` while the kubelet reserves
+only the limit, so `default_vcpus` threads float and the rest are pinned.
+Lowering `default_vcpus` shrinks the overhang but cannot remove it, as `0`
+means one vCPU. If `dedicated-cpus` is far below the vCPU count instead, the
+CPUSet itself is small: check that the pod is Guaranteed with an integer
+`cpu` (see [Step 2](#step-2-kubernetes-cpu-manager-policy)) and that CPU
+manager reservations (`reservedSystemCPUs`) left enough CPUs in the pool.
 NUMA locality is preserved either way.
 
 ### NUMA node lost its host locality
@@ -688,12 +719,13 @@ EOF
   CPU/memory hotplug).
 - The VM needs at least as many vCPUs as NUMA nodes. If fewer vCPUs are
   available, multi-NUMA is silently skipped.
-- One host CPU per vCPU thread requires the pod to hold an exclusive CPUSet
-  with at least one CPU per vCPU, that is Guaranteed QoS under
-  `cpuManagerPolicy: static`. With any other combination the vCPU threads are
-  confined to their host NUMA node and share its CPUs. `static` in turn tends
-  to restrict the CPUSet to a single host NUMA node, so a multi-node guest
-  and per-vCPU pinning rarely come together.
+- One host CPU per vCPU thread requires the pod to hold an exclusive CPUSet,
+  that is Guaranteed QoS under `cpuManagerPolicy: static`. Without one, the
+  vCPU threads are confined to their host NUMA node and share its CPUs; with
+  one that holds fewer CPUs than the guest has vCPUs, the vCPUs it can back
+  get a CPU each and the rest are confined to their node. `static` in turn
+  tends to restrict the CPUSet to a single host NUMA node, so a multi-node
+  guest and per-vCPU pinning rarely come together.
 - Confidential guests (SEV-SNP, TDX) with NUMA require a QEMU patch
   ([accel/kvm: Fix kvm_convert_memory calls crossing memory regions](https://github.com/AMDESE/qemu/commit/6b0eaa20))
   to handle page conversions that span multiple NUMA memory backends.

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -3031,18 +3031,28 @@ func (s *Sandbox) fetchContainers(ctx context.Context) error {
 // is set to true.
 //
 // When NUMA topology is configured (GuestNUMANodes is non-empty), vCPU
-// threads are pinned to host CPUs belonging to the same host NUMA node
-// as the vCPU's assigned guest NUMA node, preserving memory locality.
-// vCPUs are distributed proportionally across nodes and each vCPU is
-// pinned round-robin to the host CPUs within its NUMA node; the 1:1
-// count equality check does not apply.
+// threads are constrained to host CPUs belonging to the same host NUMA
+// node as the vCPU's assigned guest NUMA node, preserving memory
+// locality. Two levels of constraint exist:
 //
-// This is true for both multi-node sandboxes and right-sized
-// single-node sandboxes: when buildNUMATopology()/maybeRightSizeAutoNUMA
+//   - 1:1 pinning, each vCPU thread on a host CPU of its own that no
+//     other vCPU of the sandbox uses. This requires the sandbox to own
+//     its CPUSet exclusively (Guaranteed pod under the kubelet static
+//     CPU manager policy), otherwise sandboxes would pin to each other's
+//     CPUs, and it requires that CPUSet to hold at least one CPU per
+//     vCPU.
+//   - NUMA node affinity, each vCPU thread free to run on any host CPU
+//     of its guest node. This is the fallback whenever 1:1 pinning is
+//     not safe or not possible: the host scheduler balances the threads
+//     within the node instead of several of them time-sharing one CPU.
+//
+// Both apply to multi-node sandboxes and to right-sized single-node
+// sandboxes alike: when buildNUMATopology()/maybeRightSizeAutoNUMA
 // collapses the topology to one node, that single node still carries a
 // meaningful HostCPUs subset (the CPUs of the chosen host NUMA node),
-// and pinning to that subset is what makes right-sizing actually deliver
-// host-thread locality, not just guest-topology locality.
+// and constraining threads to that subset is what makes right-sizing
+// actually deliver host-thread locality, not just guest-topology
+// locality.
 //
 // In the non-NUMA path (GuestNUMANodes is empty, e.g. enable_numa=false),
 // it fetches the sandbox's number of vCPU threads and number of CPUs in
@@ -3101,37 +3111,38 @@ func (s *Sandbox) checkVCPUsPinning(ctx context.Context) error {
 
 	numaNodes := s.config.HypervisorConfig.GuestNUMANodes
 
-	if len(cpuSetSlice) == 0 {
-		if len(numaNodes) >= 1 {
-			// No cpuset constraint (e.g. ctr without k8s, or a Burstable
-			// pod with cpuManagerPolicy=none). Build an effective cpuset
-			// from the NUMA nodes' HostCPUs so pinning works using the
-			// (possibly right-sized) host NUMA topology. Even a single
-			// NUMA node here meaningfully constrains pinning to that
-			// node's host CPUs.
-			for _, gn := range numaNodes {
-				hostCPUs, err := cpuset.Parse(gn.HostCPUs)
-				if err != nil {
-					continue
-				}
-				cpuSet = cpuSet.Union(hostCPUs)
-			}
-			cpuSetSlice = cpuSet.ToSlice()
-			if len(cpuSetSlice) == 0 {
-				s.Logger().Warn("sandbox CPUSet is empty and cannot derive from NUMA HostCPUs; skipping vCPU pinning")
-				s.isVCPUsPinningOn = false
-				return nil
-			}
-			s.Logger().WithField("effective-cpuset", cpuSet.String()).Debug("derived cpuset from NUMA HostCPUs for pinning")
-		} else {
+	// An empty CPUSet means no cpuset was assigned to this sandbox alone
+	// (e.g. ctr without k8s, or any pod while the kubelet runs
+	// cpuManagerPolicy=none). The CPUs derived below are then shared with
+	// every other sandbox on the host, so they may only be used as a NUMA
+	// affinity mask, never as exclusive per-vCPU pins.
+	exclusiveCPUSet := len(cpuSetSlice) != 0
+
+	if !exclusiveCPUSet {
+		if len(numaNodes) == 0 {
 			s.Logger().Warn("sandbox CPUSet is empty; skipping vCPU pinning")
 			s.isVCPUsPinningOn = false
 			return nil
 		}
+
+		for _, gn := range numaNodes {
+			hostCPUs, err := cpuset.Parse(gn.HostCPUs)
+			if err != nil {
+				continue
+			}
+			cpuSet = cpuSet.Union(hostCPUs)
+		}
+		cpuSetSlice = cpuSet.ToSlice()
+		if len(cpuSetSlice) == 0 {
+			s.Logger().Warn("sandbox CPUSet is empty and cannot derive from NUMA HostCPUs; skipping vCPU pinning")
+			s.isVCPUsPinningOn = false
+			return nil
+		}
+		s.Logger().WithField("effective-cpuset", cpuSet.String()).Debug("derived cpuset from NUMA HostCPUs for NUMA affinity")
 	}
 
 	if len(numaNodes) >= 1 {
-		return s.checkVCPUsPinningNUMA(ctx, vCPUThreadsMap, numaNodes, cpuSetSlice)
+		return s.checkVCPUsPinningNUMA(ctx, vCPUThreadsMap, numaNodes, cpuSetSlice, exclusiveCPUSet)
 	}
 
 	numVCPUs, numCPUs := len(vCPUThreadsMap.vcpus), len(cpuSetSlice)
@@ -3154,13 +3165,18 @@ func (s *Sandbox) checkVCPUsPinning(ctx context.Context) error {
 	return nil
 }
 
-// checkVCPUsPinningNUMA pins vCPU threads to host CPUs that belong to the
+// checkVCPUsPinningNUMA binds vCPU threads to host CPUs that belong to the
 // same NUMA node as the vCPU's guest NUMA node assignment. vCPUs are
 // distributed proportionally to the host CPU count per NUMA node
 // (matching buildNUMATopology). It handles any non-empty numaNodes
 // slice — including the right-sized single-node case, where every vCPU
-// is pinned within the single chosen host NUMA node's CPU set.
-func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap VcpuThreadIDs, numaNodes []types.GuestNUMANode, cpuSetSlice []int) error {
+// is bound within the single chosen host NUMA node's CPU set.
+//
+// exclusiveCPUSet tells whether cpuSetSlice belongs to this sandbox alone.
+// Only then may a vCPU thread be given a host CPU of its own; otherwise,
+// and whenever the CPUs are too few to give each vCPU a distinct one, the
+// threads get their NUMA node's CPUs as an affinity mask instead.
+func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap VcpuThreadIDs, numaNodes []types.GuestNUMANode, cpuSetSlice []int, exclusiveCPUSet bool) error {
 	numVCPUs := uint32(len(vCPUThreadsMap.vcpus))
 	numNodes := uint32(len(numaNodes))
 
@@ -3188,48 +3204,141 @@ func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap Vcpu
 		}
 	}
 
-	cpuSetAll := cpuset.NewCPUSet(cpuSetSlice...)
+	nodeCPUs, detachedNodes, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	if err != nil {
+		return err
+	}
+	for _, i := range detachedNodes {
+		s.Logger().WithFields(logrus.Fields{
+			"numa-node":    i,
+			"host-cpus":    numaNodes[i].HostCPUs,
+			"sandbox-cpus": cpuSetSlice,
+		}).Warn("NUMA node HostCPUs do not intersect sandbox CPUSet; its vCPUs lose host NUMA locality")
+	}
 
-	var cpuOffset uint32
-	for i, gn := range numaNodes {
-		hostCPUs, err := cpuset.Parse(gn.HostCPUs)
-		if err != nil {
-			return fmt.Errorf("failed to parse HostCPUs for NUMA node %d: %v", i, err)
-		}
-		allowedCPUs := hostCPUs.Intersection(cpuSetAll).ToSlice()
-		if len(allowedCPUs) == 0 {
-			s.Logger().WithFields(logrus.Fields{
-				"numa-node":    i,
-				"host-cpus":    gn.HostCPUs,
-				"sandbox-cpus": cpuSetSlice,
-			}).Warn("NUMA node HostCPUs do not intersect sandbox CPUSet; pinning vCPUs to full cpuset for this node")
-			allowedCPUs = cpuSetSlice
-		}
+	affinities, pinned := numaAffinityPlan(nodeCPUs, vcpusPerNode, cpuSetSlice, exclusiveCPUSet)
+	if !pinned {
+		s.Logger().WithFields(logrus.Fields{
+			"vcpus":            numVCPUs,
+			"sandbox-cpus":     cpuSetSlice,
+			"exclusive-cpuset": exclusiveCPUSet,
+		}).Info("cannot give every vCPU a host CPU of its own; constraining vCPU threads to their NUMA node instead")
+	}
 
-		startVCPU := cpuOffset
-		endVCPU := startVCPU + vcpusPerNode[i]
-		cpuOffset = endVCPU
-
-		for vcpuIdx := startVCPU; vcpuIdx < endVCPU; vcpuIdx++ {
-			tid, ok := vCPUThreadsMap.vcpus[int(vcpuIdx)]
-			if !ok {
-				if err := s.resetVCPUsPinning(ctx, vCPUThreadsMap, cpuSetSlice); err != nil {
-					return err
-				}
-				return fmt.Errorf("missing vcpu thread id for vcpu index %d", vcpuIdx)
+	for vcpuIdx, allowedCPUs := range affinities {
+		tid, ok := vCPUThreadsMap.vcpus[vcpuIdx]
+		if !ok {
+			if err := s.resetVCPUsPinning(ctx, vCPUThreadsMap, cpuSetSlice); err != nil {
+				return err
 			}
-			pinIdx := int(vcpuIdx-startVCPU) % len(allowedCPUs)
-			if err := resCtrl.SetThreadAffinity(tid, allowedCPUs[pinIdx:pinIdx+1]); err != nil {
-				if err := s.resetVCPUsPinning(ctx, vCPUThreadsMap, cpuSetSlice); err != nil {
-					return err
-				}
-				return fmt.Errorf("failed to set vcpu thread %d affinity to cpu %d (NUMA node %d): %v", tid, allowedCPUs[pinIdx], i, err)
+			return fmt.Errorf("missing vcpu thread id for vcpu index %d", vcpuIdx)
+		}
+		if err := resCtrl.SetThreadAffinity(tid, allowedCPUs); err != nil {
+			if err := s.resetVCPUsPinning(ctx, vCPUThreadsMap, cpuSetSlice); err != nil {
+				return err
 			}
+			return fmt.Errorf("failed to set vcpu thread %d affinity to cpus %v: %v", tid, allowedCPUs, err)
 		}
 	}
 
+	// The threads no longer run with the affinity they were started with,
+	// whether they got a CPU each or a node mask, so a later pass that can
+	// no longer honour NUMA placement has to restore the sandbox CPUSet.
 	s.isVCPUsPinningOn = true
 	return nil
+}
+
+// numaNodeCPUs returns, for each guest NUMA node, the host CPUs of that node
+// the sandbox is allowed to use, that is its HostCPUs intersected with
+// cpuSetSlice. A node whose host CPUs lie entirely outside cpuSetSlice gets
+// the whole cpuset — it has no locality left to preserve — and its index is
+// returned alongside so the caller can log it.
+func numaNodeCPUs(numaNodes []types.GuestNUMANode, cpuSetSlice []int) ([][]int, []int, error) {
+	cpuSetAll := cpuset.NewCPUSet(cpuSetSlice...)
+
+	nodeCPUs := make([][]int, len(numaNodes))
+	var detachedNodes []int
+	for i, gn := range numaNodes {
+		hostCPUs, err := cpuset.Parse(gn.HostCPUs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse HostCPUs for NUMA node %d: %v", i, err)
+		}
+		nodeCPUs[i] = hostCPUs.Intersection(cpuSetAll).ToSlice()
+		if len(nodeCPUs[i]) == 0 {
+			nodeCPUs[i] = cpuSetSlice
+			detachedNodes = append(detachedNodes, i)
+		}
+	}
+
+	return nodeCPUs, detachedNodes, nil
+}
+
+// numaAffinityPlan returns the host CPUs each vCPU thread may run on,
+// indexed by vCPU number. vCPUs are laid out over the guest NUMA nodes in
+// order, vcpusPerNode[i] of them on node i, the same way the -numa cpus=
+// ranges are built for QEMU.
+//
+// The plan gives every vCPU a host CPU of its own, taken from its node and
+// falling back to the rest of the cpuset once the node runs out, and reports
+// true. When the sandbox does not own the cpuset, or when the cpuset holds
+// fewer usable CPUs than there are vCPUs, no such assignment is safe: every
+// vCPU then gets its node's CPUs as a mask and the plan reports false.
+func numaAffinityPlan(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []int, exclusiveCPUSet bool) ([][]int, bool) {
+	var numVCPUs uint32
+	for _, n := range vcpusPerNode {
+		numVCPUs += n
+	}
+
+	if exclusiveCPUSet {
+		if pins, ok := assignDistinctCPUs(nodeCPUs, vcpusPerNode, cpuSetSlice); ok {
+			affinities := make([][]int, numVCPUs)
+			for vcpuIdx, cpu := range pins {
+				affinities[vcpuIdx] = []int{cpu}
+			}
+			return affinities, true
+		}
+	}
+
+	affinities := make([][]int, 0, numVCPUs)
+	for i := range nodeCPUs {
+		for j := uint32(0); j < vcpusPerNode[i]; j++ {
+			affinities = append(affinities, nodeCPUs[i])
+		}
+	}
+	return affinities, false
+}
+
+// assignDistinctCPUs hands each vCPU a host CPU no other vCPU of the sandbox
+// uses, preferring the CPUs of the vCPU's own NUMA node and borrowing from
+// the rest of the cpuset only once its node has none left. It reports false,
+// and no assignment, when the cpuset cannot back every vCPU with a CPU of
+// its own.
+func assignDistinctCPUs(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []int) ([]int, bool) {
+	used := make(map[int]bool, len(cpuSetSlice))
+	take := func(candidates []int) (int, bool) {
+		for _, cpu := range candidates {
+			if !used[cpu] {
+				used[cpu] = true
+				return cpu, true
+			}
+		}
+		return 0, false
+	}
+
+	var pins []int
+	for i := range nodeCPUs {
+		for j := uint32(0); j < vcpusPerNode[i]; j++ {
+			cpu, ok := take(nodeCPUs[i])
+			if !ok {
+				if cpu, ok = take(cpuSetSlice); !ok {
+					return nil, false
+				}
+			}
+			pins = append(pins, cpu)
+		}
+	}
+
+	return pins, true
 }
 
 // resetVCPUsPinning cancels current pinning and restores default random vCPU threads scheduling

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -3039,12 +3039,19 @@ func (s *Sandbox) fetchContainers(ctx context.Context) error {
 //     other vCPU of the sandbox uses. This requires the sandbox to own
 //     its CPUSet exclusively (Guaranteed pod under the kubelet static
 //     CPU manager policy), otherwise sandboxes would pin to each other's
-//     CPUs, and it requires that CPUSet to hold at least one CPU per
-//     vCPU.
+//     CPUs, and it requires a free CPU to be left in that CPUSet.
 //   - NUMA node affinity, each vCPU thread free to run on any host CPU
-//     of its guest node. This is the fallback whenever 1:1 pinning is
-//     not safe or not possible: the host scheduler balances the threads
-//     within the node instead of several of them time-sharing one CPU.
+//     of its guest node. This is what a vCPU gets when pinning is not
+//     safe (a shared CPUSet) or when the CPUSet has no CPU left for it:
+//     the host scheduler places the thread wherever there is slack
+//     within its node, rather than the runtime forcing it to time-share
+//     one CPU with a vCPU that owns it.
+//
+// The two mix: a CPUSet holding fewer CPUs than the sandbox has vCPUs
+// pins as many vCPU threads as it can and constrains the rest to their
+// node. That is the common shape under static sizing, where the guest
+// boots with default_vcpus on top of the pod's CPU limit while the
+// kubelet reserves only the limit.
 //
 // Both apply to multi-node sandboxes and to right-sized single-node
 // sandboxes alike: when buildNUMATopology()/maybeRightSizeAutoNUMA
@@ -3174,8 +3181,8 @@ func (s *Sandbox) checkVCPUsPinning(ctx context.Context) error {
 //
 // exclusiveCPUSet tells whether cpuSetSlice belongs to this sandbox alone.
 // Only then may a vCPU thread be given a host CPU of its own; otherwise,
-// and whenever the CPUs are too few to give each vCPU a distinct one, the
-// threads get their NUMA node's CPUs as an affinity mask instead.
+// and for the vCPUs left over once the CPUs run out, the threads get
+// their NUMA node's CPUs as an affinity mask instead.
 func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap VcpuThreadIDs, numaNodes []types.GuestNUMANode, cpuSetSlice []int, exclusiveCPUSet bool) error {
 	numVCPUs := uint32(len(vCPUThreadsMap.vcpus))
 	numNodes := uint32(len(numaNodes))
@@ -3216,13 +3223,14 @@ func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap Vcpu
 		}).Warn("NUMA node HostCPUs do not intersect sandbox CPUSet; its vCPUs lose host NUMA locality")
 	}
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, vcpusPerNode, cpuSetSlice, exclusiveCPUSet)
-	if !pinned {
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, vcpusPerNode, cpuSetSlice, exclusiveCPUSet)
+	if dedicated < len(affinities) {
 		s.Logger().WithFields(logrus.Fields{
 			"vcpus":            numVCPUs,
+			"dedicated-cpus":   dedicated,
 			"sandbox-cpus":     cpuSetSlice,
 			"exclusive-cpuset": exclusiveCPUSet,
-		}).Info("cannot give every vCPU a host CPU of its own; constraining vCPU threads to their NUMA node instead")
+		}).Info("cannot give every vCPU a host CPU of its own; constraining the remaining vCPU threads to their NUMA node instead")
 	}
 
 	for vcpuIdx, allowedCPUs := range affinities {
@@ -3250,8 +3258,9 @@ func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap Vcpu
 
 // numaNodeCPUs returns, for each guest NUMA node, the host CPUs of that node
 // the sandbox is allowed to use, that is its HostCPUs intersected with
-// cpuSetSlice. A node whose host CPUs lie entirely outside cpuSetSlice gets
-// the whole cpuset — it has no locality left to preserve — and its index is
+// cpuSetSlice. A node whose host CPUs lie entirely outside cpuSetSlice gets no
+// CPUs at all: it has no locality left to preserve, and the CPUs it could take
+// are all local to some other node, which is to be served first. Its index is
 // returned alongside so the caller can log it.
 func numaNodeCPUs(numaNodes []types.GuestNUMANode, cpuSetSlice []int) ([][]int, []int, error) {
 	cpuSetAll := cpuset.NewCPUSet(cpuSetSlice...)
@@ -3265,7 +3274,6 @@ func numaNodeCPUs(numaNodes []types.GuestNUMANode, cpuSetSlice []int) ([][]int, 
 		}
 		nodeCPUs[i] = hostCPUs.Intersection(cpuSetAll).ToSlice()
 		if len(nodeCPUs[i]) == 0 {
-			nodeCPUs[i] = cpuSetSlice
 			detachedNodes = append(detachedNodes, i)
 		}
 	}
@@ -3278,42 +3286,33 @@ func numaNodeCPUs(numaNodes []types.GuestNUMANode, cpuSetSlice []int) ([][]int, 
 // order, vcpusPerNode[i] of them on node i, the same way the -numa cpus=
 // ranges are built for QEMU.
 //
-// The plan gives every vCPU a host CPU of its own, taken from its node and
-// falling back to the rest of the cpuset once the node runs out, and reports
-// true. When the sandbox does not own the cpuset, or when the cpuset holds
-// fewer usable CPUs than there are vCPUs, no such assignment is safe: every
-// vCPU then gets its node's CPUs as a mask and the plan reports false.
-func numaAffinityPlan(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []int, exclusiveCPUSet bool) ([][]int, bool) {
+// A vCPU gets a host CPU of its own for as long as the sandbox owns the cpuset
+// and a CPU is still free, its own node's first and another node's only once
+// every node has served its own vCPUs. The vCPUs left after that get their
+// node's CPUs as a mask: sharing chosen by the host scheduler, which can move
+// such a thread to whichever CPU of the node has slack, rather than the fixed
+// pairing that pinning two vCPUs to one CPU would impose. The plan reports how
+// many vCPUs did get a CPU of their own, zero when the cpuset is shared.
+//
+// A node with no CPUs of its own in the cpuset waits for both: it has nothing
+// to serve its vCPUs from, so they borrow with the rest and fall back to the
+// whole cpuset, the only affinity that means anything to them.
+func numaAffinityPlan(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []int, exclusiveCPUSet bool) ([][]int, int) {
 	var numVCPUs uint32
 	for _, n := range vcpusPerNode {
 		numVCPUs += n
 	}
 
-	if exclusiveCPUSet {
-		if pins, ok := assignDistinctCPUs(nodeCPUs, vcpusPerNode, cpuSetSlice); ok {
-			affinities := make([][]int, numVCPUs)
-			for vcpuIdx, cpu := range pins {
-				affinities[vcpuIdx] = []int{cpu}
+	if !exclusiveCPUSet {
+		affinities := make([][]int, 0, numVCPUs)
+		for i := range nodeCPUs {
+			for j := uint32(0); j < vcpusPerNode[i]; j++ {
+				affinities = append(affinities, nodeAffinityMask(nodeCPUs[i], cpuSetSlice))
 			}
-			return affinities, true
 		}
+		return affinities, 0
 	}
 
-	affinities := make([][]int, 0, numVCPUs)
-	for i := range nodeCPUs {
-		for j := uint32(0); j < vcpusPerNode[i]; j++ {
-			affinities = append(affinities, nodeCPUs[i])
-		}
-	}
-	return affinities, false
-}
-
-// assignDistinctCPUs hands each vCPU a host CPU no other vCPU of the sandbox
-// uses, preferring the CPUs of the vCPU's own NUMA node and borrowing from
-// the rest of the cpuset only once its node has none left. It reports false,
-// and no assignment, when the cpuset cannot back every vCPU with a CPU of
-// its own.
-func assignDistinctCPUs(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []int) ([]int, bool) {
 	used := make(map[int]bool, len(cpuSetSlice))
 	take := func(candidates []int) (int, bool) {
 		for _, cpu := range candidates {
@@ -3325,20 +3324,49 @@ func assignDistinctCPUs(nodeCPUs [][]int, vcpusPerNode []uint32, cpuSetSlice []i
 		return 0, false
 	}
 
-	var pins []int
+	// Serve every node from its own CPUs first. A node that ran out cannot
+	// be given a CPU of another node yet: that node may still need it for a
+	// vCPU of its own, and a remote pin is worse than a local one for both.
+	type pending struct{ vcpu, node int }
+	var deferred []pending
+	affinities := make([][]int, numVCPUs)
+	dedicated := 0
+	vcpuIdx := 0
 	for i := range nodeCPUs {
 		for j := uint32(0); j < vcpusPerNode[i]; j++ {
-			cpu, ok := take(nodeCPUs[i])
-			if !ok {
-				if cpu, ok = take(cpuSetSlice); !ok {
-					return nil, false
-				}
+			if cpu, ok := take(nodeCPUs[i]); ok {
+				affinities[vcpuIdx] = []int{cpu}
+				dedicated++
+			} else {
+				deferred = append(deferred, pending{vcpu: vcpuIdx, node: i})
 			}
-			pins = append(pins, cpu)
+			vcpuIdx++
 		}
 	}
 
-	return pins, true
+	// What no node claimed is genuine surplus, and a remote CPU of its own
+	// still beats sharing for a vCPU whose node is crowded. Whoever is left
+	// once that runs out keeps its node, where the scheduler can at least
+	// place it on the CPUs its memory is local to.
+	for _, p := range deferred {
+		if cpu, ok := take(cpuSetSlice); ok {
+			affinities[p.vcpu] = []int{cpu}
+			dedicated++
+			continue
+		}
+		affinities[p.vcpu] = nodeAffinityMask(nodeCPUs[p.node], cpuSetSlice)
+	}
+
+	return affinities, dedicated
+}
+
+// nodeAffinityMask returns the CPUs a vCPU thread that got no CPU of its own
+// may run on: its node's, or the whole cpuset when its node has none there.
+func nodeAffinityMask(nodeCPUs []int, cpuSetSlice []int) []int {
+	if len(nodeCPUs) == 0 {
+		return cpuSetSlice
+	}
+	return nodeCPUs
 }
 
 // resetVCPUsPinning cancels current pinning and restores default random vCPU threads scheduling

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1752,8 +1752,8 @@ func TestNUMAAffinityPlanPinsEachVCPUToItsOwnNodeCPU(t *testing.T) {
 	assert.NoError(err)
 	assert.Empty(detached)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{4, 4}, cpuSetSlice, true)
-	assert.True(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{4, 4}, cpuSetSlice, true)
+	assert.Equal(8, dedicated)
 	assert.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7}, assertDistinctPins(t, affinities))
 }
 
@@ -1771,8 +1771,8 @@ func TestNUMAAffinityPlanSharedHostNode(t *testing.T) {
 	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
 	assert.NoError(err)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, true)
-	assert.True(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, true)
+	assert.Equal(4, dedicated)
 	assert.Equal([]int{0, 1, 2, 3}, assertDistinctPins(t, affinities))
 }
 
@@ -1792,17 +1792,18 @@ func TestNUMAAffinityPlanBorrowsFromOtherNodes(t *testing.T) {
 	assert.NoError(err)
 	assert.Empty(detached)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
-	assert.True(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
+	assert.Equal(6, dedicated)
 	pins := assertDistinctPins(t, affinities)
 	assert.Equal([]int{0, 1}, pins[:2], "node 0 vCPUs should stay on node 0 CPUs")
 	assert.Subset([]int{4, 5, 6, 7}, pins[2:])
 }
 
-// Without enough CPUs for a 1:1 assignment, the threads get their node as an
-// affinity mask: the host scheduler spreads them instead of several of them
-// time-sharing a single CPU.
-func TestNUMAAffinityPlanFallsBackToNodeMask(t *testing.T) {
+// Without enough CPUs for every vCPU, the ones the cpuset can back keep a CPU
+// of their own and the rest get their node as an affinity mask: the host
+// scheduler places them where there is slack, instead of the runtime pinning
+// two vCPUs onto one CPU and leaving them to time-share it.
+func TestNUMAAffinityPlanPinsWhatFitsAndMasksTheRest(t *testing.T) {
 	assert := assert.New(t)
 
 	numaNodes := []types.GuestNUMANode{
@@ -1814,11 +1815,37 @@ func TestNUMAAffinityPlanFallsBackToNodeMask(t *testing.T) {
 	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
 	assert.NoError(err)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
-	assert.False(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
+	assert.Equal(4, dedicated)
 	assert.Equal([][]int{
-		{0, 1}, {0, 1}, {0, 1},
-		{2, 3}, {2, 3}, {2, 3},
+		{0}, {1}, {0, 1},
+		{2}, {3}, {2, 3},
+	}, affinities)
+}
+
+// Static sizing boots the guest with default_vcpus on top of the pod's CPU
+// limit, while the kubelet reserves only the limit, so a Guaranteed pod
+// asking for 8 CPUs runs a 9 vCPU guest. The extra vCPU must not cost the
+// other eight their own CPU.
+func TestNUMAAffinityPlanOneVCPUMoreThanCPUs(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3, 4, 5, 6, 7}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{5, 4}, cpuSetSlice, true)
+	assert.Equal(8, dedicated)
+	// The vCPU node 0 cannot back keeps node 0, rather than taking a CPU of
+	// node 1 that node 1's own vCPUs still need.
+	assert.Equal([][]int{
+		{0}, {1}, {2}, {3}, {0, 1, 2, 3},
+		{4}, {5}, {6}, {7},
 	}, affinities)
 }
 
@@ -1837,8 +1864,8 @@ func TestNUMAAffinityPlanNonExclusiveCPUSet(t *testing.T) {
 	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
 	assert.NoError(err)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, false)
-	assert.False(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, false)
+	assert.Zero(dedicated)
 	assert.Equal([][]int{
 		{0, 1, 2, 3}, {0, 1, 2, 3},
 		{4, 5, 6, 7}, {4, 5, 6, 7},
@@ -1858,8 +1885,8 @@ func TestNUMAAffinityPlanSkipsNodesWithoutVCPUs(t *testing.T) {
 	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
 	assert.NoError(err)
 
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{1, 0}, cpuSetSlice, true)
-	assert.True(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{1, 0}, cpuSetSlice, true)
+	assert.Equal(1, dedicated)
 	assert.Equal([][]int{{0}}, affinities)
 }
 
@@ -1876,13 +1903,58 @@ func TestNUMANodeCPUsDetachedNode(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]int{1}, detached)
 	assert.Equal([]int{0, 1, 2, 3}, nodeCPUs[0])
-	assert.Equal(cpuSetSlice, nodeCPUs[1])
+	assert.Empty(nodeCPUs[1])
 
 	// A node with no CPUs of its own inside the cpuset must still not push
 	// its vCPUs onto CPUs another node's vCPUs already hold.
-	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 2}, cpuSetSlice, true)
-	assert.True(pinned)
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{3, 2}, cpuSetSlice, true)
+	assert.Equal(5, dedicated)
 	assert.Equal([]int{0, 1, 2, 3, 4}, assertDistinctPins(t, affinities))
+}
+
+// A node whose CPUs are all outside the cpuset has nothing to serve its vCPUs
+// from, and the CPUs it could reach are another node's. Taking them before that
+// node has served its own vCPUs would spend the only locality left in the
+// sandbox, so a detached node waits its turn even when it comes first.
+func TestNUMAAffinityPlanDetachedNodeYieldsToALocalNode(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "8-11"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	cpuSetSlice := []int{4, 5, 6, 7}
+
+	nodeCPUs, detached, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+	assert.Equal([]int{0}, detached)
+
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{2, 4}, cpuSetSlice, true)
+	assert.Equal(4, dedicated)
+	assert.Equal([][]int{
+		{4, 5, 6, 7}, {4, 5, 6, 7},
+		{4}, {5}, {6}, {7},
+	}, affinities)
+}
+
+// The whole cpuset is the only affinity that means anything to a detached
+// node's vCPUs when there is no CPU left for them, and a shared cpuset gives
+// them nothing else either.
+func TestNUMAAffinityPlanDetachedNodeNonExclusiveCPUSet(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "8-11"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, dedicated := numaAffinityPlan(nodeCPUs, []uint32{1, 1}, cpuSetSlice, false)
+	assert.Zero(dedicated)
+	assert.Equal([][]int{{0, 1, 2, 3}, {0, 1, 2, 3}}, affinities)
 }
 
 func TestHotplugVfioNetworkDeviceAlreadyAttached(t *testing.T) {

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1695,7 +1695,7 @@ func TestCheckVCPUsPinningNUMAMemoryOnly(t *testing.T) {
 		{HostNodes: "0", HostCPUs: "0-3"},
 		{HostNodes: "1", HostCPUs: "4-7"},
 	}
-	err := s.checkVCPUsPinningNUMA(context.Background(), vCPUThreadsMap, numaNodes, []int{0, 1, 2, 3, 4, 5, 6, 7})
+	err := s.checkVCPUsPinningNUMA(context.Background(), vCPUThreadsMap, numaNodes, []int{0, 1, 2, 3, 4, 5, 6, 7}, true)
 	if err != nil {
 		// The only permissible failure here is a low-level affinity syscall
 		// error (no real thread in the test process).  A NUMA-topology error
@@ -1715,9 +1715,174 @@ func TestCheckVCPUsPinningNUMABadHostCPUs(t *testing.T) {
 		{HostNodes: "0", HostCPUs: "not-valid"},
 		{HostNodes: "1", HostCPUs: "4-7"},
 	}
-	err := s.checkVCPUsPinningNUMA(context.Background(), vCPUThreadsMap, numaNodes, []int{0, 1, 2, 3, 4, 5, 6, 7})
+	err := s.checkVCPUsPinningNUMA(context.Background(), vCPUThreadsMap, numaNodes, []int{0, 1, 2, 3, 4, 5, 6, 7}, true)
 	assert.Error(err)
 	assert.Contains(err.Error(), "failed to parse HostCPUs")
+}
+
+// assertDistinctPins checks that a plan gives every vCPU exactly one host
+// CPU and that no host CPU is handed out twice — two vCPU threads hard-pinned
+// to one host CPU each get about half of it while other CPUs sit idle.
+func assertDistinctPins(t *testing.T, affinities [][]int) []int {
+	t.Helper()
+	assert := assert.New(t)
+
+	pins := make([]int, 0, len(affinities))
+	seen := make(map[int]bool, len(affinities))
+	for vcpuIdx, cpus := range affinities {
+		assert.Len(cpus, 1, "vcpu %d is not pinned to a single host CPU", vcpuIdx)
+		assert.False(seen[cpus[0]], "host CPU %d pinned to more than one vcpu", cpus[0])
+		seen[cpus[0]] = true
+		pins = append(pins, cpus[0])
+	}
+
+	return pins
+}
+
+func TestNUMAAffinityPlanPinsEachVCPUToItsOwnNodeCPU(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3, 4, 5, 6, 7}
+
+	nodeCPUs, detached, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+	assert.Empty(detached)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{4, 4}, cpuSetSlice, true)
+	assert.True(pinned)
+	assert.Equal([]int{0, 1, 2, 3, 4, 5, 6, 7}, assertDistinctPins(t, affinities))
+}
+
+// Two guest nodes mapped onto the same host node (numa_mapping = ["0", "0"])
+// used to make a sandbox pin its own vCPUs in pairs: 0 1 0 1.
+func TestNUMAAffinityPlanSharedHostNode(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "0", HostCPUs: "0-3"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, true)
+	assert.True(pinned)
+	assert.Equal([]int{0, 1, 2, 3}, assertDistinctPins(t, affinities))
+}
+
+// A node holding fewer cpuset CPUs than the vCPUs assigned to it used to wrap
+// around its own CPU list; the surplus vCPUs must borrow unused CPUs instead.
+func TestNUMAAffinityPlanBorrowsFromOtherNodes(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	// The kubelet handed the sandbox only two CPUs of host node 0.
+	cpuSetSlice := []int{0, 1, 4, 5, 6, 7}
+
+	nodeCPUs, detached, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+	assert.Empty(detached)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
+	assert.True(pinned)
+	pins := assertDistinctPins(t, affinities)
+	assert.Equal([]int{0, 1}, pins[:2], "node 0 vCPUs should stay on node 0 CPUs")
+	assert.Subset([]int{4, 5, 6, 7}, pins[2:])
+}
+
+// Without enough CPUs for a 1:1 assignment, the threads get their node as an
+// affinity mask: the host scheduler spreads them instead of several of them
+// time-sharing a single CPU.
+func TestNUMAAffinityPlanFallsBackToNodeMask(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-1"},
+		{HostNodes: "1", HostCPUs: "2-3"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 3}, cpuSetSlice, true)
+	assert.False(pinned)
+	assert.Equal([][]int{
+		{0, 1}, {0, 1}, {0, 1},
+		{2, 3}, {2, 3}, {2, 3},
+	}, affinities)
+}
+
+// A cpuset the sandbox does not own alone (cpuManagerPolicy=none) is shared
+// with every other sandbox on the host, so pinning to single CPUs would make
+// all of them land on the same ones.
+func TestNUMAAffinityPlanNonExclusiveCPUSet(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3, 4, 5, 6, 7}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{2, 2}, cpuSetSlice, false)
+	assert.False(pinned)
+	assert.Equal([][]int{
+		{0, 1, 2, 3}, {0, 1, 2, 3},
+		{4, 5, 6, 7}, {4, 5, 6, 7},
+	}, affinities)
+}
+
+// Memory-only nodes carry no vCPU and must not consume any host CPU.
+func TestNUMAAffinityPlanSkipsNodesWithoutVCPUs(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "4-7"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3, 4, 5, 6, 7}
+
+	nodeCPUs, _, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{1, 0}, cpuSetSlice, true)
+	assert.True(pinned)
+	assert.Equal([][]int{{0}}, affinities)
+}
+
+func TestNUMANodeCPUsDetachedNode(t *testing.T) {
+	assert := assert.New(t)
+
+	numaNodes := []types.GuestNUMANode{
+		{HostNodes: "0", HostCPUs: "0-3"},
+		{HostNodes: "1", HostCPUs: "8-11"},
+	}
+	cpuSetSlice := []int{0, 1, 2, 3, 4, 5}
+
+	nodeCPUs, detached, err := numaNodeCPUs(numaNodes, cpuSetSlice)
+	assert.NoError(err)
+	assert.Equal([]int{1}, detached)
+	assert.Equal([]int{0, 1, 2, 3}, nodeCPUs[0])
+	assert.Equal(cpuSetSlice, nodeCPUs[1])
+
+	// A node with no CPUs of its own inside the cpuset must still not push
+	// its vCPUs onto CPUs another node's vCPUs already hold.
+	affinities, pinned := numaAffinityPlan(nodeCPUs, []uint32{3, 2}, cpuSetSlice, true)
+	assert.True(pinned)
+	assert.Equal([]int{0, 1, 2, 3, 4}, assertDistinctPins(t, affinities))
 }
 
 func TestHotplugVfioNetworkDeviceAlreadyAttached(t *testing.T) {

--- a/tests/integration/kubernetes/k8s-nvidia-numa.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-numa.bats
@@ -6,7 +6,7 @@
 #
 # NUMA topology and vCPU pinning verification tests for Kata Containers.
 #
-# Five tests cover the main paths in the runtime's NUMA logic:
+# Seven tests cover the main paths in the runtime's NUMA logic:
 #   1. Multi-node sandbox: a workload that does NOT fit in a single host
 #      NUMA node should be balanced across host nodes — the guest sees
 #      multiple NUMA nodes with even vCPU/memory distribution and host
@@ -28,6 +28,13 @@
 #      maybeRightSizeAutoNUMA() must be a no-op and buildNUMATopology()
 #      must propagate the binding (memory + vCPU pinning land on the
 #      chosen host node, regardless of how small the workload is).
+#   6. Two sandboxes side by side: neither may claim a host CPU the other
+#      already claimed, whatever the host NUMA node count.
+#   7. Two guest NUMA nodes on one host node (numa_mapping = ["0", "0"]):
+#      a single sandbox must not put two of its own vCPUs on one host CPU.
+#
+# Tests 6 and 7 guard kata-containers#13539 and run on single-NUMA hosts
+# too, since that is where the reported reproduction lives.
 #
 # The NVIDIA configurations ship with NUMA and vCPU pinning turned off,
 # so every test here turns both on through a config.d/ drop-in before it
@@ -42,10 +49,16 @@
 #
 # WARNING: The host-side pinning check runs numa-pinning-check.sh directly
 # on the host (not inside a container).  This requires the bats runner to
-# execute on the k8s node with privileged access to /proc, /sys, crictl,
-# and taskset.  If the test environment changes so that bats no longer
-# runs on the node, these calls must be reworked to use exec_host or
-# equivalent.
+# execute on the k8s node with privileged access to /proc, /sys and crictl.
+# If the test environment changes so that bats no longer runs on the node,
+# these calls must be reworked to use exec_host or equivalent.
+#
+# The host-side checks assert on where the vCPU threads may run, not on how
+# narrow their affinity is: the runtime gives each vCPU a host CPU of its own
+# only when the sandbox owns its cpuset, and confines the threads to their
+# NUMA node otherwise.  What must hold in either case is that the threads
+# stay on the expected host node(s) and that no two of them are pinned to the
+# same host CPU.
 
 load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/confidential_common.sh"
@@ -91,7 +104,12 @@ NUMA_TEST_MEMORY_GPU="${NUMA_TEST_MEMORY_GPU:-64Gi}"
 NUMA_TEST_VCPUS_GPU_SMALL="${NUMA_TEST_VCPUS_GPU_SMALL:-4}"
 NUMA_TEST_MEMORY_GPU_SMALL="${NUMA_TEST_MEMORY_GPU_SMALL:-4Gi}"
 
+# Two-sandbox test: small enough to run a pair of them side by side.
+NUMA_TEST_VCPUS_PAIR="${NUMA_TEST_VCPUS_PAIR:-2}"
+NUMA_TEST_MEMORY_PAIR="${NUMA_TEST_MEMORY_PAIR:-1Gi}"
+
 export POD_NAME_NUMA="numa-topology-test"
+POD_NAME_NUMA_B="numa-topology-test-b"
 POD_NAME_NUMA_GPU="numa-topology-gpu-test"
 
 POD_WAIT_TIMEOUT=${POD_WAIT_TIMEOUT:-600s}
@@ -105,6 +123,7 @@ setup() {
 
     pod_yaml_in="${pod_config_dir}/${POD_NAME_NUMA}.yaml.in"
     pod_yaml="${pod_config_dir}/${POD_NAME_NUMA}.yaml"
+    pod_yaml_b="${pod_config_dir}/${POD_NAME_NUMA_B}.yaml"
 
     policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
     add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
@@ -114,15 +133,25 @@ setup() {
 # Skip / topology helpers
 # -----------------------------------------------------------------------------
 
-# numa_skip_reason returns a non-empty skip reason on stdout when the
-# current test should be skipped (hypervisor does not support NUMA OR
-# host has fewer than 2 NUMA nodes).  Empty stdout means run.
+# numa_unsupported_reason returns a non-empty reason on stdout when the
+# hypervisor under test does not implement NUMA, and nothing when it does.
+# Tests that hold on any host NUMA topology use this one.
 # Callers must invoke `skip` themselves — bats `skip` inside command
 # substitution does not propagate.
-numa_skip_reason() {
+numa_unsupported_reason() {
     # shellcheck disable=SC2076
     if [[ ! " ${NUMA_SUPPORTED[*]} " =~ " ${KATA_HYPERVISOR} " ]]; then
         echo "NUMA not supported on ${KATA_HYPERVISOR}"
+    fi
+}
+
+# numa_skip_reason extends numa_unsupported_reason with the >= 2 host NUMA
+# nodes a test needs to tell node-local placement from node-remote.
+numa_skip_reason() {
+    local reason
+    reason=$(numa_unsupported_reason)
+    if [[ -n "${reason}" ]]; then
+        echo "${reason}"
         return 0
     fi
     local nodes
@@ -163,6 +192,23 @@ deploy_and_get_guest_logs() {
     kubectl wait --for=condition=Ready --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_NUMA}"
     sleep 2
     kubectl logs "${POD_NAME_NUMA}"
+}
+
+# deploy_second_pod <vcpus> <memory> <node> renders the same template under a
+# second name and runs it on <node>, so both sandboxes compete for the same
+# host CPUs — otherwise there is nothing for them to collide over. Waits for
+# the pod to be Ready.
+deploy_second_pod() {
+    local vcpus="${1}" memory="${2}" target_node="${3}"
+
+    POD_NAME_NUMA="${POD_NAME_NUMA_B}" NUMA_TEST_VCPUS="${vcpus}" \
+        NUMA_TEST_MEMORY="${memory}" \
+        envsubst < "${pod_yaml_in}" > "${pod_yaml_b}"
+    set_node "${pod_yaml_b}" "${target_node}"
+    auto_generate_policy "${policy_settings_dir}" "${pod_yaml_b}"
+
+    kubectl apply -f "${pod_yaml_b}"
+    kubectl wait --for=condition=Ready --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_NUMA_B}"
 }
 
 # -----------------------------------------------------------------------------
@@ -206,11 +252,89 @@ pinning_thread_total() {
     echo "${1}" | awk -F: '/^node[0-9]+:/ {sum+=$2} END {print sum+0}'
 }
 
+# assert_no_shared_host_cpus <check_output>
+# Fails when two vCPU threads are pinned to the same host CPU.  Both then
+# sustain roughly half the throughput of a thread that owns its CPU, while
+# other CPUs stay idle (kata-containers#13539).
+assert_no_shared_host_cpus() {
+    local threads cpus
+    threads=$(check_output_field "${1}" single_cpu_threads)
+    cpus=$(check_output_field "${1}" distinct_single_cpus)
+    echo "# vCPU threads pinned to one CPU: ${threads:-0} on ${cpus:-0} distinct host CPUs"
+    [[ "${threads:-0}" -eq "${cpus:-0}" ]] \
+        || die "${threads} vCPU threads pinned to only ${cpus} host CPUs: ${1}"
+}
+
+# node_cpu_manager_policy <node>
+# Echoes the kubelet's cpuManagerPolicy on <node>, or an empty string when the
+# kubelet configuration cannot be read — the node may not allow the configz
+# endpoint.  Never fails, so that a caller running under `set -e` reaches its
+# own handling of an unknown policy.
+node_cpu_manager_policy() {
+    local config
+    config=$(kubectl get --raw "/api/v1/nodes/${1}/proxy/configz" 2>/dev/null) \
+        || return 0
+    echo "${config}" | grep -o '"cpuManagerPolicy":"[^"]*"' | cut -d'"' -f4 \
+        || return 0
+}
+
+# assert_pins_match_exclusive_cpus <pod_name> <check_output> <pod_cpu_limit>
+# The kubelet reserves a Guaranteed pod's whole CPU limit under
+# cpuManagerPolicy=static and nothing at all under none, so a sandbox pins
+# exactly that many vCPU threads to a host CPU each under static, and none at
+# all under none.  A count in between means the runtime handed out CPUs it does
+# not hold, or left vCPUs unpinned that the cpuset could back.  Checking only
+# that no two threads share a CPU would pass on a node reserving CPUs even if
+# nothing were pinned at all.
+assert_pins_match_exclusive_cpus() {
+    local pod_name="${1}" output="${2}" expected="${3}"
+    local node policy threads
+    threads=$(check_output_field "${output}" single_cpu_threads)
+    threads="${threads:-0}"
+
+    node=$(kubectl get pod "${pod_name}" -o jsonpath='{.spec.nodeName}') \
+        || die "cannot tell which node pod ${pod_name} runs on"
+    [[ -n "${node}" ]] || die "pod ${pod_name} has no node assigned"
+
+    policy=$(node_cpu_manager_policy "${node}") || policy=""
+    echo "# cpuManagerPolicy on ${node}: ${policy:-<unreadable>}"
+
+    case "${policy}" in
+        static)
+            [[ "${threads}" -eq "${expected}" ]] \
+                || die "cpuManagerPolicy=static reserves ${expected} CPUs for the pod, but ${threads} vCPU threads hold a host CPU of their own: ${output}"
+            ;;
+        none)
+            [[ "${threads}" -eq 0 ]] \
+                || die "cpuManagerPolicy=none reserves no CPU for the pod, yet ${threads} vCPU threads hold one of their own: ${output}"
+            ;;
+        *)
+            echo "# Skipping the pin count check: the kubelet's cpuManagerPolicy is unknown"
+            ;;
+    esac
+}
+
+# check_output_field <check_output> <field>
+# Echoes the value of a "<field>: <value>" line of numa-pinning-check.sh
+# output, empty when the field is absent.  awk rather than grep so a missing
+# field yields an empty value instead of failing the calling test.
+check_output_field() {
+    echo "${1}" | awk -v field="${2}:" '$1 == field {print $2}'
+}
+
+# pinned_cpu_list <check_output>
+# Echoes the comma-separated host CPUs the sandbox claimed for a single vCPU
+# thread each, empty when it claimed none.
+pinned_cpu_list() {
+    check_output_field "${1}" pinned_cpus
+}
+
 # wait_for_host_pinning <qemu_pid> <expected_vcpus>
 # Polls numa-pinning-check.sh until at least <expected_vcpus> threads
-# report per-CPU affinity, or until HOST_PINNING_RETRIES is exhausted.
-# Echoes the final script output regardless of whether convergence was
-# reached, so callers can inspect/assert on the bucket distribution.
+# are confined to a single host NUMA node, or until HOST_PINNING_RETRIES
+# is exhausted.  Echoes the final script output regardless of whether
+# convergence was reached, so callers can inspect/assert on the bucket
+# distribution.
 wait_for_host_pinning() {
     local qemu_pid="${1}" expected="${2}"
     local script="${BATS_TEST_DIRNAME}/numa-pinning-check.sh"
@@ -223,7 +347,7 @@ wait_for_host_pinning() {
             echo "${output}"
             return 0
         fi
-        echo "# Host pinning attempt ${attempt}/${HOST_PINNING_RETRIES}: ${total}/${expected} threads pinned" >&2
+        echo "# Host pinning attempt ${attempt}/${HOST_PINNING_RETRIES}: ${total}/${expected} threads placed" >&2
         sleep "${HOST_PINNING_SLEEP}"
     done
     echo "${output}"
@@ -414,6 +538,8 @@ host_gpu_numa() {
     diff=$(minmax_diff "${host_counts[@]}")
     echo "# Host pinning diff: ${diff}"
     [[ "${diff}" -le 1 ]] || die "host pinning imbalance: ${host_output}"
+
+    assert_no_shared_host_cpus "${host_output}"
 }
 
 @test "NUMA: small workload right-sizes to a single guest NUMA node" {
@@ -470,7 +596,108 @@ host_gpu_numa() {
     [[ ${#host_counts[@]} -eq 1 ]] \
         || die "right-sized sandbox vCPU threads should land on a single host NUMA node, got ${#host_counts[@]} buckets: ${host_output}"
     [[ "${host_counts[0]}" -ge "${NUMA_TEST_VCPUS_SMALL}" ]] \
-        || die "expected at least ${NUMA_TEST_VCPUS_SMALL} vCPU threads pinned, got ${host_counts[0]}: ${host_output}"
+        || die "expected at least ${NUMA_TEST_VCPUS_SMALL} vCPU threads placed, got ${host_counts[0]}: ${host_output}"
+
+    assert_no_shared_host_cpus "${host_output}"
+    assert_pins_match_exclusive_cpus "${POD_NAME_NUMA}" "${host_output}" "${NUMA_TEST_VCPUS_SMALL}"
+}
+
+@test "NUMA: two sandboxes do not claim the same host CPUs" {
+    # A sandbox cannot see what the other sandboxes on the node are using, so
+    # placing its vCPU threads from a CPU list it does not own puts every
+    # sandbox on the same CPUs (kata-containers#13539).  Both sandboxes here
+    # are sized alike and land on the same node, which is exactly the case
+    # that used to make them pick the same host CPUs.
+    #
+    # No minimum host NUMA node count: the collision does not need a second
+    # host node, and the reported reproduction is a single-node host.
+    local skip_reason
+    skip_reason=$(numa_unsupported_reason)
+    [[ -z "${skip_reason}" ]] || skip "${skip_reason}"
+
+    patch_kata_numa_config
+
+    local guest_logs target_node
+    guest_logs=$(deploy_and_get_guest_logs "${NUMA_TEST_VCPUS_PAIR}" "${NUMA_TEST_MEMORY_PAIR}")
+    echo "# First sandbox guest NUMA output:"
+    echo "# ${guest_logs}"
+
+    target_node=$(kubectl get pod "${POD_NAME_NUMA}" -o jsonpath='{.spec.nodeName}')
+    [[ -n "${target_node}" ]] || die "pod ${POD_NAME_NUMA} has no node assigned"
+    deploy_second_pod "${NUMA_TEST_VCPUS_PAIR}" "${NUMA_TEST_MEMORY_PAIR}" "${target_node}"
+    echo "# Both sandboxes running on node ${target_node}"
+
+    local qemu_pid_a qemu_pid_b output_a output_b
+    qemu_pid_a=$(get_qemu_pid_for_pod "${POD_NAME_NUMA}")
+    qemu_pid_b=$(get_qemu_pid_for_pod "${POD_NAME_NUMA_B}")
+    [[ "${qemu_pid_a}" != "${qemu_pid_b}" ]] \
+        || die "both pods resolved to the same QEMU PID ${qemu_pid_a}"
+
+    output_a=$(wait_for_host_pinning "${qemu_pid_a}" "${NUMA_TEST_VCPUS_PAIR}")
+    output_b=$(wait_for_host_pinning "${qemu_pid_b}" "${NUMA_TEST_VCPUS_PAIR}")
+    echo "# Sandbox A placement: ${output_a}"
+    echo "# Sandbox B placement: ${output_b}"
+
+    # Neither sandbox may double-pin on its own ...
+    assert_no_shared_host_cpus "${output_a}"
+    assert_no_shared_host_cpus "${output_b}"
+
+    # ... nor may the two of them pin onto each other's CPUs.
+    local pins_a pins_b shared
+    pins_a=$(pinned_cpu_list "${output_a}")
+    pins_b=$(pinned_cpu_list "${output_b}")
+    echo "# Sandbox A pinned CPUs: ${pins_a:-<none>}"
+    echo "# Sandbox B pinned CPUs: ${pins_b:-<none>}"
+
+    shared=$(comm -12 \
+        <(echo "${pins_a}" | tr ',' '\n' | grep -v '^$' | sort -u) \
+        <(echo "${pins_b}" | tr ',' '\n' | grep -v '^$' | sort -u) \
+        | paste -sd,)
+    [[ -z "${shared}" ]] \
+        || die "both sandboxes pinned vCPU threads to host CPU(s) ${shared}"
+}
+
+@test "NUMA: two guest nodes on one host node keep one vCPU per host CPU" {
+    # numa_mapping = ["0", "0"] puts both guest NUMA nodes on host node 0, so
+    # the two nodes draw their vCPUs from one host CPU list.  The runtime used
+    # to walk that list once per guest node and pinned the sandbox's own vCPUs
+    # in pairs (0 1 0 1).  Needs one host node only.
+    [[ "${KATA_HYPERVISOR}" == qemu-* ]] \
+        || skip "explicit numa_mapping test is QEMU-only (got ${KATA_HYPERVISOR})"
+
+    local skip_reason
+    skip_reason=$(numa_unsupported_reason)
+    [[ -z "${skip_reason}" ]] || skip "${skip_reason}"
+
+    # Patch the active runtime config; teardown() restores it.
+    patch_kata_numa_config '["0","0"]'
+
+    local guest_logs
+    guest_logs=$(deploy_and_get_guest_logs "${NUMA_TEST_VCPUS_SMALL}" "${NUMA_TEST_MEMORY_SMALL}")
+    echo "# Guest NUMA output:"
+    echo "# ${guest_logs}"
+
+    # --- Guest sees the two nodes the mapping asked for ---
+    local online guest_count
+    online=$(guest_field "${guest_logs}" numa_online)
+    guest_count=$(guest_online_count "${online}")
+    echo "# Guest NUMA online: ${online} -> ${guest_count} node(s)"
+    [[ "${guest_count}" -eq 2 ]] \
+        || die "numa_mapping=[0,0] should expose 2 guest NUMA nodes, got ${guest_count}"
+
+    # --- Every vCPU thread keeps a host CPU to itself ---
+    local qemu_pid host_output
+    qemu_pid=$(get_qemu_pid_for_pod "${POD_NAME_NUMA}")
+    host_output=$(wait_for_host_pinning "${qemu_pid}" "${NUMA_TEST_VCPUS_SMALL}")
+    echo "# Host placement: ${host_output}"
+
+    # Both guest nodes map to host node 0, so all threads bucket there.
+    mapfile -t host_counts < <(echo "${host_output}" | grep -oP '^node[0-9]+:\s*\K\d+')
+    [[ ${#host_counts[@]} -eq 1 ]] \
+        || die "numa_mapping=[0,0] should keep every vCPU on host node 0, got ${#host_counts[@]} buckets: ${host_output}"
+
+    assert_no_shared_host_cpus "${host_output}"
+    assert_pins_match_exclusive_cpus "${POD_NAME_NUMA}" "${host_output}" "${NUMA_TEST_VCPUS_SMALL}"
 }
 
 @test "NUMA: GPU passthrough with VFIO has correct NUMA placement" {
@@ -557,6 +784,8 @@ host_gpu_numa() {
     diff=$(minmax_diff "${host_counts[@]}")
     echo "# Host pinning diff: ${diff}"
     [[ "${diff}" -le 1 ]] || die "GPU pod host pinning imbalance: ${host_output}"
+
+    assert_no_shared_host_cpus "${host_output}"
 
     # --- QEMU command line: pxb-pcie and NUMA binding ---
     echo "# Checking QEMU cmdline for pxb-pcie..."
@@ -647,6 +876,8 @@ host_gpu_numa() {
     pinned_node=$(echo "${host_output}" | grep -oP '^node\K[0-9]+' | head -1)
     [[ "${pinned_node}" -eq "${host_node}" ]] \
         || die "right-sized GPU sandbox vCPUs pinned to node ${pinned_node} but GPU is on host node ${host_node}"
+
+    assert_no_shared_host_cpus "${host_output}"
 }
 
 @test "NUMA: explicit numa_mapping in TOML pins the sandbox to the chosen host node" {
@@ -715,15 +946,19 @@ host_gpu_numa() {
     pinned_node=$(echo "${host_output}" | grep -oP '^node\K[0-9]+' | head -1)
     [[ "${pinned_node}" -eq 1 ]] \
         || die "explicit numa_mapping=[1] pinned vCPUs to node ${pinned_node}, expected 1"
+
+    assert_no_shared_host_cpus "${host_output}"
 }
 
 teardown() {
     echo "=== NUMA test pod describe ==="
     kubectl describe pod "${POD_NAME_NUMA}" || true
+    kubectl describe pod "${POD_NAME_NUMA_B}" 2>/dev/null || true
     kubectl describe pod "${POD_NAME_NUMA_GPU}" 2>/dev/null || true
 
     echo "=== NUMA test pod logs ==="
     kubectl logs "${POD_NAME_NUMA}" || true
+    kubectl logs "${POD_NAME_NUMA_B}" 2>/dev/null || true
     kubectl logs "${POD_NAME_NUMA_GPU}" 2>/dev/null || true
 
     # Always restore the Kata config (no-op if no patch was applied).
@@ -732,6 +967,7 @@ teardown() {
     delete_tmp_policy_settings_dir "${policy_settings_dir}"
 
     [ -f "${pod_yaml}" ] && kubectl delete -f "${pod_yaml}" --ignore-not-found=true
+    [ -f "${pod_yaml_b}" ] && kubectl delete -f "${pod_yaml_b}" --ignore-not-found=true
     local gpu_yaml="${pod_config_dir}/${POD_NAME_NUMA_GPU}.yaml"
     [ -f "${gpu_yaml}" ] && kubectl delete -f "${gpu_yaml}" --ignore-not-found=true
 

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -185,9 +185,13 @@ get_pod_sandbox_id() {
 	exec_host "${node}" "command -v crictl >/dev/null" || \
 		die "crictl is required on Kubernetes node ${node}"
 
+	# The lookup goes through the pod name label rather than --name, which
+	# matches substrings: --name of a pod whose name is a prefix of another
+	# pod's would happily return that other pod's sandbox.
 	exec_host "${node}" \
 		"crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-		pods --name \"${pod_name}\" --state ready -q | head -1"
+		pods --label \"io.kubernetes.pod.name=${pod_name}\" --state ready -q \
+		| head -1"
 }
 
 # Return the QEMU PID for a running pod.

--- a/tests/integration/kubernetes/numa-pinning-check.sh
+++ b/tests/integration/kubernetes/numa-pinning-check.sh
@@ -10,14 +10,26 @@
 #
 # Usage: numa-pinning-check.sh <qemu_pid>
 #
-# Output: one line per NUMA node with the count of pinned vCPU threads.
+# Output: one line per NUMA node with the count of vCPU threads confined to
+# it, then the two totals that tell whether any host CPU carries more than
+# one vCPU thread, then the host CPUs this QEMU claimed for a single thread:
 #   node0: 32
 #   node1: 32
+#   single_cpu_threads: 64
+#   distinct_single_cpus: 64
+#   pinned_cpus: 0,1,2,3
 #
-# A vCPU thread is counted only when taskset reports it pinned to a single
-# CPU (bare number, no ranges or commas).  Threads with broad affinity
-# masks are silently skipped — the caller is expected to retry until the
-# runtime has finished per-vCPU pinning.
+# Only KVM vCPU threads ("CPU 3/KVM") are looked at, and one counts towards a
+# node when every CPU it may run on belongs to that node.  That covers both
+# ways the runtime places vCPUs: one host CPU per vCPU thread, and the NUMA
+# node affinity mask it falls back to when it cannot give each vCPU a host
+# CPU of its own.  Threads still allowed to run across nodes are skipped —
+# the caller is expected to retry until the runtime has placed the vCPUs.
+#
+# single_cpu_threads exceeds distinct_single_cpus when several vCPU threads
+# are pinned to the same host CPU, which makes them time-share it while other
+# CPUs sit idle.  pinned_cpus lets a caller compare two sandboxes and catch
+# the same overlap happening across them.
 
 set -o pipefail
 
@@ -28,17 +40,77 @@ if [[ ! -d "/proc/${QEMU_PID}/task" ]]; then
     exit 1
 fi
 
-for tid in "/proc/${QEMU_PID}/task/"*; do
-    tid="${tid##*/}"
-    list=$(taskset -pc "${tid}" 2>/dev/null | sed 's/.*: //')
-    if [[ "${list}" =~ ^[0-9]+$ ]]; then
-        # Map the CPU to its NUMA node via the sysfs topology symlink
-        for node_link in "/sys/devices/system/cpu/cpu${list}/node"*; do
-            if [[ -d "${node_link}" ]]; then
-                numa_node="${node_link##*node}"
-                echo "node${numa_node}"
-                break
-            fi
-        done
+# expand_cpu_list <list> emits one CPU per line for a cpuset-style list such
+# as "0-3,8".
+expand_cpu_list() {
+    local item cpu
+    local IFS=,
+    for item in ${1}; do
+        if [[ "${item}" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+            for ((cpu = BASH_REMATCH[1]; cpu <= BASH_REMATCH[2]; cpu++)); do
+                echo "${cpu}"
+            done
+        elif [[ "${item}" =~ ^[0-9]+$ ]]; then
+            echo "${item}"
+        fi
+    done
+}
+
+# cpu_node <cpu> echoes the NUMA node a host CPU belongs to.
+cpu_node() {
+    local node_link
+    for node_link in "/sys/devices/system/cpu/cpu${1}/node"*; do
+        if [[ -d "${node_link}" ]]; then
+            echo "${node_link##*node}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+declare -A node_threads=()
+declare -A pinned_cpus=()
+single_cpu_threads=0
+
+for task in "/proc/${QEMU_PID}/task/"*; do
+    [[ -r "${task}/comm" && -r "${task}/status" ]] || continue
+    [[ "$(<"${task}/comm")" =~ ^CPU\ [0-9]+/KVM$ ]] || continue
+
+    list=$(grep -oP '^Cpus_allowed_list:\s*\K.*' "${task}/status")
+    mapfile -t cpus < <(expand_cpu_list "${list}")
+    (( ${#cpus[@]} > 0 )) || continue
+
+    node=""
+    for cpu in "${cpus[@]}"; do
+        this_node=$(cpu_node "${cpu}") || { node=""; break; }
+        if [[ -z "${node}" ]]; then
+            node="${this_node}"
+        elif [[ "${this_node}" != "${node}" ]]; then
+            node=""
+            break
+        fi
+    done
+    # Still free to run on more than one node: not placed (yet).
+    [[ -n "${node}" ]] || continue
+
+    node_threads["${node}"]=$(( ${node_threads["${node}"]:-0} + 1 ))
+    if (( ${#cpus[@]} == 1 )); then
+        single_cpu_threads=$(( single_cpu_threads + 1 ))
+        pinned_cpus["${cpus[0]}"]=1
     fi
-done | sort | uniq -c | awk '{print $2 ": " $1}'
+done
+
+if (( ${#node_threads[@]} > 0 )); then
+    while read -r node; do
+        echo "node${node}: ${node_threads[${node}]}"
+    done < <(printf '%s\n' "${!node_threads[@]}" | sort -n)
+fi
+
+echo "single_cpu_threads: ${single_cpu_threads}"
+echo "distinct_single_cpus: ${#pinned_cpus[@]}"
+
+pinned_list=""
+if (( ${#pinned_cpus[@]} > 0 )); then
+    pinned_list=$(printf '%s\n' "${!pinned_cpus[@]}" | sort -n | paste -sd,)
+fi
+echo "pinned_cpus: ${pinned_list}"

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -96,6 +96,7 @@ delete_nvidia_gpu_test_pods_if_any_exist() {
 		"nvidia-nim-llama-3-2-nv-embedqa-1b-v2"
 		"nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee"
 		"numa-topology-test"
+		"numa-topology-test-b"
 		"numa-topology-gpu-test"
 		"vllm-qwen2-5-0-5b-instruct"
 		"vllm-qwen2-5-0-5b-instruct-tee"


### PR DESCRIPTION
NUMA-aware vCPU pinning could hard-pin several vCPU threads to one host
CPU, both within a sandbox and across sandboxes.  The threads then
time-share that CPU at roughly half throughput each while neighbouring
CPUs stay idle, and nothing is logged.

Three paths led there:

- checkVCPUsPinningNUMA() picked a node's host CPU with
  "index % len(allowedCPUs)".  The vCPU count of a node comes from the
  node's raw host CPU count while the CPUs it may use come from the
  intersection with the sandbox CPUSet, so once the two disagree the
  index wrapped and reused CPUs of that same node.

- A node whose host CPUs did not intersect the sandbox CPUSet fell back
  to pinning across the whole CPUSet, on top of the other nodes' pins.

- A sandbox without a CPUSet of its own derived one from the guest NUMA
  nodes' HostCPUs and pinned from index 0.  Every sandbox on the host
  derives the same CPUs, so all of them pinned their vCPUs to the same
  ones.  This is what any pod hits while the kubelet runs
  cpuManagerPolicy=none, whatever its QoS class.

Assign host CPUs from a pool instead, never handing out one twice: a
vCPU takes a CPU of its own NUMA node, and borrows an unused CPU of the
rest of the CPUSet only once its node has none left.

That assignment is only meaningful when the sandbox owns the CPUSet,
which is why the derived-CPUSet case cannot use it, and it needs at
least one CPU per vCPU.  When either does not hold, give each vCPU
thread the CPUs of its NUMA node as an affinity mask and log why: the
host scheduler then balances the threads inside their node, which keeps
the memory locality NUMA is about without the oversubscription.

Fixes: https://github.com/kata-containers/kata-containers/issues/13539