### PR TITLE
ci: keep ORAS installer stdout from polluting tarball paths

### DIFF
--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -88,10 +88,10 @@ build_and_install_gperf() {
 			gperf_tarball="${cached_tarball}"
 		else
 			echo "ORAS cache download failed, falling back to direct download"
-			curl -sLO "${gperf_tarball_url}"
+			curl -fsSL --retry 5 --retry-delay 5 --connect-timeout 30 --max-time 300 -O "${gperf_tarball_url}"
 		fi
 	else
-		curl -sLO "${gperf_tarball_url}"
+		curl -fsSL --retry 5 --retry-delay 5 --connect-timeout 30 --max-time 300 -O "${gperf_tarball_url}"
 	fi
 
 	tar -xf "${gperf_tarball}"
@@ -108,7 +108,7 @@ build_and_install_gperf() {
 build_and_install_libseccomp() {
 	echo "Build and install libseccomp version ${libseccomp_version}"
 	mkdir -p "${libseccomp_install_dir}"
-	curl -sLO "${libseccomp_tarball_url}"
+	curl -fsSL --retry 5 --retry-delay 5 --connect-timeout 30 --max-time 300 -O "${libseccomp_tarball_url}"
 	tar -xf "${libseccomp_tarball}"
 	pushd "libseccomp-${libseccomp_version}"
 	./configure --prefix="${libseccomp_install_dir}" CFLAGS="${cflags}" --enable-static

--- a/tools/packaging/scripts/download-with-oras-cache.sh
+++ b/tools/packaging/scripts/download-with-oras-cache.sh
@@ -58,7 +58,11 @@ ensure_oras_installed() {
 
 	if [[ -f "${install_oras_script}" ]]; then
 		info "Installing ORAS using existing script"
-		if "${install_oras_script}"; then
+		# Redirect the install script's stdout to stderr: functions in this
+		# helper communicate the downloaded tarball path via stdout (captured by
+		# callers with command substitution), so any stray stdout here would
+		# corrupt that path.
+		if "${install_oras_script}" >&2; then
 			# Verify installation succeeded
 			if command -v oras &>/dev/null; then
 				info "ORAS installed successfully"


### PR DESCRIPTION
When ORAS is not preinstalled, install_oras.sh status messages leak into the command substitution that captures the cached gperf path, so the file check fails and CI falls back to a flaky upstream curl that often times out (exit 28). Redirect installer output to stderr, and harden the direct-download fallbacks with retries and timeouts.

Fixes: #13560