### PR TITLE
kata-deploy: make node selection mean the same thing in both deployment modes

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -264,44 +264,156 @@ already-installed nodes are fast no-ops. Coverage converges on the re-run.
 
 ### Choosing which nodes get a Job
 
-In `job` mode, node selection is configured under the `job` key, with the
-following precedence (highest first):
+Node selection is **not** configured per deployment mode. Both modes read the
+same [`nodeSelector`](#nodeselector) / [`affinity`](#affinity) and
+[`tolerations`](#tolerations), so one values file installs Kata on the same nodes
+whichever mode you deploy with.
 
-1. `job.nodes`: an explicit list of node names, passed to the dispatcher verbatim.
-2. `job.nodeSelector` (an equality map) **ANDed with**
-   `job.nodeSelectorExpressions` (Kubernetes label-selector requirements using
-   the operators `In`, `NotIn`, `Exists`, `DoesNotExist`). These are compiled
-   into a single label-selector string that the dispatcher resolves live.
-3. If both are empty, **all** nodes are targeted.
+In `daemonset` mode the scheduler applies those rules when it places the
+kata-deploy pods. In `job` mode there is no pod to place — the dispatcher pins
+each per-node Job to a node by name — so the dispatcher applies the same rules
+itself while enumerating nodes:
 
-By **default the expressions target worker (non-control-plane) nodes**, so no
-custom node labeling is required (this differs from the DaemonSet `nodeSelector`
-examples above, which rely on you labeling nodes). Override as needed:
+1. `nodeSelector` and `affinity.nodeAffinity` are compiled into node queries, which
+   the dispatcher resolves live against the API server. Each `nodeSelectorTerm`
+   becomes one query and their results are combined with OR, matching Kubernetes'
+   own semantics; the `nodeSelector` labels are ANDed into every query, which is
+   how Kubernetes combines the two.
+2. Nodes carrying a taint your `tolerations` do not cover are then dropped,
+   exactly as the scheduler would refuse to place a DaemonSet pod there.
+3. `job.nodes` overrides all of the above with an explicit list of node names,
+   used verbatim.
+
+An empty `nodeSelector` therefore does **not** mean "every node": step 2 still
+applies, and that is what keeps Kata off control-plane nodes by default without
+any label filtering.
 
 ```yaml title="values.yaml"
-# Target nodes carrying a specific label:
-job:
-  nodeSelector:
-    kata-containers: "enabled"
+# Install on nodes carrying a specific label:
+nodeSelector:
+  kata-containers: "enabled"
 
-# Target every node, including control-plane (e.g. single-node clusters / CI):
-job:
-  nodeSelectorExpressions: []
+# Richer selection - Linux workers that are either GPU- or SNP-capable
+# (a node matching either term is selected):
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - { key: kubernetes.io/os, operator: In, values: ["linux"] }
+            - { key: nvidia.com/gpu.present, operator: In, values: ["true"] }
+        - matchExpressions:
+            - { key: kubernetes.io/os, operator: In, values: ["linux"] }
+            - { key: feature.node.kubernetes.io/cpu-cpuid.SEV_SNP, operator: In, values: ["true"] }
 
-# Richer expressions:
-job:
-  nodeSelectorExpressions:
-    - { key: kubernetes.io/os, operator: In, values: ["linux"] }
-    - { key: node-role.kubernetes.io/control-plane, operator: DoesNotExist }
-
-# Pin to explicit nodes:
+# Pin to explicit nodes (job mode only; tainted nodes included, since naming a
+# node is unambiguous):
 job:
   nodes: ["worker-1", "worker-2"]
 ```
 
+!!! warning "The `job.*` node-selection keys have been removed"
+    Earlier releases selected nodes with `job.nodeSelector`,
+    `job.nodeSelectorExpressions` and `job.nodeAffinity`, separately from the
+    DaemonSet's own knobs. Having two sources of truth meant a values file that
+    pinned Kata to a few nodes in `daemonset` mode could silently install it
+    everywhere in `job` mode. Rendering now **fails with a migration hint** if any
+    of those keys is still set: move the rule to the top-level `nodeSelector` or
+    `affinity.nodeAffinity`, and keep `job.nodes` for explicit node names.
+
+!!! note "Not every affinity rule can be expressed as a node query"
+    Job mode resolves nodes with a label-selector `LIST` against the API server,
+    so `matchFields` and the `Gt`/`Lt` operators cannot be represented and are
+    rejected at render time — use `job.nodes` to target nodes by name.
+    `preferredDuringSchedulingIgnoredDuringExecution` is accepted but ignored: a
+    preference never restricts where a DaemonSet may land either, so honouring
+    only the required terms keeps both modes in agreement.
+
 Use `job.parallelism` to pace the rollout — it caps how many per-node Jobs run
 concurrently (e.g. to limit how many CRI runtimes restart at once on a big
 fleet). It is effectively capped at the number of targeted nodes.
+
+#### Nodes that become eligible late
+
+A DaemonSet is level-triggered: it installs a node whenever that node becomes
+eligible, however long that takes. The dispatcher instead resolves nodes once,
+at install time, and eligibility frequently arrives seconds later — the
+`feature.node.kubernetes.io/*` labels that `affinity.nodeAffinity` matches are
+written by node-feature-discovery, which the chart can install in the very same
+release, and a freshly joined node clears its start-up taints only once it
+settles.
+
+So the install dispatcher keeps re-resolving for `job.waitForNodesSeconds`
+(default `120`) while nothing is eligible yet, and fails if the wait expires
+with no eligible node. Failing is deliberate: in `job` mode an empty selection
+is permanent — nothing installs the node later — so a silent success would leave
+the fleet without Kata and nothing to point at.
+
+```yaml title="values.yaml"
+job:
+  # Give a slow-labelling cluster longer (see the timeout warning below)...
+  waitForNodesSeconds: 300
+  # ...or resolve once and treat "no eligible node" as a no-op, the way a
+  # DaemonSet with no matching node quietly installs nothing.
+  # waitForNodesSeconds: 0
+```
+
+!!! warning "Raise `helm --timeout` alongside it"
+    The wait is spent inside the dispatcher hook, and Helm bounds that hook by
+    the release timeout (`--timeout`, 5 minutes by default) — the same budget
+    that has to cover extracting the artifacts and restarting the CRI runtime on
+    every node. Raising `waitForNodesSeconds` on its own only trades a
+    dispatcher error naming the selectors it tried for Helm's opaque
+    `timed out waiting for the condition`, which leaves the release failed and
+    the dispatcher Job orphaned.
+
+The uninstall dispatcher never waits: it has to run to completion on a release
+that may never have labeled a node.
+
+#### Installing on control-plane nodes
+
+Control-plane nodes are normally tainted, which is what keeps Kata off them in
+both modes. Reaching them takes a matching toleration — and, if you want *only*
+those nodes, a selector as well:
+
+=== "Control-plane nodes only"
+    ```yaml title="values.yaml"
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: ""
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+    ```
+
+=== "Control-plane nodes and workers"
+    ```yaml title="values.yaml"
+    # No selector: every node is eligible, and the toleration lets the tainted
+    # control-plane nodes through as well.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+    ```
+
+!!! tip "Single-node clusters usually need nothing"
+    Single-node distributions (k3s, k0s `--single`) do not taint their node, and
+    `kubeadm` clusters used for local testing are typically untainted with
+    `kubectl taint nodes --all node-role.kubernetes.io/control-plane-`. In both
+    cases the node is selected by default. On older clusters the label and taint
+    key may be `node-role.kubernetes.io/master` instead.
+
+In `job` mode, a node skipped for a taint it does not tolerate is named in the
+dispatcher log along with the taint responsible, so an unexpectedly small rollout
+is easy to explain:
+
+```sh title="$ kubectl logs job/kata-deploy-install-dispatcher"
+skipping node cp-1: it carries the taint node-role.kubernetes.io/control-plane:NoSchedule,
+which this install does not tolerate (a DaemonSet would not have been scheduled there either)
+```
+
+If *every* selected node is skipped this way the dispatcher fails rather than
+reporting success with nothing done, and its error quotes the toleration to add.
 
 ### Choosing which nodes are cleaned up on uninstall
 
@@ -320,9 +432,8 @@ part way through — the ones most likely to have artifacts or CRI configuration
 left on them. Nothing schedules onto a claimed node in the meantime, since the
 RuntimeClasses select the exact value `"true"`.
 
-Override it under `job.cleanup`, with the same precedence/semantics as install
-(`cleanup.nodes`, then `cleanup.nodeSelector` ANDed with
-`cleanup.nodeSelectorExpressions`, else all nodes):
+Override it under `job.cleanup` (`cleanup.nodes`, then `cleanup.nodeSelector`
+ANDed with `cleanup.nodeAffinity`, else all nodes):
 
 ```yaml title="values.yaml"
 # Only uninstall from specific nodes:
@@ -333,9 +444,18 @@ job:
 # Use an explicit selector instead of the kata-runtime label default:
 job:
   cleanup:
-    nodeSelectorExpressions:
-      - { key: node-role.kubernetes.io/control-plane, operator: DoesNotExist }
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - { key: node-role.kubernetes.io/control-plane, operator: DoesNotExist }
 ```
+
+!!! note "Uninstall is deliberately independent of install"
+    Cleanup is **not** narrowed by the top-level `nodeSelector`/`affinity`, and
+    tainted nodes are cleaned rather than skipped. It has to be able to revert
+    every node the install ever touched, even one whose labels or taints have
+    changed since — so it targets what was installed, not what is selected now.
 
 See the default [`values.yaml`](#parameters) for the remaining `job.*` options
 (e.g. `dispatcherImage`, `parallelism`, `ttlSecondsAfterFinished`,
@@ -427,6 +547,47 @@ nodeSelector:
 $ helm install kata-deploy -f values.yaml "${CHART}" --version "${VERSION}"
 ```
 
+!!! info "Applies to both deployment modes"
+    `nodeSelector` selects nodes in `daemonset` and `job` mode alike — see
+    [Choosing which nodes get a Job](#choosing-which-nodes-get-a-job) for how job
+    mode applies it. Note that leaving it empty does not mean "every node": nodes
+    carrying a taint you do not tolerate are still excluded, which is what keeps
+    Kata off control-plane nodes.
+
+!!! info "Combining it with `affinity.nodeAffinity`"
+    Both may be set at once and are **ANDed**, exactly as they would be on any pod
+    spec: a node has to satisfy the `nodeSelector` labels *and* match one of the
+    `nodeSelectorTerms`. Job mode reproduces this by folding the `nodeSelector`
+    equalities into every term, so the two modes select the same nodes.
+
+### `tolerations`
+
+Tolerations decide which **tainted** nodes Kata may be installed on. Selecting a
+node is not enough on its own: if the node carries a `NoSchedule` or `NoExecute`
+taint that your tolerations do not cover, it is excluded — in `daemonset` mode by
+the scheduler, and in `job` mode by the dispatcher applying the same rule.
+
+That default is what keeps Kata off control-plane nodes, and off nodes your
+platform has reserved for something else, without you having to exclude them by
+label.
+
+```yaml title="values.yaml"
+tolerations:
+  - key: "reservedFor"
+    operator: "Exists"
+    effect: "NoSchedule"
+```
+
+To install on control-plane nodes, see
+[Installing on control-plane nodes](#installing-on-control-plane-nodes).
+
+!!! note "Cordoned and pressured nodes are still installed on"
+    Kubernetes gives every DaemonSet pod an implicit set of tolerations so that
+    node conditions — `unschedulable` (a cordoned node), plus disk, memory and PID
+    pressure — never stop a node agent from running. Job mode applies the same
+    implicit set, so cordoning a node does not make it silently miss the install
+    in either mode.
+
 ### `podLabels`
 
 You can add extra labels to the kata-deploy DaemonSet pods. These are applied
@@ -477,6 +638,15 @@ node; affinity gives you `matchExpressions` (e.g. `In`, `NotIn`) and rules
 about other pods on the same node. For example, you might want kata-deploy on
 nodes reserved for your platform team but *not* on nodes that run the GPU
 operator.
+
+!!! info "`nodeAffinity` selects nodes in both modes; pod affinity only in `daemonset` mode"
+    `affinity.nodeAffinity` is the match-expression form of `nodeSelector` and, like
+    it, decides which nodes get Kata in **both** deployment modes. The two can be
+    combined, and are ANDed. `podAffinity`/`podAntiAffinity` describe how to
+    *schedule a pod*, so they only apply in `daemonset` mode; job mode pins each
+    per-node Job to a node by name and has no scheduling decision to influence. See
+    [Choosing which nodes get a Job](#choosing-which-nodes-get-a-job) for which
+    `nodeAffinity` constructs job mode can and cannot express.
 
 ```sh
 # First, label the nodes where kata-deploy should run

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -9,9 +9,12 @@
 # The pod-template metadata (podLabels, podAnnotations) is asserted in both
 # deployment modes: on the DaemonSet pod template (deploymentMode: daemonset)
 # and on the per-node install/cleanup Job pod templates (deploymentMode: job).
-# Affinity is DaemonSet-only: in job mode the dispatcher pins each per-node Job
-# to a node via spec.template.spec.nodeName (so pod affinity is a scheduling
-# no-op) and node selection is done through job.nodeSelectorExpressions instead.
+#
+# Node selection comes from the same nodeSelector/affinity.nodeAffinity in both
+# modes; in job mode it is compiled into the dispatcher's --node-selector flags,
+# asserted at the end of this file. Pod-level affinity (podAffinity,
+# podAntiAffinity) stays DaemonSet-only, because the dispatcher pins each per-node
+# Job to a node via spec.template.spec.nodeName, making it a scheduling no-op.
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 
@@ -36,6 +39,33 @@ render_job_templates() {
 		--set deploymentMode=job \
 		--show-only templates/kata-deploy-job-templates.yaml \
 		"$@" > "${RENDERED_JOBS}"
+}
+
+# Render one of the job-mode dispatcher Jobs (stage: install|cleanup) and print
+# the label selectors it will hand to the dispatcher, one per line. Node selection
+# in job mode is expressed as repeated --node-selector flags, which the dispatcher
+# unions - that is how nodeSelectorTerms keep their OR semantics.
+dispatcher_selectors() {
+	local stage="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		--set deploymentMode=job \
+		--show-only "templates/kata-deploy-${stage}-job.yaml" \
+		"$@" |
+		sed -n 's/^ *- "--node-selector=\(.*\)"$/\1/p'
+}
+
+# Assert that rendered output does NOT contain a pattern. `! grep ...` would be
+# exempt from set -e, so as anything but the last line of a test it could never
+# fail one.
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
 }
 
 # Extract one per-node Job manifest (stage: install|cleanup) from the rendered
@@ -457,7 +487,7 @@ EOF
 	echo "${cleanup}" | grep -q "example.com/owner: platform-team"
 }
 
-@test "Helm template (job mode): user affinity does not leak into per-node Jobs" {
+@test "Helm template (job mode): node affinity is compiled away, not copied into per-node Jobs" {
 	local values_file
 	values_file=$(mktemp)
 	cat > "${values_file}" <<EOF
@@ -473,14 +503,282 @@ affinity:
 EOF
 
 	render_job_templates -f "${values_file}"
-	rm -f "${values_file}"
 
 	local install
 	install=$(extract_pernode_job install)
 
+	# The per-node Jobs are pinned by nodeName, so affinity would be a no-op
+	# there; the rule is enforced by the dispatcher's node query instead.
 	[[ -n "${install}" ]]
 	! echo "${install}" | grep -q "affinity:"
 	! echo "${install}" | grep -q "node.cloud/reserved"
+
+	local selectors
+	selectors=$(dispatcher_selectors install -f "${values_file}")
+	rm -f "${values_file}"
+
+	[[ "${selectors}" == 'node.cloud/reserved in (platform-team)' ]]
+}
+
+# =============================================================================
+# Job-mode node selection (nodeSelector / affinity.nodeAffinity)
+# =============================================================================
+
+@test "Helm template (job mode): default selects every node and lets taints decide" {
+	local selectors
+	selectors=$(dispatcher_selectors install)
+
+	# No selector at all: the dispatcher lists every node and then drops the
+	# ones whose taints the install does not tolerate, which is what keeps Kata
+	# off control-plane nodes without any label filtering.
+	[[ -z "${selectors}" ]]
+}
+
+@test "Helm template (job mode): nodeSelector is compiled into the node query" {
+	local selectors
+	selectors=$(dispatcher_selectors install --set nodeSelector.kata-containers=enabled)
+
+	[[ "${selectors}" == 'kata-containers=enabled' ]]
+}
+
+@test "Helm template (job mode): control-plane nodes can be targeted by label" {
+	local selectors
+	selectors=$(dispatcher_selectors install \
+		--set 'nodeSelector.node-role\.kubernetes\.io/control-plane=')
+
+	# The label is present with an empty value, so "key=" is the correct query.
+	[[ "${selectors}" == 'node-role.kubernetes.io/control-plane=' ]]
+}
+
+@test "Helm template (job mode): each nodeSelectorTerm becomes one query (OR)" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+            - key: nvidia.com/gpu.present
+              operator: In
+              values:
+                - "true"
+        - matchExpressions:
+            - key: tee
+              operator: Exists
+EOF
+
+	local selectors
+	selectors=$(dispatcher_selectors install -f "${values_file}")
+	rm -f "${values_file}"
+
+	[[ "$(echo "${selectors}" | wc -l)" -eq 2 ]]
+	echo "${selectors}" | grep -qx 'kubernetes.io/os in (linux),nvidia.com/gpu.present in (true)'
+	echo "${selectors}" | grep -qx 'tee'
+}
+
+@test "Helm template (job mode): preferred node affinity is ignored, not rejected" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 10
+        preference:
+          matchExpressions:
+            - key: node.cloud/fast
+              operator: Exists
+EOF
+
+	local selectors
+	selectors=$(dispatcher_selectors install -f "${values_file}")
+	rm -f "${values_file}"
+
+	# A preference never restricts where a DaemonSet may land, so honouring only
+	# the required terms keeps both modes targeting the same nodes.
+	[[ -z "${selectors}" ]]
+}
+
+@test "Helm template (job mode): NFD virtualization requirements gate node selection" {
+	local selectors
+	selectors=$(dispatcher_selectors install --set 'node-feature-discovery.enabled=true')
+
+	# One query per NFD virtualization term, mirroring the nodeAffinity the
+	# DaemonSet is given, so job mode cannot install on a node the DaemonSet
+	# would have refused.
+	[[ "$(echo "${selectors}" | wc -l)" -eq 6 ]]
+	echo "${selectors}" | grep -qx 'feature.node.kubernetes.io/cpu-cpuid.VMX in (true),kubernetes.io/arch in (amd64)'
+	echo "${selectors}" | grep -qx 'feature.node.kubernetes.io/cpu-cpuid.SVM in (true),kubernetes.io/arch in (amd64)'
+}
+
+@test "Helm template (job mode): tolerations reach the per-node Jobs the dispatcher reads" {
+	render_job_templates \
+		--set 'tolerations[0].key=node-role.kubernetes.io/control-plane' \
+		--set 'tolerations[0].operator=Exists' \
+		--set 'tolerations[0].effect=NoSchedule'
+
+	local install cleanup
+	install=$(extract_pernode_job install)
+	cleanup=$(extract_pernode_job cleanup)
+
+	# Load-bearing: the dispatcher decides which tainted nodes are eligible by
+	# reading the tolerations out of this very template, so dropping them here
+	# would silently skip every tainted node.
+	echo "${install}" | grep -q "key: node-role.kubernetes.io/control-plane"
+	echo "${install}" | grep -q "operator: Exists"
+	echo "${cleanup}" | grep -q "key: node-role.kubernetes.io/control-plane"
+}
+
+@test "Helm template (job mode): uninstall targets labeled nodes and ignores taints" {
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set nodeSelector.kata-containers=enabled \
+		--show-only templates/kata-deploy-cleanup-job.yaml)
+
+	# Cleanup must reach every node the install labeled, so it is neither
+	# narrowed by the top-level nodeSelector nor blocked by taints added since.
+	echo "${rendered}" | grep -q -- '--node-selector=katacontainers.io/kata-runtime'
+	refute_match "${rendered}" 'kata-containers=enabled'
+	echo "${rendered}" | grep -q -- '--ignore-node-taints'
+}
+
+@test "Helm template (job mode): job.nodes wins over the compiled selection" {
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set nodeSelector.kata-containers=enabled \
+		--set 'job.nodes[0]=worker-1' \
+		--set 'job.nodes[1]=worker-2' \
+		--show-only templates/kata-deploy-install-job.yaml)
+
+	echo "${rendered}" | grep -q -- '--nodes=worker-1,worker-2'
+	refute_match "${rendered}" '--node-selector='
+}
+
+@test "Helm template (job mode): install waits for nodes to become eligible" {
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only templates/kata-deploy-install-job.yaml)
+
+	# The dispatcher runs once, but eligibility arrives late: the labels the
+	# selection matches are written by NFD, which starts with this very release.
+	# Resolving nodes off the first snapshot would install nowhere and exit 0.
+	echo "${rendered}" | grep -q -- '--wait-for-nodes-secs=120'
+
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set job.waitForNodesSeconds=0 \
+		--show-only templates/kata-deploy-install-job.yaml)
+
+	echo "${rendered}" | grep -q -- '--wait-for-nodes-secs=0'
+}
+
+@test "Helm template (job mode): named nodes and uninstall never wait" {
+	local install cleanup
+	install=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set 'job.nodes[0]=worker-1' \
+		--show-only templates/kata-deploy-install-job.yaml)
+	cleanup=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only templates/kata-deploy-cleanup-job.yaml)
+
+	# Named nodes need no discovery, and uninstall must not stall for two
+	# minutes on a release that never labeled a node in the first place.
+	refute_match "${install}" '--wait-for-nodes-secs'
+	refute_match "${cleanup}" '--wait-for-nodes-secs'
+}
+
+# =============================================================================
+# Node-selection validation (one source of truth)
+# =============================================================================
+
+@test "Helm template: nodeSelector and nodeAffinity are ANDed, as Kubernetes does" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+nodeSelector:
+  kata-containers: "enabled"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+        - matchExpressions:
+            - key: tee
+              operator: Exists
+EOF
+
+	# Daemonset mode hands both to the scheduler untouched and lets Kubernetes
+	# AND them, which is the behaviour job mode has to reproduce.
+	render_chart -f "${values_file}"
+	local ds
+	ds=$(extract_kata_deploy_ds)
+	echo "${ds}" | grep -q "kata-containers: enabled"
+	echo "${ds}" | grep -q "nodeAffinity:"
+
+	# Job mode folds the nodeSelector equalities into EVERY term, which is the
+	# same node set by distribution: eq AND (t1 OR t2) == (eq AND t1) OR (eq AND t2).
+	local selectors
+	selectors=$(dispatcher_selectors install -f "${values_file}")
+	rm -f "${values_file}"
+
+	[[ "$(echo "${selectors}" | wc -l)" -eq 2 ]]
+	echo "${selectors}" | grep -qx 'kata-containers=enabled,kubernetes.io/os in (linux)'
+	echo "${selectors}" | grep -qx 'kata-containers=enabled,tee'
+}
+
+@test "Helm template: nodeSelector combined with podAntiAffinity is allowed" {
+	run helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--set nodeSelector.kata-containers=enabled \
+		--set 'affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey=kubernetes.io/hostname'
+
+	[ "${status}" -eq 0 ]
+}
+
+@test "Helm template: removed job-mode selection keys fail with a migration hint" {
+	run helm template kata-deploy "${CHART_PATH}" --set deploymentMode=job \
+		--set job.nodeSelector.kata-containers=enabled
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q "job.nodeSelector has been removed"
+
+	run helm template kata-deploy "${CHART_PATH}" --set deploymentMode=job \
+		--set 'job.nodeSelectorExpressions[0].key=kata' \
+		--set 'job.nodeSelectorExpressions[0].operator=Exists'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q "job.nodeSelectorExpressions has been removed"
+
+	run helm template kata-deploy "${CHART_PATH}" --set deploymentMode=job \
+		--set 'job.cleanup.nodeSelectorExpressions[0].key=kata' \
+		--set 'job.cleanup.nodeSelectorExpressions[0].operator=Exists'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q "renamed to job.cleanup.nodeAffinity"
+}
+
+@test "Helm template (job mode): rules a node query cannot express are rejected" {
+	run helm template kata-deploy "${CHART_PATH}" --set deploymentMode=job \
+		--set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=cpus' \
+		--set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=Gt'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'unsupported operator "Gt"'
+
+	run helm template kata-deploy "${CHART_PATH}" --set deploymentMode=job \
+		--set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].key=metadata.name' \
+		--set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].operator=In'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q "matchFields cannot be used"
 }
 
 @test "Helm template (job mode): the dispatcher can be confined to trusted nodes" {

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -717,13 +717,12 @@ function helm_helper() {
 	local deployment_mode
 	deployment_mode="$(yq -r '.deploymentMode // "daemonset"' "${values_yaml}")"
 
-	# In "job" mode, the dispatcher's default node selector targets only worker
-	# (non-control-plane) nodes. Our CI clusters are typically single-node, where
-	# the only node carries the control-plane label, so clear the role filter to
-	# target every discovered node (matching the documented single-node/CI setup).
-	if [[ "${deployment_mode}" == "job" ]]; then
-		yq -i ".job.nodeSelectorExpressions = []" "${values_yaml}"
-	fi
+	# No node-selection override is needed for "job" mode: with an empty
+	# nodeSelector the dispatcher targets every node whose taints the install
+	# tolerates, which is exactly the set a DaemonSet would land on. Our
+	# single-node CI clusters keep that node schedulable (deploy_vanilla_k8s
+	# untaints it, k3s/k0s --single never taint it), so it is selected in both
+	# deployment modes without any special casing.
 
 	[[ -n "${HELM_K8S_DISTRIBUTION}" ]] && yq -i ".k8sDistribution = \"${HELM_K8S_DISTRIBUTION}\"" "${values_yaml}"
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -741,7 +741,7 @@ Returns the comma-joined selector string (possibly empty, meaning "all nodes").
 {{- else if eq $op "NotIn" -}}
 {{- $parts = append $parts (printf "%s notin (%s)" $expr.key (join "," ($expr.values | default list))) -}}
 {{- else -}}
-{{- fail (printf "nodeSelectorExpressions: unsupported operator %q for key %q (use In, NotIn, Exists, DoesNotExist)" $op $expr.key) -}}
+{{- fail (printf "affinity.nodeAffinity matchExpressions: unsupported operator %q for key %q. Node selection compiles to a label selector, which supports In, NotIn, Exists and DoesNotExist only - Gt and Lt cannot be expressed." $op $expr.key) -}}
 {{- end -}}
 {{- end -}}
 {{- join "," $parts -}}
@@ -814,6 +814,132 @@ nodeSelector:
 tolerations:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Reject the job-mode-specific node-selection keys that used to exist, rather than
+silently ignoring them: an ignored node-selection rule means installing Kata on
+nodes the operator never intended.
+
+Note that `nodeSelector` and `affinity.nodeAffinity` may be combined freely, just
+as they can on any pod spec - Kubernetes ANDs them, and so do we.
+*/}}
+{{- define "kata-deploy.failOnRemovedJobSelectionKeys" -}}
+{{- $job := .Values.job | default dict -}}
+{{- range $key := (list "nodeSelector" "nodeAffinity" "nodeSelectorExpressions") -}}
+{{- if hasKey $job $key -}}
+{{- fail (printf "job.%s has been removed. Node selection is now expressed once, at the top level, and applies to both deployment modes: use `nodeSelector` for exact label matches and/or `affinity.nodeAffinity` for match expressions. Use `job.nodes` to name nodes explicitly." $key) -}}
+{{- end -}}
+{{- end -}}
+{{- if hasKey ($job.cleanup | default dict) "nodeSelectorExpressions" -}}
+{{- fail "job.cleanup.nodeSelectorExpressions has been renamed to job.cleanup.nodeAffinity, which takes the standard Kubernetes nodeAffinity shape. Move each entry into job.cleanup.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile node selection into the list of label-selector STRINGS handed to the
+dispatcher as repeated `--node-selector` flags (job mode). The dispatcher unions
+the matches, which is what preserves nodeAffinity's OR semantics:
+nodeSelectorTerms are OR-ed, while the matchExpressions inside one term are
+AND-ed - and a single label selector is exactly one AND-group, hence one selector
+string per term.
+
+Selection comes from the same `nodeSelector` / `affinity.nodeAffinity` the
+DaemonSet uses, plus the NFD virtualization requirements when NFD is
+chart-managed (AND-ed as a cross-product, exactly as
+`kata-deploy.daemonsetAffinity` does), so both modes target the same nodes.
+
+`nodeSelector` and `affinity.nodeAffinity` may be set together, exactly as on a
+pod spec: the DaemonSet lets Kubernetes AND the two, and we reproduce that by
+folding the `nodeSelector` equalities into EVERY term, which is the same thing by
+distribution - `eq AND (t1 OR t2)` is `(eq AND t1) OR (eq AND t2)`.
+
+`preferredDuringSchedulingIgnoredDuringExecution` is intentionally ignored rather
+than rejected: it never restricts which nodes a DaemonSet may land on, so
+honouring only the required terms keeps the two modes in agreement.
+
+Returns the selector strings joined by newlines. EMPTY output means "every node",
+and the call site then passes no `--node-selector` at all. Note that this is not
+the same as "every node gets Kata": the dispatcher still drops nodes whose taints
+the install does not tolerate, mirroring what the scheduler does for a DaemonSet.
+*/}}
+{{- define "kata-deploy.installNodeSelectors" -}}
+{{- include "kata-deploy.failOnRemovedJobSelectionKeys" . -}}
+{{- $eq := .Values.nodeSelector | default dict -}}
+{{- $terms := list -}}
+{{- $nodeAffinity := (.Values.affinity | default dict).nodeAffinity | default dict -}}
+{{- with $nodeAffinity -}}
+{{- $required := .requiredDuringSchedulingIgnoredDuringExecution | default dict -}}
+{{- $terms = $required.nodeSelectorTerms | default list -}}
+{{- end -}}
+{{- range $term := $terms -}}
+{{- if $term.matchFields -}}
+{{- fail "affinity.nodeAffinity: matchFields cannot be used with deploymentMode: job. Node selection is a label-selector LIST against the Kubernetes API server, which cannot match on fields. To target nodes by name, use job.nodes instead." -}}
+{{- end -}}
+{{- end -}}
+{{- if index .Values "node-feature-discovery" "enabled" -}}
+{{- $nfd := include "kata-deploy.nfdVirtualizationNodeAffinity" . | fromYaml -}}
+{{- $nfdTerms := $nfd.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms | default list -}}
+{{- $merged := list -}}
+{{- range $nfdTerm := $nfdTerms -}}
+{{- if $terms -}}
+{{- range $userTerm := $terms -}}
+{{- $merged = append $merged (dict "matchExpressions" (concat ($nfdTerm.matchExpressions | default list) ($userTerm.matchExpressions | default list))) -}}
+{{- end -}}
+{{- else -}}
+{{- $merged = append $merged $nfdTerm -}}
+{{- end -}}
+{{- end -}}
+{{- $terms = $merged -}}
+{{- end -}}
+{{- $selectors := list -}}
+{{- if $terms -}}
+{{- range $term := $terms -}}
+{{- $selectors = append $selectors (include "kata-deploy.nodeLabelSelector" (dict "eq" $eq "exprs" ($term.matchExpressions | default list))) -}}
+{{- end -}}
+{{- else -}}
+{{- $selectors = append $selectors (include "kata-deploy.nodeLabelSelector" (dict "eq" $eq "exprs" list)) -}}
+{{- end -}}
+{{- $selectors = $selectors | uniq -}}
+{{- /* An empty selector matches every node, so it subsumes all the others. */ -}}
+{{- if not (has "" $selectors) -}}
+{{- join "\n" $selectors -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile the UNINSTALL dispatcher's node selection (job.cleanup.*).
+
+Kept separate from install on purpose: cleanup must reach every node the install
+ever labeled - not the nodes currently selected - so it defaults to "nodes
+carrying katacontainers.io/kata-runtime" and is never narrowed by the top-level
+selection or by the NFD requirements.
+
+Same return contract as `kata-deploy.installNodeSelectors`.
+*/}}
+{{- define "kata-deploy.cleanupNodeSelectors" -}}
+{{- $cleanup := (.Values.job | default dict).cleanup | default dict -}}
+{{- $eq := $cleanup.nodeSelector | default dict -}}
+{{- $terms := list -}}
+{{- with $cleanup.nodeAffinity -}}
+{{- $required := .requiredDuringSchedulingIgnoredDuringExecution | default dict -}}
+{{- $terms = $required.nodeSelectorTerms | default list -}}
+{{- end -}}
+{{- $selectors := list -}}
+{{- if $terms -}}
+{{- range $term := $terms -}}
+{{- if $term.matchFields -}}
+{{- fail "job.cleanup.nodeAffinity: matchFields is not supported; use job.cleanup.nodes to name nodes explicitly." -}}
+{{- end -}}
+{{- $selectors = append $selectors (include "kata-deploy.nodeLabelSelector" (dict "eq" $eq "exprs" ($term.matchExpressions | default list))) -}}
+{{- end -}}
+{{- else -}}
+{{- $selectors = append $selectors (include "kata-deploy.nodeLabelSelector" (dict "eq" $eq "exprs" list)) -}}
+{{- end -}}
+{{- $selectors = $selectors | uniq -}}
+{{- if not (has "" $selectors) -}}
+{{- join "\n" $selectors -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -1355,6 +1481,7 @@ product: each NFD term is AND-ed with each user term. NFD virtualization
 requirements cannot be bypassed by user affinity.
 */}}
 {{- define "kata-deploy.daemonsetAffinity" -}}
+{{- include "kata-deploy.failOnRemovedJobSelectionKeys" . -}}
 {{- $affinity := .Values.affinity | default dict | deepCopy -}}
 {{- if index .Values "node-feature-discovery" "enabled" -}}
 {{- $nfd := include "kata-deploy.nfdVirtualizationNodeAffinity" . | fromYaml -}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -30,7 +30,7 @@ ConfigMap still exist; they are torn down only after pre-delete hooks complete.
 {{- $dispatcherName := printf "%s-cleanup-dispatcher" $base | trunc 63 | trimSuffix "-" }}
 {{- $cleanup := .Values.job.cleanup | default dict }}
 {{- $cNodes := $cleanup.nodes | default list }}
-{{- $cSelector := include "kata-deploy.nodeLabelSelector" (dict "eq" ($cleanup.nodeSelector | default dict) "exprs" ($cleanup.nodeSelectorExpressions | default list)) }}
+{{- $cSelectors := include "kata-deploy.cleanupNodeSelectors" . | splitList "\n" | compact }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -94,9 +94,19 @@ spec:
             - "--parallelism={{ $root.Values.job.parallelism }}"
 {{- if $cNodes }}
             - "--nodes={{ join "," $cNodes }}"
-{{- else if $cSelector }}
-            - "--node-selector={{ $cSelector }}"
+{{- else }}
+{{- /* One flag per nodeSelectorTerm; the dispatcher unions the matches (OR). */}}
+{{- range $selector := $cSelectors }}
+            - "--node-selector={{ $selector }}"
 {{- end }}
+{{- end }}
+{{- /*
+  Uninstall must reach every node the install ever labeled, including any that
+  have since been tainted, so the dispatcher's DaemonSet-equivalent taint check
+  is disabled here. The per-node cleanup Jobs are pinned by nodeName and so are
+  admitted regardless of taints.
+*/}}
+            - "--ignore-node-taints"
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -27,7 +27,7 @@ pick up newly added ones).
 {{- $sa := include "kata-deploy.dispatcherServiceAccountName" . }}
 {{- $dispatcherName := printf "%s-install-dispatcher" $base | trunc 63 | trimSuffix "-" }}
 {{- $nodes := .Values.job.nodes | default list }}
-{{- $selector := include "kata-deploy.nodeLabelSelector" (dict "eq" (.Values.job.nodeSelector | default dict) "exprs" (.Values.job.nodeSelectorExpressions | default list)) }}
+{{- $selectors := include "kata-deploy.installNodeSelectors" . | splitList "\n" | compact }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -97,8 +97,18 @@ spec:
             - "--parallelism={{ $root.Values.job.parallelism }}"
 {{- if $nodes }}
             - "--nodes={{ join "," $nodes }}"
-{{- else if $selector }}
+{{- else }}
+{{- /* One flag per nodeSelectorTerm; the dispatcher unions the matches (OR). */}}
+{{- range $selector := $selectors }}
             - "--node-selector={{ $selector }}"
+{{- end }}
+{{- /*
+Node eligibility is a moving target at install time (NFD is still labelling,
+new nodes are still settling), so let the dispatcher re-resolve instead of
+acting on the first snapshot it happens to see. Not passed with an explicit
+job.nodes list, which names nodes outright and needs no discovery.
+*/}}
+            - "--wait-for-nodes-secs={{ $root.Values.job.waitForNodesSeconds | default 0 }}"
 {{- end }}
           env:
             - name: POD_NAMESPACE

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -62,47 +62,48 @@ job:
   # pace the rollout (e.g. limit how many CRI runtimes restart at once on a big
   # fleet); raise it to install faster. Effectively capped at the node count.
   parallelism: 100
-  # How to choose which nodes get a per-node INSTALL Job. Precedence:
-  #   1. job.nodes (explicit list of node names) - if non-empty, used verbatim
-  #      (passed to the dispatcher as --nodes).
-  #   2. otherwise a label selector built from job.nodeSelector (equality) ANDed
-  #      with job.nodeSelectorExpressions (In/NotIn/Exists/DoesNotExist) is
-  #      passed to the dispatcher, which resolves matching nodes LIVE at run time.
-  #   3. if both are empty, ALL nodes are targeted.
+  # Which nodes get a per-node INSTALL Job is NOT configured here: it comes from
+  # the top-level `nodeSelector` / `affinity.nodeAffinity` (see below), the very
+  # same knobs the DaemonSet uses, so both deployment modes install Kata on the
+  # same nodes. Selected nodes whose taints the install does not tolerate are
+  # skipped, mirroring how the scheduler admits a DaemonSet pod - which is what
+  # keeps Kata off control-plane nodes unless you tolerate their taint.
   #
-  # DEFAULT: target worker (non-control-plane) nodes, so no custom labeling is
-  # required. Override these freely:
-  #   - Target nodes with a specific label:
-  #       job:
-  #         nodeSelector: { kata-containers: "enabled" }
-  #   - Target every node (including control-plane), e.g. single-node clusters/CI:
-  #       job:
-  #         nodeSelectorExpressions: []
-  #   - Richer expressions:
-  #       job:
-  #         nodeSelectorExpressions:
-  #           - { key: kubernetes.io/os, operator: In, values: ["linux"] }
-  #           - { key: node-role.kubernetes.io/control-plane, operator: DoesNotExist }
-  #   - Pin to explicit nodes:
-  #       job:
-  #         nodes: ["worker-1", "worker-2"]
+  # The only job-mode-specific override is an explicit list of node names, which
+  # takes precedence over the selection above and is used verbatim (including
+  # tainted nodes, since naming a node is unambiguous):
+  #   job:
+  #     nodes: ["worker-1", "worker-2"]
   nodes: []
-  # Equality label selector (ANDed with nodeSelectorExpressions). Ignored when
-  # job.nodes is set. Empty by default.
-  nodeSelector: {}
-  # Kubernetes-style label selector requirements (ANDed with nodeSelector).
-  # Each entry: { key, operator, values }. operator is one of:
-  #   In | NotIn (values required) | Exists | DoesNotExist (values must be empty).
-  # Default selects nodes that are NOT control-plane/master (i.e. worker nodes).
-  # Set to [] to disable role filtering and target all discovered nodes.
-  nodeSelectorExpressions:
-    - key: node-role.kubernetes.io/control-plane
-      operator: DoesNotExist
-    - key: node-role.kubernetes.io/master
-      operator: DoesNotExist
-  # Node selection for the UNINSTALL (pre-delete hook) dispatcher. Same precedence
-  # and semantics as install (cleanup.nodes, else cleanup.nodeSelector ANDed with
-  # cleanup.nodeSelectorExpressions, else all nodes).
+  # How long the install dispatcher keeps re-checking for eligible nodes before
+  # giving up (seconds).
+  #
+  # A DaemonSet is level-triggered and installs a node whenever it becomes
+  # eligible; the dispatcher runs once, at install time, so it needs to give the
+  # cluster a moment to converge. Nodes commonly become eligible seconds AFTER
+  # the dispatcher starts: `affinity.nodeAffinity` matches labels written by
+  # node-feature-discovery, which this chart can install in the same release,
+  # and a freshly joined node clears its start-up taints only once it settles.
+  #
+  # Because this says "at least one node is expected", the install FAILS rather
+  # than quietly doing nothing if the wait expires with no eligible node - in
+  # job mode an empty selection is permanent, not a state that later heals.
+  # Set it to 0 on clusters that may legitimately have no eligible node, which
+  # resolves once and treats an empty selection as a no-op.
+  #
+  # The default leaves room for the rest of the install: this wait is spent
+  # inside the dispatcher hook, which Helm bounds by the release timeout
+  # (`--timeout`, 5m by default) TOGETHER with extracting the artifacts and
+  # restarting the CRI runtime on every node. Raise both or neither - raising
+  # this alone just trades a dispatcher error that names the selectors it tried
+  # for Helm's opaque "timed out waiting for the condition".
+  waitForNodesSeconds: 120
+  # Node selection for the UNINSTALL (pre-delete hook) dispatcher.
+  #
+  # Deliberately independent of the install selection: uninstall has to reach
+  # every node the install ever labeled, not the nodes currently selected, so it
+  # is never narrowed by the top-level nodeSelector/affinity, and tainted nodes
+  # are cleaned rather than skipped.
   #
   # The cleanup dispatcher resolves nodes LIVE when it runs at `helm uninstall`
   # (the dispatcher does the lookup), so - unlike a frozen Helm-rendered hook -
@@ -112,17 +113,22 @@ job:
   # node with katacontainers.io/kata-runtime=false before it writes anything to
   # it, and only sets "true" once the node is kata-capable. Uninstall therefore
   # also reaches nodes where the install failed half way, which are precisely
-  # the nodes with something left on them. Override to clean a different set,
-  # e.g.:
+  # the nodes with something left on them.
+  #
+  # Precedence: cleanup.nodes, else cleanup.nodeSelector (equality) ANDed with
+  # cleanup.nodeAffinity, else all nodes. Override to clean a different set, e.g.:
   #   job:
   #     cleanup:
   #       nodes: ["worker-1"]
   cleanup:
     nodes: []
     nodeSelector: {}
-    nodeSelectorExpressions:
-      - key: katacontainers.io/kata-runtime
-        operator: Exists
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: katacontainers.io/kata-runtime
+                operator: Exists
   # How long finished per-node Jobs are retained before automatic garbage
   # collection (seconds). Applies to both install and cleanup per-node Jobs.
   ttlSecondsAfterFinished: 600
@@ -200,7 +206,22 @@ containerd:
   #     default_size = "20G"
   userDropIn: ""
 
-# Node selector and tolerations to control which nodes the kata-deploy daemonset runs on
+# Which nodes Kata is installed on, and which taints that installation tolerates.
+#
+# These apply to BOTH deployment modes. In daemonset mode they are set on the
+# kata-deploy DaemonSet pods and the scheduler decides where those land; in job
+# mode the dispatcher applies the same rules itself when it enumerates nodes
+# (nodeSelector/affinity to select, tolerations to decide which tainted nodes are
+# still eligible). One values file therefore targets the same nodes either way.
+#
+# nodeSelector matches exact label key/value pairs. For match expressions, use
+# `affinity.nodeAffinity` below. Both may be set at once and are ANDed, exactly as
+# Kubernetes ANDs them on any pod spec.
+#
+# An empty nodeSelector does NOT mean "every node": nodes whose taints are not
+# tolerated are still excluded, which is what keeps Kata off control-plane nodes
+# by default.
+#
 # Examples:
 # nodeSelector:
 #   kata-containers: "enabled"
@@ -209,6 +230,19 @@ containerd:
 #   - key: "reservedFor"
 #     operator: "Exists"
 #     effect: "NoSchedule"
+#
+# Install on control-plane nodes ONLY (select them, and tolerate their taint -
+# both parts are required, in either deployment mode):
+# nodeSelector:
+#   node-role.kubernetes.io/control-plane: ""
+# tolerations:
+#   - key: node-role.kubernetes.io/control-plane
+#     operator: Exists
+#     effect: NoSchedule
+#
+# Install on control-plane nodes IN ADDITION to workers: keep nodeSelector empty
+# and set only the toleration above. On older clusters the label and taint key may
+# be node-role.kubernetes.io/master instead.
 nodeSelector: {}
 tolerations: []
 
@@ -254,9 +288,25 @@ podLabels: {}
 #   prometheus.io/scrape: "false"
 podAnnotations: {}
 
-# Affinity rules for the kata-deploy DaemonSet.
+# Affinity rules for kata-deploy.
 # nodeSelector matches exact key/value pairs; affinity supports matchExpressions
 # and rules about other pods on the same node (e.g. podAntiAffinity).
+#
+# `nodeAffinity` is the match-expression form of `nodeSelector` and, like it,
+# selects nodes in BOTH deployment modes. Setting both is fine: they are ANDed,
+# just as Kubernetes ANDs them for a pod. In job mode the nodeSelector equalities
+# are folded into every affinity term to get the same result.
+#
+# podAffinity/podAntiAffinity describe how to schedule a POD, so they only apply
+# in daemonset mode; job mode pins each per-node Job to a node by name and has no
+# scheduling decision to influence.
+#
+# In job mode only the `required...` node affinity terms are used - each term
+# becomes one node query and their results are OR-ed, matching Kubernetes'
+# semantics. `preferred...` terms are ignored there (they never restrict which
+# nodes a DaemonSet may land on either), and `matchFields` plus the Gt/Lt
+# operators are rejected because a node query cannot express them; use `job.nodes`
+# to target nodes by name.
 # When node-feature-discovery.enabled=true, the chart merges in a virtualization
 # nodeAffinity rule. User required nodeSelectorTerms are AND-combined with the
 # built-in virtualization terms; multiple user required terms remain OR among

--- a/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
@@ -17,6 +17,7 @@
 //! create/get/delete Jobs in its namespace.
 
 mod job;
+mod node_filter;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
@@ -25,13 +26,14 @@ use job::{
     OWNER_LABEL,
 };
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::Node;
+use k8s_openapi::api::core::v1::{Node, Toleration};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{Api, ListParams, PostParams};
 use kube::Client;
 use log::{error, info};
+use node_filter::{describe_taint, partition_by_tolerations, suggested_toleration, SkippedNode};
 use std::collections::{HashMap, VecDeque};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -62,8 +64,14 @@ struct Args {
     /// Server-side label selector used to pick target nodes, e.g.
     /// "kubernetes.io/os=linux" or "node-role.kubernetes.io/control-plane".
     /// Supports the full label-selector grammar (In/NotIn/Exists/DoesNotExist).
+    ///
+    /// May be repeated, in which case the target set is the UNION of the
+    /// per-selector matches. A single label selector expresses one AND-group of
+    /// requirements, so repeating the flag is how OR is expressed - it mirrors
+    /// nodeAffinity's `nodeSelectorTerms`, where terms are OR-ed while the
+    /// requirements within a term are AND-ed.
     #[arg(long)]
-    node_selector: Option<String>,
+    node_selector: Vec<String>,
 
     /// Server-side field selector used to pick target nodes (ANDed with the
     /// label selector).
@@ -74,6 +82,30 @@ struct Args {
     /// ignored and exactly these nodes are targeted.
     #[arg(long)]
     nodes: Option<String>,
+
+    /// Target selector-matched nodes even when they carry a taint the Job's
+    /// tolerations do not cover.
+    ///
+    /// By default such nodes are skipped, mirroring the scheduler's admission of
+    /// an equivalent DaemonSet pod. Set this for reverse/cleanup runs, which must
+    /// reach every node previously acted on even if it has been tainted since.
+    #[arg(long, default_value_t = false)]
+    ignore_node_taints: bool,
+
+    /// Seconds to keep re-resolving the target nodes while none is eligible yet.
+    ///
+    /// A DaemonSet is level-triggered: it picks a node up whenever it becomes
+    /// eligible. The dispatcher runs once, so on a fresh cluster it can resolve
+    /// nodes before the labels its selectors match even exist - a cluster that
+    /// installs node-feature-discovery alongside kata-deploy only grows the
+    /// `feature.node.kubernetes.io/*` labels seconds later. Waiting closes that
+    /// window; 0 resolves once and moves on.
+    ///
+    /// Setting this also declares that at least one node is expected, so an
+    /// empty selection becomes an error once the wait expires instead of a
+    /// silent no-op that would leave every node uninstalled.
+    #[arg(long, default_value_t = 0)]
+    wait_for_nodes_secs: u64,
 
     /// Optional owner Job name (in the dispatcher's namespace). When set, every
     /// per-node Job gets an ownerReference to it so they are garbage-collected
@@ -107,16 +139,18 @@ async fn main() -> Result<()> {
     let namespace = resolve_namespace(args.namespace.clone());
     info!("kata-deploy-job-dispatcher starting (namespace: {namespace})");
 
-    let nodes = resolve_nodes(&client, &args).await?;
-    if nodes.is_empty() {
-        info!("no target nodes matched the selection; nothing to do");
-        return Ok(());
-    }
-
+    // Read the template up front: the tolerations in its pod spec decide which
+    // tainted nodes the per-node Jobs are allowed to run on.
     let template_raw = std::fs::read_to_string(&args.job_template)
         .with_context(|| format!("failed to read job template {}", args.job_template))?;
     let template: Job = serde_yaml::from_str(&template_raw)
         .with_context(|| format!("failed to parse job template {}", args.job_template))?;
+
+    let nodes = resolve_nodes(&client, &args, &template_tolerations(&template)).await?;
+    if nodes.is_empty() {
+        info!("no target nodes matched the selection; nothing to do");
+        return Ok(());
+    }
 
     let owner = match args.owner_job_name.as_deref() {
         Some(name) => Some(owner_ref_for_job(&client, &namespace, name).await?),
@@ -166,9 +200,45 @@ fn resolve_namespace(flag: Option<String>) -> String {
     "default".to_string()
 }
 
+/// The tolerations the per-node Jobs will run with, read straight out of the
+/// template's pod spec so node admission is checked against exactly what the
+/// Jobs carry.
+fn template_tolerations(template: &Job) -> Vec<Toleration> {
+    template
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .and_then(|pod| pod.tolerations.clone())
+        .unwrap_or_default()
+}
+
+/// Turn the repeatable `--node-selector` flag into the list of LIST passes to
+/// run. No selector at all means a single unfiltered pass (every node); each
+/// selector otherwise contributes one pass, and the caller unions the results.
+fn selector_passes(selectors: &[String]) -> Vec<Option<&str>> {
+    if selectors.is_empty() {
+        return vec![None];
+    }
+    selectors.iter().map(|s| Some(s.as_str())).collect()
+}
+
 /// Resolve the set of target node names: an explicit `--nodes` list when given,
-/// otherwise a paginated, server-side-filtered LIST of nodes.
-async fn resolve_nodes(client: &Client, args: &Args) -> Result<Vec<String>> {
+/// otherwise a paginated, server-side-filtered LIST of nodes per selector, with
+/// the results unioned (see `--node-selector`).
+///
+/// Selector-matched nodes are then held to the same taint rules a DaemonSet pod
+/// would face, so job mode installs on the same nodes daemonset mode does. An
+/// explicit `--nodes` list is taken verbatim: it has no daemonset equivalent and
+/// names exact nodes, so it is honoured as a deliberate override.
+///
+/// Eligibility is re-checked until `--wait-for-nodes-secs` expires, so a node
+/// that is still being labelled - or still carries a start-up taint - when the
+/// dispatcher starts is picked up rather than missed.
+async fn resolve_nodes(
+    client: &Client,
+    args: &Args,
+    tolerations: &[Toleration],
+) -> Result<Vec<String>> {
     if let Some(list) = args.nodes.as_deref() {
         let mut names: Vec<String> = list
             .split(',')
@@ -181,24 +251,147 @@ async fn resolve_nodes(client: &Client, args: &Args) -> Result<Vec<String>> {
     }
 
     let api: Api<Node> = Api::all(client.clone());
-    let mut names = Vec::new();
+    let poll = Duration::from_secs(args.poll_interval_secs.max(1));
+    let deadline = Instant::now() + Duration::from_secs(args.wait_for_nodes_secs);
+    let mut announced_wait = false;
+
+    loop {
+        let (admitted, skipped) = select_nodes(&api, args, tolerations).await?;
+
+        if !admitted.is_empty() || Instant::now() >= deadline {
+            for node in &skipped {
+                info!(
+                    "skipping node {}: it carries the taint {}, which this install does not \
+                     tolerate (a DaemonSet would not have been scheduled there either)",
+                    node.name,
+                    describe_taint(&node.taint)
+                );
+            }
+            if !admitted.is_empty() {
+                return Ok(admitted);
+            }
+            return no_eligible_nodes(args, &skipped);
+        }
+
+        if !announced_wait {
+            info!(
+                "no node is eligible yet; re-checking for up to {}s. Nodes become eligible \
+                 asynchronously: the labels a selector matches are often written by an add-on \
+                 (node-feature-discovery, say) that starts alongside this dispatcher, and \
+                 start-up taints clear only once the node settles",
+                args.wait_for_nodes_secs
+            );
+            announced_wait = true;
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+/// One resolution pass: LIST the nodes matching each selector, union them, and
+/// split the result by taint admission (unless `--ignore-node-taints`, where
+/// every matched node is admitted).
+async fn select_nodes(
+    api: &Api<Node>,
+    args: &Args,
+    tolerations: &[Toleration],
+) -> Result<(Vec<String>, Vec<SkippedNode>)> {
+    let mut matched: Vec<Node> = Vec::new();
+    for selector in selector_passes(&args.node_selector) {
+        matched.extend(list_nodes(api, args, selector).await?);
+    }
+
+    if args.ignore_node_taints {
+        let mut names: Vec<String> = matched
+            .iter()
+            .filter_map(|node| node.metadata.name.clone())
+            .collect();
+        names.sort();
+        names.dedup();
+        return Ok((names, Vec::new()));
+    }
+
+    Ok(partition_by_tolerations(&matched, tolerations))
+}
+
+/// Decide what "nothing is eligible" means once we have stopped looking.
+///
+/// Nodes matched but none tolerated is almost always a forgotten toleration -
+/// classically when targeting control-plane nodes - so it fails with the fix.
+/// Nothing matched at all is only a no-op when the caller never asked us to
+/// wait: having waited means nodes were expected, and exiting 0 there would
+/// leave the whole fleet uninstalled with nothing to show for it.
+fn no_eligible_nodes(args: &Args, skipped: &[SkippedNode]) -> Result<Vec<String>> {
+    let waited = if args.wait_for_nodes_secs > 0 {
+        format!(" after waiting {}s", args.wait_for_nodes_secs)
+    } else {
+        String::new()
+    };
+
+    if let Some(blocked) = skipped.first() {
+        bail!(
+            "all {} selected node(s) carry a taint this install does not tolerate{}, so there is \
+             nowhere to install. First blocker: node {} has taint {}. If you meant to target \
+             these nodes, tolerate it by adding to your values:\n{}",
+            skipped.len(),
+            waited,
+            blocked.name,
+            describe_taint(&blocked.taint),
+            suggested_toleration(&blocked.taint)
+        );
+    }
+
+    if args.wait_for_nodes_secs > 0 {
+        bail!(
+            "no node matched the selection{}, so there is nowhere to install. A node matching \
+             any one of these selectors is enough: {}. Check that whatever applies those labels \
+             (node-feature-discovery, for one) is running, or set --wait-for-nodes-secs=0 \
+             (job.waitForNodesSeconds in the Helm chart) to make an empty selection a no-op.",
+            waited,
+            describe_selectors(&args.node_selector)
+        );
+    }
+
+    Ok(Vec::new())
+}
+
+/// The selectors we tried, spelled out for error messages.
+fn describe_selectors(selectors: &[String]) -> String {
+    if selectors.is_empty() {
+        return "<none> (every node)".to_string();
+    }
+    selectors
+        .iter()
+        .map(|s| format!("[{s}]"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// One paginated LIST of nodes matching `label_selector` (ANDed with the global
+/// field selector, if any).
+async fn list_nodes(
+    api: &Api<Node>,
+    args: &Args,
+    label_selector: Option<&str>,
+) -> Result<Vec<Node>> {
+    let mut nodes = Vec::new();
     let mut continue_token: Option<String> = None;
 
     loop {
         let lp = ListParams {
             limit: Some(args.node_page_size.max(1)),
-            label_selector: args.node_selector.clone(),
+            label_selector: label_selector.map(str::to_string),
             field_selector: args.node_field_selector.clone(),
             continue_token: continue_token.clone(),
             ..Default::default()
         };
 
-        let page = api.list(&lp).await.context("failed to list nodes")?;
-        for node in &page.items {
-            if let Some(name) = node.metadata.name.clone() {
-                names.push(name);
-            }
-        }
+        let page = api.list(&lp).await.with_context(|| {
+            format!(
+                "failed to list nodes (label selector: {})",
+                label_selector.unwrap_or("<none>")
+            )
+        })?;
+        nodes.extend(page.items);
 
         match page.metadata.continue_ {
             Some(token) if !token.is_empty() => continue_token = Some(token),
@@ -206,9 +399,7 @@ async fn resolve_nodes(client: &Client, args: &Args) -> Result<Vec<String>> {
         }
     }
 
-    names.sort();
-    names.dedup();
-    Ok(names)
+    Ok(nodes)
 }
 
 /// Fetch the owner Job and build an `ownerReference` to it (non-controller, so
@@ -359,4 +550,145 @@ async fn run_fanout(
 
     info!("all {succeeded} node(s) completed successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::batch::v1::JobSpec;
+    use k8s_openapi::api::core::v1::{PodSpec, PodTemplateSpec};
+
+    #[test]
+    fn no_selector_means_one_unfiltered_pass() {
+        assert_eq!(selector_passes(&[]), vec![None]);
+    }
+
+    #[test]
+    fn one_selector_means_one_filtered_pass() {
+        let selectors = vec!["kubernetes.io/os=linux".to_string()];
+        assert_eq!(
+            selector_passes(&selectors),
+            vec![Some("kubernetes.io/os=linux")]
+        );
+    }
+
+    #[test]
+    fn repeated_selectors_become_one_pass_each() {
+        let selectors = vec![
+            "feature.node.kubernetes.io/cpu-cpuid.VMX=true".to_string(),
+            "feature.node.kubernetes.io/cpu-cpuid.SVM=true".to_string(),
+        ];
+        assert_eq!(
+            selector_passes(&selectors),
+            vec![
+                Some("feature.node.kubernetes.io/cpu-cpuid.VMX=true"),
+                Some("feature.node.kubernetes.io/cpu-cpuid.SVM=true"),
+            ]
+        );
+    }
+
+    fn job_with_tolerations(tolerations: Option<Vec<Toleration>>) -> Job {
+        Job {
+            spec: Some(JobSpec {
+                template: PodTemplateSpec {
+                    spec: Some(PodSpec {
+                        tolerations,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn template_tolerations_are_read_from_the_pod_spec() {
+        let toleration = Toleration {
+            key: Some("node-role.kubernetes.io/control-plane".to_string()),
+            operator: Some("Exists".to_string()),
+            ..Default::default()
+        };
+        let template = job_with_tolerations(Some(vec![toleration.clone()]));
+
+        assert_eq!(template_tolerations(&template), vec![toleration]);
+    }
+
+    #[test]
+    fn template_without_tolerations_yields_an_empty_list() {
+        assert!(template_tolerations(&job_with_tolerations(None)).is_empty());
+        assert!(template_tolerations(&Job::default()).is_empty());
+    }
+
+    fn args_from(extra: &[&str]) -> Args {
+        let mut argv = vec![
+            "kata-deploy-job-dispatcher",
+            "--job-template=/etc/kata-job/install-job.yaml",
+            "--name-prefix=kata-deploy-install",
+        ];
+        argv.extend_from_slice(extra);
+        Args::parse_from(argv)
+    }
+
+    fn skipped_node(name: &str) -> SkippedNode {
+        SkippedNode {
+            name: name.to_string(),
+            taint: k8s_openapi::api::core::v1::Taint {
+                key: "node-role.kubernetes.io/control-plane".to_string(),
+                effect: "NoSchedule".to_string(),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn nodes_are_resolved_once_by_default() {
+        assert_eq!(args_from(&[]).wait_for_nodes_secs, 0);
+    }
+
+    #[test]
+    fn an_empty_selection_is_a_no_op_when_we_never_waited() {
+        let nodes = no_eligible_nodes(&args_from(&[]), &[]).expect("empty selection is a no-op");
+        assert!(nodes.is_empty());
+    }
+
+    #[test]
+    fn an_empty_selection_fails_once_the_wait_expires() {
+        let args = args_from(&[
+            "--wait-for-nodes-secs=120",
+            "--node-selector=feature.node.kubernetes.io/cpu-cpuid.SVM in (true)",
+        ]);
+        let err = no_eligible_nodes(&args, &[]).expect_err("waiting means nodes were expected");
+        let msg = err.to_string();
+
+        assert!(msg.contains("after waiting 120s"), "{msg}");
+        assert!(
+            msg.contains("[feature.node.kubernetes.io/cpu-cpuid.SVM in (true)]"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn nodes_matched_but_all_tainted_fail_with_the_missing_toleration() {
+        let err = no_eligible_nodes(&args_from(&[]), &[skipped_node("cp-0")])
+            .expect_err("a fully tainted selection has nowhere to install");
+        let msg = err.to_string();
+
+        assert!(msg.contains("node cp-0"), "{msg}");
+        assert!(
+            msg.contains("node-role.kubernetes.io/control-plane:NoSchedule"),
+            "{msg}"
+        );
+        assert!(msg.contains("operator: Exists"), "{msg}");
+    }
+
+    #[test]
+    fn selectors_are_spelled_out_for_errors() {
+        assert_eq!(describe_selectors(&[]), "<none> (every node)");
+        assert_eq!(
+            describe_selectors(&["a=b".to_string(), "c=d".to_string()]),
+            "[a=b], [c=d]"
+        );
+    }
 }

--- a/tools/packaging/kata-deploy/job-dispatcher/src/node_filter.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/node_filter.rs
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! DaemonSet-equivalent node admission for job mode.
+//!
+//! In daemonset mode the scheduler keeps kata-deploy off nodes whose taints its
+//! pods do not tolerate - that, rather than any selector, is what keeps it off
+//! control-plane nodes by default. Job mode cannot lean on that: the dispatcher
+//! pins each per-node Job via `spec.nodeName`, which bypasses the scheduler
+//! entirely, and `NoSchedule` is a scheduler-side check the kubelet never
+//! repeats. Without the check below, job mode would install Kata on tainted
+//! nodes a DaemonSet would have skipped.
+//!
+//! So we replicate it here, against the very tolerations the per-node Jobs will
+//! run with, which keeps "which nodes get Kata" identical in both modes.
+
+use k8s_openapi::api::core::v1::{Node, Taint, Toleration};
+
+/// Taint effects that keep a pod off a node. `PreferNoSchedule` expresses a
+/// scheduling preference and never blocks admission, so it is not listed.
+const BLOCKING_EFFECTS: [&str; 2] = ["NoSchedule", "NoExecute"];
+
+/// A node left out of the rollout, and the taint responsible for it.
+pub struct SkippedNode {
+    pub name: String,
+    pub taint: Taint,
+}
+
+/// Render a taint the way `kubectl taint` spells it, for logs and errors.
+pub fn describe_taint(taint: &Taint) -> String {
+    match taint.value.as_deref() {
+        Some(value) if !value.is_empty() => {
+            format!("{}={}:{}", taint.key, value, taint.effect)
+        }
+        _ => format!("{}:{}", taint.key, taint.effect),
+    }
+}
+
+/// The toleration a user needs to add to reach a node blocked by `taint`.
+pub fn suggested_toleration(taint: &Taint) -> String {
+    format!(
+        "tolerations:\n  - key: {}\n    operator: Exists\n    effect: {}",
+        taint.key, taint.effect
+    )
+}
+
+/// Tolerations the DaemonSet controller silently adds to every DaemonSet pod.
+/// We add the same set so job mode still reaches the nodes a DaemonSet would
+/// have - most visibly cordoned (`unschedulable`) and resource-pressured nodes.
+///
+/// `node.kubernetes.io/network-unavailable` is deliberately absent: the
+/// controller only adds it for host-network pods, and kata-deploy does not use
+/// host networking.
+fn daemonset_controller_tolerations() -> Vec<Toleration> {
+    [
+        ("node.kubernetes.io/not-ready", "NoExecute"),
+        ("node.kubernetes.io/unreachable", "NoExecute"),
+        ("node.kubernetes.io/disk-pressure", "NoSchedule"),
+        ("node.kubernetes.io/memory-pressure", "NoSchedule"),
+        ("node.kubernetes.io/pid-pressure", "NoSchedule"),
+        ("node.kubernetes.io/unschedulable", "NoSchedule"),
+    ]
+    .into_iter()
+    .map(|(key, effect)| Toleration {
+        key: Some(key.to_string()),
+        operator: Some("Exists".to_string()),
+        effect: Some(effect.to_string()),
+        ..Default::default()
+    })
+    .collect()
+}
+
+/// Whether `toleration` tolerates `taint`, following Kubernetes' own matching
+/// rules: an empty effect matches any effect, an empty key matches any key, and
+/// the operator defaults to `Equal` (which compares values).
+pub fn tolerates(toleration: &Toleration, taint: &Taint) -> bool {
+    if let Some(effect) = toleration.effect.as_deref() {
+        if !effect.is_empty() && effect != taint.effect {
+            return false;
+        }
+    }
+    if let Some(key) = toleration.key.as_deref() {
+        if !key.is_empty() && key != taint.key {
+            return false;
+        }
+    }
+
+    match toleration.operator.as_deref().unwrap_or("Equal") {
+        "Exists" => true,
+        _ => toleration.value.as_deref().unwrap_or("") == taint.value.as_deref().unwrap_or(""),
+    }
+}
+
+/// The first blocking taint on the node that nothing tolerates, if any.
+pub fn untolerated_taint<'a>(taints: &'a [Taint], tolerations: &[Toleration]) -> Option<&'a Taint> {
+    taints.iter().find(|taint| {
+        BLOCKING_EFFECTS.contains(&taint.effect.as_str())
+            && !tolerations.iter().any(|tol| tolerates(tol, taint))
+    })
+}
+
+/// Split the selected nodes into those the per-node Jobs may run on and those
+/// blocked by a taint they do not tolerate, applying the same admission rules a
+/// DaemonSet pod would face.
+pub fn partition_by_tolerations(
+    nodes: &[Node],
+    tolerations: &[Toleration],
+) -> (Vec<String>, Vec<SkippedNode>) {
+    let mut effective = tolerations.to_vec();
+    effective.extend(daemonset_controller_tolerations());
+
+    let mut admitted = Vec::new();
+    let mut skipped = Vec::new();
+
+    for node in nodes {
+        let Some(name) = node.metadata.name.clone() else {
+            continue;
+        };
+        let taints = node
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.taints.as_deref())
+            .unwrap_or(&[]);
+
+        match untolerated_taint(taints, &effective) {
+            Some(taint) => skipped.push(SkippedNode {
+                name,
+                taint: taint.clone(),
+            }),
+            None => admitted.push(name),
+        }
+    }
+
+    // A node matching several selectors is listed once per match, and both
+    // halves are reported to the user ("N node(s) skipped"), so collapse the
+    // repeats rather than inflating the counts.
+    admitted.sort();
+    admitted.dedup();
+    skipped.sort_by(|a, b| a.name.cmp(&b.name));
+    skipped.dedup_by(|a, b| a.name == b.name);
+    (admitted, skipped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::NodeSpec;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    fn taint(key: &str, value: Option<&str>, effect: &str) -> Taint {
+        Taint {
+            key: key.to_string(),
+            value: value.map(str::to_string),
+            effect: effect.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn toleration(key: Option<&str>, operator: &str, effect: Option<&str>) -> Toleration {
+        Toleration {
+            key: key.map(str::to_string),
+            operator: Some(operator.to_string()),
+            effect: effect.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn node(name: &str, taints: Vec<Taint>) -> Node {
+        Node {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            spec: Some(NodeSpec {
+                taints: Some(taints),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn control_plane_taint() -> Taint {
+        taint("node-role.kubernetes.io/control-plane", None, "NoSchedule")
+    }
+
+    #[test]
+    fn a_node_matched_by_several_selectors_is_reported_once() {
+        let admitted_twice = node("worker-1", vec![]);
+        let skipped_twice = node("cp-1", vec![control_plane_taint()]);
+        let nodes = vec![
+            admitted_twice.clone(),
+            skipped_twice.clone(),
+            admitted_twice,
+            skipped_twice,
+        ];
+
+        let (admitted, skipped) = partition_by_tolerations(&nodes, &[]);
+
+        assert_eq!(admitted, vec!["worker-1".to_string()]);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name, "cp-1");
+    }
+
+    #[test]
+    fn exists_toleration_matches_regardless_of_value() {
+        let tol = toleration(
+            Some("node-role.kubernetes.io/control-plane"),
+            "Exists",
+            Some("NoSchedule"),
+        );
+        assert!(tolerates(&tol, &control_plane_taint()));
+    }
+
+    #[test]
+    fn empty_key_with_exists_tolerates_everything() {
+        let tol = toleration(None, "Exists", None);
+        assert!(tolerates(&tol, &control_plane_taint()));
+        assert!(tolerates(&tol, &taint("custom", Some("v"), "NoExecute")));
+    }
+
+    #[test]
+    fn effect_must_match_when_specified() {
+        let tol = toleration(
+            Some("node-role.kubernetes.io/control-plane"),
+            "Exists",
+            Some("NoExecute"),
+        );
+        assert!(!tolerates(&tol, &control_plane_taint()));
+    }
+
+    #[test]
+    fn equal_operator_compares_values() {
+        let mut tol = toleration(Some("dedicated"), "Equal", None);
+        tol.value = Some("kata".to_string());
+
+        assert!(tolerates(
+            &tol,
+            &taint("dedicated", Some("kata"), "NoSchedule")
+        ));
+        assert!(!tolerates(
+            &tol,
+            &taint("dedicated", Some("other"), "NoSchedule")
+        ));
+    }
+
+    #[test]
+    fn prefer_no_schedule_never_blocks() {
+        let taints = vec![taint("spot", None, "PreferNoSchedule")];
+        assert!(untolerated_taint(&taints, &[]).is_none());
+    }
+
+    #[test]
+    fn control_plane_node_is_skipped_without_a_toleration() {
+        let nodes = vec![
+            node("worker-1", vec![]),
+            node("cp-1", vec![control_plane_taint()]),
+        ];
+
+        let (admitted, skipped) = partition_by_tolerations(&nodes, &[]);
+
+        assert_eq!(admitted, vec!["worker-1"]);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name, "cp-1");
+        assert_eq!(
+            describe_taint(&skipped[0].taint),
+            "node-role.kubernetes.io/control-plane:NoSchedule"
+        );
+    }
+
+    #[test]
+    fn control_plane_node_is_admitted_once_tolerated() {
+        let nodes = vec![node("cp-1", vec![control_plane_taint()])];
+        let tolerations = vec![toleration(
+            Some("node-role.kubernetes.io/control-plane"),
+            "Exists",
+            Some("NoSchedule"),
+        )];
+
+        let (admitted, skipped) = partition_by_tolerations(&nodes, &tolerations);
+
+        assert_eq!(admitted, vec!["cp-1"]);
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn cordoned_and_pressured_nodes_stay_admitted_like_a_daemonset() {
+        // The DaemonSet controller tolerates these implicitly, so job mode must
+        // too, otherwise a cordoned node silently misses the install.
+        let nodes = vec![
+            node(
+                "cordoned",
+                vec![taint(
+                    "node.kubernetes.io/unschedulable",
+                    None,
+                    "NoSchedule",
+                )],
+            ),
+            node(
+                "pressured",
+                vec![taint(
+                    "node.kubernetes.io/memory-pressure",
+                    None,
+                    "NoSchedule",
+                )],
+            ),
+        ];
+
+        let (admitted, skipped) = partition_by_tolerations(&nodes, &[]);
+
+        assert_eq!(admitted, vec!["cordoned", "pressured"]);
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn nodes_without_a_spec_or_taints_are_admitted() {
+        let bare = Node {
+            metadata: ObjectMeta {
+                name: Some("bare".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let (admitted, skipped) = partition_by_tolerations(&[bare], &[]);
+
+        assert_eq!(admitted, vec!["bare"]);
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn suggested_toleration_names_the_blocking_taint() {
+        let suggestion = suggested_toleration(&control_plane_taint());
+
+        assert!(suggestion.contains("key: node-role.kubernetes.io/control-plane"));
+        assert!(suggestion.contains("effect: NoSchedule"));
+    }
+
+    #[test]
+    fn describe_taint_includes_the_value_when_present() {
+        assert_eq!(
+            describe_taint(&taint("dedicated", Some("kata"), "NoSchedule")),
+            "dedicated=kata:NoSchedule"
+        );
+    }
+}


### PR DESCRIPTION
`job` mode had its own node-selection knobs — `job.nodeSelector`,
`job.nodeSelectorExpressions`, `job.cleanup.*` — completely separate from the
`nodeSelector` / `affinity` the DaemonSet uses. Two sources of truth for "which
nodes get Kata" produced three concrete bugs:
- A values file that pins Kata to a handful of nodes in `daemonset` mode
  installs it **fleet-wide** in `job` mode, because the top-level `nodeSelector`
  is simply not read.
- The NFD virtualization requirements that the DaemonSet enforces through its
  `nodeAffinity` were not applied at all in `job` mode.
- **Taints were ignored entirely.** The dispatcher pins each per-node Job with
  `spec.nodeName`, which bypasses the scheduler, and `NoSchedule` is a
  scheduler-side check the kubelet never repeats. Taints — not selectors — are
  what keep kata-deploy off control-plane nodes in `daemonset` mode, so job mode
  was installing Kata on nodes a DaemonSet would never have touched.
## What this does
Node selection is now compiled from the same top-level `nodeSelector` and
`affinity.nodeAffinity` in both modes, so one values file targets one set of
nodes:
- Each `nodeSelectorTerm` becomes one node query and the dispatcher unions the
  results, preserving Kubernetes' OR semantics. `--node-selector` is now
  repeatable for that reason: a single label selector can only express one ANDed
  group.
- The `nodeSelector` equalities are folded into every query, which is how
  Kubernetes ANDs the two — `eq AND (t1 OR t2)` is `(eq AND t1) OR (eq AND t2)`.
- The NFD virtualization terms are merged as a cross-product, exactly as
  `daemonsetAffinity` already does.
- The dispatcher replicates the scheduler's taint admission, checked against the
  tolerations read back from the per-node Job template's own pod spec, so it is
  evaluated against exactly what those Jobs will run with. The DaemonSet
  controller's implicit tolerations are included, so cordoned and
  resource-pressured nodes are still installed on, as a DaemonSet would.
- Selecting nodes but tolerating none of them fails with the toleration to add,
  rather than reporting "nothing to do" and exiting 0.
Uninstall keeps its own selection under `job.cleanup` and passes
`--ignore-node-taints`: it has to reach every node the install ever labeled,
including one that has been tainted since.

***note***:
    An empty `nodeSelector` still does not mean "every node" — untolerated taints
    exclude them, in both modes.

## Breaking changes
These keys are **removed** and now fail rendering with a migration hint, rather
than being silently ignored — an ignored node-selection rule means installing
Kata somewhere the operator never asked for:
| removed | replacement |
| ------- | ----------- |
| `job.nodeSelector` | top-level `nodeSelector` |
| `job.nodeAffinity` | top-level `affinity.nodeAffinity` |
| `job.nodeSelectorExpressions` | top-level `affinity.nodeAffinity` |
| `job.cleanup.nodeSelectorExpressions` | `job.cleanup.nodeAffinity` (standard shape) |

### What job mode cannot express, and what happens if you ask

In job mode the dispatcher finds nodes by asking the API server for them with a
label selector — the same thing as `kubectl get nodes -l foo=bar`. Label
selectors only match on labels, and only by equality or set membership. Two
`nodeAffinity` features fall outside that:

- **`matchFields`**, which matches on a node's fields rather than its labels
  (in practice `metadata.name`). There is no label to select on.
- **The `Gt` and `Lt` operators**, which compare numbers. Label selectors have
  no numeric comparison.

If your values use either one, `helm install` now fails and tells you to use
`job.nodes` if what you meant was "these specific nodes". Previously the setting
would have been accepted and quietly had no effect, which is the dangerous
outcome: you would think Kata was restricted to a few nodes while it installed
everywhere. `job.nodes` is the one node-selection knob that remains specific to
job mode.

Soft affinity (`preferredDuringSchedulingIgnoredDuringExecution`) is accepted
and ignored, and that is deliberate rather than a gap. A preference never stops
a DaemonSet from landing on a node either, so ignoring it is what keeps the two
modes in agreement.

### A CI workaround disappears

Job mode used to ship a built-in selector that skipped control-plane nodes. Our
CI clusters are usually a single node, and that node carries the control-plane
label, so job mode would have selected nothing at all. CI papered over it by
rewriting `job.nodeSelectorExpressions` to an empty list before every install.

That built-in selector is gone. Selection now starts from the top-level
`nodeSelector`, which is empty by default, and the only thing that removes a
node from the set is a taint the install does not tolerate. The single CI node
is untainted — `deploy_vanilla_k8s` removes the control-plane taint, and
single-node k3s and k0s never add one — so it is selected in both modes and the
workaround is deleted.
