### PR TITLE
runtime-rs: Restore Firecracker drives to placeholder on detach

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/firecracker/fc_api.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/fc_api.rs
@@ -208,6 +208,38 @@ impl FcInner {
         Ok(())
     }
 
+    // Restore a drive to the empty placeholder file created by
+    // prepare_vmm_resources, mirroring the golang runtime's
+    // hotplugBlockDevice remove path: unmount the jailed resource so the
+    // path resolves to the placeholder again, then PATCH the drive so
+    // Firecracker reopens it and releases the previous backing device.
+    pub(crate) async fn patch_drive_to_placeholder(&mut self, drive_id: &str) -> Result<()> {
+        let drive_name = [DRIVE_PREFIX, drive_id].concat();
+
+        // The bind mount sits on top of the placeholder file; MNT_DETACH is
+        // lazy, so Firecracker's open handle stays valid until the PATCH
+        // below swaps the backing file.
+        if self.jailed {
+            self.umount_jail_resource(&drive_name)
+                .with_context(|| format!("umount jailed resource {drive_name}"))?;
+        }
+
+        let placeholder_path = match self.jailed {
+            true => format!("/{drive_name}"),
+            false => format!("{}/{}/{}", self.vm_path, ROOT, drive_name),
+        };
+
+        let body: String = json!({
+            "drive_id": drive_name,
+            "path_on_host": placeholder_path,
+        })
+        .to_string();
+
+        self.request_with_retry(Method::PATCH, &format!("/drives/{drive_name}"), body)
+            .await
+            .with_context(|| format!("patch {drive_name} back to placeholder"))
+    }
+
     pub(crate) async fn add_net_device(
         &mut self,
         config: &NetworkConfig,

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner_device.rs
@@ -55,9 +55,38 @@ impl FcInner {
         Ok(())
     }
 
+    // Firecracker does not support post-boot drive removal, so instead of
+    // detaching the drive we patch it back to the empty placeholder file it
+    // was created with at boot, which makes Firecracker close its handle on
+    // the real backing device so the host can destroy it. Without this, a
+    // terminated container's backing device (e.g. a devmapper snapshot)
+    // stays open in the VMM while the generic device manager recycles the
+    // drive index, and the next container reusing the slot fails.
+    pub(crate) async fn unplug_block_device(&mut self, id: u64) -> Result<()> {
+        if id > 0 {
+            self.patch_drive_to_placeholder(&id.to_string()).await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn remove_device(&mut self, device: DeviceType) -> Result<()> {
         info!(sl(), "Remove Device {} ", device);
-        Ok(())
+        if self.state != VmmState::VmRunning {
+            // Nothing was attached to a running VMM, so there is nothing to
+            // release; sandbox teardown unmounts any jailed resources.
+            return Ok(());
+        }
+        match device {
+            DeviceType::BlockModern(block_mod) => {
+                let block = block_mod.lock().await.clone();
+                self.unplug_block_device(block.config.index)
+                    .await
+                    .context("unplug block device")
+            }
+            // Firecracker cannot remove network or vsock devices from a
+            // running VMM and they hold no per-container host resources.
+            _ => Ok(()),
+        }
     }
 
     pub(crate) async fn update_device(&mut self, device: DeviceType) -> Result<()> {


### PR DESCRIPTION
# What this PR does

`FcInner::remove_device()` was a no-op, so a removed container's block drive was never restored to its placeholder: Firecracker kept the previous backing device (e.g. a devmapper snapshot) open, the jailed bind mount of that device leaked (stacking on each slot reuse), and the generic device manager recycled the drive index anyway. The next container reusing the slot then failed, which breaks any pod with init containers when using the devmapper snapshotter.

This mirrors the golang runtime's `hotplugBlockDevice` remove path (`src/runtime/virtcontainers/fc.go`):

- unmount the jailed drive resource (lazy `MNT_DETACH`, so Firecracker's open handle stays valid until the PATCH swaps it),
- `PATCH /drives/driveN` back to the empty placeholder file created by `prepare_vmm_resources`, so Firecracker releases the backing device and the host can destroy it,
- propagate errors: on failure, `BlockDeviceModernHandle::detach()` restores the attach count and `DeviceManager::try_remove_device()` keeps the index reserved, so a slot that was never freed is not recycled.

Per Firecracker's documented post-boot drive-update contract, PATCH of `path_on_host` on a pre-configured drive is the supported "hot unplug" mechanism: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/patch-block.md

Non-block devices remain a no-op on removal: Firecracker cannot remove network/vsock devices from a running VMM and they hold no per-container host resources.

Fixes: #13565

# Testing

- `cargo check`, `cargo clippy --all-targets -- -D warnings`, and `rustfmt --check` on the changed files pass with the pinned toolchain (1.95). The one pre-existing rustfmt divergence in `add_device` is intentionally left untouched.
- Behavior mirrors the golang runtime's remove path 1:1 (umount then PATCH-to-placeholder, jailed path `/driveN`, non-jailed path under the VM dir).
- Runtime validation on an EKS + devmapper + jailer environment (pods with multiple sequential init containers, verifying devmapper open counts return to zero between containers and slots reuse cleanly) is in progress; results will be reported on #13565.
