### PR TITLE
ci: Run full self-hosted matrix in ci-devel

### DIFF
--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -43,6 +43,15 @@ jobs:
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}
 
   build-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep this matrix in sync with the one in static-checks-self-hosted.yaml + static-checks.yaml
+        instance:
+          - "ubuntu-22.04"
+          - "ubuntu-24.04-arm"
+          - "ubuntu-24.04-s390x"
+          - "ppc64le"
     uses: ./.github/workflows/build-checks.yaml
     with:
-      instance: ubuntu-22.04
+      instance: ${{ matrix.instance }}

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep this matrix in sync with the one in ci-devel (minus non-self-hosted instances)
         instance:
           - "ubuntu-24.04-arm"
           - "ubuntu-24.04-s390x"


### PR DESCRIPTION
Modify ci-devel to run the self-hosted tests on the complete instance matrix, matching the one used by ci-on-push.

Generated-By: GitHub Copilot
Signed-off-by: Aurélien Bombo <abombo@microsoft.com>