### PR TITLE
kata-deploy: converge job-mode CRI stage across restart-induced retries

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -273,7 +273,15 @@ Because the cleanup dispatcher resolves nodes **live when it runs** at
 node set is *not* frozen into the stored release. This means the **default
 cleanup selector can simply be "nodes carrying the
 `katacontainers.io/kata-runtime` label"** — i.e. exactly the nodes the install
-actually labeled, regardless of how the install selector has drifted since.
+touched, regardless of how the install selector has drifted since.
+
+The selector matches the label's *key*, not the value `"true"`, and that is
+deliberate. An install claims its node with `katacontainers.io/kata-runtime=false`
+before it writes anything to it, and only promotes it to `"true"` once the node
+is kata-capable. Uninstall therefore also reaches nodes where the install failed
+part way through — the ones most likely to have artifacts or CRI configuration
+left on them. Nothing schedules onto a claimed node in the meantime, since the
+RuntimeClasses select the exact value `"true"`.
 
 Override it under `job.cleanup`, with the same precedence/semantics as install
 (`cleanup.nodes`, then `cleanup.nodeSelector` ANDed with

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -460,6 +460,17 @@ impl Config {
         Ok(config)
     }
 
+    /// The CRI runtime handlers this install writes for its shims.
+    ///
+    /// Custom runtimes and variants are left out: they are configured
+    /// conditionally, so their absence from a runtime would say nothing.
+    pub fn shim_handlers(&self) -> Vec<String> {
+        self.shims_for_arch
+            .iter()
+            .map(|shim| shim_handler(shim, self.multi_install_suffix.as_deref()))
+            .collect()
+    }
+
     /// Validate configuration parameters
     ///
     /// All validations are performed on the `_for_arch` values, which are the final
@@ -972,6 +983,19 @@ impl Variant {
             Self::Debug => "debug",
             Self::Devkit => "devkit",
         }
+    }
+}
+
+/// The handler name, and hence the RuntimeClass name, of a shim.
+///
+/// In one place because it is both written into the CRI configuration and read
+/// back out of a running CRI to confirm that configuration was loaded.
+pub fn shim_handler(shim: &str, multi_install_suffix: Option<&str>) -> String {
+    match multi_install_suffix {
+        Some(install_suffix) if !install_suffix.is_empty() => {
+            format!("kata-{shim}-{install_suffix}")
+        }
+        _ => format!("kata-{shim}"),
     }
 }
 
@@ -1959,6 +1983,13 @@ mod tests {
         assert!(debug_variants[0].crio_pull_type.is_none());
 
         cleanup_env_vars();
+    }
+
+    #[test]
+    fn shim_handlers_name_what_the_cri_config_declares() {
+        assert_eq!(shim_handler("qemu", None), "kata-qemu");
+        assert_eq!(shim_handler("qemu", Some("")), "kata-qemu");
+        assert_eq!(shim_handler("qemu", Some("dev")), "kata-qemu-dev");
     }
 
     #[serial]

--- a/tools/packaging/kata-deploy/binary/src/k8s/client.rs
+++ b/tools/packaging/kata-deploy/binary/src/k8s/client.rs
@@ -654,6 +654,30 @@ pub async fn get_node_ready_status(config: &Config) -> Result<String> {
     Ok("Unknown".to_string())
 }
 
+/// The CRI runtime handlers the kubelet reports this node's runtime as serving.
+///
+/// `None` means the node does not report them at all - the kubelet only fills
+/// this in with RecursiveReadOnlyMounts or UserNamespacesSupport enabled, and an
+/// older runtime returns none - which is not the same as kata being missing.
+pub async fn get_node_runtime_handlers(config: &Config) -> Result<Option<Vec<String>>> {
+    let client = K8sClient::new(&config.node_name).await?;
+    let node = client.get_node().await?;
+
+    let handlers: Vec<String> = node
+        .status
+        .and_then(|status| status.runtime_handlers)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|handler| handler.name)
+        .collect();
+
+    if handlers.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(handlers))
+}
+
 pub async fn label_node(
     config: &Config,
     label_key: &str,

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -99,6 +99,9 @@ enum Action {
 /// Node label applied to mark a node as kata-capable. Shared across the
 /// install/cleanup label stages so the key stays consistent.
 const KATA_RUNTIME_LABEL: &str = "katacontainers.io/kata-runtime";
+/// The value [`KATA_RUNTIME_LABEL`] carries while an install is under way: this
+/// node has to be cleaned up, but cannot run kata workloads yet.
+const KATA_RUNTIME_PENDING: &str = "false";
 const SUGGESTED_KUBELET_RUNTIME_REQUEST_TIMEOUT_SECS: u64 = 10 * 60;
 const MKFS_EROFS: &str = "mkfs.erofs";
 const MIN_EROFS_UTILS_VERSION: &str = "1.8.2";
@@ -756,10 +759,42 @@ fn mapping_contains_value(mapping: Option<&str>, expected_value: &str) -> bool {
     })
 }
 
+/// Mark the node as one kata-deploy has started installing on, before anything
+/// is written to it.
+///
+/// `helm uninstall` cleans the nodes carrying the kata-runtime label, whatever
+/// its value, so a node labelled only once the install *finishes* is out of
+/// uninstall's reach for the whole time it is half-installed. Not `true`,
+/// because RuntimeClasses select that exact value; an existing label is left
+/// alone, so reinstalling over a working node cannot withdraw it from
+/// scheduling.
+///
+/// Best-effort: this guards a failure that may never happen, and refusing to
+/// install over one failed label write would trade a rare orphan for a common
+/// outage.
+async fn claim_node(config: &config::Config) {
+    if let Err(e) = k8s::label_node(
+        config,
+        KATA_RUNTIME_LABEL,
+        Some(KATA_RUNTIME_PENDING),
+        false,
+    )
+    .await
+    {
+        log::warn!(
+            "install: could not mark node {} as being installed on ({e}). Should this install \
+             fail before it labels the node, `helm uninstall` will not clean this node up.",
+            config.node_name
+        );
+    }
+}
+
 /// Install stage 1 (artifacts): place kata artifacts/config on the host and set
 /// up any configured snapshotters. This does not touch CRI configuration.
 async fn install_stage_artifacts(config: &config::Config, runtime: &str) -> Result<()> {
     info!("install (artifacts): installing kata artifacts on host");
+
+    claim_node(config).await;
 
     artifacts::install_artifacts(config, runtime).await?;
 

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -793,13 +793,19 @@ async fn install_stage_artifacts(config: &config::Config, runtime: &str) -> Resu
 ///     restarting the very containerd that manages this pod tears the init
 ///     container down (exit 255, no logs) before it can finish - so the Job
 ///     retries with a fresh pod. To let the retry converge we skip the restart
-///     once the config we just (idempotently) re-applied is byte-for-byte what
-///     was already on disk *and* systemd says the runtime has been up since it
-///     was written. Neither half is enough alone: an unchanged config also
-///     describes an attempt that died before restarting anything, and a recent
-///     restart says nothing about an upgrade that changes the config. A genuine
+///     once three things hold: the config we just (idempotently) re-applied is
+///     byte-for-byte what was already on disk, systemd says the runtime has been
+///     up since it was written, and the node reports the runtime serving the
+///     handlers that config defines. No one of them is enough: an unchanged
+///     config also describes an attempt that died before restarting anything, a
+///     recent restart says nothing about an upgrade that changes the config, and
+///     a node that cannot report handlers cannot rule either way. A genuine
 ///     change still restarts; if that restart kills the init container again,
-///     the next retry finds both satisfied and takes the skip path.
+///     the next retry finds all three satisfied and takes the skip path.
+///
+/// Either way the stage ends by confirming the runtime is serving kata handlers,
+/// so a runtime that ignored what we wrote fails here rather than at the first
+/// kata pod scheduled onto the node.
 async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool) -> Result<()> {
     info!("install (cri): configuring CRI runtime");
 
@@ -822,6 +828,8 @@ async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool)
         }
     }
 
+    let handlers = config.shim_handlers();
+
     if staged {
         if let Some(before) = config_before {
             let unchanged =
@@ -829,15 +837,29 @@ async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool)
             if unchanged
                 && runtime::lifecycle::cri_serving_config_from(runtime, before.written_at()).await
             {
-                info!(
-                    "install (cri): CRI config for {runtime} is unchanged from a previous \
-                     attempt, and {runtime} has been running since it was written, so it is \
-                     already serving it. Skipping the (self-terminating) restart and \
-                     checking the runtime is up instead."
-                );
-                runtime::lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
-                info!("install (cri): runtime is up; CRI stage complete without restart");
-                return Ok(());
+                // Everything up to here is inference about a pod no longer around
+                // to ask. The node seeing our handlers is the one direct answer.
+                let report =
+                    runtime::lifecycle::kata_handlers_loaded(config, &handlers, HANDLER_WAIT_SECS)
+                        .await;
+
+                if let runtime::lifecycle::HandlerReport::Missing(missing) = report {
+                    info!(
+                        "install (cri): {runtime} has been up since this config was written, but \
+                         node {} still does not report {missing:?}, so it is not serving it after \
+                         all. Restarting.",
+                        config.node_name
+                    );
+                } else {
+                    info!(
+                        "install (cri): CRI config for {runtime} is unchanged from a previous \
+                         attempt, and {runtime} is already serving it. Skipping the \
+                         (self-terminating) restart and checking the runtime is up instead."
+                    );
+                    runtime::lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
+                    info!("install (cri): runtime is up; CRI stage complete without restart");
+                    return Ok(());
+                }
             }
         }
     }
@@ -846,7 +868,51 @@ async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool)
     runtime::lifecycle::restart_runtime(config, runtime, staged).await?;
     info!("Runtime restart completed successfully");
 
-    Ok(())
+    confirm_handlers_are_served(config, runtime, &handlers).await
+}
+
+/// Generous: the kubelet republishes this on every node status sync.
+const HANDLER_WAIT_SECS: u64 = 120;
+
+/// Fail the cri stage if the runtime came back without a single kata handler.
+///
+/// Restarting a unit says the unit restarted, not that it liked what we wrote.
+/// A runtime that ignored our drop-in would otherwise reach the label stage and
+/// leave a node advertised as kata-capable that cannot run a single kata pod.
+///
+/// A partial list is only reported: a node serving some of our handlers is
+/// running a CRI that read our configuration, which is what this stage is
+/// answerable for.
+async fn confirm_handlers_are_served(
+    config: &config::Config,
+    runtime: &str,
+    handlers: &[String],
+) -> Result<()> {
+    use runtime::lifecycle::HandlerReport;
+
+    match runtime::lifecycle::kata_handlers_loaded(config, handlers, HANDLER_WAIT_SECS).await {
+        HandlerReport::AllLoaded => {
+            info!("install (cri): {runtime} is serving {handlers:?}");
+            Ok(())
+        }
+        HandlerReport::Missing(missing) if missing.len() == handlers.len() => {
+            anyhow::bail!(
+                "{runtime} restarted but node {} reports none of {handlers:?} among its runtime \
+                 handlers, so it is not serving the kata configuration this stage wrote. Check \
+                 {runtime}'s logs for a rejected or unread configuration file.",
+                config.node_name
+            )
+        }
+        HandlerReport::Missing(missing) => {
+            log::warn!(
+                "install (cri): {runtime} is serving kata handlers, but not {missing:?}. The \
+                 RuntimeClasses naming them will not be usable on node {}.",
+                config.node_name
+            );
+            Ok(())
+        }
+        HandlerReport::Unknown => Ok(()),
+    }
 }
 
 /// Install stage 3 (label): apply the kata-runtime node label. Unprivileged,

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -310,7 +310,7 @@ async fn main() -> Result<()> {
             info!("Install artifacts stage completed, exiting");
         }
         Action::InstallStageCri => {
-            install_stage_cri(&config, &runtime).await?;
+            install_stage_cri(&config, &runtime, true).await?;
             info!("Install CRI stage completed, exiting");
         }
         Action::InstallStageLabel => {
@@ -369,7 +369,7 @@ async fn install(config: &config::Config, runtime: &str) -> Result<()> {
 
     install_stage_host_check(config, runtime).await?;
     install_stage_artifacts(config, runtime).await?;
-    install_stage_cri(config, runtime).await?;
+    install_stage_cri(config, runtime, false).await?;
     install_stage_label(config).await?;
 
     info!("Kata Containers installation completed successfully");
@@ -778,8 +778,36 @@ async fn install_stage_artifacts(config: &config::Config, runtime: &str) -> Resu
 /// Install stage 2 (cri): write CRI drop-ins, configure snapshotters, restart
 /// the runtime, and wait for the node to become ready. This node-disrupting
 /// stage is kept short-lived.
-async fn install_stage_cri(config: &config::Config, runtime: &str) -> Result<()> {
+///
+/// `staged` distinguishes the two deployment models, because they survive the
+/// runtime restart very differently:
+///
+///   - DaemonSet (`staged == false`): this runs inside a long-lived, regular
+///     container. When containerd is restarted the kubelet re-attaches to the
+///     still-running container, so the process survives the bounce, reaches the
+///     readiness wait, and goes on to label the node in a single shot. It
+///     therefore always restarts.
+///
+///   - Job (`staged == true`): this runs as a short-lived *init* container in a
+///     `restartPolicy: Never` per-node Job. On some platforms (notably AKS)
+///     restarting the very containerd that manages this pod tears the init
+///     container down (exit 255, no logs) before it can finish - so the Job
+///     retries with a fresh pod. To let the retry converge we skip the restart
+///     once the config we just (idempotently) re-applied is byte-for-byte what
+///     was already on disk *and* systemd says the runtime has been up since it
+///     was written. Neither half is enough alone: an unchanged config also
+///     describes an attempt that died before restarting anything, and a recent
+///     restart says nothing about an upgrade that changes the config. A genuine
+///     change still restarts; if that restart kills the init container again,
+///     the next retry finds both satisfied and takes the skip path.
+async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool) -> Result<()> {
     info!("install (cri): configuring CRI runtime");
+
+    let config_before = if staged {
+        runtime::cri_config_snapshot(config, runtime).await
+    } else {
+        None
+    };
 
     runtime::containerd::setup_containerd_config_files(runtime, config).await?;
 
@@ -794,8 +822,28 @@ async fn install_stage_cri(config: &config::Config, runtime: &str) -> Result<()>
         }
     }
 
+    if staged {
+        if let Some(before) = config_before {
+            let unchanged =
+                runtime::cri_config_snapshot(config, runtime).await.as_ref() == Some(&before);
+            if unchanged
+                && runtime::lifecycle::cri_serving_config_from(runtime, before.written_at()).await
+            {
+                info!(
+                    "install (cri): CRI config for {runtime} is unchanged from a previous \
+                     attempt, and {runtime} has been running since it was written, so it is \
+                     already serving it. Skipping the (self-terminating) restart and \
+                     checking the runtime is up instead."
+                );
+                runtime::lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
+                info!("install (cri): runtime is up; CRI stage complete without restart");
+                return Ok(());
+            }
+        }
+    }
+
     info!("About to restart runtime: {}", runtime);
-    runtime::lifecycle::restart_runtime(config, runtime).await?;
+    runtime::lifecycle::restart_runtime(config, runtime, staged).await?;
     info!("Runtime restart completed successfully");
 
     Ok(())

--- a/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config;
 use crate::config::{Config, ContainerdPaths, CustomRuntime, NYDUS_FOR_KATA_TEE};
 use crate::k8s;
 use crate::utils;
@@ -310,11 +311,7 @@ pub async fn configure_containerd_runtime(
 ) -> Result<()> {
     log::info!("configure_containerd_runtime: Starting for shim={}", shim);
 
-    let adjusted_shim = match config.multi_install_suffix.as_ref() {
-        Some(suffix) if !suffix.is_empty() => format!("{shim}-{suffix}"),
-        _ => shim.to_string(),
-    };
-    let runtime_name = format!("kata-{adjusted_shim}");
+    let runtime_name = config::shim_handler(shim, config.multi_install_suffix.as_deref());
     let configuration = format!("configuration-{shim}");
 
     let paths = config.get_containerd_paths(runtime).await?;

--- a/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
@@ -138,6 +138,30 @@ fn get_containerd_output_path(paths: &ContainerdPaths) -> PathBuf {
     }
 }
 
+/// Every containerd configuration file [`configure_containerd`] can write, the
+/// effective kata output file first.
+///
+/// All of them, because an unchanged kata drop-in says nothing about the user
+/// drop-in next to it, or about the `imports` entry in the main config that
+/// makes containerd read either of them in the first place.
+pub(crate) async fn kata_cri_config_files(config: &Config, runtime: &str) -> Option<Vec<PathBuf>> {
+    let paths = config.get_containerd_paths(runtime).await.ok()?;
+
+    let mut files = vec![get_containerd_output_path(&paths)];
+    if let Ok((user_drop_in, _)) = get_user_containerd_drop_in_output_path(&paths) {
+        files.push(user_drop_in);
+    }
+    if let Some(imports_file) = &paths.imports_file {
+        files.push(PathBuf::from(imports_file));
+    }
+
+    // Without drop-in support the output file is the main config, which is also
+    // where imports would go.
+    files.dedup();
+
+    Some(files)
+}
+
 fn get_user_containerd_drop_in_output_path(paths: &ContainerdPaths) -> Result<(PathBuf, String)> {
     if !paths.use_drop_in {
         anyhow::bail!(

--- a/tools/packaging/kata-deploy/binary/src/runtime/crio.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/crio.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config;
 use crate::config::{Config, CustomRuntime};
 use crate::utils;
 use anyhow::Result;
@@ -45,11 +46,7 @@ fn write_crio_runtime_config(file: &mut fs::File, params: &CrioRuntimeParams) ->
 }
 
 pub async fn configure_crio_runtime(config: &Config, shim: &str) -> Result<()> {
-    let adjusted_shim = match config.multi_install_suffix.as_ref() {
-        Some(suffix) if !suffix.is_empty() => format!("{shim}-{suffix}"),
-        _ => shim.to_string(),
-    };
-    let runtime_name = format!("kata-{adjusted_shim}");
+    let runtime_name = config::shim_handler(shim, config.multi_install_suffix.as_deref());
     let configuration = format!("configuration-{shim}");
 
     // Determine if guest-pull is configured for this shim

--- a/tools/packaging/kata-deploy/binary/src/runtime/crio.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/crio.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use log::info;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 struct CrioRuntimeParams<'a> {
     /// Runtime name (e.g., "kata-qemu")
@@ -189,6 +189,15 @@ log_level = "debug""#
     );
 
     Ok(())
+}
+
+/// Every CRI-O configuration file [`configure_crio`] writes, the runtime drop-in
+/// first. The debug one is in there so that toggling debug reads as a change.
+pub(crate) fn kata_cri_config_files(config: &Config) -> Vec<PathBuf> {
+    vec![
+        PathBuf::from(&config.crio_drop_in_conf_file),
+        PathBuf::from(&config.crio_drop_in_conf_file_debug),
+    ]
 }
 
 pub async fn cleanup_crio(config: &Config) -> Result<()> {

--- a/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
@@ -87,6 +87,96 @@ pub async fn wait_till_cri_unit_active(runtime: &str, timeout_secs: u64) -> Resu
     }
 }
 
+/// What the node says about the kata handlers the CRI runtime is serving.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HandlerReport {
+    AllLoaded,
+    Missing(Vec<String>),
+    /// The node does not report handlers, or could not be read. Never a
+    /// failure: this check exists to catch a runtime that ignored our
+    /// configuration, not to make installs depend on being able to ask.
+    Unknown,
+}
+
+/// Ask the node which kata handlers its CRI runtime is serving, waiting up to
+/// `timeout_secs` for `expected` to show up.
+///
+/// The only view we have of what the runtime actually *loaded*, as opposed to
+/// what we wrote and hoped it would read. It trails the runtime by a node status
+/// sync or two, hence the wait - but a cluster that cannot answer at all says so
+/// immediately, rather than spending the timeout on it.
+pub async fn kata_handlers_loaded(
+    config: &Config,
+    expected: &[String],
+    timeout_secs: u64,
+) -> HandlerReport {
+    if expected.is_empty() {
+        return HandlerReport::Unknown;
+    }
+
+    // A best-effort check is not worth the full timeout to give up on.
+    const READ_FAILURES_BEFORE_GIVING_UP: u32 = 3;
+
+    let start = std::time::Instant::now();
+    let mut last_missing: Option<Vec<String>> = None;
+    let mut failures = 0;
+
+    loop {
+        match k8s::get_node_runtime_handlers(config).await {
+            Ok(Some(loaded)) => {
+                let missing = missing_handlers(expected, &loaded);
+
+                if missing.is_empty() {
+                    return HandlerReport::AllLoaded;
+                }
+
+                info!(
+                    "kata_handlers_loaded: node {} reports {loaded:?}; still waiting for {missing:?}",
+                    config.node_name
+                );
+                failures = 0;
+                last_missing = Some(missing);
+            }
+            Ok(None) => {
+                info!(
+                    "kata_handlers_loaded: node {} reports no runtime handlers, so what the \
+                     runtime loaded cannot be checked here",
+                    config.node_name
+                );
+                return HandlerReport::Unknown;
+            }
+            Err(e) => {
+                info!("kata_handlers_loaded: could not read the node's handlers: {e}");
+                failures += 1;
+                if failures >= READ_FAILURES_BEFORE_GIVING_UP {
+                    return HandlerReport::Unknown;
+                }
+            }
+        }
+
+        if start.elapsed().as_secs() >= timeout_secs {
+            return match last_missing {
+                Some(missing) => HandlerReport::Missing(missing),
+                None => HandlerReport::Unknown,
+            };
+        }
+
+        sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Which of `expected` the runtime is not serving.
+///
+/// Only ever looks for ours: a runtime is free to serve handlers we know
+/// nothing about.
+fn missing_handlers(expected: &[String], loaded: &[String]) -> Vec<String> {
+    expected
+        .iter()
+        .filter(|handler| !loaded.contains(handler))
+        .cloned()
+        .collect()
+}
+
 /// Whether the CRI runtime has been running continuously since `written_at`, and
 /// is therefore serving the configuration that was on disk at that moment.
 ///
@@ -174,4 +264,42 @@ pub async fn restart_cri_runtime(_config: &Config, runtime: &str) -> Result<()> 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handlers(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn a_runtime_serving_everything_we_wrote_is_missing_nothing() {
+        assert!(missing_handlers(
+            &handlers(&["kata-qemu", "kata-clh"]),
+            &handlers(&["runc", "kata-qemu", "kata-clh"]),
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn a_runtime_that_never_read_our_config_is_missing_all_of_them() {
+        assert_eq!(
+            missing_handlers(&handlers(&["kata-qemu", "kata-clh"]), &handlers(&["runc"])),
+            handlers(&["kata-qemu", "kata-clh"]),
+        );
+    }
+
+    #[test]
+    fn another_installs_handlers_do_not_count_as_ours() {
+        // A multi-install alongside us serves kata handlers under its own suffix.
+        assert_eq!(
+            missing_handlers(
+                &handlers(&["kata-qemu"]),
+                &handlers(&["kata-qemu-tee", "kata-qemu-debug"]),
+            ),
+            handlers(&["kata-qemu"]),
+        );
+    }
 }

--- a/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/lifecycle.rs
@@ -10,7 +10,7 @@ use crate::utils;
 use super::manager;
 use anyhow::Result;
 use log::info;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tokio::time::sleep;
 
 pub async fn wait_till_node_is_ready_timeout(
@@ -56,7 +56,80 @@ pub async fn wait_till_node_is_ready_timeout(
     }
 }
 
-pub async fn restart_runtime(config: &Config, runtime: &str) -> Result<()> {
+/// Wait until the CRI runtime's systemd unit is active again, up to `timeout_secs`.
+///
+/// Scoped to what this stage is answerable for: the runtime it bounced serving
+/// again. Whether the node as a whole is Ready is checked by the stage that
+/// labels it kata-capable.
+pub async fn wait_till_cri_unit_active(runtime: &str, timeout_secs: u64) -> Result<()> {
+    let unit = manager::cri_systemd_unit(runtime);
+    let start = std::time::Instant::now();
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+        if utils::host_systemctl(&["is-active", "--quiet", &unit])
+            .await
+            .is_ok()
+        {
+            info!("Unit {unit} is active again (attempt {attempt})");
+            return Ok(());
+        }
+
+        if start.elapsed().as_secs() >= timeout_secs {
+            return Err(anyhow::anyhow!(
+                "Timed out after {timeout_secs}s waiting for {unit} to become active again"
+            ));
+        }
+
+        info!("wait_till_cri_unit_active: {unit} not active yet, sleeping 2 seconds...");
+        sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Whether the CRI runtime has been running continuously since `written_at`, and
+/// is therefore serving the configuration that was on disk at that moment.
+///
+/// Finding the configuration a job-mode retry would have written proves it was
+/// written, not that anything restarted to read it: an attempt that died in
+/// between leaves the two indistinguishable on disk. Only systemd can tell them
+/// apart, having recorded the restart regardless of who asked for it.
+///
+/// Anything that cannot be established is answered `false`, costing a restart
+/// that may turn out to be unnecessary. The opposite mistake labels a node
+/// kata-capable while its runtime knows nothing about kata.
+pub async fn cri_serving_config_from(runtime: &str, written_at: Option<SystemTime>) -> bool {
+    // k0s reloads without a restart, so there is none for a retry to have missed.
+    if matches!(runtime, "k0s-worker" | "k0s-controller") {
+        return true;
+    }
+
+    let Some(written_at) = written_at else {
+        return false;
+    };
+
+    let unit = manager::cri_systemd_unit(runtime);
+    let active_since = match utils::host_unit_active_since(&unit).await {
+        Ok(Some(active_since)) => active_since,
+        Ok(None) => {
+            info!("{unit} has not been active since boot; a restart is still needed");
+            return false;
+        }
+        Err(e) => {
+            info!("Could not tell when {unit} last started ({e}); assuming a restart is needed");
+            return false;
+        }
+    };
+
+    active_since > written_at
+}
+
+/// Restart the CRI runtime, then wait for it to come back.
+///
+/// `staged` selects how that wait is done: the DaemonSet survives the bounce and
+/// can wait for the node's Ready condition, while a staged per-node Job is torn
+/// down along with the runtime it restarts and waits on the systemd unit instead.
+pub async fn restart_runtime(config: &Config, runtime: &str, staged: bool) -> Result<()> {
     info!("restart_runtime: Starting restart for runtime={}", runtime);
     match runtime {
         "k0s-worker" | "k0s-controller" => {
@@ -71,6 +144,15 @@ pub async fn restart_runtime(config: &Config, runtime: &str) -> Result<()> {
             utils::host_systemctl(&["restart", &unit]).await?;
             info!("restart_runtime: Successfully restarted {}", unit);
         }
+    }
+
+    if staged {
+        // k0s never restarted anything above, so there is nothing to wait for.
+        if !matches!(runtime, "k0s-worker" | "k0s-controller") {
+            info!("restart_runtime: Waiting for the CRI runtime unit to come back");
+            wait_till_cri_unit_active(runtime, 300).await?;
+        }
+        return Ok(());
     }
 
     info!("restart_runtime: Waiting for node to become ready");

--- a/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
@@ -8,6 +8,9 @@ use crate::k8s;
 use crate::utils;
 use anyhow::{Context, Result};
 use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use super::containerd;
 use super::crio;
@@ -206,6 +209,73 @@ pub async fn configure_cri_runtime(config: &Config, runtime: &str) -> Result<()>
     Ok(())
 }
 
+/// What the kata CRI configuration for a runtime looked like at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CriConfigSnapshot {
+    fingerprint: String,
+    written_at: Option<SystemTime>,
+}
+
+impl CriConfigSnapshot {
+    pub fn written_at(&self) -> Option<SystemTime> {
+        self.written_at
+    }
+}
+
+/// Snapshot the current on-disk kata CRI configuration for `runtime`.
+///
+/// The config writes are idempotent, so comparing a snapshot from before a
+/// re-apply with one from after says whether the runtime has to be restarted to
+/// pick anything up.
+pub async fn cri_config_snapshot(config: &Config, runtime: &str) -> Option<CriConfigSnapshot> {
+    let files = if runtime == "crio" {
+        crio::kata_cri_config_files(config)
+    } else if is_containerd_based(runtime) {
+        containerd::kata_cri_config_files(config, runtime).await?
+    } else {
+        return None;
+    };
+
+    snapshot_files(&files)
+}
+
+/// Fold `files` into a single snapshot, in order.
+///
+/// A missing first entry means kata was never configured here. The rest count
+/// as empty when absent, so a user drop-in appearing still reads as a change.
+fn snapshot_files(files: &[PathBuf]) -> Option<CriConfigSnapshot> {
+    let (primary, rest) = files.split_first()?;
+
+    let mut fingerprint = read_for_fingerprint(primary)?;
+    let mut written_at = mtime(primary);
+
+    for file in rest {
+        fingerprint.push_str(&read_for_fingerprint(file).unwrap_or_default());
+        written_at = written_at.max(mtime(file));
+    }
+
+    Some(CriConfigSnapshot {
+        fingerprint,
+        written_at,
+    })
+}
+
+/// Path and content, framed so that content moving between files still reads as
+/// a change.
+fn read_for_fingerprint(file: &Path) -> Option<String> {
+    let content = fs::read_to_string(file).ok()?;
+
+    Some(format!(
+        "{}\n{}\n{content}\n",
+        file.display(),
+        content.len()
+    ))
+}
+
+fn mtime(file: &Path) -> Option<SystemTime> {
+    fs::metadata(file).ok()?.modified().ok()
+}
+
 /// Remove CRI runtime configuration (containerd/crio config files) without restarting.
 pub async fn cleanup_cri_runtime_config(config: &Config, runtime: &str) -> Result<()> {
     log::info!(
@@ -246,6 +316,86 @@ pub async fn restart_and_wait_for_ready(config: &Config, runtime: &str) -> Resul
 mod tests {
     use super::*;
     use rstest::rstest;
+    use tempfile::tempdir;
+
+    // --- snapshot_files ---
+    //
+    // What install_stage_cri decides on: equal fingerprints across per-node Job
+    // retries mean this config is already on disk, so the retry can converge
+    // instead of restarting the runtime (and getting killed) again.
+
+    #[test]
+    fn absent_primary_file_is_none() {
+        let dir = tempdir().unwrap();
+
+        assert_eq!(
+            snapshot_files(&[dir.path().join("kata-deploy.toml")]),
+            None,
+            "no config on disk yet must read as None (fresh install -> restart)"
+        );
+    }
+
+    #[test]
+    fn a_secondary_file_appearing_is_a_change() {
+        let dir = tempdir().unwrap();
+        let drop_in = dir.path().join("kata-deploy.toml");
+        let user_drop_in = dir.path().join("zz-kata-deploy-user.toml");
+        fs::write(&drop_in, "kata").unwrap();
+
+        let files = [drop_in, user_drop_in.clone()];
+        let before = snapshot_files(&files).unwrap();
+
+        // A user drop-in added by an upgrade leaves the kata drop-in untouched,
+        // so this is exactly the change a single-file snapshot used to miss.
+        fs::write(&user_drop_in, "user").unwrap();
+        assert_ne!(
+            before.fingerprint,
+            snapshot_files(&files).unwrap().fingerprint
+        );
+    }
+
+    #[test]
+    fn identical_content_fingerprints_the_same() {
+        let dir = tempdir().unwrap();
+        let drop_in = dir.path().join("kata-deploy.toml");
+        let main_config = dir.path().join("config.toml");
+        fs::write(&drop_in, "kata").unwrap();
+        fs::write(&main_config, "imports = [\"kata-deploy.toml\"]").unwrap();
+
+        let files = [drop_in, main_config.clone()];
+        let before = snapshot_files(&files).unwrap();
+
+        assert_eq!(
+            before.fingerprint,
+            snapshot_files(&files).unwrap().fingerprint
+        );
+
+        // Losing the import means containerd no longer reads the drop-in, even
+        // though the drop-in itself is byte-for-byte what we want.
+        fs::write(&main_config, "imports = []").unwrap();
+        assert_ne!(
+            before.fingerprint,
+            snapshot_files(&files).unwrap().fingerprint
+        );
+    }
+
+    #[test]
+    fn written_at_is_the_newest_file() {
+        let dir = tempdir().unwrap();
+        let drop_in = dir.path().join("kata-deploy.toml");
+        let user_drop_in = dir.path().join("zz-kata-deploy-user.toml");
+        fs::write(&drop_in, "kata").unwrap();
+        fs::write(&user_drop_in, "user").unwrap();
+
+        let newest = mtime(&drop_in).max(mtime(&user_drop_in));
+        assert_eq!(
+            snapshot_files(&[drop_in, user_drop_in])
+                .unwrap()
+                .written_at(),
+            newest,
+            "the restart has to be newer than the last write, whichever file it landed in"
+        );
+    }
 
     // --- containerd_version_is_2_or_newer ---
 

--- a/tools/packaging/kata-deploy/binary/src/utils/system.rs
+++ b/tools/packaging/kata-deploy/binary/src/utils/system.rs
@@ -54,6 +54,10 @@ pub async fn host_systemctl(args: &[&str]) -> Result<()> {
     super::systemd::systemctl(args).await
 }
 
+pub async fn host_unit_active_since(unit: &str) -> Result<Option<std::time::SystemTime>> {
+    super::systemd::unit_active_since(unit).await
+}
+
 /// Get kata containers config path based on shim type.
 /// This returns the path where the shim's configuration will be read from.
 /// For standard runtimes using drop-in configuration, this is the per-shim directory.

--- a/tools/packaging/kata-deploy/binary/src/utils/systemd.rs
+++ b/tools/packaging/kata-deploy/binary/src/utils/systemd.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Context, Result};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use zvariant::{OwnedObjectPath, OwnedValue};
 
 use super::dbus::{Connection, Method};
@@ -36,6 +36,24 @@ pub async fn systemctl(args: &[&str]) -> Result<()> {
     tokio::task::spawn_blocking(move || run(&args))
         .await
         .context("The systemd worker thread panicked")?
+}
+
+/// When systemd last saw `unit` enter the active state, or `None` if it never
+/// did in this boot.
+///
+/// Readable by a process other than the one that asked for the restart, which
+/// is the point: a container torn down mid-restart leaves no record of its own.
+pub async fn unit_active_since(unit: &str) -> Result<Option<SystemTime>> {
+    let unit = unit.to_owned();
+
+    tokio::task::spawn_blocking(move || {
+        let mut connection = Connection::connect(SYSTEMD_SOCKET, IO_TIMEOUT)
+            .context("Failed to connect to the host systemd private socket")?;
+
+        active_enter_timestamp(&mut connection, &service_name(&unit))
+    })
+    .await
+    .context("The systemd worker thread panicked")?
 }
 
 fn manager(member: &str) -> Method<'_> {
@@ -182,7 +200,7 @@ fn wait_for_job(connection: &mut Connection, job: &OwnedObjectPath, unit: &str) 
     }
 }
 
-fn active_state(connection: &mut Connection, unit: &str) -> Result<String> {
+fn unit_property(connection: &mut Connection, unit: &str, name: &str) -> Result<OwnedValue> {
     let reply = connection
         .call(&manager("GetUnit"), &(unit,))
         .with_context(|| format!("Failed to find systemd unit {unit}"))?;
@@ -197,15 +215,33 @@ fn active_state(connection: &mut Connection, unit: &str) -> Result<String> {
         member: "Get",
     };
     let reply = connection
-        .call(&property, &(UNIT_INTERFACE, "ActiveState"))
-        .with_context(|| format!("Failed to get systemd unit {unit} state"))?;
+        .call(&property, &(UNIT_INTERFACE, name))
+        .with_context(|| format!("Failed to get {name} of systemd unit {unit}"))?;
 
-    let state: OwnedValue = reply
+    reply
         .body()
-        .with_context(|| format!("Failed to read the state of systemd unit {unit}"))?;
+        .with_context(|| format!("Failed to read {name} of systemd unit {unit}"))
+}
+
+fn active_state(connection: &mut Connection, unit: &str) -> Result<String> {
+    let state = unit_property(connection, unit, "ActiveState")?;
 
     String::try_from(state)
         .with_context(|| format!("Systemd reported a non-string state for unit {unit}"))
+}
+
+fn active_enter_timestamp(connection: &mut Connection, unit: &str) -> Result<Option<SystemTime>> {
+    let timestamp = unit_property(connection, unit, "ActiveEnterTimestamp")?;
+
+    // Microseconds on the same clock as a file's mtime; zero for a unit that
+    // has never been active.
+    let micros = u64::try_from(timestamp)
+        .with_context(|| format!("Systemd reported a non-numeric timestamp for unit {unit}"))?;
+    if micros == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(UNIX_EPOCH + Duration::from_micros(micros)))
 }
 
 #[cfg(test)]

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -12,8 +12,10 @@ pipeline in reverse and exits:
 Unlike the old per-node hook model, node selection here is resolved LIVE when the
 hook runs at `helm uninstall` (the dispatcher does the lookup), not frozen at
 install/upgrade time. That is why the default cleanup selector can be
-"nodes carrying the katacontainers.io/kata-runtime label" (i.e. exactly the
-nodes install actually labeled) - see values.yaml job.cleanup.
+"nodes carrying the katacontainers.io/kata-runtime label", whatever its value:
+install claims a node with =false before writing to it and promotes it to =true
+once it is kata-capable, so this covers half-installed nodes too - see
+values.yaml job.cleanup.
 
 This runs while the release's kept ServiceAccount/RBAC and the job-templates
 ConfigMap still exist; they are torn down only after pre-delete hooks complete.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -82,9 +82,14 @@ job:
   #
   # The cleanup dispatcher resolves nodes LIVE when it runs at `helm uninstall`
   # (the dispatcher does the lookup), so - unlike a frozen Helm-rendered hook -
-  # the DEFAULT below can safely be "nodes carrying katacontainers.io/kata-runtime",
-  # i.e. exactly the nodes install actually labeled. Override to clean a
-  # different set, e.g.:
+  # the DEFAULT below can safely be "nodes carrying katacontainers.io/kata-runtime".
+  #
+  # Note the selector matches the KEY, not the value "true": install claims a
+  # node with katacontainers.io/kata-runtime=false before it writes anything to
+  # it, and only sets "true" once the node is kata-capable. Uninstall therefore
+  # also reaches nodes where the install failed half way, which are precisely
+  # the nodes with something left on them. Override to clean a different set,
+  # e.g.:
   #   job:
   #     cleanup:
   #       nodes: ["worker-1"]


### PR DESCRIPTION
In job mode the per-node install pipeline runs as ordered initContainers in a
restartPolicy: Never Job. The cri stage restarts the very CRI runtime that
manages its own pod, and on some platforms (notably AKS) that restart tears the
init container down (exit 255, ~1s, no logs) before it can finish. The Job then
retries with a fresh pod that restarts the runtime again and dies the same way,
until the per-node Job hits BackoffLimitExceeded and the dispatcher fails the
whole install. DaemonSet mode is unaffected: install runs in a long-lived,
regular container the kubelet re-attaches to after the bounce, so it reaches the
label stage in one shot.

Make the staged cri action idempotent so the retry converges. Snapshot the
effective kata CRI config (containerd drop-in / main config, or the CRI-O
drop-in) before and after re-applying it; if it is byte-for-byte unchanged, a
previous attempt already applied it and systemd completed the restart
independently of the dead pod, so the runtime is already serving this config.
Skip the self-terminating restart and just verify node readiness, letting the
label stage run. A genuine change (fresh install, or an upgrade that alters the
config) still restarts; if that restart again kills the init container, the next
retry sees an unchanged config and takes the skip path.

The DaemonSet install path passes staged=false and keeps its always-restart
behavior, so this only affects job mode.

Signed-off-by: Fabiano Fidêncio <ffidencio@nvidia.com>
Assisted-by: Cursor <cursoragent@cursor.com>
