### PR TITLE
ci/openvmm: Enable block-plain emptyDir test

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner.rs
@@ -76,7 +76,11 @@ impl std::fmt::Debug for OpenVmmInner {
 impl OpenVmmInner {
     pub(crate) fn new(exit_notify: watch::Sender<Option<i32>>) -> Self {
         let mut capabilities = Capabilities::new();
-        capabilities.set(CapabilityBits::BlockDeviceSupport | CapabilityBits::FsSharingSupport);
+        capabilities.set(
+            CapabilityBits::BlockDeviceSupport
+                | CapabilityBits::BlockDeviceDiscardSupport
+                | CapabilityBits::FsSharingSupport,
+        );
 
         OpenVmmInner {
             id: String::new(),

--- a/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
@@ -12,16 +12,6 @@ load "${BATS_TEST_DIRNAME}/emptydir_common.sh"
 
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-skip_unsupported_runtime() {
-	# OpenVMM can hotplug BlockModern devices, but block-plain emptyDir
-	# filesystem setup is not yet supported end to end.
-	case "${KATA_HYPERVISOR}" in
-		openvmm-azure-runtime-rs)
-			skip "block-plain emptyDir is not yet supported for ${KATA_HYPERVISOR}"
-			;;
-	esac
-}
-
 # Return the full mountinfo row whose field 5 is the tested mount point.
 mountinfo_for_mountpoint() {
 	pod_exec "${pod_name}" sh -c \
@@ -57,7 +47,6 @@ guest_discard_max_bytes() {
 setup() {
 	local runtime_config_dropin_file
 
-	skip_unsupported_runtime
 	setup_common || die "setup_common failed"
 
 	pod_name="plain-ephemeral-data-storage"
@@ -173,8 +162,6 @@ EOF
 }
 
 teardown() {
-	skip_unsupported_runtime
-
 	echo "=== Plain ephemeral data storage pod describe ==="
 	kubectl describe pod "${pod_name:-plain-ephemeral-data-storage}" || true
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -80,7 +80,7 @@ assets:
         OpenVMM is a modular, cross-platform Virtual Machine Monitor written
         in Rust
       url: "https://github.com/microsoft/openvmm"
-      version: "00693a5d2e4db2484c576abd0c3dee95632c9fcc"
+      version: "d8c1f25a35d85d7cd2ea762a2a7b2e7328a6fc9d"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
```
ci/openvmm: Enable block-plain emptyDir test

OpenVMM implemented discard support for file-backed virtio-blk disks in
microsoft/openvmm#4088.

Advertise this support in runtime-rs so block-plain emptyDirs request
discard for both the virtual disk and guest mount, then enable the tests.
```