### PR TITLE
kata-deploy: let the job-mode dispatcher be confined to trusted nodes

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -177,6 +177,43 @@ membership is resolved at run time, and the dispatcher itself paces the rollout
 per node**. Per-node Jobs are garbage-collected via an `ownerReference` to the
 dispatcher and `job.ttlSecondsAfterFinished`.
 
+### Where the dispatcher runs
+
+The dispatcher holds the one token in `job` mode that can enumerate every node
+in the cluster and create the privileged per-node Jobs, and root on whatever
+node it lands on can read it. Confine it to nodes you trust — typically the
+control plane — with `job.dispatcherNodeSelector` and
+`job.dispatcherTolerations`:
+
+```yaml title="values.yaml"
+job:
+  dispatcherNodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  dispatcherTolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+```
+
+The toleration is needed because control-plane nodes are normally tainted. These
+settings say nothing about where Kata is installed — that remains the top-level
+`nodeSelector` / `affinity` / `tolerations`, and the per-node Jobs do not inherit
+the dispatcher's placement. When `job.dispatcherTolerations` is empty it falls
+back to the top-level `tolerations`, so the dispatcher stays schedulable on a
+cluster whose every node is tainted.
+
+!!! warning "What this does, and what it leaves alone"
+
+    Pinning moves one credential, not all of them. The per-node Jobs still run
+    under the `kata-deploy` ServiceAccount on every node Kata is installed on,
+    so a worker still hosts a token that can patch nodes and RuntimeClasses.
+    What it takes off those workers is the credential that reaches the *whole*
+    cluster: node enumeration, and the ability to create privileged Jobs
+    anywhere.
+
+    That much is a boundary `daemonset` mode cannot draw at all, since the pod
+    holding its token has to run on every node by definition.
+
 ### Adding nodes in `job` mode
 
 The dispatcher only runs on `helm install` / `helm upgrade` / `helm uninstall`.

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -482,3 +482,53 @@ EOF
 	! echo "${install}" | grep -q "affinity:"
 	! echo "${install}" | grep -q "node.cloud/reserved"
 }
+
+@test "Helm template (job mode): the dispatcher can be confined to trusted nodes" {
+	local args=(
+		--set 'job.dispatcherNodeSelector.node-role\.kubernetes\.io/control-plane='
+		--set 'job.dispatcherTolerations[0].key=node-role.kubernetes.io/control-plane'
+		--set 'job.dispatcherTolerations[0].operator=Exists'
+		--set 'job.dispatcherTolerations[0].effect=NoSchedule'
+	)
+
+	# The dispatcher's token is the one that reaches every node in the cluster, so
+	# an operator must be able to keep it off the nodes Kata runs on: root on the
+	# node it lands on can read that token.
+	local stage rendered
+	for stage in install cleanup; do
+		rendered=$(helm template kata-deploy "${CHART_PATH}" \
+			--set deploymentMode=job \
+			"${args[@]}" \
+			--show-only "templates/kata-deploy-${stage}-job.yaml")
+		echo "${rendered}" | grep -q 'node-role.kubernetes.io/control-plane: ""'
+		echo "${rendered}" | grep -q 'key: node-role.kubernetes.io/control-plane'
+	done
+
+	# Where the dispatcher may run says nothing about where Kata is installed: the
+	# per-node Jobs must not inherit its placement, or pinning the dispatcher to
+	# the control plane would quietly stop installing on the workers.
+	local jobs
+	jobs=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		"${args[@]}" \
+		--show-only templates/kata-deploy-job-templates.yaml)
+	# Spelled out rather than `! ... grep`, whose return value bash leaves out of
+	# set -e: as anything but the last line of a test, it cannot fail it.
+	if echo "${jobs}" | grep -q 'node-role.kubernetes.io/control-plane'; then
+		echo "per-node Jobs inherited the dispatcher's placement" >&2
+		return 1
+	fi
+}
+
+@test "Helm template (job mode): dispatcher tolerations default to the top-level ones" {
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set 'tolerations[0].operator=Exists' \
+		--show-only templates/kata-deploy-install-job.yaml)
+
+	# Without this fallback a cluster whose every node is tainted - a single-node
+	# cluster, say - would select nodes it has nowhere to dispatch from.
+	echo "${rendered}" | grep -q 'tolerations:'
+	echo "${rendered}" | grep -q 'operator: Exists'
+}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -789,6 +789,34 @@ true
 {{- end -}}
 
 {{/*
+Where a dispatcher pod may run: `nodeSelector` and `tolerations` blocks for the
+install and cleanup dispatchers.
+
+This is about the dispatcher pod, not about which nodes get Kata. The dispatcher
+holds the one token that reaches the whole cluster - it enumerates every node and
+creates the privileged per-node Jobs - and root on the node it lands on can read
+it; confining it to trusted nodes is a hardening step a DaemonSet cannot offer,
+having to run everywhere by definition.
+
+Tolerations fall back to the top-level `tolerations` so the dispatcher stays
+schedulable wherever the per-node Jobs are allowed to run - without that, a
+cluster whose every node is tainted could select nodes it cannot dispatch from.
+
+Emitted at column 0; embed with `nindent` at the call site.
+*/}}
+{{- define "kata-deploy.dispatcherPlacement" -}}
+{{- $job := .Values.job | default dict -}}
+{{- with $job.dispatcherNodeSelector }}
+nodeSelector:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with ($job.dispatcherTolerations | default .Values.tolerations) }}
+tolerations:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Per-node staged Job manifest (deploymentMode: job), embedded verbatim into the
 job-templates ConfigMap. The dispatcher (kata-deploy-job-dispatcher) clones this once per
 target node, injecting metadata.name + spec.template.spec.nodeName, so the

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -69,9 +69,8 @@ spec:
         runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
-{{- with $root.Values.tolerations }}
-      tolerations:
-{{- toYaml . | nindent 8 }}
+{{- with include "kata-deploy.dispatcherPlacement" $root | trim }}
+{{- . | nindent 6 }}
 {{- end }}
 {{- with $root.Values.priorityClassName }}
       priorityClassName: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -72,9 +72,8 @@ spec:
         runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
-{{- with $root.Values.tolerations }}
-      tolerations:
-{{- toYaml . | nindent 8 }}
+{{- with include "kata-deploy.dispatcherPlacement" $root | trim }}
+{{- . | nindent 6 }}
 {{- end }}
 {{- with $root.Values.priorityClassName }}
       priorityClassName: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -33,6 +33,30 @@ job:
   dispatcherImage:
     reference: quay.io/kata-containers/kata-deploy-job-dispatcher
     tag: ""
+  # Where the dispatcher pods themselves may run (install and uninstall). Nothing
+  # to do with which nodes get Kata - that is the top-level `nodeSelector` /
+  # `affinity` / `tolerations`.
+  #
+  # Worth setting: the dispatcher is the component that holds Kubernetes
+  # credentials, and root on whatever node it lands on can read them.
+  # Confining it to nodes you trust - typically the control plane - means a
+  # compromised worker cannot reach them, something a DaemonSet can never offer
+  # because it must run everywhere.
+  #
+  # Example (control plane only; the toleration is required because those nodes are
+  # normally tainted):
+  #   job:
+  #     dispatcherNodeSelector:
+  #       node-role.kubernetes.io/control-plane: ""
+  #     dispatcherTolerations:
+  #       - key: node-role.kubernetes.io/control-plane
+  #         operator: Exists
+  #         effect: NoSchedule
+  dispatcherNodeSelector: {}
+  # Defaults to the top-level `tolerations` when empty, so the dispatcher stays
+  # schedulable on clusters whose every node is tainted (a single-node cluster, for
+  # instance). Set it to override that.
+  dispatcherTolerations: []
   # Maximum number of nodes processed concurrently (the dispatcher keeps at most
   # this many per-node Jobs in flight, refilling as they finish). Lower it to
   # pace the rollout (e.g. limit how many CRI runtimes restart at once on a big


### PR DESCRIPTION
## What this changes

In `job` mode the dispatcher is the only component holding Kubernetes
credentials. Its ServiceAccount can list nodes cluster-wide and create Jobs in
the release namespace — and those Jobs are privileged, with host mounts. Reading
that token is therefore worth root on any node in the cluster.

Today the dispatcher has no placement of its own: it goes wherever the top-level
`tolerations` allow, which on a typical cluster means any worker, including the
ones running the untrusted workloads Kata exists to isolate.

This adds two knobs so an operator can keep it on nodes they trust, typically the
control plane:

```yaml title="values.yaml"
job:
  dispatcherNodeSelector:
    node-role.kubernetes.io/control-plane: ""
  dispatcherTolerations:
    - key: node-role.kubernetes.io/control-plane
      operator: Exists
      effect: NoSchedule
```

This is a hardening step `daemonset` mode cannot offer: that pod has to run on
every node by definition, so its token is present everywhere.

## What it deliberately does not do

- **It does not change which nodes get Kata.** That stays the top-level
  `nodeSelector` / `affinity` / `tolerations`, and the per-node Jobs do not
  inherit the dispatcher's placement — otherwise pinning the dispatcher to the
  control plane would quietly stop installing Kata on the workers. There is a
  test for exactly that.
- **The dispatcher does not inherit the top-level `nodeSelector`.** That selector
  describes where Kata is installed, which is usually the opposite of where you
  want the credentialed pod to run.
- `dispatcherTolerations` *does* fall back to the top-level `tolerations` when
  unset, so the dispatcher stays schedulable on a cluster whose every node is
  tainted — a single-node cluster, for instance. Without that fallback it could
  select nodes it has nowhere to dispatch from.

## Compatibility

Both values default to empty, so rendered output is unchanged unless you set
them. Install and uninstall dispatchers share one helper, so they cannot drift
apart.