### PR TITLE
shim: serialize container stop and delete

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/container.go
+++ b/src/runtime/pkg/containerd-shim-v2/container.go
@@ -19,26 +19,27 @@ import (
 )
 
 type container struct {
-	s           *service
-	ttyio       *ttyIO
-	spec        *specs.Spec
-	exitTime    time.Time
-	execsMu     sync.RWMutex
-	execs       map[string]*exec
-	exitIOch    chan struct{}
-	stdinPipe   io.WriteCloser
-	stdinCloser chan struct{}
-	exitCh      chan uint32
-	id          string
-	stdin       string
-	stdout      string
-	stderr      string
-	bundle      string
-	cType       vc.ContainerType
-	exit        uint32
-	status      task.Status
-	terminal    bool
-	mounted     bool
+	s            *service
+	ttyio        *ttyIO
+	spec         *specs.Spec
+	exitTime     time.Time
+	execsMu      sync.RWMutex
+	execs        map[string]*exec
+	exitIOch     chan struct{}
+	stdinPipe    io.WriteCloser
+	stdinCloser  chan struct{}
+	exitCh       chan uint32
+	id           string
+	stdin        string
+	stdout       string
+	stderr       string
+	bundle       string
+	cType        vc.ContainerType
+	exit         uint32
+	status       task.Status
+	terminal     bool
+	mounted      bool
+	teardownDone chan struct{}
 }
 
 func newContainer(s *service, r *taskAPI.CreateTaskRequest, containerType vc.ContainerType, spec *specs.Spec, mounted bool) (*container, error) {

--- a/src/runtime/pkg/containerd-shim-v2/delete.go
+++ b/src/runtime/pkg/containerd-shim-v2/delete.go
@@ -16,6 +16,14 @@ import (
 
 func deleteContainer(ctx context.Context, s *service, c *container) error {
 	if !c.cType.IsSandbox() {
+		if c.teardownDone != nil {
+			select {
+			case <-c.teardownDone:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
 		if c.status != task.Status_STOPPED {
 			if _, err := s.sandbox.StopContainer(ctx, c.id, false); err != nil && !isNotFound(err) {
 				return err

--- a/src/runtime/pkg/containerd-shim-v2/wait.go
+++ b/src/runtime/pkg/containerd-shim-v2/wait.go
@@ -61,12 +61,17 @@ func wait(ctx context.Context, s *service, c *container, execID string) (int32, 
 	}
 
 	timeStamp := time.Now()
+	var containerTeardownDone chan struct{}
 
 	if execID == "" {
 		s.mu.Lock()
 		c.status = task.Status_STOPPED
 		c.exit = uint32(ret)
 		c.exitTime = timeStamp
+		if !c.cType.IsSandbox() {
+			containerTeardownDone = make(chan struct{})
+			c.teardownDone = containerTeardownDone
+		}
 
 		// Cancel the sandbox watcher while holding s.mu so we do not race
 		// with watchSandbox()'s own (killed-VMM) teardown path.
@@ -120,6 +125,7 @@ func wait(ctx context.Context, s *service, c *container, execID string) (int32, 
 				}
 			})
 		} else {
+			defer close(containerTeardownDone)
 			if _, err = s.sandbox.StopContainer(ctx, c.id, true); err != nil {
 				shimLog.WithError(err).WithField("container", c.id).Warn("stop container failed")
 			}


### PR DESCRIPTION
## Summary

Serialize stop and delete for regular containers in the Kata shim.

`TaskExit` may be published before `StopContainer` finishes. containerd can then
immediately issue `Task.Delete`, causing `DeleteContainer` to observe a
still-running container and fail.

This change adds a per-container teardown completion signal. `Task.Delete`
waits for the signal before deleting the virtcontainers state.

## Motivation

This avoids the `TaskExit` / `Task.Delete` race and prevents a failed early
delete from leaving the container in the shim's internal map.

Fixes: #13557 

## Testing

Reproduced the race with a regular CRI container stop flow before the change.
