### PR TITLE
runtime-rs/QEMU: pass VFIO devices by fd

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -22,10 +22,11 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 use std::fmt::{Display, Write};
-use std::fs::{read_to_string, File};
+use std::fs::{read_to_string, File, OpenOptions};
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str;
 use tokio;
 
@@ -2284,25 +2285,60 @@ const DEFAULT_START_ADDR: &str = "0x5";
 //const DEFAULT_ADDR: &str = "0x0";
 
 /// Configuration for the IOMMUFD object backend.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ObjectIommufd {
     id: String,
+    fd: Option<File>,
 }
 
 impl ObjectIommufd {
     pub fn new(id: impl Into<String>) -> Self {
-        Self { id: id.into() }
+        Self {
+            id: id.into(),
+            fd: None,
+        }
+    }
+
+    pub fn with_fd(id: impl Into<String>, path: &Path) -> Result<Self> {
+        Ok(Self {
+            id: id.into(),
+            fd: Some(open_qemu_device_fd(path)?),
+        })
     }
 }
 
 #[async_trait]
 impl ToQemuParams for ObjectIommufd {
     async fn qemu_params(&self) -> Result<Vec<String>> {
-        Ok(vec![
-            "-object".to_string(),
-            format!("iommufd,id={}", self.id),
-        ])
+        let mut params = format!("iommufd,id={}", self.id);
+        if let Some(fd) = &self.fd {
+            write!(params, ",fd={}", fd.as_raw_fd()).unwrap();
+        }
+        Ok(vec!["-object".to_string(), params])
     }
+}
+
+fn open_qemu_device_fd(path: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC)
+        .open(path)
+        .with_context(|| format!("open QEMU host device {}", path.display()))?;
+    if !file
+        .metadata()
+        .with_context(|| format!("stat QEMU host device {}", path.display()))?
+        .file_type()
+        .is_char_device()
+    {
+        return Err(anyhow!(
+            "QEMU host device {} is not a character device",
+            path.display()
+        ));
+    }
+    clear_cloexec(file.as_raw_fd())
+        .with_context(|| format!("clear O_CLOEXEC on QEMU host device {}", path.display()))?;
+    Ok(file)
 }
 
 /// Representation of a PCIe Root Port device in QEMU.
@@ -2522,7 +2558,7 @@ impl ToQemuParams for PCIeSwitchDownstreamPortDevice {
 }
 
 /// VFIO PCI device
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PCIeVfioDevice {
     host_bdf: String,
     bus: String,
@@ -2532,6 +2568,7 @@ pub struct PCIeVfioDevice {
     /// via QMP (`qom-get`) or the runtime can match it to a guest PCI path.
     id: Option<String>,
     iommufd: Option<String>,
+    fd: Option<File>,
     x_pci_vendor_id: Option<String>,
     x_pci_device_id: Option<String>,
 }
@@ -2548,6 +2585,7 @@ impl PCIeVfioDevice {
             addr: "0x0".to_string(),
             id: None,
             iommufd: Some(iommufd.into()),
+            fd: None,
             x_pci_vendor_id: None,
             x_pci_device_id: None,
         }
@@ -2562,6 +2600,7 @@ impl PCIeVfioDevice {
             addr: "0x0".to_string(),
             id: None,
             iommufd: None,
+            fd: None,
             x_pci_vendor_id: None,
             x_pci_device_id: None,
         }
@@ -2570,6 +2609,11 @@ impl PCIeVfioDevice {
     pub fn with_id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self
+    }
+
+    pub fn with_fd(mut self, path: &Path) -> Result<Self> {
+        self.fd = Some(open_qemu_device_fd(path)?);
+        Ok(self)
     }
 
     #[allow(dead_code)]
@@ -2609,7 +2653,10 @@ impl ToQemuParams for PCIeVfioDevice {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = String::with_capacity(256);
 
-        write!(params, "vfio-pci,host={}", self.host_bdf).unwrap();
+        write!(params, "vfio-pci").unwrap();
+        if self.fd.is_none() {
+            write!(params, ",host={}", self.host_bdf).unwrap();
+        }
         write!(params, ",bus={}", self.bus).unwrap();
         write!(params, ",addr={}", self.addr).unwrap();
 
@@ -2619,6 +2666,10 @@ impl ToQemuParams for PCIeVfioDevice {
 
         if let Some(iommufd) = &self.iommufd {
             write!(params, ",iommufd={}", iommufd).unwrap();
+        }
+
+        if let Some(fd) = &self.fd {
+            write!(params, ",fd={}", fd.as_raw_fd()).unwrap();
         }
 
         if let Some(vendor) = &self.x_pci_vendor_id {
@@ -2643,6 +2694,19 @@ pub struct VfioDeviceBase {
 
     /// IOMMU file descriptor ID (e.g., "iommufd0").
     pub iommufd: Option<String>,
+}
+
+/// Resources required to pass an externally opened VFIO device to QEMU.
+#[derive(Debug, Clone)]
+pub struct VfioDeviceFdConfig {
+    /// Host IOMMUFD device opened by the privileged shim for QEMU.
+    pub iommufd_dev: PathBuf,
+
+    /// Per-device VFIO cdev opened by the privileged shim for QEMU.
+    pub vfio_cdev: PathBuf,
+
+    /// Stable QEMU ID required when vfio-pci receives an external device fd.
+    pub qemu_device_id: String,
 }
 
 /// Comprehensive configuration for a VFIO device.
@@ -2680,6 +2744,9 @@ pub struct VfioDeviceConfig {
 
     /// Optional PCI Device ID override.
     pub x_pci_device_id: Option<String>,
+
+    /// Resources for passing an externally opened VFIO device to QEMU.
+    pub fd_config: Option<VfioDeviceFdConfig>,
 }
 
 impl VfioDeviceConfig {
@@ -2698,6 +2765,7 @@ impl VfioDeviceConfig {
             vfio_addr: format!("0x{}", port),
             x_pci_vendor_id: None,
             x_pci_device_id: None,
+            fd_config: None,
         }
     }
 
@@ -2753,6 +2821,20 @@ impl VfioDeviceConfig {
     #[allow(dead_code)]
     pub fn with_device_id(mut self, device_id: impl Into<String>) -> Self {
         self.x_pci_device_id = Some(device_id.into());
+        self
+    }
+
+    pub fn with_device_fds(
+        mut self,
+        iommufd_dev: impl Into<PathBuf>,
+        vfio_cdev: impl Into<PathBuf>,
+        qemu_device_id: impl Into<String>,
+    ) -> Self {
+        self.fd_config = Some(VfioDeviceFdConfig {
+            iommufd_dev: iommufd_dev.into(),
+            vfio_cdev: vfio_cdev.into(),
+            qemu_device_id: qemu_device_id.into(),
+        });
         self
     }
 }
@@ -3535,7 +3617,15 @@ impl<'a> QemuCmdLine<'a> {
         };
 
         let iommufd_name = format!("iommufd{}", config.bus);
-        self.add_iommufd(&iommufd_name)?;
+        let fd_config = config.fd_config.as_ref();
+        if let Some(fd_config) = fd_config {
+            self.devices.push(Box::new(ObjectIommufd::with_fd(
+                &iommufd_name,
+                &fd_config.iommufd_dev,
+            )?));
+        } else {
+            self.add_iommufd(&iommufd_name)?;
+        }
 
         let root_port_id = config.bus.clone();
         let root_port = PCIeRootPortDevice::new(&root_port_id, DEFAULT_PCIE_ROOT_BUS)
@@ -3546,6 +3636,11 @@ impl<'a> QemuCmdLine<'a> {
         info!(sl!(), "PCIe Root Port: {:?}", root_port.clone());
 
         let mut vfio_device = PCIeVfioDevice::new(&config.host_bdf, root_port_id, &iommufd_name);
+        if let Some(fd_config) = fd_config {
+            vfio_device = vfio_device
+                .with_id(&fd_config.qemu_device_id)
+                .with_fd(&fd_config.vfio_cdev)?;
+        }
 
         if let Some(vendor_id) = &config.x_pci_vendor_id {
             vfio_device = vfio_device.with_vendor_id(vendor_id);
@@ -3999,6 +4094,106 @@ mod tests {
         let scsi_hd = DeviceScsiHd::new("blk0", "scsi0.0", None);
         let scsi_hd_params = scsi_hd.qemu_params().await.unwrap();
         assert!(!contains_param(&scsi_hd_params, "discard=on"));
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    async fn test_vfio_uses_inherited_device_fds() {
+        let config = test_qemu_config(Some("none"), false);
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+        let mut cmdline = QemuCmdLine::new("vfio-device-fds", &config).unwrap();
+        let vfio = VfioDeviceConfig::new("0000:21:00.0", 9, 10)
+            .with_vfio_bus("rp0")
+            .with_device_fds("/dev/null", "/dev/null", "vfio-test");
+
+        cmdline.add_pcie_vfio_device(vfio).unwrap();
+        let params = cmdline.build().await.unwrap();
+
+        let iommufd = params
+            .windows(2)
+            .find(|args| args[0] == "-object" && args[1].starts_with("iommufd,"))
+            .expect("missing IOMMUFD object");
+        assert!(contains_param(&iommufd[1..2], "id=iommufdrp0"));
+        assert!(iommufd[1].split(',').any(|param| param.starts_with("fd=")));
+
+        let vfio = params
+            .windows(2)
+            .find(|args| args[0] == "-device" && args[1].starts_with("vfio-pci,"))
+            .expect("missing VFIO device");
+        assert!(contains_param(&vfio[1..2], "id=vfio-test"));
+        assert!(contains_param(&vfio[1..2], "iommufd=iommufdrp0"));
+        assert!(vfio[1].split(',').any(|param| param.starts_with("fd=")));
+        assert!(!vfio[1].split(',').any(|param| param.starts_with("host=")));
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    async fn test_multiple_vfio_devices_use_independent_fds() {
+        let config = test_qemu_config(Some("none"), false);
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+        let mut cmdline = QemuCmdLine::new("multiple-vfio-device-fds", &config).unwrap();
+
+        let vfio0 = VfioDeviceConfig::new("0000:21:00.0", 9, 10)
+            .with_vfio_bus("rp0")
+            .with_device_fds("/dev/null", "/dev/null", "vfio-gpu-0");
+        let vfio1 = VfioDeviceConfig::new("0000:81:00.0", 10, 11)
+            .with_vfio_bus("rp1")
+            .with_device_fds("/dev/null", "/dev/null", "vfio-gpu-1");
+
+        cmdline.add_pcie_vfio_device(vfio0).unwrap();
+        cmdline.add_pcie_vfio_device(vfio1).unwrap();
+        let params = cmdline.build().await.unwrap();
+
+        let iommufds: Vec<&str> = params
+            .windows(2)
+            .filter_map(|args| {
+                (args[0] == "-object" && args[1].starts_with("iommufd,"))
+                    .then_some(args[1].as_str())
+            })
+            .collect();
+        assert_eq!(iommufds.len(), 2);
+        assert!(iommufds
+            .iter()
+            .any(|arg| arg.split(',').any(|param| param == "id=iommufdrp0")));
+        assert!(iommufds
+            .iter()
+            .any(|arg| arg.split(',').any(|param| param == "id=iommufdrp1")));
+
+        let vfio_devices: Vec<&str> = params
+            .windows(2)
+            .filter_map(|args| {
+                (args[0] == "-device" && args[1].starts_with("vfio-pci,"))
+                    .then_some(args[1].as_str())
+            })
+            .collect();
+        assert_eq!(vfio_devices.len(), 2);
+        assert!(vfio_devices.iter().any(|arg| {
+            arg.split(',').any(|param| param == "id=vfio-gpu-0")
+                && arg.split(',').any(|param| param == "iommufd=iommufdrp0")
+        }));
+        assert!(vfio_devices.iter().any(|arg| {
+            arg.split(',').any(|param| param == "id=vfio-gpu-1")
+                && arg.split(',').any(|param| param == "iommufd=iommufdrp1")
+        }));
+        assert!(vfio_devices
+            .iter()
+            .all(|arg| !arg.split(',').any(|param| param.starts_with("host="))));
+
+        let mut inherited_fds: Vec<&str> = iommufds
+            .iter()
+            .chain(vfio_devices.iter())
+            .map(|arg| {
+                arg.split(',')
+                    .find(|param| param.starts_with("fd="))
+                    .expect("missing inherited device fd")
+            })
+            .collect();
+        inherited_fds.sort_unstable();
+        inherited_fds.dedup();
+        assert_eq!(inherited_fds.len(), 4);
+        assert!(cmdline.requires_memlock());
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
     }
 
     #[actix_rt::test]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2977,6 +2977,7 @@ pub struct QemuCmdLine<'a> {
     ccw_subchannel: Option<CcwSubChannel>,
     block_fdsets: HashMap<String, Vec<i64>>,
     next_fdset_id: i64,
+    requires_memlock: bool,
 }
 
 impl<'a> QemuCmdLine<'a> {
@@ -3000,6 +3001,7 @@ impl<'a> QemuCmdLine<'a> {
             ccw_subchannel,
             block_fdsets: HashMap::new(),
             next_fdset_id: 1,
+            requires_memlock: false,
         };
 
         // add_virtiofs_share() installs the file-backed memory backend when
@@ -3081,6 +3083,10 @@ impl<'a> QemuCmdLine<'a> {
     /// the descriptors if one of those devices is subsequently unplugged.
     pub fn take_block_fdsets(&mut self) -> HashMap<String, Vec<i64>> {
         std::mem::take(&mut self.block_fdsets)
+    }
+
+    pub fn requires_memlock(&self) -> bool {
+        self.requires_memlock
     }
 
     fn add_monitor(&mut self, proto: &str) -> Result<()> {
@@ -3640,6 +3646,7 @@ impl<'a> QemuCmdLine<'a> {
             vfio_device = vfio_device
                 .with_id(&fd_config.qemu_device_id)
                 .with_fd(&fd_config.vfio_cdev)?;
+            self.requires_memlock = true;
         }
 
         if let Some(vendor_id) = &config.x_pci_vendor_id {
@@ -4124,6 +4131,7 @@ mod tests {
         assert!(contains_param(&vfio[1..2], "iommufd=iommufdrp0"));
         assert!(vfio[1].split(',').any(|param| param.starts_with("fd=")));
         assert!(!vfio[1].split(',').any(|param| param.starts_with("host=")));
+        assert!(cmdline.requires_memlock());
         let _ = std::fs::remove_file(QMP_SOCKET_FILE);
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -53,6 +53,7 @@ use tokio::{
 };
 
 const VSOCK_SCHEME: &str = "vsock";
+const MEMLOCK_HEADROOM_DIVISOR: u64 = 10;
 
 #[derive(Debug)]
 pub struct QemuInner {
@@ -395,6 +396,9 @@ impl QemuInner {
         let ccw_subchannel = cmdline.take_ccw_subchannel();
         let block_fdsets = cmdline.take_block_fdsets();
         let has_memory_hotplug_region = cmdline.has_memory_hotplug_region();
+        let memlock_limit = cmdline.requires_memlock().then(|| {
+            memlock_limit_with_headroom(megs_to_bytes(self.config.memory_info.default_memory))
+        });
 
         info!(sl!(), "qemu cmd: {:?}", command);
 
@@ -430,6 +434,10 @@ impl QemuInner {
                     }
                 }
                 if let Some(user) = &user {
+                    if let Some(limit) = memlock_limit {
+                        set_memlock_rlimit(limit)
+                            .map_err(|err| io::Error::other(format!("{err:#}")))?;
+                    }
                     set_process_credentials(user)
                         .map_err(|err| io::Error::other(format!("{err:#}")))?;
                 }
@@ -1036,6 +1044,22 @@ fn set_process_credentials(user: &RootlessUser) -> Result<()> {
     )
 }
 
+fn memlock_limit_with_headroom(guest_memory: u64) -> u64 {
+    guest_memory.saturating_add(guest_memory / MEMLOCK_HEADROOM_DIVISOR)
+}
+
+fn set_memlock_rlimit(memlock_limit: u64) -> Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: memlock_limit,
+        rlim_max: memlock_limit,
+    };
+    let result = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error()).context("set RLIMIT_MEMLOCK failed");
+    }
+    Ok(())
+}
+
 fn set_process_credentials_with<SetGroups, SetGid, SetUid>(
     user: &RootlessUser,
     set_groups_fn: SetGroups,
@@ -1459,6 +1483,12 @@ mod tests {
             .await
             .unwrap()
             .is_network_device_hotplug_supported());
+    }
+
+    #[test]
+    fn test_memlock_limit_adds_headroom() {
+        assert_eq!(memlock_limit_with_headroom(10 * 1024), 11 * 1024);
+        assert_eq!(memlock_limit_with_headroom(u64::MAX), u64::MAX);
     }
 
     #[rstest]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -247,8 +247,9 @@ impl QemuInner {
                 }
                 DeviceType::VfioModern(vfio_dev) => {
                     // Snapshot parameters under the lock; release before doing cmdline work.
-                    let (device_type, ap_sysfs_path, devices, bus_port_id) = {
+                    let (vfio_device_id, device_type, ap_sysfs_path, devices, iommufd, bus_port_id) = {
                         let vfio_device = vfio_dev.lock().await;
+                        let vfio_device_id = vfio_device.device_id.clone();
                         let device_type = vfio_device.device.device_type.clone();
                         let ap_sysfs_path =
                             vfio_device.device.primary.sysfs_path.display().to_string();
@@ -262,9 +263,11 @@ impl QemuInner {
                             .map(|g| g.devices.clone())
                             .unwrap_or_else(|| vfio_device.device.devices.clone());
                         (
+                            vfio_device_id,
                             device_type,
                             ap_sysfs_path,
                             devices,
+                            vfio_device.device.iommufd.clone(),
                             vfio_device.config.bus_port_id.clone(),
                         )
                     };
@@ -279,15 +282,24 @@ impl QemuInner {
                         );
                     } else {
                         // PCI cold plug devices
-                        for dev in devices.iter() {
+                        for (index, dev) in devices.iter().enumerate() {
                             let host_bdf = dev.addr.to_string();
 
-                            let vfio_cfg = VfioDeviceConfig::new(
+                            let mut vfio_cfg = VfioDeviceConfig::new(
                                 host_bdf,
                                 bus_port_id.1 as u16,
                                 bus_port_id.1 + 1,
                             )
                             .with_vfio_bus(bus_port_id.0.clone());
+                            if let (Some(iommufd), Some(cdev)) =
+                                (iommufd.as_ref(), dev.vfio_cdev.as_ref())
+                            {
+                                vfio_cfg = vfio_cfg.with_device_fds(
+                                    &iommufd.iommufd_dev,
+                                    &cdev.devnode,
+                                    format!("vfio-{vfio_device_id}-{index}"),
+                                );
+                            }
 
                             cmdline.add_pcie_vfio_device(vfio_cfg)?;
                         }

--- a/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
+++ b/tests/integration/kubernetes/k8s-qemu-rootless-sandbox.bats
@@ -42,6 +42,25 @@ wait_for_rootless_host_resources() {
 	return 1
 }
 
+# Remove this helper once NVIDIA GPU runtime-rs configurations enable rootless
+# by default. Until then, explicitly request a GPU so this test exercises the
+# runtime-rs VFIO file-descriptor path.
+request_gpu_for_nvidia_gpu_runtime_rs() {
+	local available_gpus
+	local config="$1"
+
+	is_runtime_rs || return 0
+	is_nvidia_gpu_platform || return 0
+
+	available_gpus="$(kubectl get node "${node}" \
+		-o jsonpath='{.status.allocatable.nvidia\.com/pgpu}')"
+	[[ "${available_gpus}" =~ ^[1-9][0-9]*$ ]] || \
+		die "${node} has no allocatable nvidia.com/pgpu resource"
+
+	yq -i '.spec.containers[0].resources.limits."nvidia.com/pgpu" = "1"' \
+		"${config}"
+}
+
 qemu_rootless_sandbox_supported() {
 	[[ "${KATA_HYPERVISOR}" == qemu* ]] || return 1
 
@@ -111,11 +130,13 @@ setup() {
 		' "${pod_config}"
 	fi
 	set_container_command "${pod_config}" 0 sleep 30
+	request_gpu_for_nvidia_gpu_runtime_rs "${pod_config}"
 
 	watchable_pod_config="${BATS_FILE_TMPDIR}/inotify-configmap-pod.yaml"
 	cp "${pod_config_dir}/inotify-configmap-pod.yaml" "${watchable_pod_config}"
 	yq -i ".spec.runtimeClassName = \"$(get_test_runtime_class)\"" "${watchable_pod_config}"
 	set_node "${watchable_pod_config}" "${node}"
+	request_gpu_for_nvidia_gpu_runtime_rs "${watchable_pod_config}"
 
 	auto_generate_policy "${pod_config_dir}" "${pod_config}"
 	auto_generate_policy "${pod_config_dir}" "${watchable_pod_config}"


### PR DESCRIPTION
This PR enables unprivileged runtime-rs QEMU to start pods with VFIO devices attached (e.g. NVIDIA GPUs) without granting the temporary VMM user direct access to host VFIO and IOMMUFD device nodes. It continues the staged rootless and seccomp-sandbox work tracked by #13424.

**ATTENTION:** This targets modern IOMMUFD and VFIO cdev devices known before QEMU starts. Legacy VFIO group-node access, device hotplug after launch are intentionally not covered.

The following provides a description of two major problems addressed:

#### Problem 1 (runtime-rs/VFIO): rootless QEMU opened device nodes itself

Runtime-rs previously passed a PCI BDF to QEMU. QEMU then opened `/dev/iommu` and the corresponding `/dev/vfio/devices/vfioX` node after dropping to the temporary unprivileged VMM user.

Restrictive device-node permissions therefore caused rootless GPU VMs to exit before QMP became available.

Open the selected IOMMUFD and VFIO cdev nodes in the privileged shim and pass their descriptors through QEMU's `iommufd` and `vfio-pci` `fd` properties. Supply the explicit QEMU device ID required by the fd-only VFIO form and omit the host BDF when descriptors are available.

Use this descriptor path for privileged and rootless QEMU alike. This keeps host device permissions unchanged and avoids per-VM ownership, ACL, supplementary-group, and cleanup changes. Multiple VFIO devices receive independent descriptors.

Retain direct host-BDF handling as a fallback when IOMMUFD cdev discovery is unavailable.

#### Problem 2 (runtime-rs/VFIO): rootless QEMU could not lock guest memory

After dropping privileges, QEMU no longer has the privilege that exempts VFIO DMA mappings from `RLIMIT_MEMLOCK`. Containerd commonly provides an 8 MiB hard limit, which is insufficient for mapping guest memory and caused IOMMUFD setup to fail with `ENOMEM`.

Detect command lines containing externally opened VFIO devices and raise `RLIMIT_MEMLOCK` in the QEMU child before dropping credentials. Fail the launch if the limit cannot be raised, while leaving non-VFIO rootless QEMU launches unchanged.

Remaining rootless and seccomp-sandbox work is tracked in #13424.