### PR TITLE
ci: unbreak CI for s390x

### DIFF
--- a/src/runtime-rs/crates/hypervisor/build.rs
+++ b/src/runtime-rs/crates/hypervisor/build.rs
@@ -45,8 +45,8 @@ fn replace_in_file(path: &str, from: &str, to: &str) -> std::io::Result<()> {
 
 fn main() {
     // The generated bindings are only needed for the OpenVMM backend, whose
-    // module is `#[cfg(feature = "openvmm")]`. When the feature is off the
-    // gitignored output is never referenced, so skip codegen entirely.
+    // module also requires `target_arch = "x86_64"`. When the feature is off,
+    // the gitignored output is never referenced, so skip codegen entirely.
     if std::env::var("CARGO_FEATURE_OPENVMM").is_err() {
         return;
     }

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -26,10 +26,7 @@ pub mod dragonball;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod firecracker;
 mod kernel_param;
-#[cfg(all(
-    feature = "openvmm",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
+#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 pub mod openvmm;
 pub mod qemu;
 pub mod remote;
@@ -52,10 +49,7 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 
 pub use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 
-#[cfg(all(
-    feature = "openvmm",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
+#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 pub use kata_types::config::hypervisor::HYPERVISOR_NAME_OPENVMM;
 
 // Config which driver to use as vm root dev

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -26,7 +26,10 @@ pub mod dragonball;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub mod firecracker;
 mod kernel_param;
-#[cfg(feature = "openvmm")]
+#[cfg(all(
+    feature = "openvmm",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub mod openvmm;
 pub mod qemu;
 pub mod remote;
@@ -49,7 +52,10 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 
 pub use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 
-#[cfg(feature = "openvmm")]
+#[cfg(all(
+    feature = "openvmm",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub use kata_types::config::hypervisor::HYPERVISOR_NAME_OPENVMM;
 
 // Config which driver to use as vm root dev

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -53,9 +53,15 @@ use hypervisor::ch::CloudHypervisor;
 ))]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
 
-#[cfg(feature = "openvmm")]
+#[cfg(all(
+    feature = "openvmm",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
-#[cfg(feature = "openvmm")]
+#[cfg(all(
+    feature = "openvmm",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use kata_types::config::OpenVmmConfig;
 
 use crate::factory::vm::VmConfig;
@@ -107,7 +113,10 @@ impl RuntimeHandler for VirtContainer {
         let remote_config = Arc::new(RemoteConfig::new());
         register_hypervisor_plugin("remote", remote_config);
 
-        #[cfg(feature = "openvmm")]
+        #[cfg(all(
+            feature = "openvmm",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         {
             let openvmm_config = Arc::new(OpenVmmConfig::new());
             register_hypervisor_plugin(HYPERVISOR_NAME_OPENVMM, openvmm_config);
@@ -269,7 +278,10 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
                 .await;
             Ok(Arc::new(hypervisor))
         }
-        #[cfg(feature = "openvmm")]
+        #[cfg(all(
+            feature = "openvmm",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         HYPERVISOR_NAME_OPENVMM => {
             let hypervisor = OpenVmm::new();
             hypervisor

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -53,15 +53,9 @@ use hypervisor::ch::CloudHypervisor;
 ))]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
 
-#[cfg(all(
-    feature = "openvmm",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
+#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
-#[cfg(all(
-    feature = "openvmm",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
+#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 use kata_types::config::OpenVmmConfig;
 
 use crate::factory::vm::VmConfig;
@@ -113,10 +107,7 @@ impl RuntimeHandler for VirtContainer {
         let remote_config = Arc::new(RemoteConfig::new());
         register_hypervisor_plugin("remote", remote_config);
 
-        #[cfg(all(
-            feature = "openvmm",
-            any(target_arch = "x86_64", target_arch = "aarch64")
-        ))]
+        #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
         {
             let openvmm_config = Arc::new(OpenVmmConfig::new());
             register_hypervisor_plugin(HYPERVISOR_NAME_OPENVMM, openvmm_config);
@@ -278,10 +269,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
                 .await;
             Ok(Arc::new(hypervisor))
         }
-        #[cfg(all(
-            feature = "openvmm",
-            any(target_arch = "x86_64", target_arch = "aarch64")
-        ))]
+        #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
         HYPERVISOR_NAME_OPENVMM => {
             let hypervisor = OpenVmm::new();
             hypervisor

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -43,10 +43,7 @@ use hypervisor::HYPERVISOR_REMOTE;
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
-#[cfg(all(
-    feature = "openvmm",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
+#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
@@ -1499,10 +1496,7 @@ impl Persist for VirtSandbox {
                 HYPERVISOR_FIRECRACKER => Ok(Some(hypervisor_state)),
                 HYPERVISOR_QEMU => Ok(Some(hypervisor_state)),
                 HYPERVISOR_REMOTE => Ok(Some(hypervisor_state)),
-                #[cfg(all(
-                    feature = "openvmm",
-                    any(target_arch = "x86_64", target_arch = "aarch64")
-                ))]
+                #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
                 HYPERVISOR_NAME_OPENVMM => Ok(Some(hypervisor_state)),
                 _ => Err(anyhow!(
                     "Unsupported hypervisor {}",
@@ -1566,10 +1560,7 @@ impl Persist for VirtSandbox {
                 let hypervisor = Arc::new(Remote::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)
             }
-            #[cfg(all(
-                feature = "openvmm",
-                any(target_arch = "x86_64", target_arch = "aarch64")
-            ))]
+            #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
             HYPERVISOR_NAME_OPENVMM => {
                 let hypervisor = Arc::new(OpenVmm::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -43,7 +43,10 @@ use hypervisor::HYPERVISOR_REMOTE;
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
-#[cfg(feature = "openvmm")]
+#[cfg(all(
+    feature = "openvmm",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
@@ -1496,7 +1499,10 @@ impl Persist for VirtSandbox {
                 HYPERVISOR_FIRECRACKER => Ok(Some(hypervisor_state)),
                 HYPERVISOR_QEMU => Ok(Some(hypervisor_state)),
                 HYPERVISOR_REMOTE => Ok(Some(hypervisor_state)),
-                #[cfg(feature = "openvmm")]
+                #[cfg(all(
+                    feature = "openvmm",
+                    any(target_arch = "x86_64", target_arch = "aarch64")
+                ))]
                 HYPERVISOR_NAME_OPENVMM => Ok(Some(hypervisor_state)),
                 _ => Err(anyhow!(
                     "Unsupported hypervisor {}",
@@ -1560,7 +1566,10 @@ impl Persist for VirtSandbox {
                 let hypervisor = Arc::new(Remote::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)
             }
-            #[cfg(feature = "openvmm")]
+            #[cfg(all(
+                feature = "openvmm",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ))]
             HYPERVISOR_NAME_OPENVMM => {
                 let hypervisor = Arc::new(OpenVmm::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)


### PR DESCRIPTION
This is to fix the CI failure introduced in #13346:

https://github.com/kata-containers/kata-containers/actions/runs/30894490011/job/92035351827?pr=13281

#13543 adds the self-hosted CIs to ci-devel so we catch these errors earlier in the future.