### PR TITLE
CI: Restore skipped s390x test

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -134,7 +134,7 @@ jobs:
         if: ${{ startsWith(matrix.vmm, 'qemu-coco-dev') }}
 
       - name: Install `kbs-client`
-        timeout-minutes: 20
+        timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
         if: ${{ startsWith(matrix.vmm, 'qemu-coco-dev') }}
 

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -106,10 +106,6 @@ setup() {
     # The image pulled in the guest will be downloaded and unpacked in the `/run/kata-containers/image` directory.
     # The tests will use `cryptsetup` to encrypt a block device and mount it at `/run/kata-containers/image`.
 
-    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
-        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
-    fi
-
     storage_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${storage_config_template}").XXXXXX.yaml")
     local_device=$(create_loop_device)
     PV_NAME=trusted-block-pv PVC_NAME=trusted-pvc \
@@ -158,10 +154,6 @@ setup() {
 }
 
 @test "Test we cannot pull a large image that pull time exceeds createcontainer timeout inside the guest" {
-    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
-        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
-    fi
-
     storage_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${storage_config_template}").XXXXXX.yaml")
     local_device=$(create_loop_device)
     PV_NAME=trusted-block-pv PVC_NAME=trusted-pvc \
@@ -217,9 +209,6 @@ setup() {
 }
 
 @test "Test we can pull a large image inside the guest with large createcontainer timeout" {
-    if [[ "$(uname -m)" == "s390x" ]] && [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]]; then
-        skip "skip large image pod tests on s390x zVSI due to insufficient CPU resources"
-    fi
     if [[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] && [ "${KBS_INGRESS}" = "aks" ]; then
         skip "skip this specific one due to issue https://github.com/kata-containers/kata-containers/issues/10299"
     fi


### PR DESCRIPTION
In https://github.com/kata-containers/kata-containers/pull/13353, three tests in k8s-guest-pull-image.bats were skipped because of the downsized runners. Now they have been restored. Let's get those skipped tests to run again.

Signed-off-by: Annu Sharma <annu-sharma@ibm.com>
