### PR TITLE
runtime-rs/QEMU: pass block sources by fd

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -50,6 +50,7 @@ persist = { workspace = true }
 ch-config = { workspace = true, optional = true }
 safe-path = { workspace = true }
 tests_utils = { workspace = true }
+tempfile = { workspace = true }
 
 # Dependencies that only exist to support hypervisors which upstream only
 # build on x86_64 and aarch64 (dragonball, firecracker). Keeping them in a
@@ -95,7 +96,6 @@ openvmm = ["dep:protobuf"]
 [dev-dependencies]
 rstest = { workspace = true }
 serial_test = "2.0.0"
-tempfile = { workspace = true }
 
 # Local dev-dependencies
 hypervisor = { workspace = true }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -33,9 +33,8 @@ pub use vfio_device::{
 pub use vhost_user::{VhostUserConfig, VhostUserDevice, VhostUserType};
 pub use vhost_user_net::VhostUserNetDevice;
 pub use virtio_blk_modern::{
-    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, BlockDeviceModern,
-    BlockDeviceModernHandle, VmdkConfig, VmdkExtent, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO,
-    VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+    BlockConfigModern, BlockDeviceAio, BlockDeviceModern, BlockDeviceModernHandle, VmdkConfig,
+    VmdkExtent, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
 pub use virtio_fs::{
     ShareFsConfig, ShareFsDevice, ShareFsMountConfig, ShareFsMountOperation, ShareFsMountType,

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -34,7 +34,8 @@ pub use vhost_user::{VhostUserConfig, VhostUserDevice, VhostUserType};
 pub use vhost_user_net::VhostUserNetDevice;
 pub use virtio_blk_modern::{
     BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, BlockDeviceModern,
-    BlockDeviceModernHandle, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+    BlockDeviceModernHandle, VmdkConfig, VmdkExtent, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO,
+    VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
 pub use virtio_fs::{
     ShareFsConfig, ShareFsDevice, ShareFsMountConfig, ShareFsMountOperation, ShareFsMountType,

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
@@ -63,6 +63,47 @@ pub enum BlockDeviceFormat {
     Vmdk,
 }
 
+const MAX_VMDK_EXTENT_SECTORS: u64 = 0x8000_0000 >> 9;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmdkExtent {
+    pub path_on_host: String,
+    pub sectors: u64,
+    pub file_offset: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VmdkConfig {
+    pub extents: Vec<VmdkExtent>,
+}
+
+impl VmdkConfig {
+    pub fn push_extent(&mut self, path_on_host: &str, sectors: u64, file_offset: u64) {
+        self.extents.push(VmdkExtent {
+            path_on_host: path_on_host.to_string(),
+            sectors,
+            file_offset,
+        });
+    }
+
+    pub fn push_extent_chunked(&mut self, path_on_host: &str, total_sectors: u64) {
+        let mut remaining = total_sectors;
+        let mut file_offset = 0;
+        while remaining > 0 {
+            let sectors = remaining.min(MAX_VMDK_EXTENT_SECTORS);
+            self.push_extent(path_on_host, sectors, file_offset);
+            file_offset += sectors;
+            remaining -= sectors;
+        }
+    }
+
+    pub fn total_sectors(&self) -> Option<u64> {
+        self.extents
+            .iter()
+            .try_fold(0_u64, |total, extent| total.checked_add(extent.sectors))
+    }
+}
+
 impl std::fmt::Display for BlockDeviceFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let to_string = match *self {
@@ -75,7 +116,15 @@ impl std::fmt::Display for BlockDeviceFormat {
 
 #[derive(Debug, Clone, Default)]
 pub struct BlockConfigModern {
-    /// Path of the drive.
+    /// Actual host path for a raw block source; every backend consumes this
+    /// value according to its block transport. When `vmdk` is present, QEMU is
+    /// currently the only backend that consumes the structured layout. In that
+    /// case, this is a reserved descriptor path used as the block-device key and
+    /// for logging; QEMU neither creates nor opens a file at this path. A future
+    /// backend may instead materialize and open its descriptor here. If
+    /// structured layouts gain more consumers, replace this field and `vmdk`
+    /// with explicit source variants distinguishing a raw host path from a
+    /// VMDK descriptor path and layout.
     pub path_on_host: String,
 
     /// If set to true, the drive is opened in read-only mode. Otherwise, the
@@ -90,6 +139,12 @@ pub struct BlockConfigModern {
 
     /// raw, vmdk, etc. And default to raw if not set.
     pub format: BlockDeviceFormat,
+
+    /// Structured VMDK layout, currently consumed only by QEMU. When present,
+    /// the QEMU backend opens the backing extents in the shim, renders an
+    /// anonymous descriptor containing fdset paths, and passes it to QEMU by
+    /// file descriptor. No descriptor file is created at `path_on_host`.
+    pub vmdk: Option<VmdkConfig>,
 
     /// Specifies cache-related options for block devices.
     /// Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
@@ -56,13 +56,6 @@ impl std::fmt::Display for BlockDeviceAio {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum BlockDeviceFormat {
-    #[default]
-    Raw,
-    Vmdk,
-}
-
 const MAX_VMDK_EXTENT_SECTORS: u64 = 0x8000_0000 >> 9;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -104,16 +97,6 @@ impl VmdkConfig {
     }
 }
 
-impl std::fmt::Display for BlockDeviceFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let to_string = match *self {
-            BlockDeviceFormat::Raw => "raw".to_string(),
-            BlockDeviceFormat::Vmdk => "vmdk".to_string(),
-        };
-        write!(f, "{to_string}")
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct BlockConfigModern {
     /// Actual host path for a raw block source; every backend consumes this
@@ -137,13 +120,11 @@ pub struct BlockConfigModern {
     /// Don't close `path_on_host` file when dropping the device.
     pub no_drop: bool,
 
-    /// raw, vmdk, etc. And default to raw if not set.
-    pub format: BlockDeviceFormat,
-
     /// Structured VMDK layout, currently consumed only by QEMU. When present,
     /// the QEMU backend opens the backing extents in the shim, renders an
     /// anonymous descriptor containing fdset paths, and passes it to QEMU by
     /// file descriptor. No descriptor file is created at `path_on_host`.
+    /// Without a structured layout, the block source is raw.
     pub vmdk: Option<VmdkConfig>,
 
     /// Specifies cache-related options for block devices.

--- a/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::BlockDeviceFormat;
+
+use anyhow::{anyhow, Context, Result};
+use std::fs::{File, OpenOptions};
+use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
+
+const BLOCK_FD_OPAQUE_PREFIX: &str = "kata-block:";
+
+pub(super) fn block_fd_opaque(node_name: &str, label: &str) -> String {
+    format!("{BLOCK_FD_OPAQUE_PREFIX}{node_name}:{label}")
+}
+
+pub(super) fn block_fd_node_name(opaque: &str) -> Option<&str> {
+    opaque
+        .strip_prefix(BLOCK_FD_OPAQUE_PREFIX)?
+        .split_once(':')
+        .map(|(node_name, _)| node_name)
+        .filter(|node_name| !node_name.is_empty())
+}
+
+#[derive(Debug)]
+pub(super) struct PreparedBlockSource {
+    pub filename: String,
+    pub is_regular_file: bool,
+}
+
+fn open_block_source(
+    path: &str,
+    is_readonly: bool,
+    is_direct: bool,
+    regular_file_only: bool,
+) -> Result<(File, std::fs::Metadata)> {
+    let mut options = OpenOptions::new();
+    let direct_flag = if is_direct { libc::O_DIRECT } else { 0 };
+    options
+        .read(true)
+        .write(!is_readonly)
+        // Rust opens files close-on-exec by default; specify it here as part of
+        // this security boundary and clear it only for descriptors intentionally
+        // inherited by QEMU at startup.
+        .custom_flags(direct_flag | libc::O_CLOEXEC);
+
+    let file = options
+        .open(path)
+        .with_context(|| format!("open QEMU block source {path}"))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("stat opened QEMU block source {path}"))?;
+    let file_type = metadata.file_type();
+    if regular_file_only && !file_type.is_file() {
+        return Err(anyhow!("QEMU block source {path} is not a regular file"));
+    }
+    if !regular_file_only && !file_type.is_file() && !file_type.is_block_device() {
+        return Err(anyhow!(
+            "QEMU block source {path} is neither an allowed regular file nor block device"
+        ));
+    }
+
+    Ok((file, metadata))
+}
+
+/// Open a raw block source while the shim still has host privileges and
+/// register the resulting descriptor with QEMU. Other formats retain their
+/// existing path-based transport.
+pub(super) fn prepare_block_source<F>(
+    path: &str,
+    format: &BlockDeviceFormat,
+    is_readonly: bool,
+    is_direct: bool,
+    mut register: F,
+) -> Result<PreparedBlockSource>
+where
+    F: FnMut(File, &str) -> Result<String>,
+{
+    if *format != BlockDeviceFormat::Raw {
+        let metadata =
+            std::fs::metadata(path).with_context(|| format!("stat QEMU block source {path}"))?;
+        return Ok(PreparedBlockSource {
+            filename: path.to_string(),
+            is_regular_file: metadata.is_file(),
+        });
+    }
+
+    let (file, metadata) = open_block_source(path, is_readonly, is_direct, false)?;
+    let is_regular_file = metadata.is_file();
+    let filename = register(file, "block-source")?;
+    Ok(PreparedBlockSource {
+        filename,
+        is_regular_file,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+    use std::cell::RefCell;
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    #[test]
+    fn prepares_raw_source_with_requested_access() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("disk.img");
+        std::fs::write(&path, b"disk").unwrap();
+
+        let prepared = prepare_block_source(
+            path.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            true,
+            false,
+            |file, _| {
+                assert_eq!(file.metadata()?.len(), 4);
+                Ok("/dev/fdset/7".to_string())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(prepared.filename, "/dev/fdset/7");
+        assert!(prepared.is_regular_file);
+    }
+
+    #[test]
+    fn opens_writable_raw_source_read_write() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("writable.raw");
+        std::fs::write(&path, b"disk").unwrap();
+
+        prepare_block_source(
+            path.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            false,
+            false,
+            |mut file, _| {
+                file.seek(SeekFrom::End(0))?;
+                file.write_all(b"-writable")?;
+                Ok("/dev/fdset/8".to_string())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"disk-writable");
+    }
+
+    #[test]
+    fn opens_readonly_raw_source_without_write_access() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("readonly.raw");
+        std::fs::write(&path, b"readonly").unwrap();
+
+        prepare_block_source(
+            path.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            true,
+            false,
+            |mut file, _| {
+                assert!(file.write_all(b"no").is_err());
+                Ok("/dev/fdset/8".to_string())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"readonly");
+    }
+
+    #[test]
+    fn preserves_direct_io_on_registered_files() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("disk.img");
+        std::fs::write(&path, vec![0u8; 4096]).unwrap();
+
+        prepare_block_source(
+            path.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            true,
+            true,
+            |file, _| {
+                let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
+                assert!(flags.contains(OFlag::O_DIRECT));
+                Ok("/dev/fdset/8".to_string())
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn follows_final_component_symlink() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("target.raw");
+        let link = dir.path().join("source.raw");
+        std::fs::write(&target, b"disk").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let prepared = prepare_block_source(
+            link.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            true,
+            false,
+            |file, _| {
+                assert!(file.metadata()?.is_file());
+                Ok("/dev/fdset/1".to_string())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(prepared.filename, "/dev/fdset/1");
+        assert!(prepared.is_regular_file);
+    }
+
+    #[test]
+    fn registered_source_survives_path_removal() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("source.raw");
+        std::fs::write(&path, b"persistent").unwrap();
+        let received = RefCell::new(None);
+
+        prepare_block_source(
+            path.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            true,
+            false,
+            |file, _| {
+                *received.borrow_mut() = Some(file.try_clone()?);
+                Ok("/dev/fdset/1".to_string())
+            },
+        )
+        .unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        let mut contents = String::new();
+        received
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        assert_eq!(contents, "persistent");
+    }
+
+    #[test]
+    fn identifies_owned_block_fdsets() {
+        let opaque = block_fd_opaque("drive-3", "block-source");
+
+        assert_eq!(block_fd_node_name(&opaque), Some("drive-3"));
+        assert_eq!(block_fd_node_name("unrelated"), None);
+        assert_eq!(block_fd_node_name("kata-block::source"), None);
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BlockDeviceFormat, VmdkConfig};
+use crate::VmdkConfig;
 
 use anyhow::{anyhow, Context, Result};
 use nix::sys::memfd::{memfd_create, MFdFlags};
@@ -159,7 +159,6 @@ fn create_vmdk_descriptor_file(
 /// once after their backing extents have been registered.
 pub(super) fn prepare_block_source<F>(
     path: &str,
-    format: &BlockDeviceFormat,
     vmdk: Option<&VmdkConfig>,
     is_readonly: bool,
     is_direct: bool,
@@ -168,7 +167,7 @@ pub(super) fn prepare_block_source<F>(
 where
     F: FnMut(File, &str) -> Result<String>,
 {
-    if *format == BlockDeviceFormat::Raw {
+    let Some(vmdk) = vmdk else {
         let (file, metadata) = open_block_source(path, is_readonly, is_direct, false)?;
         let is_regular_file = metadata.is_file();
         let filename = register(file, "block-source")?;
@@ -176,9 +175,8 @@ where
             filename,
             is_regular_file,
         });
-    }
+    };
 
-    let vmdk = vmdk.ok_or_else(|| anyhow!("VMDK block source is missing its extent layout"))?;
     if vmdk.extents.is_empty() {
         return Err(anyhow!("VMDK contains no extents"));
     }
@@ -264,18 +262,12 @@ mod tests {
         let path = dir.path().join("disk.img");
         std::fs::write(&path, b"disk").unwrap();
 
-        let prepared = prepare_block_source(
-            path.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            true,
-            false,
-            |file, _| {
+        let prepared =
+            prepare_block_source(path.to_str().unwrap(), None, true, false, |file, _| {
                 assert_eq!(file.metadata()?.len(), 4);
                 Ok("/dev/fdset/7".to_string())
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
 
         assert_eq!(prepared.filename, "/dev/fdset/7");
         assert!(prepared.is_regular_file);
@@ -287,18 +279,11 @@ mod tests {
         let path = dir.path().join("writable.raw");
         std::fs::write(&path, b"disk").unwrap();
 
-        prepare_block_source(
-            path.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            false,
-            false,
-            |mut file, _| {
-                file.seek(SeekFrom::End(0))?;
-                file.write_all(b"-writable")?;
-                Ok("/dev/fdset/8".to_string())
-            },
-        )
+        prepare_block_source(path.to_str().unwrap(), None, false, false, |mut file, _| {
+            file.seek(SeekFrom::End(0))?;
+            file.write_all(b"-writable")?;
+            Ok("/dev/fdset/8".to_string())
+        })
         .unwrap();
 
         assert_eq!(std::fs::read(&path).unwrap(), b"disk-writable");
@@ -310,17 +295,10 @@ mod tests {
         let path = dir.path().join("readonly.raw");
         std::fs::write(&path, b"readonly").unwrap();
 
-        prepare_block_source(
-            path.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            true,
-            false,
-            |mut file, _| {
-                assert!(file.write_all(b"no").is_err());
-                Ok("/dev/fdset/8".to_string())
-            },
-        )
+        prepare_block_source(path.to_str().unwrap(), None, true, false, |mut file, _| {
+            assert!(file.write_all(b"no").is_err());
+            Ok("/dev/fdset/8".to_string())
+        })
         .unwrap();
 
         assert_eq!(std::fs::read(&path).unwrap(), b"readonly");
@@ -341,7 +319,6 @@ mod tests {
         let registered = RefCell::new(Vec::new());
         let prepared = prepare_block_source(
             "merged.vmdk",
-            &BlockDeviceFormat::Vmdk,
             Some(&vmdk),
             true,
             false,
@@ -376,18 +353,11 @@ mod tests {
         let path = dir.path().join("disk.img");
         std::fs::write(&path, vec![0u8; 4096]).unwrap();
 
-        prepare_block_source(
-            path.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            true,
-            true,
-            |file, _| {
-                let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
-                assert!(flags.contains(OFlag::O_DIRECT));
-                Ok("/dev/fdset/8".to_string())
-            },
-        )
+        prepare_block_source(path.to_str().unwrap(), None, true, true, |file, _| {
+            let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
+            assert!(flags.contains(OFlag::O_DIRECT));
+            Ok("/dev/fdset/8".to_string())
+        })
         .unwrap();
     }
 
@@ -402,7 +372,6 @@ mod tests {
 
         prepare_block_source(
             descriptor.to_str().unwrap(),
-            &BlockDeviceFormat::Vmdk,
             Some(&vmdk),
             true,
             true,
@@ -429,18 +398,12 @@ mod tests {
         std::fs::write(&target, b"disk").unwrap();
         symlink(&target, &link).unwrap();
 
-        let prepared = prepare_block_source(
-            link.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            true,
-            false,
-            |file, _| {
+        let prepared =
+            prepare_block_source(link.to_str().unwrap(), None, true, false, |file, _| {
                 assert!(file.metadata()?.is_file());
                 Ok("/dev/fdset/1".to_string())
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
 
         assert_eq!(prepared.filename, "/dev/fdset/1");
         assert!(prepared.is_regular_file);
@@ -455,14 +418,9 @@ mod tests {
         vmdk.push_extent(extent.to_str().unwrap(), 1, 0);
         vmdk.push_extent(extent.to_str().unwrap(), 1, 1);
 
-        let error = prepare_block_source(
-            "disk.vmdk",
-            &BlockDeviceFormat::Vmdk,
-            Some(&vmdk),
-            true,
-            false,
-            |_, _| Ok("/dev/fdset/1".to_string()),
-        )
+        let error = prepare_block_source("disk.vmdk", Some(&vmdk), true, false, |_, _| {
+            Ok("/dev/fdset/1".to_string())
+        })
         .unwrap_err();
 
         assert!(error
@@ -477,17 +435,10 @@ mod tests {
         std::fs::write(&path, b"persistent").unwrap();
         let received = RefCell::new(None);
 
-        prepare_block_source(
-            path.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
-            None,
-            true,
-            false,
-            |file, _| {
-                *received.borrow_mut() = Some(file.try_clone()?);
-                Ok("/dev/fdset/1".to_string())
-            },
-        )
+        prepare_block_source(path.to_str().unwrap(), None, true, false, |file, _| {
+            *received.borrow_mut() = Some(file.try_clone()?);
+            Ok("/dev/fdset/1".to_string())
+        })
         .unwrap();
         std::fs::remove_file(&path).unwrap();
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
@@ -2,11 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::BlockDeviceFormat;
+use crate::{BlockDeviceFormat, VmdkConfig};
 
 use anyhow::{anyhow, Context, Result};
+use nix::sys::memfd::{memfd_create, MFdFlags};
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::fmt::Write as _;
 use std::fs::{File, OpenOptions};
+use std::io::Write as _;
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
+use std::path::Path;
 
 const BLOCK_FD_OPAQUE_PREFIX: &str = "kata-block:";
 
@@ -63,12 +70,97 @@ fn open_block_source(
     Ok((file, metadata))
 }
 
-/// Open a raw block source while the shim still has host privileges and
-/// register the resulting descriptor with QEMU. Other formats retain their
-/// existing path-based transport.
+fn render_vmdk_descriptor(
+    config: &VmdkConfig,
+    backing_paths: &HashMap<String, String>,
+) -> Result<String> {
+    let total_sectors = config
+        .total_sectors()
+        .ok_or_else(|| anyhow!("VMDK total sector count overflow"))?;
+    if total_sectors == 0 {
+        return Err(anyhow!("VMDK contains no non-empty extents"));
+    }
+
+    let mut descriptor = String::new();
+    writeln!(descriptor, "# Disk DescriptorFile")?;
+    writeln!(descriptor, "version=1")?;
+    writeln!(descriptor, "CID=fffffffe")?;
+    writeln!(descriptor, "parentCID=ffffffff")?;
+    writeln!(descriptor, "createType=\"twoGbMaxExtentFlat\"")?;
+    writeln!(descriptor)?;
+    writeln!(descriptor, "# Extent description")?;
+    for extent in &config.extents {
+        let path = backing_paths
+            .get(&extent.path_on_host)
+            .ok_or_else(|| anyhow!("missing prepared VMDK extent {}", extent.path_on_host))?;
+        writeln!(
+            descriptor,
+            "RW {} FLAT \"{}\" {}",
+            extent.sectors, path, extent.file_offset
+        )?;
+    }
+
+    let cylinders = total_sectors.div_ceil(63 * 16);
+    writeln!(descriptor)?;
+    writeln!(descriptor, "# The Disk Data Base")?;
+    writeln!(descriptor, "#DDB")?;
+    writeln!(descriptor)?;
+    writeln!(descriptor, "ddb.virtualHWVersion = \"4\"")?;
+    writeln!(descriptor, "ddb.geometry.cylinders = \"{cylinders}\"")?;
+    writeln!(descriptor, "ddb.geometry.heads = \"16\"")?;
+    writeln!(descriptor, "ddb.geometry.sectors = \"63\"")?;
+    writeln!(descriptor, "ddb.adapterType = \"ide\"")?;
+
+    Ok(descriptor)
+}
+
+fn create_vmdk_descriptor_file(
+    descriptor_path: &Path,
+    descriptor: &str,
+    is_readonly: bool,
+    is_direct: bool,
+) -> Result<File> {
+    let mut writable = if is_direct {
+        let descriptor_dir = descriptor_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .ok_or_else(|| anyhow!("QEMU VMDK descriptor path has no parent directory"))?;
+        tempfile::tempfile_in(descriptor_dir).with_context(|| {
+            format!(
+                "create anonymous QEMU VMDK descriptor file in {}",
+                descriptor_dir.display()
+            )
+        })?
+    } else {
+        let name = CString::new("kata-qemu-vmdk")?;
+        let fd = memfd_create(name.as_c_str(), MFdFlags::MFD_CLOEXEC)
+            .context("create QEMU VMDK descriptor memfd")?;
+        File::from(fd)
+    };
+    writable
+        .write_all(descriptor.as_bytes())
+        .context("write anonymous QEMU VMDK descriptor")?;
+
+    // QEMU's fdset lookup requires the descriptor's access and O_DIRECT flags
+    // to match the flags requested by the block layer. Reopen the completed
+    // anonymous file with the requested access rather than passing its writable
+    // construction descriptor.
+    let fd_path = format!("/proc/self/fd/{}", writable.as_raw_fd());
+    OpenOptions::new()
+        .read(true)
+        .write(!is_readonly)
+        .custom_flags(if is_direct { libc::O_DIRECT } else { 0 })
+        .open(&fd_path)
+        .context("reopen anonymous QEMU VMDK descriptor read-only")
+}
+
+/// Open a block source while the shim still has host privileges and register
+/// the resulting descriptors with QEMU. Structured VMDK layouts are serialized
+/// once after their backing extents have been registered.
 pub(super) fn prepare_block_source<F>(
     path: &str,
     format: &BlockDeviceFormat,
+    vmdk: Option<&VmdkConfig>,
     is_readonly: bool,
     is_direct: bool,
     mut register: F,
@@ -76,21 +168,66 @@ pub(super) fn prepare_block_source<F>(
 where
     F: FnMut(File, &str) -> Result<String>,
 {
-    if *format != BlockDeviceFormat::Raw {
-        let metadata =
-            std::fs::metadata(path).with_context(|| format!("stat QEMU block source {path}"))?;
+    if *format == BlockDeviceFormat::Raw {
+        let (file, metadata) = open_block_source(path, is_readonly, is_direct, false)?;
+        let is_regular_file = metadata.is_file();
+        let filename = register(file, "block-source")?;
         return Ok(PreparedBlockSource {
-            filename: path.to_string(),
-            is_regular_file: metadata.is_file(),
+            filename,
+            is_regular_file,
         });
     }
 
-    let (file, metadata) = open_block_source(path, is_readonly, is_direct, false)?;
-    let is_regular_file = metadata.is_file();
-    let filename = register(file, "block-source")?;
+    let vmdk = vmdk.ok_or_else(|| anyhow!("VMDK block source is missing its extent layout"))?;
+    if vmdk.extents.is_empty() {
+        return Err(anyhow!("VMDK contains no extents"));
+    }
+
+    let mut required_sectors_by_path: HashMap<&str, u64> = HashMap::new();
+    for extent in &vmdk.extents {
+        let required_sectors = extent
+            .file_offset
+            .checked_add(extent.sectors)
+            .ok_or_else(|| anyhow!("VMDK extent sector count overflow"))?;
+        required_sectors_by_path
+            .entry(extent.path_on_host.as_str())
+            .and_modify(|maximum| *maximum = (*maximum).max(required_sectors))
+            .or_insert(required_sectors);
+    }
+
+    let mut backing_paths = HashMap::new();
+    for extent in &vmdk.extents {
+        if backing_paths.contains_key(&extent.path_on_host) {
+            continue;
+        }
+        // QEMU applies cache.direct to the file node containing the VMDK
+        // descriptor, but the VMDK driver opens its flat extents without
+        // O_DIRECT. QEMU fdsets require an exact O_DIRECT match, so preserve
+        // that existing reopen behavior for delegated extent descriptors.
+        let (file, metadata) = open_block_source(&extent.path_on_host, is_readonly, false, true)?;
+        let required_sectors = required_sectors_by_path
+            .get(extent.path_on_host.as_str())
+            .copied()
+            .ok_or_else(|| anyhow!("missing VMDK extent size for {}", extent.path_on_host))?;
+        if metadata.len().div_ceil(512) < required_sectors {
+            return Err(anyhow!(
+                "VMDK extent {} is shorter than its declared layout",
+                extent.path_on_host
+            ));
+        }
+        let index = backing_paths.len();
+        let fd_path = register(file, &format!("vmdk-extent-{index}"))?;
+        backing_paths.insert(extent.path_on_host.clone(), fd_path);
+    }
+
+    let descriptor = render_vmdk_descriptor(vmdk, &backing_paths)?;
+    let descriptor =
+        create_vmdk_descriptor_file(Path::new(path), &descriptor, is_readonly, is_direct)?;
+    let filename = register(descriptor, "vmdk-descriptor")?;
+
     Ok(PreparedBlockSource {
         filename,
-        is_regular_file,
+        is_regular_file: true,
     })
 }
 
@@ -99,9 +236,27 @@ mod tests {
     use super::*;
     use nix::fcntl::{fcntl, FcntlArg, OFlag};
     use std::cell::RefCell;
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::{Read, Seek, SeekFrom};
     use std::os::unix::fs::symlink;
     use tempfile::tempdir;
+
+    #[test]
+    fn renders_structured_vmdk_layout() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/images/first.raw", 8, 0);
+        config.push_extent("/images/first.raw", 4, 8);
+        config.push_extent("/images/second.raw", 16, 0);
+        let backing_paths = HashMap::from([
+            ("/images/first.raw".to_string(), "/dev/fdset/1".to_string()),
+            ("/images/second.raw".to_string(), "/dev/fdset/2".to_string()),
+        ]);
+
+        let descriptor = render_vmdk_descriptor(&config, &backing_paths).unwrap();
+        assert!(descriptor.contains("RW 8 FLAT \"/dev/fdset/1\" 0"));
+        assert!(descriptor.contains("RW 4 FLAT \"/dev/fdset/1\" 8"));
+        assert!(descriptor.contains("RW 16 FLAT \"/dev/fdset/2\" 0"));
+        assert!(descriptor.contains("ddb.geometry.cylinders = \"1\""));
+    }
 
     #[test]
     fn prepares_raw_source_with_requested_access() {
@@ -112,6 +267,7 @@ mod tests {
         let prepared = prepare_block_source(
             path.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             true,
             false,
             |file, _| {
@@ -134,6 +290,7 @@ mod tests {
         prepare_block_source(
             path.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             false,
             false,
             |mut file, _| {
@@ -156,6 +313,7 @@ mod tests {
         prepare_block_source(
             path.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             true,
             false,
             |mut file, _| {
@@ -169,6 +327,50 @@ mod tests {
     }
 
     #[test]
+    fn prepares_every_structured_vmdk_extent() {
+        let dir = tempdir().unwrap();
+        let first = dir.path().join("first.raw");
+        let second = dir.path().join("second.raw");
+        std::fs::write(&first, vec![0u8; 512]).unwrap();
+        std::fs::write(&second, vec![0u8; 1024]).unwrap();
+
+        let mut vmdk = VmdkConfig::default();
+        vmdk.push_extent(first.to_str().unwrap(), 1, 0);
+        vmdk.push_extent(second.to_str().unwrap(), 2, 0);
+
+        let registered = RefCell::new(Vec::new());
+        let prepared = prepare_block_source(
+            "merged.vmdk",
+            &BlockDeviceFormat::Vmdk,
+            Some(&vmdk),
+            true,
+            false,
+            |mut file, label| {
+                let index = registered.borrow().len() + 10;
+                if label == "vmdk-descriptor" {
+                    let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
+                    assert_eq!(flags & OFlag::O_ACCMODE, OFlag::O_RDONLY);
+                    let mut descriptor = String::new();
+                    file.read_to_string(&mut descriptor)?;
+                    assert!(descriptor.contains("\"/dev/fdset/10\""));
+                    assert!(descriptor.contains("\"/dev/fdset/11\""));
+                    assert!(!descriptor.contains(first.to_str().unwrap()));
+                    assert!(!descriptor.contains(second.to_str().unwrap()));
+                }
+                registered.borrow_mut().push(label.to_string());
+                Ok(format!("/dev/fdset/{index}"))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(prepared.filename, "/dev/fdset/12");
+        assert_eq!(
+            registered.into_inner(),
+            vec!["vmdk-extent-0", "vmdk-extent-1", "vmdk-descriptor"]
+        );
+    }
+
+    #[test]
     fn preserves_direct_io_on_registered_files() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("disk.img");
@@ -177,12 +379,43 @@ mod tests {
         prepare_block_source(
             path.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             true,
             true,
             |file, _| {
                 let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
                 assert!(flags.contains(OFlag::O_DIRECT));
                 Ok("/dev/fdset/8".to_string())
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn preserves_qemu_direct_io_flags_on_vmdk_files() {
+        let dir = tempdir().unwrap();
+        let extent = dir.path().join("extent.raw");
+        let descriptor = dir.path().join("merged.vmdk");
+        std::fs::write(&extent, vec![0u8; 4096]).unwrap();
+        let mut vmdk = VmdkConfig::default();
+        vmdk.push_extent(extent.to_str().unwrap(), 8, 0);
+
+        prepare_block_source(
+            descriptor.to_str().unwrap(),
+            &BlockDeviceFormat::Vmdk,
+            Some(&vmdk),
+            true,
+            true,
+            |file, label| {
+                let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
+                if label == "vmdk-descriptor" {
+                    assert!(flags.contains(OFlag::O_DIRECT));
+                    let fd_path = format!("/proc/self/fd/{}", file.as_raw_fd());
+                    assert!(std::fs::read_link(fd_path)?.starts_with(dir.path()));
+                } else {
+                    assert!(!flags.contains(OFlag::O_DIRECT));
+                }
+                Ok("/dev/fdset/9".to_string())
             },
         )
         .unwrap();
@@ -199,6 +432,7 @@ mod tests {
         let prepared = prepare_block_source(
             link.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             true,
             false,
             |file, _| {
@@ -213,6 +447,30 @@ mod tests {
     }
 
     #[test]
+    fn rejects_short_vmdk_extent() {
+        let dir = tempdir().unwrap();
+        let extent = dir.path().join("extent.raw");
+        std::fs::write(&extent, vec![0_u8; 512]).unwrap();
+        let mut vmdk = VmdkConfig::default();
+        vmdk.push_extent(extent.to_str().unwrap(), 1, 0);
+        vmdk.push_extent(extent.to_str().unwrap(), 1, 1);
+
+        let error = prepare_block_source(
+            "disk.vmdk",
+            &BlockDeviceFormat::Vmdk,
+            Some(&vmdk),
+            true,
+            false,
+            |_, _| Ok("/dev/fdset/1".to_string()),
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("shorter than its declared layout"));
+    }
+
+    #[test]
     fn registered_source_survives_path_removal() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("source.raw");
@@ -222,6 +480,7 @@ mod tests {
         prepare_block_source(
             path.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             true,
             false,
             |file, _| {
@@ -244,7 +503,7 @@ mod tests {
 
     #[test]
     fn identifies_owned_block_fdsets() {
-        let opaque = block_fd_opaque("drive-3", "block-source");
+        let opaque = block_fd_opaque("drive-3", "vmdk-extent-0");
 
         assert_eq!(block_fd_node_name(&opaque), Some("drive-3"));
         assert_eq!(block_fd_node_name("unrelated"), None);

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -4,6 +4,7 @@
 //
 
 use crate::device::topology::{TopologyPortDevice, DEFAULT_PCIE_ROOT_BUS};
+use crate::qemu::block_source::{block_fd_opaque, prepare_block_source};
 use crate::qemu::qmp::get_qmp_socket_path;
 use crate::utils::{
     chown_to_parent, clear_cloexec, create_vhost_net_fds, open_named_tuntap, uses_native_ccw_bus,
@@ -1018,6 +1019,28 @@ struct BlockBackend {
     cache_no_flush: bool,
     read_only: bool,
     discard_unmap: bool,
+}
+
+#[derive(Debug)]
+struct AddFd {
+    file: File,
+    fdset_id: i64,
+    opaque: String,
+}
+
+#[async_trait]
+impl ToQemuParams for AddFd {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        Ok(vec![
+            "-add-fd".to_string(),
+            format!(
+                "fd={},set={},opaque={}",
+                self.file.as_raw_fd(),
+                self.fdset_id,
+                self.opaque
+            ),
+        ])
+    }
 }
 
 impl BlockBackend {
@@ -2812,6 +2835,8 @@ pub struct QemuCmdLine<'a> {
 
     devices: Vec<Box<dyn ToQemuParams>>,
     ccw_subchannel: Option<CcwSubChannel>,
+    block_fdsets: HashMap<String, Vec<i64>>,
+    next_fdset_id: i64,
 }
 
 impl<'a> QemuCmdLine<'a> {
@@ -2833,6 +2858,8 @@ impl<'a> QemuCmdLine<'a> {
             bios: None,
             devices: Vec::new(),
             ccw_subchannel,
+            block_fdsets: HashMap::new(),
+            next_fdset_id: 1,
         };
 
         // add_virtiofs_share() installs the file-backed memory backend when
@@ -2908,6 +2935,12 @@ impl<'a> QemuCmdLine<'a> {
     /// Used to transfer boot-time CCW state to Qmp for hotplug allocation.
     pub fn take_ccw_subchannel(&mut self) -> Option<CcwSubChannel> {
         self.ccw_subchannel.take()
+    }
+
+    /// Takes ownership of cold-plug block fdset bookkeeping so QMP can remove
+    /// the descriptors if one of those devices is subsequently unplugged.
+    pub fn take_block_fdsets(&mut self) -> HashMap<String, Vec<i64>> {
+        std::mem::take(&mut self.block_fdsets)
     }
 
     fn add_monitor(&mut self, proto: &str) -> Result<()> {
@@ -3144,13 +3177,29 @@ impl<'a> QemuCmdLine<'a> {
         &mut self,
         device_id: &str,
         path: &str,
+        format: &crate::BlockDeviceFormat,
         is_direct: bool,
         is_readonly: bool,
         is_scsi: bool,
         discard_unmap: bool,
         serial_override: Option<&str>,
     ) -> Result<()> {
-        let mut backend = BlockBackend::new(device_id, path, is_direct);
+        if self.block_fdsets.contains_key(device_id) {
+            return Err(anyhow!("duplicate QEMU block device ID {device_id}"));
+        }
+        let mut fdset_ids = Vec::new();
+        let path = prepare_block_source(path, format, is_readonly, is_direct, |file, label| {
+            let (path, fdset_id) =
+                self.add_block_source_fd(file, &block_fd_opaque(device_id, label))?;
+            fdset_ids.push(fdset_id);
+            Ok(path)
+        })?
+        .filename;
+        if !fdset_ids.is_empty() {
+            self.block_fdsets.insert(device_id.to_string(), fdset_ids);
+        }
+
+        let mut backend = BlockBackend::new(device_id, &path, is_direct);
         backend.set_read_only(is_readonly);
         backend.set_discard_unmap(discard_unmap);
         self.devices.push(Box::new(backend));
@@ -3168,6 +3217,23 @@ impl<'a> QemuCmdLine<'a> {
         }
 
         Ok(())
+    }
+
+    fn add_block_source_fd(&mut self, file: File, label: &str) -> Result<(String, i64)> {
+        clear_cloexec(file.as_raw_fd()).context("clear O_CLOEXEC on QEMU block source")?;
+
+        let fdset_id = self.next_fdset_id;
+        self.next_fdset_id = self
+            .next_fdset_id
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("QEMU block fdset ID exhausted"))?;
+        self.devices.push(Box::new(AddFd {
+            file,
+            fdset_id,
+            opaque: label.to_string(),
+        }));
+
+        Ok((format!("/dev/fdset/{fdset_id}"), fdset_id))
     }
 
     #[allow(dead_code)]
@@ -3781,8 +3847,10 @@ impl ToQemuParams for SeccompSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BlockDeviceFormat;
     use rstest::rstest;
     use serial_test::serial;
+    use tempfile::tempdir;
 
     fn contains_param(params: &[String], expected: &str) -> bool {
         params
@@ -3873,6 +3941,48 @@ mod tests {
         assert!(!contains_param(&scsi_hd_params, "discard=on"));
     }
 
+    #[actix_rt::test]
+    #[serial]
+    async fn test_block_source_uses_inherited_fdset() {
+        let dir = tempdir().unwrap();
+        let image = dir.path().join("image.raw");
+        std::fs::write(&image, vec![0u8; 4096]).unwrap();
+
+        let config = test_qemu_config(Some("none"), false);
+        let mut cmdline = QemuCmdLine::new("rootless-block-fd", &config).unwrap();
+        let result = cmdline.add_block_device(
+            "rootfs",
+            image.to_str().unwrap(),
+            &BlockDeviceFormat::Raw,
+            false,
+            true,
+            false,
+            false,
+            None,
+        );
+        result.unwrap();
+
+        let params = cmdline.build().await.unwrap();
+        let add_fd = params
+            .windows(2)
+            .find(|args| args[0] == "-add-fd")
+            .expect("missing inherited block fd");
+        assert!(add_fd[1].contains("set=1"));
+        assert!(add_fd[1].contains("opaque=kata-block:rootfs:block-source"));
+
+        let blockdev = params
+            .windows(2)
+            .find(|args| args[0] == "-blockdev")
+            .expect("missing block backend");
+        assert!(blockdev[1].contains("filename=/dev/fdset/1"));
+        assert!(!blockdev[1].contains(image.to_str().unwrap()));
+
+        assert_eq!(
+            cmdline.take_block_fdsets(),
+            HashMap::from([("rootfs".to_string(), vec![1])])
+        );
+    }
+
     #[rstest]
     #[case::read_only(true, "read-only=on")]
     #[case::writable(false, "read-only=off")]
@@ -3882,13 +3992,17 @@ mod tests {
         #[case] is_readonly: bool,
         #[case] expected_param: &str,
     ) {
+        let dir = tempdir().unwrap();
+        let image = dir.path().join("image.raw");
+        std::fs::write(&image, vec![0_u8; 4096]).unwrap();
         let config = test_qemu_config(Some("none"), false);
         let _ = std::fs::remove_file(QMP_SOCKET_FILE);
         let mut cmdline = QemuCmdLine::new("block-read-only", &config).unwrap();
         cmdline
             .add_block_device(
                 "blk0",
-                "/tmp/disk.img",
+                image.to_str().unwrap(),
+                &BlockDeviceFormat::Raw,
                 true,
                 is_readonly,
                 false,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1028,6 +1028,12 @@ struct AddFd {
     opaque: String,
 }
 
+#[derive(Debug)]
+struct VmdkFormatNode {
+    id: String,
+    file: BlockBackend,
+}
+
 #[async_trait]
 impl ToQemuParams for AddFd {
     async fn qemu_params(&self) -> Result<Vec<String>> {
@@ -1092,34 +1098,85 @@ impl BlockBackend {
         self.discard_unmap = discard_unmap;
         self
     }
+
+    fn options(&self, prefix: &str, include_node_name: bool) -> Vec<String> {
+        let mut params = vec![format!("{prefix}driver={}", self.driver)];
+        if include_node_name {
+            params.push(format!("node-name=image-{}", self.id));
+        }
+        params.push(format!("{prefix}filename={}", self.path));
+        params.push(format!("{prefix}aio={}", self.aio));
+        params.push(format!(
+            "{prefix}cache.direct={}",
+            if self.cache_direct { "on" } else { "off" }
+        ));
+        params.push(format!(
+            "{prefix}cache.no-flush={}",
+            if self.cache_no_flush { "on" } else { "off" }
+        ));
+        params.push(format!(
+            "{prefix}read-only={}",
+            if self.read_only { "on" } else { "off" }
+        ));
+        if self.discard_unmap {
+            params.push(format!("{prefix}discard=unmap"));
+        }
+        params
+    }
 }
 
 #[async_trait]
 impl ToQemuParams for BlockBackend {
     async fn qemu_params(&self) -> Result<Vec<String>> {
-        let mut params = Vec::new();
-        params.push(format!("driver={}", self.driver));
-        params.push(format!("node-name=image-{}", self.id));
-        params.push(format!("filename={}", self.path));
-        params.push(format!("aio={}", self.aio));
-        if self.cache_direct {
-            params.push("cache.direct=on".to_owned());
-        } else {
-            params.push("cache.direct=off".to_owned());
+        let params = self.options("", true);
+        Ok(vec!["-blockdev".to_owned(), params.join(",")])
+    }
+}
+
+impl VmdkFormatNode {
+    fn new(id: &str, file: BlockBackend) -> Self {
+        Self {
+            id: id.to_owned(),
+            file,
         }
-        if self.cache_no_flush {
-            params.push("cache.no-flush=on".to_owned());
-        } else {
-            params.push("cache.no-flush=off".to_owned());
-        }
-        params.push(format!(
-            "read-only={}",
-            if self.read_only { "on" } else { "off" }
-        ));
-        if self.discard_unmap {
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for VmdkFormatNode {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        let mut params = vec![
+            "driver=vmdk".to_owned(),
+            format!("node-name=image-{}", self.id),
+            format!(
+                "read-only={}",
+                if self.file.read_only { "on" } else { "off" }
+            ),
+            "force-share=on".to_owned(),
+        ];
+        if self.file.discard_unmap {
             params.push("discard=unmap".to_owned());
         }
+        params.extend(self.file.options("file.", false));
         Ok(vec!["-blockdev".to_owned(), params.join(",")])
+    }
+}
+
+fn block_backend_node(
+    device_id: &str,
+    path: &str,
+    format: &crate::BlockDeviceFormat,
+    is_direct: bool,
+    is_readonly: bool,
+    discard_unmap: bool,
+) -> Box<dyn ToQemuParams> {
+    let mut backend = BlockBackend::new(device_id, path, is_direct);
+    backend.set_read_only(is_readonly);
+    backend.set_discard_unmap(discard_unmap);
+
+    match format {
+        crate::BlockDeviceFormat::Raw => Box::new(backend),
+        crate::BlockDeviceFormat::Vmdk => Box::new(VmdkFormatNode::new(device_id, backend)),
     }
 }
 
@@ -3178,6 +3235,7 @@ impl<'a> QemuCmdLine<'a> {
         device_id: &str,
         path: &str,
         format: &crate::BlockDeviceFormat,
+        vmdk: Option<&crate::VmdkConfig>,
         is_direct: bool,
         is_readonly: bool,
         is_scsi: bool,
@@ -3188,21 +3246,25 @@ impl<'a> QemuCmdLine<'a> {
             return Err(anyhow!("duplicate QEMU block device ID {device_id}"));
         }
         let mut fdset_ids = Vec::new();
-        let path = prepare_block_source(path, format, is_readonly, is_direct, |file, label| {
-            let (path, fdset_id) =
-                self.add_block_source_fd(file, &block_fd_opaque(device_id, label))?;
-            fdset_ids.push(fdset_id);
-            Ok(path)
-        })?
-        .filename;
-        if !fdset_ids.is_empty() {
-            self.block_fdsets.insert(device_id.to_string(), fdset_ids);
-        }
+        let path =
+            prepare_block_source(path, format, vmdk, is_readonly, is_direct, |file, label| {
+                let (path, fdset_id) =
+                    self.add_block_source_fd(file, &block_fd_opaque(device_id, label))?;
+                fdset_ids.push(fdset_id);
+                Ok(path)
+            })?
+            .filename;
+        self.block_fdsets.insert(device_id.to_string(), fdset_ids);
 
-        let mut backend = BlockBackend::new(device_id, &path, is_direct);
-        backend.set_read_only(is_readonly);
-        backend.set_discard_unmap(discard_unmap);
-        self.devices.push(Box::new(backend));
+        let backend = block_backend_node(
+            device_id,
+            &path,
+            format,
+            is_direct,
+            is_readonly,
+            discard_unmap,
+        );
+        self.devices.push(backend);
         let devno = get_devno_ccw(&mut self.ccw_subchannel, device_id);
         if is_scsi {
             self.devices
@@ -3954,6 +4016,7 @@ mod tests {
             "rootfs",
             image.to_str().unwrap(),
             &BlockDeviceFormat::Raw,
+            None,
             false,
             true,
             false,
@@ -3983,6 +4046,41 @@ mod tests {
         );
     }
 
+    #[actix_rt::test]
+    async fn test_cold_plug_vmdk_uses_format_node() {
+        let format_node = block_backend_node(
+            "rootfs",
+            "/dev/fdset/2",
+            &BlockDeviceFormat::Vmdk,
+            false,
+            true,
+            false,
+        );
+
+        let format_params = format_node.qemu_params().await.unwrap();
+        assert_eq!(format_params[0], "-blockdev");
+        assert!(contains_param(&format_params[1..2], "driver=vmdk"));
+        assert!(contains_param(
+            &format_params[1..2],
+            "node-name=image-rootfs"
+        ));
+        assert!(contains_param(&format_params[1..2], "read-only=on"));
+        assert!(contains_param(&format_params[1..2], "force-share=on"));
+        assert!(contains_param(&format_params[1..2], "file.driver=file"));
+        assert!(contains_param(
+            &format_params[1..2],
+            "file.filename=/dev/fdset/2"
+        ));
+        assert!(contains_param(&format_params[1..2], "file.read-only=on"));
+        assert!(!format_params[1].contains("file.node-name="));
+
+        let frontend = DeviceVirtioBlk::new("rootfs", VirtioBusType::Pci, None)
+            .qemu_params()
+            .await
+            .unwrap();
+        assert!(contains_param(&frontend[1..2], "drive=image-rootfs"));
+    }
+
     #[rstest]
     #[case::read_only(true, "read-only=on")]
     #[case::writable(false, "read-only=off")]
@@ -4003,6 +4101,7 @@ mod tests {
                 "blk0",
                 image.to_str().unwrap(),
                 &BlockDeviceFormat::Raw,
+                None,
                 true,
                 is_readonly,
                 false,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1165,7 +1165,7 @@ impl ToQemuParams for VmdkFormatNode {
 fn block_backend_node(
     device_id: &str,
     path: &str,
-    format: &crate::BlockDeviceFormat,
+    vmdk: Option<&crate::VmdkConfig>,
     is_direct: bool,
     is_readonly: bool,
     discard_unmap: bool,
@@ -1174,9 +1174,10 @@ fn block_backend_node(
     backend.set_read_only(is_readonly);
     backend.set_discard_unmap(discard_unmap);
 
-    match format {
-        crate::BlockDeviceFormat::Raw => Box::new(backend),
-        crate::BlockDeviceFormat::Vmdk => Box::new(VmdkFormatNode::new(device_id, backend)),
+    if vmdk.is_some() {
+        Box::new(VmdkFormatNode::new(device_id, backend))
+    } else {
+        Box::new(backend)
     }
 }
 
@@ -3234,7 +3235,6 @@ impl<'a> QemuCmdLine<'a> {
         &mut self,
         device_id: &str,
         path: &str,
-        format: &crate::BlockDeviceFormat,
         vmdk: Option<&crate::VmdkConfig>,
         is_direct: bool,
         is_readonly: bool,
@@ -3246,20 +3246,19 @@ impl<'a> QemuCmdLine<'a> {
             return Err(anyhow!("duplicate QEMU block device ID {device_id}"));
         }
         let mut fdset_ids = Vec::new();
-        let path =
-            prepare_block_source(path, format, vmdk, is_readonly, is_direct, |file, label| {
-                let (path, fdset_id) =
-                    self.add_block_source_fd(file, &block_fd_opaque(device_id, label))?;
-                fdset_ids.push(fdset_id);
-                Ok(path)
-            })?
-            .filename;
+        let path = prepare_block_source(path, vmdk, is_readonly, is_direct, |file, label| {
+            let (path, fdset_id) =
+                self.add_block_source_fd(file, &block_fd_opaque(device_id, label))?;
+            fdset_ids.push(fdset_id);
+            Ok(path)
+        })?
+        .filename;
         self.block_fdsets.insert(device_id.to_string(), fdset_ids);
 
         let backend = block_backend_node(
             device_id,
             &path,
-            format,
+            vmdk,
             is_direct,
             is_readonly,
             discard_unmap,
@@ -3909,7 +3908,6 @@ impl ToQemuParams for SeccompSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BlockDeviceFormat;
     use rstest::rstest;
     use serial_test::serial;
     use tempfile::tempdir;
@@ -4015,7 +4013,6 @@ mod tests {
         let result = cmdline.add_block_device(
             "rootfs",
             image.to_str().unwrap(),
-            &BlockDeviceFormat::Raw,
             None,
             false,
             true,
@@ -4048,14 +4045,9 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_cold_plug_vmdk_uses_format_node() {
-        let format_node = block_backend_node(
-            "rootfs",
-            "/dev/fdset/2",
-            &BlockDeviceFormat::Vmdk,
-            false,
-            true,
-            false,
-        );
+        let vmdk = crate::VmdkConfig::default();
+        let format_node =
+            block_backend_node("rootfs", "/dev/fdset/2", Some(&vmdk), false, true, false);
 
         let format_params = format_node.qemu_params().await.unwrap();
         assert_eq!(format_params[0], "-blockdev");
@@ -4100,7 +4092,6 @@ mod tests {
             .add_block_device(
                 "blk0",
                 image.to_str().unwrap(),
-                &BlockDeviceFormat::Raw,
                 None,
                 true,
                 is_readonly,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -147,7 +147,6 @@ impl QemuInner {
                     let (
                         device_id,
                         path_on_host,
-                        format,
                         vmdk,
                         is_direct,
                         is_readonly,
@@ -161,7 +160,6 @@ impl QemuInner {
                         (
                             device_id,
                             cfg.path_on_host.clone(),
-                            cfg.format.clone(),
                             cfg.vmdk.clone(),
                             cfg.is_direct
                                 .unwrap_or(self.config.blockdev_info.block_device_cache_direct),
@@ -188,7 +186,6 @@ impl QemuInner {
                             cmdline.add_block_device(
                                 device_id.as_str(),
                                 &path_on_host,
-                                &format,
                                 vmdk.as_ref(),
                                 is_direct,
                                 is_readonly,
@@ -1213,7 +1210,6 @@ impl QemuInner {
                     is_direct,
                     is_readonly,
                     no_drop,
-                    block_format,
                     vmdk,
                     discard_unmap,
                     driver,
@@ -1231,7 +1227,6 @@ impl QemuInner {
                         ),
                         cfg.is_readonly,
                         cfg.no_drop,
-                        cfg.format.clone(),
                         cfg.vmdk.clone(),
                         cfg.discard_unmap,
                         self.config.blockdev_info.block_device_driver.clone(),
@@ -1269,7 +1264,6 @@ impl QemuInner {
                         discard_unmap,
                         logical_sector_size,
                         physical_sector_size,
-                        &block_format,
                         vmdk.as_ref(),
                         iothread,
                     )

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -148,6 +148,7 @@ impl QemuInner {
                         device_id,
                         path_on_host,
                         format,
+                        vmdk,
                         is_direct,
                         is_readonly,
                         discard_unmap,
@@ -161,6 +162,7 @@ impl QemuInner {
                             device_id,
                             cfg.path_on_host.clone(),
                             cfg.format.clone(),
+                            cfg.vmdk.clone(),
                             cfg.is_direct
                                 .unwrap_or(self.config.blockdev_info.block_device_cache_direct),
                             cfg.is_readonly,
@@ -187,6 +189,7 @@ impl QemuInner {
                                 device_id.as_str(),
                                 &path_on_host,
                                 &format,
+                                vmdk.as_ref(),
                                 is_direct,
                                 is_readonly,
                                 driver_option.as_str() == KATA_SCSI_DEV_TYPE,
@@ -1211,6 +1214,7 @@ impl QemuInner {
                     is_readonly,
                     no_drop,
                     block_format,
+                    vmdk,
                     discard_unmap,
                     driver,
                     logical_sector_size,
@@ -1228,6 +1232,7 @@ impl QemuInner {
                         cfg.is_readonly,
                         cfg.no_drop,
                         cfg.format.clone(),
+                        cfg.vmdk.clone(),
                         cfg.discard_unmap,
                         self.config.blockdev_info.block_device_driver.clone(),
                         cfg.logical_sector_size,
@@ -1265,6 +1270,7 @@ impl QemuInner {
                         logical_sector_size,
                         physical_sector_size,
                         &block_format,
+                        vmdk.as_ref(),
                         iothread,
                     )
                     .context("hotplug block device")?;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -147,6 +147,7 @@ impl QemuInner {
                     let (
                         device_id,
                         path_on_host,
+                        format,
                         is_direct,
                         is_readonly,
                         discard_unmap,
@@ -159,6 +160,7 @@ impl QemuInner {
                         (
                             device_id,
                             cfg.path_on_host.clone(),
+                            cfg.format.clone(),
                             cfg.is_direct
                                 .unwrap_or(self.config.blockdev_info.block_device_cache_direct),
                             cfg.is_readonly,
@@ -184,6 +186,7 @@ impl QemuInner {
                             cmdline.add_block_device(
                                 device_id.as_str(),
                                 &path_on_host,
+                                &format,
                                 is_direct,
                                 is_readonly,
                                 driver_option.as_str() == KATA_SCSI_DEV_TYPE,
@@ -373,9 +376,13 @@ impl QemuInner {
         let console_socket_path = Path::new(&jailer_root).join("console.sock");
         cmdline.add_console(console_socket_path.to_str().unwrap());
 
-        info!(sl!(), "qemu args: {}", cmdline.build().await?.join(" "));
+        let qemu_args = cmdline.build().await?;
+        info!(sl!(), "qemu args: {}", qemu_args.join(" "));
         let mut command = Command::new(&self.config.path);
-        command.args(cmdline.build().await?);
+        command.args(qemu_args);
+        let ccw_subchannel = cmdline.take_ccw_subchannel();
+        let block_fdsets = cmdline.take_block_fdsets();
+        let has_memory_hotplug_region = cmdline.has_memory_hotplug_region();
 
         info!(sl!(), "qemu cmd: {:?}", command);
 
@@ -420,6 +427,9 @@ impl QemuInner {
         }
 
         let mut qemu_process = command.stderr(Stdio::piped()).spawn()?;
+        // QEMU inherited its startup descriptors during spawn. Drop the
+        // privileged shim's copies immediately; QEMU owns the fdsets from here.
+        drop(cmdline);
         let stderr = qemu_process.stderr.take().unwrap();
         self.qemu_process = Mutex::new(Some(qemu_process));
 
@@ -436,9 +446,10 @@ impl QemuInner {
 
         match Qmp::new(&qmp_socket_path) {
             Ok(mut qmp) => {
-                if let Some(subchannel) = cmdline.take_ccw_subchannel() {
+                if let Some(subchannel) = ccw_subchannel {
                     qmp.set_ccw_subchannel(subchannel);
                 }
+                qmp.verify_block_fdsets(block_fdsets)?;
                 // Setup virtio-mem device if enabled.  It requires a memory
                 // hotplug region (maxmem) on the QEMU command line; that region
                 // is not reserved for every configuration (e.g. on s390x the
@@ -449,7 +460,7 @@ impl QemuInner {
                 // boot memory -- instead of failing VM start with
                 // "the configuration is not prepared for memory devices".
                 if self.config.memory_info.enable_virtio_mem {
-                    if cmdline.has_memory_hotplug_region() {
+                    if has_memory_hotplug_region {
                         qmp.setup_virtio_mem(
                             self.config.memory_info.default_memory,
                             self.config.memory_info.default_maxmemory,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+mod block_source;
 mod cmdline_generator;
 mod inner;
 mod qmp;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -4,10 +4,10 @@
 //
 
 use crate::device::pci_path::PciPath;
+use crate::qemu::block_source::{block_fd_node_name, block_fd_opaque, prepare_block_source};
 use crate::qemu::cmdline_generator::{CcwSubChannel, DeviceVirtioNet, Netdev, QMP_SOCKET_FILE};
 use crate::utils::get_jailer_root;
-use crate::BlockDeviceFormat;
-use crate::VcpuThreadIds;
+use crate::{BlockDeviceFormat, VcpuThreadIds};
 
 use anyhow::{anyhow, Context, Result};
 use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_SCSI};
@@ -41,6 +41,22 @@ const DEFAULT_QMP_RETRY_SLEEP_MS: u64 = 50;
 
 const DEVICE_DELETED_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn collect_block_fdsets(fdsets: Vec<qmp::FdsetInfo>) -> HashMap<String, Vec<i64>> {
+    let mut block_fdsets: HashMap<String, Vec<i64>> = HashMap::new();
+    for fdset in fdsets {
+        for fd in fdset.fds {
+            let Some(node_name) = fd.opaque.as_deref().and_then(block_fd_node_name) else {
+                continue;
+            };
+            let ids = block_fdsets.entry(node_name.to_string()).or_default();
+            if !ids.contains(&fdset.fdset_id) {
+                ids.push(fdset.fdset_id);
+            }
+        }
+    }
+    block_fdsets
+}
+
 pub struct Qmp {
     qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
 
@@ -64,6 +80,11 @@ pub struct Qmp {
     // Hot-plug slot tracking for cold-plugged pci-bridge-N devices. Mirrors
     // virtcontainers/types/bridges.go Bridge.Devices (slots 1..30).
     pci_bridge_devices: HashMap<String, HashMap<i64, String>>,
+
+    // QMP fdsets backing hot-plugged block devices. Keep them until the
+    // backend is removed because format drivers such as VMDK may reopen an
+    // extent after blockdev-add completes.
+    block_fdsets: HashMap<String, Vec<i64>>,
 }
 
 // We have to implement Debug since the Hypervisor trait requires it and Qmp
@@ -92,10 +113,12 @@ impl Qmp {
                 guest_memory_block_size: 0,
                 ccw_subchannel: None,
                 pci_bridge_devices: HashMap::new(),
+                block_fdsets: HashMap::new(),
             };
 
             let info = qmp.qmp.handshake().context("qmp handshake failed")?;
             info!(sl!(), "QMP initialized: {:#?}", info);
+            qmp.refresh_block_fdsets()?;
 
             Ok(qmp)
         };
@@ -116,6 +139,31 @@ impl Qmp {
 
         Err(last_err.unwrap_or_else(|| anyhow!("QMP init timed out")))
             .with_context(|| format!("timed out waiting for QMP ready: {}", qmp_sock_path))
+    }
+
+    fn refresh_block_fdsets(&mut self) -> Result<()> {
+        let fdsets = self
+            .qmp
+            .execute(&qmp::query_fdsets {})
+            .context("query QEMU fdsets")?;
+        self.block_fdsets = collect_block_fdsets(fdsets);
+        Ok(())
+    }
+
+    pub fn verify_block_fdsets(&self, mut expected: HashMap<String, Vec<i64>>) -> Result<()> {
+        let mut actual = self.block_fdsets.clone();
+        for ids in expected.values_mut() {
+            ids.sort_unstable();
+        }
+        for ids in actual.values_mut() {
+            ids.sort_unstable();
+        }
+        if actual != expected {
+            return Err(anyhow!(
+                "QEMU startup block fdsets do not match the descriptors passed by the shim"
+            ));
+        }
+        Ok(())
     }
 
     pub fn set_ccw_subchannel(&mut self, subchannel: CcwSubChannel) {
@@ -842,6 +890,57 @@ impl Qmp {
         }
     }
 
+    fn pass_block_fd(&mut self, fd: RawFd, opaque: &str) -> Result<qmp::AddfdInfo> {
+        let command = serde_json::json!({
+            "execute": "add-fd",
+            "arguments": { "opaque": opaque },
+        })
+        .to_string();
+        let bufs = &mut [std::io::IoSlice::new(command.as_bytes())][..];
+        let fds = [fd];
+        let cmsg = [ControlMessage::ScmRights(&fds)];
+
+        sendmsg::<()>(
+            self.qmp.inner_mut().get_mut_write().as_raw_fd(),
+            bufs,
+            &cmsg,
+            MsgFlags::empty(),
+            None,
+        )
+        .with_context(|| format!("send QEMU block fd for {opaque}"))?;
+
+        self.qmp
+            .read_response::<&qmp::add_fd>()
+            .with_context(|| format!("add QEMU block fd for {opaque}"))
+    }
+
+    fn remove_block_fdsets(&mut self, node_name: &str) {
+        let Some(fdset_ids) = self.block_fdsets.remove(node_name) else {
+            return;
+        };
+
+        self.remove_fdset_ids(node_name, fdset_ids);
+    }
+
+    fn remove_fdset_ids(&mut self, node_name: &str, fdset_ids: Vec<i64>) {
+        let mut failed = Vec::new();
+        for fdset_id in fdset_ids {
+            if let Err(err) = self.qmp.execute(&qmp::remove_fd { fd: None, fdset_id }) {
+                warn!(
+                    sl!(),
+                    "failed to remove QEMU block fdset {} for {}: {:?}", fdset_id, node_name, err
+                );
+                failed.push(fdset_id);
+            }
+        }
+        if !failed.is_empty() {
+            self.block_fdsets
+                .entry(node_name.to_string())
+                .or_default()
+                .extend(failed);
+        }
+    }
+
     pub fn hotplug_network_device(
         &mut self,
         netdev: &Netdev,
@@ -1023,13 +1122,17 @@ impl Qmp {
             driver: driver.to_owned(),
             arguments,
         }) {
-            if let Err(e) = self.qmp.execute(&qapi_qmp::blockdev_del {
+            if let Err(blockdev_err) = self.qmp.execute(&qapi_qmp::blockdev_del {
                 node_name: node_name.to_owned(),
             }) {
                 warn!(
                     sl!(),
-                    "device_add_with_rollback(): blockdev_del failed for {}: {:?}", node_name, e
+                    "device_add_with_rollback(): blockdev_del failed for {}: {:?}",
+                    node_name,
+                    blockdev_err
                 );
+            } else {
+                self.remove_block_fdsets(node_name);
             }
             return Err(anyhow!("device_add {:?}", e));
         }
@@ -1144,6 +1247,9 @@ impl Qmp {
     ) -> Result<(Option<PciPath>, Option<String>)> {
         // `blockdev-add`
         let node_name = block_node_name(index);
+        if self.block_fdsets.contains_key(&node_name) {
+            return Err(anyhow!("duplicate QEMU block device ID {node_name}"));
+        }
         let discard_option = || discard_unmap.then_some(BlockdevDiscardOptions::unmap);
 
         let create_base_options = || qapi_qmp::BlockdevOptionsBase {
@@ -1163,6 +1269,26 @@ impl Qmp {
             read_only: Some(is_readonly),
         };
 
+        let mut fdset_ids = Vec::new();
+        let prepared_source = match prepare_block_source(
+            path_on_host,
+            format,
+            is_readonly,
+            is_direct.unwrap_or(false),
+            |file, label| {
+                let opaque = block_fd_opaque(&node_name, label);
+                let info = self.pass_block_fd(file.as_raw_fd(), &opaque)?;
+                fdset_ids.push(info.fdset_id);
+                Ok(format!("/dev/fdset/{}", info.fdset_id))
+            },
+        ) {
+            Ok(source) => source,
+            Err(err) => {
+                self.remove_fdset_ids(&node_name, fdset_ids);
+                return Err(err);
+            }
+        };
+
         let create_backend_options = || qapi_qmp::BlockdevOptionsFile {
             aio: Some(
                 BlockdevAioOptions::from_str(blkdev_aio).unwrap_or(BlockdevAioOptions::io_uring),
@@ -1172,11 +1298,11 @@ impl Qmp {
             locking: None,
             pr_manager: None,
             x_check_cache_dropped: None,
-            filename: path_on_host.to_owned(),
+            filename: prepared_source.filename.clone(),
         };
 
         // Add block device backend and check if the file is a regular file or device
-        let blockdev_file = if std::fs::metadata(path_on_host)?.is_file() {
+        let blockdev_file = if prepared_source.is_regular_file {
             // Regular file
             qmp::BlockdevOptions::file {
                 base: create_base_options(),
@@ -1236,10 +1362,14 @@ impl Qmp {
             }
         };
 
-        self.qmp
-            .execute(&qapi_qmp::blockdev_add(blockdev_options))
-            .map_err(|e| anyhow!("blockdev-add backend {:?}", e))
-            .map(|_| ())?;
+        if !fdset_ids.is_empty() {
+            self.block_fdsets.insert(node_name.clone(), fdset_ids);
+        }
+
+        if let Err(err) = self.qmp.execute(&qapi_qmp::blockdev_add(blockdev_options)) {
+            self.remove_block_fdsets(&node_name);
+            return Err(anyhow!("blockdev-add backend {:?}", err));
+        }
 
         // block device
         // `device_add`
@@ -1305,6 +1435,7 @@ impl Qmp {
                     self.qmp.execute(&qapi_qmp::blockdev_del {
                         node_name: node_name.to_owned(),
                     })?;
+                    self.remove_block_fdsets(&node_name);
 
                     return Err(anyhow!(
                         "CCW subchannel not available for virtio-blk-ccw hotplug"
@@ -1318,6 +1449,7 @@ impl Qmp {
                     self.qmp.execute(&qapi_qmp::blockdev_del {
                         node_name: node_name.to_owned(),
                     })?;
+                    self.remove_block_fdsets(&node_name);
 
                     return Err(anyhow!("CCW subchannel add_device failed: {:?}", e));
                 }
@@ -1355,7 +1487,21 @@ impl Qmp {
 
             Ok((None, Some(ccw_addr)))
         } else {
-            let (bus, slot) = self.find_free_slot()?;
+            let (bus, slot) = match self.find_free_slot() {
+                Ok(value) => value,
+                Err(err) => {
+                    if self
+                        .qmp
+                        .execute(&qapi_qmp::blockdev_del {
+                            node_name: node_name.clone(),
+                        })
+                        .is_ok()
+                    {
+                        self.remove_block_fdsets(&node_name);
+                    }
+                    return Err(err);
+                }
+            };
             blkdev_add_args.insert("addr".to_owned(), format!("{slot:02}").into());
             if !is_readonly {
                 blkdev_add_args.insert("share-rw".to_string(), true.into());
@@ -1423,6 +1569,8 @@ impl Qmp {
                     node_name: node_name.clone(),
                 })
                 .map_err(|e| anyhow!("blockdev_del for block device {}: {:?}", node_name, e))?;
+
+            self.remove_block_fdsets(&node_name);
 
             Ok(())
         })();
@@ -1689,4 +1837,34 @@ pub fn get_qmp_socket_path(sid: &str) -> String {
 /// Generate a blockdev node name based on the given index.
 fn block_node_name(index: u64) -> String {
     format!("drive-{index}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconstructs_kata_block_fdsets_from_qmp() {
+        let fdsets = vec![
+            qmp::FdsetInfo {
+                fdset_id: 7,
+                fds: vec![qmp::FdsetFdInfo {
+                    fd: 21,
+                    opaque: Some(block_fd_opaque("drive-2", "block-source")),
+                }],
+            },
+            qmp::FdsetInfo {
+                fdset_id: 9,
+                fds: vec![qmp::FdsetFdInfo {
+                    fd: 22,
+                    opaque: Some("unrelated".to_string()),
+                }],
+            },
+        ];
+
+        assert_eq!(
+            collect_block_fdsets(fdsets),
+            HashMap::from([("drive-2".to_string(), vec![7])])
+        );
+    }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -7,7 +7,8 @@ use crate::device::pci_path::PciPath;
 use crate::qemu::block_source::{block_fd_node_name, block_fd_opaque, prepare_block_source};
 use crate::qemu::cmdline_generator::{CcwSubChannel, DeviceVirtioNet, Netdev, QMP_SOCKET_FILE};
 use crate::utils::get_jailer_root;
-use crate::{BlockDeviceFormat, VcpuThreadIds};
+use crate::VcpuThreadIds;
+use crate::{BlockDeviceFormat, VmdkConfig};
 
 use anyhow::{anyhow, Context, Result};
 use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_SCSI};
@@ -1243,6 +1244,7 @@ impl Qmp {
         logical_block_size: u32,
         physical_block_size: u32,
         format: &BlockDeviceFormat,
+        vmdk: Option<&VmdkConfig>,
         iothread: Option<&str>,
     ) -> Result<(Option<PciPath>, Option<String>)> {
         // `blockdev-add`
@@ -1273,6 +1275,7 @@ impl Qmp {
         let prepared_source = match prepare_block_source(
             path_on_host,
             format,
+            vmdk,
             is_readonly,
             is_direct.unwrap_or(false),
             |file, label| {
@@ -1848,15 +1851,28 @@ mod tests {
         let fdsets = vec![
             qmp::FdsetInfo {
                 fdset_id: 7,
+                fds: vec![
+                    qmp::FdsetFdInfo {
+                        fd: 21,
+                        opaque: Some(block_fd_opaque("drive-2", "vmdk-extent-0")),
+                    },
+                    qmp::FdsetFdInfo {
+                        fd: 22,
+                        opaque: Some(block_fd_opaque("drive-2", "vmdk-extent-1")),
+                    },
+                ],
+            },
+            qmp::FdsetInfo {
+                fdset_id: 8,
                 fds: vec![qmp::FdsetFdInfo {
-                    fd: 21,
-                    opaque: Some(block_fd_opaque("drive-2", "block-source")),
+                    fd: 23,
+                    opaque: Some(block_fd_opaque("drive-2", "vmdk-descriptor")),
                 }],
             },
             qmp::FdsetInfo {
                 fdset_id: 9,
                 fds: vec![qmp::FdsetFdInfo {
-                    fd: 22,
+                    fd: 24,
                     opaque: Some("unrelated".to_string()),
                 }],
             },
@@ -1864,7 +1880,7 @@ mod tests {
 
         assert_eq!(
             collect_block_fdsets(fdsets),
-            HashMap::from([("drive-2".to_string(), vec![7])])
+            HashMap::from([("drive-2".to_string(), vec![7, 8])])
         );
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -8,7 +8,7 @@ use crate::qemu::block_source::{block_fd_node_name, block_fd_opaque, prepare_blo
 use crate::qemu::cmdline_generator::{CcwSubChannel, DeviceVirtioNet, Netdev, QMP_SOCKET_FILE};
 use crate::utils::get_jailer_root;
 use crate::VcpuThreadIds;
-use crate::{BlockDeviceFormat, VmdkConfig};
+use crate::VmdkConfig;
 
 use anyhow::{anyhow, Context, Result};
 use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_SCSI};
@@ -1243,7 +1243,6 @@ impl Qmp {
         discard_unmap: bool,
         logical_block_size: u32,
         physical_block_size: u32,
-        format: &BlockDeviceFormat,
         vmdk: Option<&VmdkConfig>,
         iothread: Option<&str>,
     ) -> Result<(Option<PciPath>, Option<String>)> {
@@ -1274,7 +1273,6 @@ impl Qmp {
         let mut fdset_ids = Vec::new();
         let prepared_source = match prepare_block_source(
             path_on_host,
-            format,
             vmdk,
             is_readonly,
             is_direct.unwrap_or(false),
@@ -1319,8 +1317,8 @@ impl Qmp {
             }
         };
 
-        let blockdev_options = match format {
-            BlockDeviceFormat::Raw => BlockdevOptions::raw {
+        let blockdev_options = if vmdk.is_none() {
+            BlockdevOptions::raw {
                 base: BlockdevOptionsBase {
                     detect_zeroes: None,
                     cache: None,
@@ -1337,31 +1335,30 @@ impl Qmp {
                     offset: None,
                     size: None,
                 },
-            },
-            BlockDeviceFormat::Vmdk => {
-                info!(
-                    sl!(),
-                    "hotplug_block_device: using VMDK format driver for {} (read_only={}, force_share=true)",
-                    path_on_host,
-                    is_readonly
-                );
-                BlockdevOptions::vmdk {
-                    base: BlockdevOptionsBase {
-                        detect_zeroes: None,
-                        cache: None,
-                        discard: discard_option(),
-                        force_share: Some(true),
-                        auto_read_only: None,
-                        node_name: Some(node_name.clone()),
-                        read_only: Some(is_readonly),
+            }
+        } else {
+            info!(
+                sl!(),
+                "hotplug_block_device: using VMDK format driver for {} (read_only={}, force_share=true)",
+                path_on_host,
+                is_readonly
+            );
+            BlockdevOptions::vmdk {
+                base: BlockdevOptionsBase {
+                    detect_zeroes: None,
+                    cache: None,
+                    discard: discard_option(),
+                    force_share: Some(true),
+                    auto_read_only: None,
+                    node_name: Some(node_name.clone()),
+                    read_only: Some(is_readonly),
+                },
+                vmdk: BlockdevOptionsGenericCOWFormat {
+                    base: BlockdevOptionsGenericFormat {
+                        file: BlockdevRef::definition(Box::new(blockdev_file)),
                     },
-                    vmdk: BlockdevOptionsGenericCOWFormat {
-                        base: BlockdevOptionsGenericFormat {
-                            file: BlockdevRef::definition(Box::new(blockdev_file)),
-                        },
-                        backing: None,
-                    },
-                }
+                    backing: None,
+                },
             }
         };
 

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -25,7 +25,7 @@ use hypervisor::{
         device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig, DeviceType,
     },
-    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, VmdkConfig,
+    BlockConfigModern, BlockDeviceAio, VmdkConfig,
 };
 use kata_types::gpt_disk::{
     extract_dmverity_annotation, extract_snapshot_id, generate_dmverity_options,
@@ -86,7 +86,7 @@ async fn generate_merged_erofs_vmdk(
     sid: &str,
     cid: &str,
     erofs_devices: &[String],
-) -> Result<(String, BlockDeviceFormat, Option<VmdkConfig>)> {
+) -> Result<(String, Option<VmdkConfig>)> {
     if erofs_devices.is_empty() {
         return Err(anyhow!("no EROFS devices provided"));
     }
@@ -103,13 +103,13 @@ async fn generate_merged_erofs_vmdk(
         }
     }
 
-    // For single device, use it directly with Raw format (no need for VMDK descriptor)
+    // For a single device, use it directly without a VMDK descriptor.
     if erofs_devices.len() == 1 {
         info!(
             sl!(),
-            "single EROFS device, using directly with Raw format: {}", erofs_devices[0]
+            "single EROFS device, using directly: {}", erofs_devices[0]
         );
-        return Ok((erofs_devices[0].clone(), BlockDeviceFormat::Raw, None));
+        return Ok((erofs_devices[0].clone(), None));
     }
 
     // This reserved path identifies the block device and is included in logs;
@@ -127,11 +127,7 @@ async fn generate_merged_erofs_vmdk(
 
     let vmdk = create_vmdk_config(erofs_devices).context("failed to create VMDK layout")?;
 
-    Ok((
-        vmdk_path.display().to_string(),
-        BlockDeviceFormat::Vmdk,
-        Some(vmdk),
-    ))
+    Ok((vmdk_path.display().to_string(), Some(vmdk)))
 }
 
 /// Create a VMDK layout for multiple EROFS extents (flatten device).
@@ -221,13 +217,7 @@ fn generate_gpt_vmdk_with_layout(
     sid: &str,
     cid: &str,
     erofs_layers: Vec<ErofsLayer>,
-) -> Result<(
-    String,
-    BlockDeviceFormat,
-    VmdkConfig,
-    GptDiskLayout,
-    GptMetadataFiles,
-)> {
+) -> Result<(String, VmdkConfig, GptDiskLayout, GptMetadataFiles)> {
     if erofs_layers.is_empty() {
         return Err(anyhow!("no EROFS layers provided for GPT VMDK generation"));
     }
@@ -263,13 +253,7 @@ fn generate_gpt_vmdk_with_layout(
         create_gpt_vmdk_config(&layout, &gpt_files).context("failed to create GPT VMDK layout")?;
     gpt_files.pad_paths = pad_paths;
 
-    Ok((
-        vmdk_path.display().to_string(),
-        BlockDeviceFormat::Vmdk,
-        vmdk,
-        layout,
-        gpt_files,
-    ))
+    Ok((vmdk_path.display().to_string(), vmdk, layout, gpt_files))
 }
 
 /// Create a structured VMDK layout for a GPT-partitioned disk.
@@ -471,7 +455,6 @@ impl ErofsMultiLayerRootfs {
 
                     let device_config = &mut BlockConfigModern {
                         driver_option: block_driver.clone(),
-                        format: BlockDeviceFormat::Raw, // rw layer should be raw format
                         path_on_host: mount.source.clone(),
                         blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
                         num_queues: blkdev_info.num_queues,
@@ -590,7 +573,7 @@ impl ErofsMultiLayerRootfs {
                         }
 
                         // Generate GPT-partitioned VMDK and get layout information
-                        let (erofs_path, erofs_format, vmdk, layout, gpt_files) =
+                        let (erofs_path, vmdk, layout, gpt_files) =
                             generate_gpt_vmdk_with_layout(sid, cid, erofs_layers)
                                 .context("gptdisk: failed to generate GPT VMDK")?;
 
@@ -613,15 +596,13 @@ impl ErofsMultiLayerRootfs {
 
                         info!(
                             sl!(),
-                            "GPT VMDK layout created - id: {}, format: {:?}, {} partitions",
+                            "GPT VMDK layout created - id: {}, {} partitions",
                             erofs_path,
-                            erofs_format,
                             layout.partitions.len()
                         );
 
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
-                            format: erofs_format,
                             vmdk: Some(vmdk),
                             path_on_host: erofs_path,
                             is_readonly: true,
@@ -760,21 +741,20 @@ impl ErofsMultiLayerRootfs {
 
                         // Build a merged VMDK layout from all EROFS devices.
                         // Multiple devices use VMDK; a single device remains Raw.
-                        let (erofs_path, erofs_format, vmdk) =
+                        let (erofs_path, vmdk) =
                             generate_merged_erofs_vmdk(sid, cid, &erofs_devices)
                                 .await
                                 .context("failed to generate EROFS VMDK")?;
 
                         info!(
                             sl!(),
-                            "EROFS block device config - path: {}, format: {:?}",
+                            "EROFS block device config - path: {}, structured VMDK: {}",
                             erofs_path,
-                            erofs_format
+                            vmdk.is_some()
                         );
 
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
-                            format: erofs_format, // Vmdk for multiple devices, Raw for single device
                             vmdk,
                             path_on_host: erofs_path,
                             is_readonly: true, // EROFS layers are read-only, must set to avoid "resize" lock errors

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -25,7 +25,7 @@ use hypervisor::{
         device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig, DeviceType,
     },
-    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat,
+    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, VmdkConfig,
 };
 use kata_types::gpt_disk::{
     extract_dmverity_annotation, extract_snapshot_id, generate_dmverity_options,
@@ -36,8 +36,7 @@ use kata_types::mount::Mount;
 use oci_spec::runtime as oci;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufWriter, Write};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -53,19 +52,7 @@ const EROFS_MERGED_VMDK: &str = "merged_fs.vmdk";
 /// This is a pre-flight sanity check before VMDK merging, to prevent excessive block devices
 /// when many layers are used without fsmerge.
 const MAX_ROOTFS_LAYER_DEVICES: usize = 129; // 128 EROFS layers + 1 rw layer (129 total)
-/// Maximum sectors per 2GB extent (2GB / 512 bytes per sector)
-const MAX_2GB_EXTENT_SECTORS: u64 = 0x8000_0000 >> 9;
-/// Sectors per track for VMDK geometry
-const SECTORS_PER_TRACK: u64 = 63;
-/// Number of heads for VMDK geometry
-const NUMBER_HEADS: u64 = 16;
-/// VMDK subformat type (twoGbMaxExtentFlat for large files)
-const VMDK_SUBFORMAT: &str = "twoGbMaxExtentFlat";
-/// VMDK adapter type
-const VMDK_ADAPTER_TYPE: &str = "ide";
-/// VMDK hardware version
-const VMDK_HW_VERSION: &str = "4";
-/// Default shared directory for guest rootfs VMDK files (for multi-layer EROFS)
+/// Default runtime directory for generated multi-layer EROFS metadata.
 pub(crate) const DEFAULT_KATA_GUEST_ROOT_SHARED_FS: &str = "/run/kata-containers/";
 /// Template for mkdir option in overlay mount (X-containerd.mkdir.path)
 const X_CONTAINERD_MKDIR_PATH: &str = "X-containerd.mkdir.path=";
@@ -87,18 +74,19 @@ pub(crate) fn ensure_container_dir(sid: &str, cid: &str) -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Generate merged VMDK file from multiple EROFS devices
+/// Generate a merged VMDK layout from multiple EROFS devices.
 ///
-/// Creates a VMDK descriptor that combines multiple EROFS images into a single
-/// virtual block device (flatten device). For a single device, the EROFS image
-/// is used directly without a VMDK wrapper.
+/// For a single device, the EROFS image is used directly without a VMDK
+/// wrapper. For multiple devices, this returns a reserved descriptor path and
+/// a structured layout but does not create a file at that path. The QEMU
+/// backend serializes the layout after preparing its backing files.
 ///
 /// And `erofs_devices` are for host paths to EROFS image files (from `source` and `device=` options)
 async fn generate_merged_erofs_vmdk(
     sid: &str,
     cid: &str,
     erofs_devices: &[String],
-) -> Result<(String, BlockDeviceFormat)> {
+) -> Result<(String, BlockDeviceFormat, Option<VmdkConfig>)> {
     if erofs_devices.is_empty() {
         return Err(anyhow!("no EROFS devices provided"));
     }
@@ -121,137 +109,35 @@ async fn generate_merged_erofs_vmdk(
             sl!(),
             "single EROFS device, using directly with Raw format: {}", erofs_devices[0]
         );
-        return Ok((erofs_devices[0].clone(), BlockDeviceFormat::Raw));
+        return Ok((erofs_devices[0].clone(), BlockDeviceFormat::Raw, None));
     }
 
-    // For multiple devices, create VMDK descriptor
+    // This reserved path identifies the block device and is included in logs;
+    // no descriptor file is created here. The QEMU backend serializes the
+    // structured layout using its fdset transport.
     let container_dir = ensure_container_dir(sid, cid)?;
     let vmdk_path = container_dir.join(EROFS_MERGED_VMDK);
 
     info!(
         sl!(),
-        "creating VMDK descriptor for {} EROFS devices: {}",
+        "creating VMDK layout for {} EROFS devices: {}",
         erofs_devices.len(),
         vmdk_path.display()
     );
 
-    // create_vmdk_descriptor uses atomic write (temp + rename) internally,
-    // so a failure will not leave a corrupt descriptor file.
-    create_vmdk_descriptor(&vmdk_path, erofs_devices)
-        .context("failed to create VMDK descriptor")?;
+    let vmdk = create_vmdk_config(erofs_devices).context("failed to create VMDK layout")?;
 
-    Ok((vmdk_path.display().to_string(), BlockDeviceFormat::Vmdk))
+    Ok((
+        vmdk_path.display().to_string(),
+        BlockDeviceFormat::Vmdk,
+        Some(vmdk),
+    ))
 }
 
-/// Helper struct for writing VMDK descriptor files atomically.
-///
-/// Encapsulates the common VMDK descriptor format: header, extent descriptions,
-/// DDB footer, and atomic write (temp file + rename). Used by both fsmerge mode
-/// (`create_vmdk_descriptor`) and GPT mode (`create_gpt_vmdk_descriptor`).
-struct VmdkDescriptorWriter {
-    writer: BufWriter<fs::File>,
-    temp_path: PathBuf,
-    final_path: PathBuf,
-}
-
-impl VmdkDescriptorWriter {
-    fn new(vmdk_path: &Path) -> Result<Self> {
-        let temp_path = vmdk_path.with_extension("vmdk.tmp");
-        if temp_path.components().any(|c| c == Component::ParentDir) {
-            return Err(anyhow!("Invalid input: {}", temp_path.display()));
-        }
-        let file = fs::File::create(&temp_path).context(format!(
-            "failed to create temp VMDK file: {}",
-            temp_path.display()
-        ))?;
-        let mut writer = BufWriter::new(file);
-
-        writeln!(writer, "# Disk DescriptorFile")?;
-        writeln!(writer, "version=1")?;
-        writeln!(writer, "CID=fffffffe")?;
-        writeln!(writer, "parentCID=ffffffff")?;
-        writeln!(writer, "createType=\"{}\"", VMDK_SUBFORMAT)?;
-        writeln!(writer)?;
-        writeln!(writer, "# Extent description")?;
-
-        Ok(Self {
-            writer,
-            temp_path,
-            final_path: vmdk_path.to_path_buf(),
-        })
-    }
-
-    // Write a single extent line (no 2GB chunking).
-    fn write_extent(&mut self, path: &str, sectors: u64, file_offset: u64) -> Result<()> {
-        writeln!(
-            self.writer,
-            "RW {} FLAT \"{}\" {}",
-            sectors, path, file_offset
-        )?;
-        Ok(())
-    }
-
-    // Write extent lines with 2GB chunking for large files.
-    fn write_extent_chunked(&mut self, path: &str, total_sectors: u64) -> Result<()> {
-        let mut remaining = total_sectors;
-        let mut file_offset: u64 = 0;
-        while remaining > 0 {
-            let chunk = remaining.min(MAX_2GB_EXTENT_SECTORS);
-            self.write_extent(path, chunk, file_offset)?;
-            file_offset += chunk;
-            remaining -= chunk;
-        }
-        Ok(())
-    }
-
-    // Write DDB footer, flush, and atomically rename to final path.
-    fn finalize(mut self, total_sectors: u64) -> Result<()> {
-        writeln!(self.writer)?;
-
-        let cylinders = total_sectors.div_ceil(SECTORS_PER_TRACK * NUMBER_HEADS);
-
-        writeln!(self.writer, "# The Disk Data Base")?;
-        writeln!(self.writer, "#DDB")?;
-        writeln!(self.writer)?;
-        writeln!(
-            self.writer,
-            "ddb.virtualHWVersion = \"{}\"",
-            VMDK_HW_VERSION
-        )?;
-        writeln!(self.writer, "ddb.geometry.cylinders = \"{}\"", cylinders)?;
-        writeln!(self.writer, "ddb.geometry.heads = \"{}\"", NUMBER_HEADS)?;
-        writeln!(
-            self.writer,
-            "ddb.geometry.sectors = \"{}\"",
-            SECTORS_PER_TRACK
-        )?;
-        writeln!(self.writer, "ddb.adapterType = \"{}\"", VMDK_ADAPTER_TYPE)?;
-
-        self.writer
-            .flush()
-            .context("failed to flush VMDK descriptor")?;
-        drop(self.writer);
-
-        fs::rename(&self.temp_path, &self.final_path).context(format!(
-            "failed to rename temp VMDK {} -> {}",
-            self.temp_path.display(),
-            self.final_path.display()
-        ))?;
-
-        Ok(())
-    }
-}
-
-/// Create VMDK descriptor for multiple EROFS extents (flatten device)
-///
-/// Generates a VMDK descriptor file (twoGbMaxExtentFlat format) that references
-/// multiple EROFS images as flat extents, allowing them to be treated as a single
-/// contiguous block device in the VM.
-fn create_vmdk_descriptor(vmdk_path: &Path, erofs_paths: &[String]) -> Result<()> {
+/// Create a VMDK layout for multiple EROFS extents (flatten device).
+fn create_vmdk_config(erofs_paths: &[String]) -> Result<VmdkConfig> {
     if erofs_paths.is_empty() {
-        return Err(anyhow!(
-            "empty EROFS path list, cannot create VMDK descriptor"
-        ));
+        return Err(anyhow!("empty EROFS path list, cannot create VMDK layout"));
     }
 
     struct ExtentInfo {
@@ -302,43 +188,46 @@ fn create_vmdk_descriptor(vmdk_path: &Path, erofs_paths: &[String]) -> Result<()
 
     if total_sectors == 0 {
         return Err(anyhow!(
-            "no valid EROFS files to create VMDK descriptor (all files are empty)"
+            "no valid EROFS files to create VMDK layout (all files are empty)"
         ));
     }
 
-    let mut vmdk = VmdkDescriptorWriter::new(vmdk_path)?;
+    let mut vmdk = VmdkConfig::default();
     for extent in &extents {
-        vmdk.write_extent_chunked(&extent.path, extent.total_sectors)?;
+        vmdk.push_extent_chunked(&extent.path, extent.total_sectors);
         info!(
             sl!(),
-            "VMDK extent: {} ({} sectors, {} extent chunk(s))",
-            extent.path,
-            extent.total_sectors,
-            extent.total_sectors.div_ceil(MAX_2GB_EXTENT_SECTORS)
+            "VMDK extent: {} ({} sectors)", extent.path, extent.total_sectors
         );
     }
 
-    vmdk.finalize(total_sectors)?;
-
     info!(
         sl!(),
-        "VMDK descriptor created: {} (total {} sectors, {} extents)",
-        vmdk_path.display(),
+        "VMDK layout created: total {} sectors, {} source extents",
         total_sectors,
         extents.len()
     );
 
-    Ok(())
+    Ok(vmdk)
 }
 
-/// Generate GPT-partitioned VMDK and return layout information for per-partition storage creation
+/// Generate a GPT-partitioned VMDK layout for per-partition storage creation.
 ///
-/// Returns: (vmdk_path, BlockDeviceFormat::Vmdk, GptDiskLayout, GptMetadataFiles)
+/// Returns a reserved descriptor path, structured VMDK layout, GPT layout,
+/// and generated metadata files. This function does not create a descriptor
+/// file at that path; the QEMU backend serializes the layout using its fdset
+/// transport.
 fn generate_gpt_vmdk_with_layout(
     sid: &str,
     cid: &str,
     erofs_layers: Vec<ErofsLayer>,
-) -> Result<(String, BlockDeviceFormat, GptDiskLayout, GptMetadataFiles)> {
+) -> Result<(
+    String,
+    BlockDeviceFormat,
+    VmdkConfig,
+    GptDiskLayout,
+    GptMetadataFiles,
+)> {
     if erofs_layers.is_empty() {
         return Err(anyhow!("no EROFS layers provided for GPT VMDK generation"));
     }
@@ -361,7 +250,7 @@ fn generate_gpt_vmdk_with_layout(
 
     info!(
         sl!(),
-        "creating GPT-partitioned VMDK for {} EROFS layers: {}",
+        "creating GPT-partitioned VMDK layout for {} EROFS layers: {}",
         erofs_layers.len(),
         vmdk_path.display()
     );
@@ -370,36 +259,35 @@ fn generate_gpt_vmdk_with_layout(
     let (layout, mut gpt_files) = generate_gpt_metadata(sid, cid, erofs_layers, &container_dir)
         .context("failed to generate GPT metadata")?;
 
-    // Create VMDK descriptor with GPT layout and collect generated padding paths
-    let pad_paths = create_gpt_vmdk_descriptor(&vmdk_path, &layout, &gpt_files)
-        .context("failed to create GPT VMDK descriptor")?;
+    let (vmdk, pad_paths) =
+        create_gpt_vmdk_config(&layout, &gpt_files).context("failed to create GPT VMDK layout")?;
     gpt_files.pad_paths = pad_paths;
 
     Ok((
         vmdk_path.display().to_string(),
         BlockDeviceFormat::Vmdk,
+        vmdk,
         layout,
         gpt_files,
     ))
 }
 
-/// Create VMDK descriptor for GPT-partitioned disk
+/// Create a structured VMDK layout for a GPT-partitioned disk.
 ///
 /// Returns the list of generated padding file paths for cleanup tracking.
-fn create_gpt_vmdk_descriptor(
-    vmdk_path: &Path,
+fn create_gpt_vmdk_config(
     layout: &GptDiskLayout,
     gpt_files: &GptMetadataFiles,
-) -> Result<Vec<PathBuf>> {
-    let mut vmdk = VmdkDescriptorWriter::new(vmdk_path)?;
+) -> Result<(VmdkConfig, Vec<PathBuf>)> {
+    let mut vmdk = VmdkConfig::default();
     let mut pad_paths: Vec<PathBuf> = Vec::new();
 
     // 1. GPT head metadata
-    vmdk.write_extent(
+    vmdk.push_extent(
         &gpt_files.head_path.display().to_string(),
         gpt_files.head_sectors,
         0,
-    )?;
+    );
     info!(
         sl!(),
         "VMDK extent: GPT head ({} sectors) at {}",
@@ -429,11 +317,11 @@ fn create_gpt_vmdk_descriptor(
                 pad_path.display()
             ))?;
 
-            vmdk.write_extent(&pad_path.display().to_string(), gap_sectors, 0)?;
+            vmdk.push_extent(&pad_path.display().to_string(), gap_sectors, 0);
             pad_paths.push(pad_path);
         }
 
-        vmdk.write_extent_chunked(&part.layer.path, part.layer.size_sectors)?;
+        vmdk.push_extent_chunked(&part.layer.path, part.layer.size_sectors);
         info!(
             sl!(),
             "VMDK extent: {} (partition {}, LBA {}-{}, {} sectors)",
@@ -447,17 +335,22 @@ fn create_gpt_vmdk_descriptor(
         prev_end_lba = part.end_lba;
     }
 
-    vmdk.finalize(layout.total_sectors)?;
-
     info!(
         sl!(),
-        "GPT VMDK descriptor created: {} (total {} sectors, {} partitions)",
-        vmdk_path.display(),
+        "GPT VMDK layout created: total {} sectors, {} partitions",
         layout.total_sectors,
         layout.partitions.len()
     );
 
-    Ok(pad_paths)
+    if vmdk.total_sectors() != Some(layout.total_sectors) {
+        return Err(anyhow!(
+            "GPT VMDK extent size does not match disk layout: {:?} != {}",
+            vmdk.total_sectors(),
+            layout.total_sectors
+        ));
+    }
+
+    Ok((vmdk, pad_paths))
 }
 
 async fn extract_block_device_info(
@@ -498,8 +391,6 @@ pub(crate) struct ErofsMultiLayerRootfs {
     rwlayer_storage: Option<Storage>,
     // Read-only EROFS layer storages (lower layers), one per partition in GPT mode
     erofs_storages: Vec<Storage>,
-    // Path to generated VMDK descriptor (only set when multiple EROFS devices are merged)
-    vmdk_path: Option<PathBuf>,
     // Paths to generated GPT metadata files (head, padding) for cleanup
     gpt_metadata_paths: Vec<PathBuf>,
     // Container-scoped runtime directory that may only contain generated helper artifacts.
@@ -523,7 +414,6 @@ impl ErofsMultiLayerRootfs {
         let mut device_ids = Vec::new();
         let mut rwlayer_storage: Option<Storage> = None;
         let mut erofs_storages: Vec<Storage> = Vec::new();
-        let mut vmdk_path: Option<PathBuf> = None;
         let mut gpt_metadata_paths: Vec<PathBuf> = Vec::new();
         // Track whether GPT+VMDK erofs layers have already been processed in bulk.
         let mut gpt_erofs_processed = false;
@@ -700,12 +590,9 @@ impl ErofsMultiLayerRootfs {
                         }
 
                         // Generate GPT-partitioned VMDK and get layout information
-                        let (erofs_path, erofs_format, layout, gpt_files) =
+                        let (erofs_path, erofs_format, vmdk, layout, gpt_files) =
                             generate_gpt_vmdk_with_layout(sid, cid, erofs_layers)
                                 .context("gptdisk: failed to generate GPT VMDK")?;
-
-                        // Track VMDK path for cleanup
-                        vmdk_path = Some(PathBuf::from(&erofs_path));
 
                         // Track GPT metadata files (head + padding) for cleanup
                         gpt_metadata_paths.push(gpt_files.head_path.clone());
@@ -726,7 +613,7 @@ impl ErofsMultiLayerRootfs {
 
                         info!(
                             sl!(),
-                            "GPT VMDK created - path: {}, format: {:?}, {} partitions",
+                            "GPT VMDK layout created - id: {}, format: {:?}, {} partitions",
                             erofs_path,
                             erofs_format,
                             layout.partitions.len()
@@ -735,6 +622,7 @@ impl ErofsMultiLayerRootfs {
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
                             format: erofs_format,
+                            vmdk: Some(vmdk),
                             path_on_host: erofs_path,
                             is_readonly: true,
                             blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
@@ -870,17 +758,12 @@ impl ErofsMultiLayerRootfs {
 
                         info!(sl!(), "EROFS devices count: {}", erofs_devices.len());
 
-                        // Generate merged VMDK file from all EROFS devices
-                        // Returns (path, format) - format is Vmdk for multiple devices, Raw for single device
-                        let (erofs_path, erofs_format) =
+                        // Build a merged VMDK layout from all EROFS devices.
+                        // Multiple devices use VMDK; a single device remains Raw.
+                        let (erofs_path, erofs_format, vmdk) =
                             generate_merged_erofs_vmdk(sid, cid, &erofs_devices)
                                 .await
                                 .context("failed to generate EROFS VMDK")?;
-
-                        // Track VMDK path for cleanup (only when VMDK is actually created)
-                        if erofs_format == BlockDeviceFormat::Vmdk {
-                            vmdk_path = Some(PathBuf::from(&erofs_path));
-                        }
 
                         info!(
                             sl!(),
@@ -892,6 +775,7 @@ impl ErofsMultiLayerRootfs {
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
                             format: erofs_format, // Vmdk for multiple devices, Raw for single device
+                            vmdk,
                             path_on_host: erofs_path,
                             is_readonly: true, // EROFS layers are read-only, must set to avoid "resize" lock errors
                             blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
@@ -988,7 +872,6 @@ impl ErofsMultiLayerRootfs {
             device_ids,
             rwlayer_storage,
             erofs_storages,
-            vmdk_path,
             gpt_metadata_paths,
             generated_artifacts_dir: PathBuf::from(kata_types::prefix_with_rootless_dir(
                 DEFAULT_KATA_GUEST_ROOT_SHARED_FS,
@@ -1048,11 +931,6 @@ impl Rootfs for ErofsMultiLayerRootfs {
         let mut dm = device_manager.write().await;
         for device_id in &self.device_ids {
             dm.try_remove_device(device_id).await?;
-        }
-
-        // Clean up generated VMDK descriptor file if it exists.
-        if let Some(ref vmdk) = self.vmdk_path {
-            safely_remove_file(vmdk, &self.generated_artifacts_dir)?;
         }
 
         // Clean up GPT metadata files (head, padding).

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -45,11 +45,11 @@ wait_for_rootless_host_resources() {
 qemu_rootless_sandbox_supported() {
 	[[ "${KATA_HYPERVISOR}" == qemu* ]] || return 1
 
-	# Additional QEMU configurations are tracked in:
-	# https://github.com/kata-containers/kata-containers/issues/13424
-	# Rootless QEMU cannot access EROFS layers below root-owned
-	# snapshot directories.
-	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && return 1
+	# Runtime-go does not pass EROFS layers to rootless QEMU by file
+	# descriptor and therefore cannot traverse their snapshot directories.
+	if [[ "${SNAPSHOTTER:-}" == "erofs" ]] && ! is_runtime_rs; then
+		return 1
+	fi
 
 	# CoCo-dev does not enable a TEE or require TEE host resources. Keep
 	# actual confidential handlers excluded until rootless QEMU can access
@@ -58,11 +58,14 @@ qemu_rootless_sandbox_supported() {
 		[[ "${KATA_HYPERVISOR}" != qemu-coco-dev* ]]; then
 		return 1
 	fi
-	# Generated CoCo policies add an init-data disk below a root-owned host
-	# path. Neither runtime passes that disk to rootless QEMU yet.
-	if [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] &&
-		[[ "${AUTO_GENERATE_POLICY:-}" == "yes" ]]; then
-		return 1
+
+	# Rootless policy testing is supported only by shared_fs=none runtime-rs
+	# handlers. Generated policy does not authorize the rootless host paths
+	# used with filesystem sharing. With shared_fs=none, policy adds an
+	# init-data disk that only runtime-rs passes to QEMU by file descriptor.
+	if auto_generate_policy_enabled; then
+		is_shared_fs_none_runtime_class "${KATA_HYPERVISOR}" || return 1
+		is_runtime_rs || return 1
 	fi
 	return 0
 }
@@ -80,8 +83,33 @@ setup() {
 	pod_name="test-e2e"
 	pod_config="$(new_pod_config \
 		"quay.io/prometheus/busybox:latest" \
-		"$(get_test_runtime_class)")"
+		"$(get_test_runtime_class)" \
+		"" "" "10")"
 	set_node "${pod_config}" "${node}"
+
+	# Adding emptyDir validates that rootless QEMU can access additional writable pod
+	# storage:
+	# - any runtime class with filesystem sharing can exercise emptyDir because QEMU
+	#   does not open a host block image.
+	# - Runtime-rs with shared_fs=none exercises this path by passing the image to
+	#   QEMU by file descriptor.
+	# - Runtime-go with shared_fs=none is skipped because the fd transport method is
+	#   not implemented.
+	# Other uses of block images for which file descriptors are passed by runtime-rs
+	# are:
+	# - raw /dev/loop* volumes (see k8s-block-volume.bats), not exercised in this
+	# bats test to reduce complexity.
+	# - init-data images, implicitly exercised by jobs where policy annotations are
+	# attached.
+	if is_runtime_rs || ! is_shared_fs_none_runtime_class "${KATA_HYPERVISOR}"; then
+		yq -i '
+			.spec.volumes += [{"name": "rootless-emptydir", "emptyDir": {}}] |
+			.spec.containers[0].volumeMounts += [{
+				"name": "rootless-emptydir",
+				"mountPath": "/mnt/rootless-emptydir"
+			}]
+		' "${pod_config}"
+	fi
 	set_container_command "${pod_config}" 0 sleep 30
 
 	watchable_pod_config="${BATS_FILE_TMPDIR}/inotify-configmap-pod.yaml"


### PR DESCRIPTION
This PR enables unprivileged runtime-rs QEMU to access selected block sources without weakening permissions on their parent directories. With this PR, the shim opens the selected block sources and arranges for QEMU to inherit the resulting file descriptors, exposing them through /dev/fdset/<id>. With this, runtime-rs now uses this fd-based transport consistently for both rootless and privileged QEMU.

**ATTENTION:** While this PR continues the staged rootless and seccomp-sandbox work tracked by #13424, this PR does not address VFIO, IOMMUFD, GPU, `/dev/sev`, or other non-block resources required for device passthrough and real confidential VMs. Those remain separate follow-up work.

**Problems 2/2 addressed:**

#### Problem 1 (runtime-rs): QEMU opened block sources by host path

Rootless QEMU runs as a temporary unprivileged user. It cannot traverse root-owned directories containing selected block sources even when the privileged shim is authorized to access them.

This affects sources such as:
- CoCo init-data disk images;
- disk-backed emptyDir images below restrictive kubelet directories;
- raw block devices such as `/dev/loopN`.

Open modern block sources in the privileged shim and pass their descriptors to QEMU. Cold-plugged sources use `-add-fd`; hot-plugged sources use QMP `add-fd`. QEMU receives `/dev/fdset/<set>` paths instead of the original host paths.

Preserve read-only, read-write, direct-I/O, regular-file, and block-device semantics. Track fdsets across QMP reconnects and remove them during rollback and unplug.

#### Problem 2 (runtime-rs/EROFS): VMDK descriptors exposed host paths

Composed EROFS images use flattened or GPT-partitioned VMDK descriptors. Runtime-rs previously wrote these descriptors to persistent host files whose extent entries contained the original snapshotter paths. Rootless QEMU could read neither those extents beneath restrictive snapshotter directories nor raw single-layer EROFS images at equivalent locations.
Keep the VMDK descriptor format, but separate its logical layout from its transport. The EROFS resource layer now supplies an in-memory list of extents. The privileged shim opens each extent and registers it with QEMU before rendering an ordinary VMDK descriptor whose entries refer only to QEMU fdset paths. The descriptor is stored in an anonymous file and is itself passed to QEMU by FD.
Only the persistent host descriptor file is removed. GPT metadata and padding remain because they are backing extents, while single-layer EROFS images remain raw and use the general block-source FD transport directly.
This keeps containerd snapshot directories restrictive while granting QEMU read-only access only to the selected layers. Enable EROFS coverage for runtime-rs in the QEMU rootless and seccomp-sandbox BATS test while retaining the runtime-go exclusion.

Remaining rootless and seccomp-sandbox work is tracked in #13424.