### PR TITLE
runtime-rs: reap QEMU on start failure + serialize sandbox.start (fix TUNSETIFF EBUSY)

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -137,6 +137,17 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
     ) -> Result<()>;
     async fn start_vm(&self, timeout: i32) -> Result<()>;
     async fn stop_vm(&self) -> Result<()>;
+    /// Stop QEMU and wait up to `timeout` for the process to be reaped.
+    ///
+    /// Used on `sandbox.start()` failure so tap FDs are released before
+    /// `release_network()` and a CreateContainer retry (fix12 / #13574).
+    /// Default: same as `stop_vm` (non-blocking) for non-QEMU hypervisors.
+    /// QEMU overrides this with a bounded join on the OS-thread reaper.
+    /// Do NOT use this for Shutdown — large TDX reclaim can exceed any
+    /// reasonable RPC budget (fix9).
+    async fn stop_vm_for_start_fail(&self, _timeout: std::time::Duration) -> Result<()> {
+        self.stop_vm().await
+    }
     async fn wait_vm(&self) -> Result<i32>;
     async fn pause_vm(&self) -> Result<()>;
     async fn save_vm(&self) -> Result<()>;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2911,6 +2911,23 @@ impl<'a> QemuCmdLine<'a> {
         self.ccw_subchannel.take()
     }
 
+    /// Drop the parent's copy of the QMP listen FD after QEMU has inherited it
+    /// via `unix:fd=` (CLOEXEC cleared before spawn).
+    ///
+    /// fix11 (kata-containers#13564): while the parent also held the listen FD,
+    /// a dead/wedged QEMU left a listener that never `accept()`s —
+    /// `UnixStream::connect` to the path could block forever and QMP bring-up
+    /// never reached its deadline (glm-0 B200).
+    pub fn drop_qmp_listen_fd(&mut self) {
+        if let QmpSockType::Fd(file) =
+            std::mem::replace(&mut self.qmp_socket.address, QmpSockType::Path(PathBuf::new()))
+        {
+            let fd = file.as_raw_fd();
+            drop(file);
+            info!(sl!(), "fix11: dropped parent QMP listen fd={}", fd);
+        }
+    }
+
     fn add_monitor(&mut self, proto: &str) -> Result<()> {
         let monitor = QmpSocket::new(self.id.as_str(), MonitorProtocol::new(proto))?;
         self.devices.push(Box::new(monitor));

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -656,10 +656,10 @@ impl QemuInner {
         // never reaped, and QEMU becomes a zombie (or live orphan) under init
         // — leaving the Kubernetes pod stuck Terminating.
         //
-        // Use start_kill() (signal only). Reaping is done by the sandbox
-        // background wait_vm waiter / Qemu::stop_vm's background task — never
-        // block stop_vm on exit. If the Child was already taken by a concurrent
-        // wait_vm(), fall back to kill(2) on the cached pid. PR_SET_PDEATHSIG
+        // Use start_kill() (signal only). Reaping is done by Qemu::stop_vm /
+        // wait_vm via an OS-thread try_wait reaper (fix10) — never block
+        // stop_vm on exit. If the Child was already taken by a concurrent
+        // waiter, fall back to kill(2) on the cached pid. PR_SET_PDEATHSIG
         // (fix9) covers the case where the shim dies before/during reclaim.
         {
             let mut qemu_process = self.qemu_process.lock().await;
@@ -698,14 +698,19 @@ impl QemuInner {
         Err(anyhow!("qemu process has not been started yet"))
     }
 
+    /// Take ownership of the QEMU Child for reaping. Used by fix10 so stop_vm
+    /// (or wait_vm) can move the Child onto an OS thread that survives tokio
+    /// task cancellation.
+    pub(crate) async fn take_qemu_child(&self) -> Option<Child> {
+        let mut qemu_process = self.qemu_process.lock().await;
+        qemu_process.take()
+    }
+
     pub(crate) async fn wait_vm(&self) -> Result<i32> {
         // Take the Child under the lock, then wait OUTSIDE it so stop_vm()
         // can always start_kill() (fix8). Holding the mutex across
         // Child::wait() was the teardown deadlock that produced zombies.
-        let child = {
-            let mut qemu_process = self.qemu_process.lock().await;
-            qemu_process.take()
-        };
+        let child = self.take_qemu_child().await;
 
         if let Some(mut child) = child {
             let status = child.wait().await?;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -468,15 +468,25 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
+                // Kill and reap the spawned QEMU child to prevent a zombie process.
+                // Without this, the QEMU process is leaked when QMP init fails
+                // (e.g. the 50s QMP-connect deadline expires on slow CC/VFIO boots).
+                // The Go runtime reaps unconditionally via LogAndWait; the Rust
+                // runtime-rs had no equivalent on the failure path.
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            self.boot_from_template()
-                .await
-                .context("boot from template")?;
+            if let Err(e) = self.boot_from_template().await {
+                error!(sl!(), "boot from template failed: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e).context("boot from template");
+            }
             self.resume_vm().context("resume vm")?;
         }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -435,28 +435,7 @@ impl QemuInner {
         // runtime reaps unconditionally via LogAndWait; runtime-rs historically
         // only cleaned up on the QMP-init / boot_from_template paths (fix4),
         // missing virtio-mem setup, resume_vm, console connect, and any future
-        // `?` after spawn. fix5: one cleanup guard covers all of them.
-        let result = self
-            .start_vm_after_spawn(cmdline, console_socket_path)
-            .await;
-        if let Err(ref e) = result {
-            error!(
-                sl!(),
-                "start_vm failed after QEMU spawn: {:?}; killing and reaping child to prevent zombie",
-                e
-            );
-            let _ = self.stop_vm().await;
-            let _ = self.wait_vm().await;
-        }
-        result
-    }
-
-    /// QMP handshake + post-spawn bring-up. Caller must kill+reap on Err.
-    async fn start_vm_after_spawn(
-        &mut self,
-        mut cmdline: QemuCmdLine<'_>,
-        console_socket_path: std::path::PathBuf,
-    ) -> Result<()> {
+        // `?` after spawn. fix5: cleanup on every failure path below.
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -475,13 +454,24 @@ impl QemuInner {
                 // "the configuration is not prepared for memory devices".
                 if self.config.memory_info.enable_virtio_mem {
                     if cmdline.has_memory_hotplug_region() {
-                        qmp.setup_virtio_mem(
-                            self.config.memory_info.default_memory,
-                            self.config.memory_info.default_maxmemory,
-                            &self.config.machine_info.machine_type,
-                            self.config.shared_fs.shared_fs.as_deref(),
-                        )
-                        .context("Failed to setup virtio-mem during VM initialization")?;
+                        if let Err(e) = qmp
+                            .setup_virtio_mem(
+                                self.config.memory_info.default_memory,
+                                self.config.memory_info.default_maxmemory,
+                                &self.config.machine_info.machine_type,
+                                self.config.shared_fs.shared_fs.as_deref(),
+                            )
+                            .context("Failed to setup virtio-mem during VM initialization")
+                        {
+                            error!(
+                                sl!(),
+                                "virtio-mem setup failed after QEMU spawn: {:?}; killing+reaping",
+                                e
+                            );
+                            let _ = self.stop_vm().await;
+                            let _ = self.wait_vm().await;
+                            return Err(e);
+                        }
                     } else {
                         info!(
                             sl!(),
@@ -497,22 +487,47 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            self.boot_from_template()
-                .await
-                .context("boot from template")?;
-            self.resume_vm().context("resume vm")?;
+            if let Err(e) = self.boot_from_template().await {
+                error!(sl!(), "boot from template failed: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e).context("boot from template");
+            }
+            if let Err(e) = self.resume_vm().context("resume vm") {
+                error!(
+                    sl!(),
+                    "resume_vm failed after QEMU spawn: {:?}; killing+reaping", e
+                );
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e);
+            }
         }
 
         // When hypervisor debug is enabled, output the kernel boot messages for debugging.
         if self.config.debug_info.enable_debug {
-            let stream = UnixStream::connect(console_socket_path.as_os_str()).await?;
-            tokio::spawn(log_qemu_console(stream));
+            match UnixStream::connect(console_socket_path.as_os_str()).await {
+                Ok(stream) => {
+                    tokio::spawn(log_qemu_console(stream));
+                }
+                Err(e) => {
+                    error!(
+                        sl!(),
+                        "console connect failed after QEMU spawn: {:?}; killing+reaping", e
+                    );
+                    let _ = self.stop_vm().await;
+                    let _ = self.wait_vm().await;
+                    return Err(e.into());
+                }
+            }
         }
 
         Ok(())

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -58,6 +58,9 @@ pub struct QemuInner {
     id: String,
 
     qemu_process: Mutex<Option<Child>>,
+    /// Cached QEMU pid so stop_vm can signal even after wait_vm() has taken
+    /// the Child out of `qemu_process` (kata-containers#13564 fix8).
+    qemu_pid: Option<u32>,
     qmp: Option<Qmp>,
 
     config: HypervisorConfig,
@@ -72,6 +75,7 @@ impl QemuInner {
         QemuInner {
             id: "".to_string(),
             qemu_process: Mutex::new(None),
+            qemu_pid: None,
             qmp: None,
             config: Default::default(),
             devices: Vec::new(),
@@ -417,9 +421,14 @@ impl QemuInner {
 
         let mut qemu_process = command.stderr(Stdio::piped()).spawn()?;
         let stderr = qemu_process.stderr.take().unwrap();
+        self.qemu_pid = qemu_process.id();
         self.qemu_process = Mutex::new(Some(qemu_process));
 
-        info!(sl!(), "qemu process started");
+        info!(
+            sl!(),
+            "qemu process started (pid={:?})",
+            self.qemu_pid
+        );
 
         let exit_notify: mpsc::Sender<()> = self
             .exit_notify
@@ -626,29 +635,65 @@ impl QemuInner {
     pub(crate) async fn stop_vm(&mut self) -> Result<()> {
         info!(sl!(), "Stopping QEMU VM");
 
-        let mut qemu_process = self.qemu_process.lock().await;
-        if let Some(qemu_process) = qemu_process.as_mut() {
-            let is_qemu_running = qemu_process.id().is_some();
-            if is_qemu_running {
-                info!(sl!(), "QemuInner::stop_vm(): kill()'ing qemu");
-                qemu_process.kill().await.map_err(anyhow::Error::from)
-            } else {
+        // CRITICAL (kata-containers#13564 fix8 / production B200+TDX):
+        // Do NOT use Child::kill().await while holding qemu_process — that
+        // waits for the process to exit under the mutex. On large confidential
+        // guests (e.g. 1.2 TiB TDX + 8×GPU) SIGKILL reclaim can take many
+        // minutes; containerd then SIGKILLs the shim mid-wait, the Child is
+        // never reaped, and QEMU becomes a zombie under init — leaving the
+        // Kubernetes pod stuck Terminating.
+        //
+        // Use start_kill() (signal only) and let wait_vm() reap outside the
+        // lock. If the Child was already taken by a concurrent wait_vm(),
+        // fall back to kill(2) on the cached pid.
+        {
+            let mut qemu_process = self.qemu_process.lock().await;
+            if let Some(child) = qemu_process.as_mut() {
+                if let Some(pid) = child.id() {
+                    self.qemu_pid = Some(pid);
+                    info!(
+                        sl!(),
+                        "QemuInner::stop_vm(): start_kill() qemu pid={}", pid
+                    );
+                    // Signal only — do not await exit here (see comment above).
+                    child.start_kill().map_err(anyhow::Error::from)?;
+                    return Ok(());
+                }
                 info!(
                     sl!(),
-                    "QemuInner::stop_vm(): qemu process isn't running (likely stopped already)"
+                    "QemuInner::stop_vm(): qemu Child present but not running \
+                     (already exited); wait_vm will reap"
                 );
-                Ok(())
+                return Ok(());
             }
-        } else {
-            Err(anyhow!("qemu process has not been started yet"))
         }
+
+        if let Some(pid) = self.qemu_pid {
+            info!(
+                sl!(),
+                "QemuInner::stop_vm(): Child already taken; kill(2) pid={}", pid
+            );
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+            return Ok(());
+        }
+
+        Err(anyhow!("qemu process has not been started yet"))
     }
 
     pub(crate) async fn wait_vm(&self) -> Result<i32> {
-        let mut qemu_process = self.qemu_process.lock().await;
+        // Take the Child under the lock, then wait OUTSIDE it so stop_vm()
+        // can always start_kill() (fix8). Holding the mutex across
+        // Child::wait() was the teardown deadlock that produced zombies.
+        let child = {
+            let mut qemu_process = self.qemu_process.lock().await;
+            qemu_process.take()
+        };
 
-        if let Some(mut qemu_process) = qemu_process.take() {
-            let status = qemu_process.wait().await?;
+        if let Some(mut child) = child {
+            let status = child.wait().await?;
             Ok(status.code().unwrap_or(0))
         } else {
             Err(anyhow!("the process has been reaped"))
@@ -720,13 +765,17 @@ impl QemuInner {
                     sl!(),
                     "QemuInner::get_vmm_master_tid(): returning {}", qemu_pid
                 );
-                Ok(qemu_pid)
-            } else {
-                Err(anyhow!("QemuInner::get_vmm_master_tid(): qemu process isn't running (likely stopped already)"))
+                return Ok(qemu_pid);
             }
-        } else {
-            Err(anyhow!("qemu process not running"))
         }
+        if let Some(qemu_pid) = self.qemu_pid {
+            info!(
+                sl!(),
+                "QemuInner::get_vmm_master_tid(): returning cached {}", qemu_pid
+            );
+            return Ok(qemu_pid);
+        }
+        Err(anyhow!("qemu process not running"))
     }
 
     pub(crate) async fn get_ns_path(&self) -> Result<String> {
@@ -1369,6 +1418,7 @@ impl Persist for QemuInner {
         Ok(QemuInner {
             id: hypervisor_state.id,
             qemu_process: Mutex::new(None),
+            qemu_pid: None,
             qmp: None,
             config: hypervisor_state.config,
             devices: Vec::new(),

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -30,6 +30,8 @@ use kata_types::{
     capabilities::{Capabilities, CapabilityBits},
     config::KATA_PATH,
 };
+use nix::sys::signal::Signal;
+use nix::sys::prctl::set_pdeathsig;
 use nix::unistd::{setgid, setuid, Gid, Uid};
 use persist::sandbox_persist::Persist;
 use qapi_qmp::MigrationStatus;
@@ -392,6 +394,17 @@ impl QemuInner {
         unsafe {
             let selinux_label = self.config.security_info.selinux_label.clone();
             let _pre_exec = command.pre_exec(move || {
+                // fix9 (kata-containers#13564): if the shim is SIGKILLed mid-
+                // teardown (or exits after Shutdown before QEMU finishes
+                // reclaiming a large TDX guest), the kernel must kill QEMU.
+                // Without this, QEMU is reparented to init as a live orphan and
+                // the Kubernetes pod stays Terminating. Set before exec; check
+                // getppid for the classic fork/PDEATHSIG race.
+                set_pdeathsig(Signal::SIGKILL).map_err(std::io::Error::from)?;
+                if nix::unistd::getppid().as_raw() == 1 {
+                    let _ = nix::sys::signal::raise(Signal::SIGKILL);
+                }
+
                 let _ = enter_netns(&netns);
                 if let Some(label) = selinux_label.as_ref() {
                     if let Err(e) = selinux::set_exec_label(label) {
@@ -635,17 +648,19 @@ impl QemuInner {
     pub(crate) async fn stop_vm(&mut self) -> Result<()> {
         info!(sl!(), "Stopping QEMU VM");
 
-        // CRITICAL (kata-containers#13564 fix8 / production B200+TDX):
+        // CRITICAL (kata-containers#13564 fix8/fix9 / production B200+TDX):
         // Do NOT use Child::kill().await while holding qemu_process — that
         // waits for the process to exit under the mutex. On large confidential
         // guests (e.g. 1.2 TiB TDX + 8×GPU) SIGKILL reclaim can take many
         // minutes; containerd then SIGKILLs the shim mid-wait, the Child is
-        // never reaped, and QEMU becomes a zombie under init — leaving the
-        // Kubernetes pod stuck Terminating.
+        // never reaped, and QEMU becomes a zombie (or live orphan) under init
+        // — leaving the Kubernetes pod stuck Terminating.
         //
-        // Use start_kill() (signal only) and let wait_vm() reap outside the
-        // lock. If the Child was already taken by a concurrent wait_vm(),
-        // fall back to kill(2) on the cached pid.
+        // Use start_kill() (signal only). Reaping is done by the sandbox
+        // background wait_vm waiter / Qemu::stop_vm's background task — never
+        // block stop_vm on exit. If the Child was already taken by a concurrent
+        // wait_vm(), fall back to kill(2) on the cached pid. PR_SET_PDEATHSIG
+        // (fix9) covers the case where the shim dies before/during reclaim.
         {
             let mut qemu_process = self.qemu_process.lock().await;
             if let Some(child) = qemu_process.as_mut() {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -4,7 +4,8 @@
 //
 
 use super::cmdline_generator::{get_network_device, QemuCmdLine};
-use super::qmp::Qmp;
+use super::qmp::{Qmp, DEFAULT_QMP_CONNECT_DEADLINE_MS};
+use super::spawn_os_reaper;
 use crate::device::pci_path::PciPath;
 use crate::device::topology::PCIePort;
 use crate::qemu::cmdline_generator::VfioDeviceConfig;
@@ -110,7 +111,7 @@ impl QemuInner {
         Ok(())
     }
 
-    pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
+    pub(crate) async fn start_vm(&mut self, timeout: i32) -> Result<()> {
         info!(sl!(), "Starting QEMU VM");
         let netns = self.netns.clone().unwrap_or_default();
 
@@ -458,9 +459,19 @@ impl QemuInner {
         // only cleaned up on the QMP-init / boot_from_template paths (fix4),
         // missing virtio-mem setup, resume_vm, console connect, and any future
         // `?` after spawn. fix5: cleanup on every failure path below.
-        let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
+        // fix11: drop parent's QMP listen FD so a dead QEMU cannot leave a
+        // non-accepting listener that wedges unbounded connect(2).
+        cmdline.drop_qmp_listen_fd();
 
-        match Qmp::new(&qmp_socket_path) {
+        let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
+        // sandbox passes 10_000 (ms). Keep at least the historical 50s QMP
+        // ceiling so slow CC bring-up is not regressed; each connect attempt
+        // is separately bounded (see Qmp::connect).
+        let qmp_timeout = Duration::from_millis(
+            DEFAULT_QMP_CONNECT_DEADLINE_MS.max(timeout.max(0) as u64),
+        );
+
+        match Qmp::connect(&qmp_socket_path, &self.qemu_process, qmp_timeout).await {
             Ok(mut qmp) => {
                 if let Some(subchannel) = cmdline.take_ccw_subchannel() {
                     qmp.set_ccw_subchannel(subchannel);
@@ -490,8 +501,7 @@ impl QemuInner {
                                 "virtio-mem setup failed after QEMU spawn: {:?}; killing+reaping",
                                 e
                             );
-                            let _ = self.stop_vm().await;
-                            let _ = self.wait_vm().await;
+                            self.kill_and_os_reap_qemu().await;
                             return Err(e);
                         }
                     } else {
@@ -509,8 +519,7 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
+                self.kill_and_os_reap_qemu().await;
                 return Err(e);
             }
         }
@@ -519,8 +528,7 @@ impl QemuInner {
         if self.config.vm_template.boot_from_template {
             if let Err(e) = self.boot_from_template().await {
                 error!(sl!(), "boot from template failed: {:?}", e);
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
+                self.kill_and_os_reap_qemu().await;
                 return Err(e).context("boot from template");
             }
             if let Err(e) = self.resume_vm().context("resume vm") {
@@ -528,8 +536,7 @@ impl QemuInner {
                     sl!(),
                     "resume_vm failed after QEMU spawn: {:?}; killing+reaping", e
                 );
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
+                self.kill_and_os_reap_qemu().await;
                 return Err(e);
             }
         }
@@ -545,8 +552,7 @@ impl QemuInner {
                         sl!(),
                         "console connect failed after QEMU spawn: {:?}; killing+reaping", e
                     );
-                    let _ = self.stop_vm().await;
-                    let _ = self.wait_vm().await;
+                    self.kill_and_os_reap_qemu().await;
                     return Err(e.into());
                 }
             }
@@ -696,6 +702,22 @@ impl QemuInner {
         }
 
         Err(anyhow!("qemu process has not been started yet"))
+    }
+
+
+    /// Kill QEMU and reap via the fix10 OS-thread path (fix11).
+    /// Do not use `wait_vm()` here — that awaits Child on a cancellable tokio
+    /// task and historically left zombies when start failed mid-QMP.
+    async fn kill_and_os_reap_qemu(&mut self) {
+        let _ = self.stop_vm().await;
+        if let Some(child) = self.take_qemu_child().await {
+            info!(
+                sl!(),
+                "fix11: start-fail OS reaper for qemu pid={:?}",
+                child.id()
+            );
+            spawn_os_reaper(child, None);
+        }
     }
 
     /// Take ownership of the QEMU Child for reaping. Used by fix10 so stop_vm

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -428,6 +428,35 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
+        // Any failure AFTER spawn must kill+reap the Child. The sandbox only
+        // starts its background wait_vm() waiter once start_vm() returns Ok, so
+        // an Err return without cleanup leaks QEMU as a zombie and wedges the
+        // shim in a Task/State timeout loop (kata-containers#13564). The Go
+        // runtime reaps unconditionally via LogAndWait; runtime-rs historically
+        // only cleaned up on the QMP-init / boot_from_template paths (fix4),
+        // missing virtio-mem setup, resume_vm, console connect, and any future
+        // `?` after spawn. fix5: one cleanup guard covers all of them.
+        let result = self
+            .start_vm_after_spawn(cmdline, console_socket_path)
+            .await;
+        if let Err(ref e) = result {
+            error!(
+                sl!(),
+                "start_vm failed after QEMU spawn: {:?}; killing and reaping child to prevent zombie",
+                e
+            );
+            let _ = self.stop_vm().await;
+            let _ = self.wait_vm().await;
+        }
+        result
+    }
+
+    /// QMP handshake + post-spawn bring-up. Caller must kill+reap on Err.
+    async fn start_vm_after_spawn(
+        &mut self,
+        mut cmdline: QemuCmdLine<'_>,
+        console_socket_path: std::path::PathBuf,
+    ) -> Result<()> {
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -468,25 +497,15 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
-                // Kill and reap the spawned QEMU child to prevent a zombie process.
-                // Without this, the QEMU process is leaked when QMP init fails
-                // (e.g. the 50s QMP-connect deadline expires on slow CC/VFIO boots).
-                // The Go runtime reaps unconditionally via LogAndWait; the Rust
-                // runtime-rs had no equivalent on the failure path.
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            if let Err(e) = self.boot_from_template().await {
-                error!(sl!(), "boot from template failed: {:?}", e);
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
-                return Err(e).context("boot from template");
-            }
+            self.boot_from_template()
+                .await
+                .context("boot from template")?;
             self.resume_vm().context("resume vm")?;
         }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -70,6 +70,67 @@ impl Qemu {
             }
         }
     }
+
+    /// Signal QEMU and spawn the OS reaper. When `wait` is true, join the
+    /// reaper for up to `timeout` (fix12 start-fail path).
+    async fn stop_vm_signal_and_reap(&self, wait: bool, timeout: Duration) -> Result<()> {
+        let (kill_result, child) = {
+            let mut inner = self.inner.write().await;
+            let kill_result = inner.stop_vm().await;
+            let child = if kill_result.is_ok() {
+                inner.take_qemu_child().await
+            } else {
+                None
+            };
+            (kill_result, child)
+        };
+        if let Some(child) = child {
+            info!(
+                sl!(),
+                "fix10: stop_vm took qemu Child pid={:?}; spawning OS reaper",
+                child.id()
+            );
+            spawn_os_reaper(child, Some(self.reaped_exit.clone()));
+        } else if kill_result.is_ok() {
+            info!(
+                sl!(),
+                "fix10: stop_vm Child already taken; start_vm waiter / prior reaper owns wait"
+            );
+        }
+
+        if wait && kill_result.is_ok() {
+            // Already reaped?
+            if self.reaped_exit.borrow().is_some() {
+                return kill_result;
+            }
+            let mut rx = self.reaped_exit.subscribe();
+            match tokio::time::timeout(timeout, async {
+                loop {
+                    if rx.borrow_and_update().is_some() {
+                        return;
+                    }
+                    if rx.changed().await.is_err() {
+                        return;
+                    }
+                }
+            })
+            .await
+            {
+                Ok(()) => {
+                    info!(sl!(), "fix12: QEMU reaped within start-fail timeout");
+                }
+                Err(_) => {
+                    warn!(
+                        sl!(),
+                        "fix12: QEMU still alive after {:?}; proceeding to release_network \
+                         (tap may still be busy if FDs held)",
+                        timeout
+                    );
+                }
+            }
+        }
+        kill_result
+    }
 }
 
 /// Reap QEMU on a dedicated OS thread using sync `try_wait()`.
@@ -131,6 +192,9 @@ impl Hypervisor for Qemu {
     }
 
     async fn start_vm(&self, timeout: i32) -> Result<()> {
+        // Reset prior exit code so fix12 start-fail wait does not observe a
+        // stale reaped_exit from an earlier attempt in this shim process.
+        let _ = self.reaped_exit.send(None);
         let mut inner = self.inner.write().await;
         inner.start_vm(timeout).await
     }
@@ -148,30 +212,21 @@ impl Hypervisor for Qemu {
         // Child ownership; the loser logged "the process has been reaped" and
         // the winner's Child::wait() was abandoned when the shim task was
         // cancelled → zombie QEMU under an orphaned live shim (glm B200).
-        let (kill_result, child) = {
-            let mut inner = self.inner.write().await;
-            let kill_result = inner.stop_vm().await;
-            let child = if kill_result.is_ok() {
-                inner.take_qemu_child().await
-            } else {
-                None
-            };
-            (kill_result, child)
-        };
-        if let Some(child) = child {
-            info!(
-                sl!(),
-                "fix10: stop_vm took qemu Child pid={:?}; spawning OS reaper",
-                child.id()
-            );
-            spawn_os_reaper(child, Some(self.reaped_exit.clone()));
-        } else if kill_result.is_ok() {
-            info!(
-                sl!(),
-                "fix10: stop_vm Child already taken; start_vm waiter / prior reaper owns wait"
-            );
-        }
-        kill_result
+        self.stop_vm_signal_and_reap(/* wait */ false, Duration::from_secs(0))
+            .await
+    }
+
+    async fn stop_vm_for_start_fail(&self, timeout: Duration) -> Result<()> {
+        // fix12: on sandbox.start() failure, CreateContainer retries immediately.
+        // Non-blocking stop leaves QEMU holding tap FDs → TUNSETIFF EBUSY.
+        // Bound the wait so we release taps before release_network(); do not
+        // use this for Shutdown (1.2 TiB TDX reclaim).
+        info!(
+            sl!(),
+            "fix12: stop_vm_for_start_fail waiting up to {:?} for QEMU reap",
+            timeout
+        );
+        self.stop_vm_signal_and_reap(/* wait */ true, timeout).await
     }
 
     async fn wait_vm(&self) -> Result<i32> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -21,13 +21,19 @@ use async_trait::async_trait;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tokio::process::Child;
 use tokio::sync::RwLock;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 
 #[derive(Debug)]
 pub struct Qemu {
     inner: Arc<RwLock<QemuInner>>,
     exit_waiter: Mutex<(mpsc::Receiver<()>, i32)>,
+    /// Exit code published by the sole OS-thread reaper (fix10).
+    /// `None` until QEMU has been reaped.
+    reaped_exit: watch::Sender<Option<i32>>,
 }
 
 impl Default for Qemu {
@@ -39,16 +45,69 @@ impl Default for Qemu {
 impl Qemu {
     pub fn new() -> Self {
         let (exit_notify, exit_waiter) = mpsc::channel(1);
+        let (reaped_exit, _) = watch::channel(None);
 
         Self {
             inner: Arc::new(RwLock::new(QemuInner::new(exit_notify))),
             exit_waiter: Mutex::new((exit_waiter, 0)),
+            reaped_exit,
         }
     }
 
     pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
+    }
+
+    /// Reap QEMU on a dedicated OS thread using sync `try_wait()`.
+    ///
+    /// fix10 (kata-containers#13564): a tokio task awaiting `Child::wait()` can
+    /// be cancelled when containerd SIGKILLs / abandons the shim after a
+    /// non-blocking Shutdown — Dropping the Child without a successful wait
+    /// leaves QEMU as a zombie under the (still-alive) orphaned shim. An OS
+    /// thread is not cancelled with the tokio task; `try_wait` reaps on Unix.
+    fn spawn_os_reaper(child: Child, reaped_exit: watch::Sender<Option<i32>>) {
+        let pid = child.id();
+        let _ = thread::Builder::new()
+            .name("qemu-reap".into())
+            .spawn(move || {
+                let mut child = child;
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            let code = status.code().unwrap_or(0);
+                            info!(
+                                sl!(),
+                                "fix10 OS reaper: qemu pid={:?} exited code={}", pid, code
+                            );
+                            let _ = reaped_exit.send(Some(code));
+                            return;
+                        }
+                        Ok(None) => thread::sleep(Duration::from_millis(200)),
+                        Err(e) => {
+                            // ECHILD if a racing reaper already collected the status.
+                            warn!(
+                                sl!(),
+                                "fix10 OS reaper: try_wait pid={:?} err={:?}", pid, e
+                            );
+                            let _ = reaped_exit.send(Some(0));
+                            return;
+                        }
+                    }
+                }
+            });
+    }
+
+    async fn wait_for_reaped_exit(&self) -> i32 {
+        let mut rx = self.reaped_exit.subscribe();
+        loop {
+            if let Some(code) = *rx.borrow_and_update() {
+                return code;
+            }
+            if rx.changed().await.is_err() {
+                return 0;
+            }
+        }
     }
 }
 
@@ -76,20 +135,36 @@ impl Hypervisor for Qemu {
         // fix9: do NOT await wait_vm() here either — that still blocked the
         // Shutdown RPC long enough for containerd to SIGKILL the shim, leaving
         // a live orphan QEMU under init (production B200+TDX, ~1.2 TiB guest).
-        // Reap in a background task; the sandbox start_vm waiter may also reap
-        // (double-take → "already reaped" is fine). PR_SET_PDEATHSIG kills
-        // QEMU if the shim process exits/dies first.
-        let kill_result = {
+        // PR_SET_PDEATHSIG kills QEMU if the shim process exits/dies first.
+        //
+        // fix10: take the Child here and reap on an OS thread (try_wait loop).
+        // The old tokio::spawn(inner.wait_vm()) raced the start_vm waiter for
+        // Child ownership; the loser logged "the process has been reaped" and
+        // the winner's Child::wait() was abandoned when the shim task was
+        // cancelled → zombie QEMU under an orphaned live shim (glm B200).
+        let (kill_result, child) = {
             let mut inner = self.inner.write().await;
-            inner.stop_vm().await
+            let kill_result = inner.stop_vm().await;
+            let child = if kill_result.is_ok() {
+                inner.take_qemu_child().await
+            } else {
+                None
+            };
+            (kill_result, child)
         };
-        let inner = self.inner.clone();
-        tokio::spawn(async move {
-            let inner = inner.read().await;
-            if let Err(e) = inner.wait_vm().await {
-                debug!(sl!(), "background wait_vm after stop_vm: {:?}", e);
-            }
-        });
+        if let Some(child) = child {
+            info!(
+                sl!(),
+                "fix10: stop_vm took qemu Child pid={:?}; spawning OS reaper",
+                child.id()
+            );
+            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+        } else if kill_result.is_ok() {
+            info!(
+                sl!(),
+                "fix10: stop_vm Child already taken; start_vm waiter / prior reaper owns wait"
+            );
+        }
         kill_result
     }
 
@@ -98,15 +173,33 @@ impl Hypervisor for Qemu {
 
         let mut waiter = self.exit_waiter.lock().await;
 
-        //wait until the qemu process exited.
+        // Wait until qemu stderr EOF (process exited / closed stderr).
         waiter.0.recv().await;
 
-        let inner = self.inner.read().await;
-        if let Ok(exit_code) = inner.wait_vm().await {
-            waiter.1 = exit_code;
+        // Already reaped by stop_vm's OS thread?
+        if let Some(code) = *self.reaped_exit.borrow() {
+            waiter.1 = code;
+            return Ok(code);
         }
 
-        Ok(waiter.1)
+        // Take Child for OS-thread reaping (same fix10 path as stop_vm).
+        // Do NOT Child::wait().await on this cancellable task.
+        let child = {
+            let inner = self.inner.read().await;
+            inner.take_qemu_child().await
+        };
+        if let Some(child) = child {
+            info!(
+                sl!(),
+                "fix10: wait_vm took qemu Child pid={:?}; spawning OS reaper",
+                child.id()
+            );
+            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+        }
+
+        let code = self.wait_for_reaped_exit().await;
+        waiter.1 = code;
+        Ok(code)
     }
 
     async fn pause_vm(&self) -> Result<()> {
@@ -257,11 +350,13 @@ impl Persist for Qemu {
         hypervisor_state: Self::State,
     ) -> Result<Self> {
         let (exit_notify, exit_waiter) = mpsc::channel(1);
+        let (reaped_exit, _) = watch::channel(None);
 
         let inner = QemuInner::restore(exit_notify, hypervisor_state).await?;
         Ok(Self {
             inner: Arc::new(RwLock::new(inner)),
             exit_waiter: Mutex::new((exit_waiter, 0)),
+            reaped_exit,
         })
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -59,45 +59,6 @@ impl Qemu {
         inner.set_hypervisor_config(config)
     }
 
-    /// Reap QEMU on a dedicated OS thread using sync `try_wait()`.
-    ///
-    /// fix10 (kata-containers#13564): a tokio task awaiting `Child::wait()` can
-    /// be cancelled when containerd SIGKILLs / abandons the shim after a
-    /// non-blocking Shutdown — Dropping the Child without a successful wait
-    /// leaves QEMU as a zombie under the (still-alive) orphaned shim. An OS
-    /// thread is not cancelled with the tokio task; `try_wait` reaps on Unix.
-    fn spawn_os_reaper(child: Child, reaped_exit: watch::Sender<Option<i32>>) {
-        let pid = child.id();
-        let _ = thread::Builder::new()
-            .name("qemu-reap".into())
-            .spawn(move || {
-                let mut child = child;
-                loop {
-                    match child.try_wait() {
-                        Ok(Some(status)) => {
-                            let code = status.code().unwrap_or(0);
-                            info!(
-                                sl!(),
-                                "fix10 OS reaper: qemu pid={:?} exited code={}", pid, code
-                            );
-                            let _ = reaped_exit.send(Some(code));
-                            return;
-                        }
-                        Ok(None) => thread::sleep(Duration::from_millis(200)),
-                        Err(e) => {
-                            // ECHILD if a racing reaper already collected the status.
-                            warn!(
-                                sl!(),
-                                "fix10 OS reaper: try_wait pid={:?} err={:?}", pid, e
-                            );
-                            let _ = reaped_exit.send(Some(0));
-                            return;
-                        }
-                    }
-                }
-            });
-    }
-
     async fn wait_for_reaped_exit(&self) -> i32 {
         let mut rx = self.reaped_exit.subscribe();
         loop {
@@ -109,6 +70,51 @@ impl Qemu {
             }
         }
     }
+}
+
+/// Reap QEMU on a dedicated OS thread using sync `try_wait()`.
+///
+/// fix10 (kata-containers#13564): a tokio task awaiting `Child::wait()` can
+/// be cancelled when containerd SIGKILLs / abandons the shim after a
+/// non-blocking Shutdown — Dropping the Child without a successful wait
+/// leaves QEMU as a zombie under the (still-alive) orphaned shim. An OS
+/// thread is not cancelled with the tokio task; `try_wait` reaps on Unix.
+///
+/// fix11: also used on start_vm failure paths (`reaped_exit = None`).
+pub(crate) fn spawn_os_reaper(child: Child, reaped_exit: Option<watch::Sender<Option<i32>>>) {
+    let pid = child.id();
+    let _ = thread::Builder::new()
+        .name("qemu-reap".into())
+        .spawn(move || {
+            let mut child = child;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        let code = status.code().unwrap_or(0);
+                        info!(
+                            sl!(),
+                            "fix10 OS reaper: qemu pid={:?} exited code={}", pid, code
+                        );
+                        if let Some(tx) = reaped_exit {
+                            let _ = tx.send(Some(code));
+                        }
+                        return;
+                    }
+                    Ok(None) => thread::sleep(Duration::from_millis(200)),
+                    Err(e) => {
+                        // ECHILD if a racing reaper already collected the status.
+                        warn!(
+                            sl!(),
+                            "fix10 OS reaper: try_wait pid={:?} err={:?}", pid, e
+                        );
+                        if let Some(tx) = reaped_exit {
+                            let _ = tx.send(Some(0));
+                        }
+                        return;
+                    }
+                }
+            }
+        });
 }
 
 #[async_trait]
@@ -158,7 +164,7 @@ impl Hypervisor for Qemu {
                 "fix10: stop_vm took qemu Child pid={:?}; spawning OS reaper",
                 child.id()
             );
-            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+            spawn_os_reaper(child, Some(self.reaped_exit.clone()));
         } else if kill_result.is_ok() {
             info!(
                 sl!(),
@@ -194,7 +200,7 @@ impl Hypervisor for Qemu {
                 "fix10: wait_vm took qemu Child pid={:?}; spawning OS reaper",
                 child.id()
             );
-            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+            spawn_os_reaper(child, Some(self.reaped_exit.clone()));
         }
 
         let code = self.wait_for_reaped_exit().await;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -71,8 +71,16 @@ impl Hypervisor for Qemu {
     }
 
     async fn stop_vm(&self) -> Result<()> {
-        let mut inner = self.inner.write().await;
-        let kill_result = inner.stop_vm().await;
+        // Signal QEMU under the write lock, then reap WITHOUT holding it.
+        // Holding inner.write() across wait_vm() blocked StateProcess and
+        // other RPCs for the entire (multi-minute) TDX teardown window;
+        // containerd then SIGKILL'd the shim and left a zombie QEMU
+        // (kata-containers#13564 fix8).
+        let kill_result = {
+            let mut inner = self.inner.write().await;
+            inner.stop_vm().await
+        };
+        let inner = self.inner.read().await;
         // Always attempt to reap after stop. Init-state / failed-start teardown
         // previously called stop_vm() without wait_vm(), leaving QEMU as a
         // zombie when the background exit waiter was absent or blocked on

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -71,22 +71,25 @@ impl Hypervisor for Qemu {
     }
 
     async fn stop_vm(&self) -> Result<()> {
-        // Signal QEMU under the write lock, then reap WITHOUT holding it.
-        // Holding inner.write() across wait_vm() blocked StateProcess and
-        // other RPCs for the entire (multi-minute) TDX teardown window;
-        // containerd then SIGKILL'd the shim and left a zombie QEMU
-        // (kata-containers#13564 fix8).
+        // fix8: signal under write lock only (start_kill), never hold locks
+        // across the multi-minute TDX reclaim wait.
+        // fix9: do NOT await wait_vm() here either — that still blocked the
+        // Shutdown RPC long enough for containerd to SIGKILL the shim, leaving
+        // a live orphan QEMU under init (production B200+TDX, ~1.2 TiB guest).
+        // Reap in a background task; the sandbox start_vm waiter may also reap
+        // (double-take → "already reaped" is fine). PR_SET_PDEATHSIG kills
+        // QEMU if the shim process exits/dies first.
         let kill_result = {
             let mut inner = self.inner.write().await;
             inner.stop_vm().await
         };
-        let inner = self.inner.read().await;
-        // Always attempt to reap after stop. Init-state / failed-start teardown
-        // previously called stop_vm() without wait_vm(), leaving QEMU as a
-        // zombie when the background exit waiter was absent or blocked on
-        // exit_notify (kata-containers#13564 fix5). Double-reap is harmless:
-        // wait_vm returns Err("already reaped") which we ignore.
-        let _ = inner.wait_vm().await;
+        let inner = self.inner.clone();
+        tokio::spawn(async move {
+            let inner = inner.read().await;
+            if let Err(e) = inner.wait_vm().await {
+                debug!(sl!(), "background wait_vm after stop_vm: {:?}", e);
+            }
+        });
         kill_result
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -72,7 +72,14 @@ impl Hypervisor for Qemu {
 
     async fn stop_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.stop_vm().await
+        let kill_result = inner.stop_vm().await;
+        // Always attempt to reap after stop. Init-state / failed-start teardown
+        // previously called stop_vm() without wait_vm(), leaving QEMU as a
+        // zombie when the background exit waiter was absent or blocked on
+        // exit_notify (kata-containers#13564 fix5). Double-reap is harmless:
+        // wait_vm returns Err("already reaped") which we ignore.
+        let _ = inner.wait_vm().await;
+        kill_result
     }
 
     async fn wait_vm(&self) -> Result<i32> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -24,22 +24,82 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Error, Formatter};
 use std::io::BufReader;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::str::FromStr;
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use qapi_spec::Dictionary;
-use std::thread;
-use std::time::Instant;
+use tokio::process::Child;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+use nix::errno::Errno;
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::sys::socket::sockopt::SocketError;
+use nix::sys::socket::{
+    connect, getsockopt, socket, AddressFamily, SockFlag, SockType, UnixAddr,
+};
 
 /// default qmp connection read timeout
 const DEFAULT_QMP_READ_TIMEOUT: u64 = 250;
 const DEFAULT_QMP_INIT_READ_TIMEOUT: u64 = 5000;
-const DEFAULT_QMP_CONNECT_DEADLINE_MS: u64 = 50000;
+/// Overall QMP bring-up ceiling (historical). Per-attempt connect is bounded
+/// separately by DEFAULT_QMP_CONNECT_ATTEMPT_MS (fix11).
+pub const DEFAULT_QMP_CONNECT_DEADLINE_MS: u64 = 50000;
 const DEFAULT_QMP_RETRY_SLEEP_MS: u64 = 50;
+/// fix11: never block forever in connect(2). Parent holding the QMP listen FD
+/// after a dead QEMU made unbounded UnixStream::connect hang (glm-0 B200).
+const DEFAULT_QMP_CONNECT_ATTEMPT_MS: u64 = 1000;
 
 const DEVICE_DELETED_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Non-blocking AF_UNIX connect with a hard timeout (fix11).
+fn connect_unix_timeout(path: &str, timeout: Duration) -> std::io::Result<UnixStream> {
+    let addr = UnixAddr::new(path).map_err(std::io::Error::from)?;
+    let sock: OwnedFd = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::SOCK_CLOEXEC | SockFlag::SOCK_NONBLOCK,
+        None,
+    )
+    .map_err(std::io::Error::from)?;
+
+    match connect(sock.as_raw_fd(), &addr) {
+        Ok(()) => {}
+        Err(Errno::EINPROGRESS) => {
+            let mut pfd = libc::pollfd {
+                fd: sock.as_raw_fd(),
+                events: libc::POLLOUT,
+                revents: 0,
+            };
+            let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+            let n = unsafe { libc::poll(&mut pfd, 1, ms) };
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "qmp unix connect timed out",
+                ));
+            }
+            if n < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let err = getsockopt(&sock, SocketError).map_err(std::io::Error::from)?;
+            if err != 0 {
+                return Err(std::io::Error::from_raw_os_error(err));
+            }
+        }
+        Err(e) => return Err(std::io::Error::from(e)),
+    }
+
+    // qapi expects a blocking stream for handshake / execute.
+    let flags = fcntl(&sock, FcntlArg::F_GETFL).map_err(std::io::Error::from)?;
+    let flags = OFlag::from_bits_truncate(flags) & !OFlag::O_NONBLOCK;
+    fcntl(&sock, FcntlArg::F_SETFL(flags)).map_err(std::io::Error::from)?;
+
+    Ok(unsafe { UnixStream::from_raw_fd(sock.into_raw_fd()) })
+}
 
 pub struct Qmp {
     qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
@@ -76,9 +136,24 @@ impl Debug for Qmp {
 }
 
 impl Qmp {
-    pub fn new(qmp_sock_path: &str) -> Result<Self> {
+    /// Connect to QEMU's QMP socket with bounded connect(2) and Child liveness
+    /// checks (fix11 / kata-containers#13564).
+    ///
+    /// Previously this used unbounded `UnixStream::connect` on a path whose
+    /// listen FD was still held by the parent after spawn. When QEMU died
+    /// before speaking QMP, connect could block forever — the 50s deadline
+    /// never fired, Err-path cleanup never ran, and QEMU stayed Z under the
+    /// shim (glm-0 on B200).
+    pub async fn connect(
+        qmp_sock_path: &str,
+        qemu_process: &Mutex<Option<Child>>,
+        overall_timeout: Duration,
+    ) -> Result<Self> {
         let try_new_once_fn = || -> Result<Qmp> {
-            let stream = UnixStream::connect(qmp_sock_path)?;
+            let stream = connect_unix_timeout(
+                qmp_sock_path,
+                Duration::from_millis(DEFAULT_QMP_CONNECT_ATTEMPT_MS),
+            )?;
 
             stream
                 .set_read_timeout(Some(Duration::from_millis(DEFAULT_QMP_INIT_READ_TIMEOUT)))
@@ -100,16 +175,38 @@ impl Qmp {
             Ok(qmp)
         };
 
-        let deadline = Instant::now() + Duration::from_millis(DEFAULT_QMP_CONNECT_DEADLINE_MS);
+        let deadline = Instant::now() + overall_timeout;
         let mut last_err: Option<anyhow::Error> = None;
 
         while Instant::now() < deadline {
+            // Fail fast if QEMU already exited (try_wait reaps a zombie Child).
+            {
+                let mut guard = qemu_process.lock().await;
+                match guard.as_mut() {
+                    Some(child) => match child.try_wait() {
+                        Ok(Some(status)) => {
+                            return Err(anyhow!(
+                                "QEMU exited before QMP ready (status={:?})",
+                                status
+                            ));
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            return Err(anyhow!("QEMU try_wait during QMP connect: {}", e));
+                        }
+                    },
+                    None => {
+                        return Err(anyhow!("QEMU Child missing before QMP ready"));
+                    }
+                }
+            }
+
             match try_new_once_fn() {
                 Ok(qmp) => return Ok(qmp),
                 Err(e) => {
                     debug!(sl!(), "QMP not ready yet: {}", e);
                     last_err = Some(e);
-                    thread::sleep(Duration::from_millis(DEFAULT_QMP_RETRY_SLEEP_MS));
+                    sleep(Duration::from_millis(DEFAULT_QMP_RETRY_SLEEP_MS)).await;
                 }
             }
         }

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -84,6 +84,14 @@ impl ResourceManager {
         inner.handle_network(network_config).await
     }
 
+    /// Tear down network endpoints / taps and clear the cached network so a
+    /// retry of `sandbox.start()` can recreate them. See kata-containers#13564
+    /// follow-up (tap0_kata TUNSETIFF EBUSY on concurrent CreateContainer).
+    pub async fn release_network(&self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.release_network().await
+    }
+
     #[instrument]
     pub async fn setup_after_start_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -951,6 +951,17 @@ impl ResourceManagerInner {
         }
     }
 
+    /// Detach endpoints and delete host-side taps, then clear `self.network` so a
+    /// subsequent `handle_network` can recreate them (sandbox.start retry path).
+    pub async fn release_network(&mut self) -> Result<()> {
+        if let Some(network) = self.network.take() {
+            if let Err(err) = network.remove(self.hypervisor.as_ref()).await {
+                warn!(sl!(), "failed to remove network: {}", err);
+            }
+        }
+        Ok(())
+    }
+
     pub async fn cleanup(&self) -> Result<()> {
         // detach network endpoints (rebinds VFs from vfio-pci back to host driver)
         if let Some(network) = &self.network {

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -13,11 +13,25 @@ use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::DeviceType;
 use hypervisor::{Hypervisor, NetworkDevice};
+use scopeguard::defer;
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, VethEndpointState};
 use super::{attach_network_device, Endpoint};
+use crate::network::utils::link;
 use crate::network::{utils, NetworkPair};
+
+async fn delete_tap_device(name: &str) -> Result<()> {
+    let (connection, handle, _) = rtnetlink::new_connection().context("new connection")?;
+    let thread_handler = tokio::spawn(connection);
+    defer!({
+        thread_handler.abort();
+    });
+    link::delete_link(&handle, name)
+        .await
+        .with_context(|| format!("delete tap {name}"))?;
+    Ok(())
+}
 
 #[derive(Debug)]
 pub struct VethEndpoint {
@@ -99,6 +113,18 @@ impl Endpoint for VethEndpoint {
         }))
         .await
         .context("remove Veth endpoint device by hypervisor failed.")?;
+
+        // create_link sets IFF_PERSIST, so the tap survives FD close / QEMU exit.
+        // Delete it explicitly so a retry of sandbox.start() can recreate it
+        // (otherwise TUNSETIFF returns EBUSY).
+        if let Err(err) = delete_tap_device(&self.net_pair.tap.tap_iface.name).await {
+            warn!(
+                sl!(),
+                "failed to delete tap {}: {:#}",
+                self.net_pair.tap.tap_iface.name,
+                err
+            );
+        }
 
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -156,7 +156,21 @@ pub async fn create_link(
     name: &str,
     queues: usize,
 ) -> Result<Box<dyn link::Link>> {
-    link::create_link(name, link::LinkType::Tap, queues)?;
+    match link::create_link(name, link::LinkType::Tap, queues) {
+        Ok(()) => {}
+        Err(e) if link::is_busy_or_exist(&e) => {
+            // IFF_PERSIST leaves tapN_kata in the netns after a failed
+            // sandbox.start(); concurrent CreateContainer retries then hit
+            // TUNSETIFF EBUSY. Reuse the existing device instead of failing.
+            warn!(
+                sl!(),
+                "tap {} already exists ({}), reusing",
+                name,
+                e
+            );
+        }
+        Err(e) => return Err(e).context("create tap device"),
+    }
 
     let link = get_link_by_name(handle, name)
         .await

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -156,12 +156,15 @@ pub async fn create_link(
     name: &str,
     queues: usize,
 ) -> Result<Box<dyn link::Link>> {
+    let mut reused = false;
     match link::create_link(name, link::LinkType::Tap, queues) {
         Ok(()) => {}
         Err(e) if link::is_busy_or_exist(&e) => {
             // IFF_PERSIST leaves tapN_kata in the netns after a failed
             // sandbox.start(); concurrent CreateContainer retries then hit
             // TUNSETIFF EBUSY. Reuse the existing device instead of failing.
+            // fix12: distinguish "netdev visible, reuse" vs "FDs held / orphan".
+            reused = true;
             warn!(
                 sl!(),
                 "tap {} already exists ({}), reusing",
@@ -172,9 +175,22 @@ pub async fn create_link(
         Err(e) => return Err(e).context("create tap device"),
     }
 
-    let link = get_link_by_name(handle, name)
-        .await
-        .context("get link by name")?;
+    let link = match get_link_by_name(handle, name).await {
+        Ok(l) => l,
+        Err(lookup_err) if reused => {
+            // Device name is busy to TUNSETIFF but netlink cannot see it —
+            // typically another live process (orphan QEMU) holds the FDs.
+            return Err(anyhow!(
+                "tap {} held by live process (TUNSETIFF EBUSY, netlink miss: {:#}); \
+                 kill orphan shim/QEMU or wait for start-fail reap (fix12)",
+                name,
+                lookup_err
+            ));
+        }
+        Err(lookup_err) => {
+            return Err(lookup_err).context("get link by name");
+        }
+    };
 
     let base = link.attrs();
     if base.master_index != 0 {

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -16,6 +16,30 @@ use nix::ioctl_write_ptr;
 
 use super::macros::{get_name, set_name};
 
+/// True when TUNSETIFF failed because the named device already exists / is busy.
+/// Used to reuse a leftover `tapN_kata` after a failed sandbox start (IFF_PERSIST
+/// keeps the device alive after the creating FDs are dropped).
+pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(ioe) = cause.downcast_ref::<io::Error>() {
+            match ioe.raw_os_error() {
+                Some(libc::EBUSY) | Some(libc::EEXIST) => return true,
+                _ => {}
+            }
+        }
+        if let Some(ne) = cause.downcast_ref::<nix::Error>() {
+            if *ne == nix::Error::EBUSY || *ne == nix::Error::EEXIST {
+                return true;
+            }
+        }
+    }
+    let s = format!("{err:#}");
+    s.contains("EBUSY")
+        || s.contains("EEXIST")
+        || s.contains("Device or resource busy")
+        || s.contains("File exists")
+}
+
 type IfName = [u8; libc::IFNAMSIZ];
 
 #[derive(Copy, Clone, Debug)]
@@ -128,23 +152,26 @@ fn create_queue(name: &str, flags: libc::c_int) -> Result<(File, String)> {
     Ok((file, req.get_name()?))
 }
 
-#[cfg(test)]
-pub mod net_test_utils {
+/// Delete a link by name (e.g. leftover `tap0_kata` after a failed start).
+pub async fn delete_link(handle: &rtnetlink::Handle, name: &str) -> Result<()> {
     use crate::network::network_model::tc_filter_model::fetch_index;
 
-    // remove a link by its name
-    #[allow(dead_code)]
-    pub async fn delete_link(
-        handle: &rtnetlink::Handle,
-        name: &str,
-    ) -> Result<(), rtnetlink::Error> {
-        let link_index = fetch_index(handle, name)
-            .await
-            .expect("failed to fetch index");
-        // the ifindex of a link will not change during its lifetime, so the index
-        // remains the same between the query above and the deletion below
-        handle.link().del(link_index).execute().await
-    }
+    let link_index = fetch_index(handle, name)
+        .await
+        .with_context(|| format!("fetch index for {name}"))?;
+    handle
+        .link()
+        .del(link_index)
+        .execute()
+        .await
+        .with_context(|| format!("delete link {name}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod net_test_utils {
+    // Back-compat for tests that imported delete_link from this module.
+    pub use super::delete_link;
 }
 
 #[cfg(test)]

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -19,6 +19,9 @@ use super::macros::{get_name, set_name};
 /// True when TUNSETIFF failed because the named device already exists / is busy.
 /// Used to reuse a leftover `tapN_kata` after a failed sandbox start (IFF_PERSIST
 /// keeps the device alive after the creating FDs are dropped).
+///
+/// fix12: match every error-shape we have seen on musl/glibc (io::Error,
+/// nix::Error / Errno, and Display text) so reuse cannot miss EBUSY.
 pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         if let Some(ioe) = cause.downcast_ref::<io::Error>() {
@@ -26,9 +29,20 @@ pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
                 Some(libc::EBUSY) | Some(libc::EEXIST) => return true,
                 _ => {}
             }
+            if ioe.kind() == io::ErrorKind::AlreadyExists
+                || ioe.kind() == io::ErrorKind::ResourceBusy
+            {
+                return true;
+            }
         }
         if let Some(ne) = cause.downcast_ref::<nix::Error>() {
             if *ne == nix::Error::EBUSY || *ne == nix::Error::EEXIST {
+                return true;
+            }
+        }
+        // nix >= 0.27 often surfaces Errno directly in the chain.
+        if let Some(errno) = cause.downcast_ref::<nix::errno::Errno>() {
+            if *errno == nix::errno::Errno::EBUSY || *errno == nix::errno::Errno::EEXIST {
                 return true;
             }
         }
@@ -38,6 +52,7 @@ pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
         || s.contains("EEXIST")
         || s.contains("Device or resource busy")
         || s.contains("File exists")
+        || s.contains("Resource busy")
 }
 
 type IfName = [u8; libc::IFNAMSIZ];
@@ -176,6 +191,7 @@ pub mod net_test_utils {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::anyhow;
     use scopeguard::defer;
     use test_utils::skip_if_not_root;
 
@@ -184,6 +200,27 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_is_busy_or_exist_shapes() {
+        let io_busy = anyhow!(io::Error::from_raw_os_error(libc::EBUSY)).context("tun set iff");
+        assert!(is_busy_or_exist(&io_busy));
+
+        let io_exist = anyhow!(io::Error::from_raw_os_error(libc::EEXIST)).context("tun set iff");
+        assert!(is_busy_or_exist(&io_exist));
+
+        let nix_busy = anyhow!(nix::Error::EBUSY).context("tun set iff");
+        assert!(is_busy_or_exist(&nix_busy));
+
+        let errno_busy = anyhow!(nix::errno::Errno::EBUSY).context("tun set iff");
+        assert!(is_busy_or_exist(&errno_busy));
+
+        let text = anyhow!("EBUSY: Device or resource busy");
+        assert!(is_busy_or_exist(&text));
+
+        let other = anyhow!(io::Error::from_raw_os_error(libc::EINVAL)).context("tun set iff");
+        assert!(!is_busy_or_exist(&other));
+    }
 
     #[actix_rt::test]
     async fn test_create_link() {

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -5,7 +5,7 @@
 //
 
 mod create;
-pub use create::{create_link, LinkType};
+pub use create::{create_link, delete_link, is_busy_or_exist, LinkType};
 mod driver_info;
 pub use driver_info::get_driver_info;
 mod macros;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -956,152 +956,180 @@ impl Sandbox for VirtSandbox {
         }
         let sandbox_config = self.sandbox_config.as_ref().unwrap();
 
-        // if sandbox is not in SandboxState::Init then return,
-        // otherwise try to create sandbox
-
-        let mut inner = self.inner.write().await;
-        if inner.state != SandboxState::Init {
-            warn!(sl!(), "sandbox is started");
-            return Ok(());
+        // Only hold the sandbox lock for the Init check — NOT across start_vm /
+        // agent connect / device setup. Holding write across the whole bring-up
+        // blocked Task/State RPCs (StateProcess timed out) while QEMU was
+        // already dead, which is the wedge we hit on am-b200-38 (fix5).
+        {
+            let inner = self.inner.read().await;
+            if inner.state != SandboxState::Init {
+                warn!(sl!(), "sandbox is started");
+                return Ok(());
+            }
         }
+
         let selinux_label = load_oci_spec().ok().and_then(|spec| {
             spec.process()
                 .as_ref()
                 .and_then(|process| process.selinux_label().clone())
         });
 
-        self.hypervisor
-            .prepare_vm(
-                id,
-                sandbox_config.network_env.netns.clone(),
-                &sandbox_config.annotations,
-                selinux_label,
-            )
-            .await
-            .context("prepare vm")?;
+        let start_result = async {
+            self.hypervisor
+                .prepare_vm(
+                    id,
+                    sandbox_config.network_env.netns.clone(),
+                    &sandbox_config.annotations,
+                    selinux_label,
+                )
+                .await
+                .context("prepare vm")?;
 
-        // generate device and setup before start vm
-        // should after hypervisor.prepare_vm
-        let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
+            // generate device and setup before start vm
+            // should after hypervisor.prepare_vm
+            let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
 
-        self.resource_manager
-            .prepare_before_start_vm(resources)
-            .await
-            .context("set up device before start vm")?;
+            self.resource_manager
+                .prepare_before_start_vm(resources)
+                .await
+                .context("set up device before start vm")?;
 
-        // start vm
-        self.hypervisor.start_vm(10_000).await.context("start vm")?;
-        info!(sl!(), "start vm");
+            // start vm
+            self.hypervisor.start_vm(10_000).await.context("start vm")?;
+            info!(sl!(), "start vm");
 
-        let sandbox = self.clone();
-        // wait for vm exit in background, and record the exit status and time when vm exited.
-        tokio::spawn(async move {
-            match sandbox.hypervisor.wait_vm().await {
-                Ok(exit_code) => {
-                    sandbox
-                        .record_stop(exit_code as u32, SystemTime::now())
-                        .await;
+            let sandbox = self.clone();
+            // wait for vm exit in background, and record the exit status and time when vm exited.
+            tokio::spawn(async move {
+                match sandbox.hypervisor.wait_vm().await {
+                    Ok(exit_code) => {
+                        sandbox
+                            .record_stop(exit_code as u32, SystemTime::now())
+                            .await;
+                    }
+                    Err(err) => {
+                        warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
+                        sandbox.record_stop(255, SystemTime::now()).await;
+                    }
                 }
-                Err(err) => {
-                    warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
-                    sandbox.record_stop(255, SystemTime::now()).await;
+            });
+
+            // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
+            let (prestart_hooks, create_runtime_hooks) =
+                if let Some(hooks) = sandbox_config.hooks.as_ref() {
+                    (
+                        hooks.prestart().clone().unwrap_or_default(),
+                        hooks.create_runtime().clone().unwrap_or_default(),
+                    )
+                } else {
+                    (Vec::new(), Vec::new())
+                };
+
+            self.execute_oci_hook_functions(
+                &prestart_hooks,
+                &create_runtime_hooks,
+                &sandbox_config.state,
+            )
+            .await?;
+
+            // 1. if there are pre-start hook functions, network config might have been changed.
+            //    We need to rescan the netns to handle the change.
+            // 2. Do not scan the netns if we want no network for the VM.
+            // TODO In case of vm factory, scan the netns to hotplug interfaces after the VM is started.
+            let config = self.resource_manager.config().await;
+            if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
+                && !config.runtime.disable_new_netns
+                && !dan_config_path(&config, &self.sid).exists()
+            {
+                if let Some(netns_path) = &sandbox_config.network_env.netns {
+                    let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
+                        network_model: config.runtime.internetworking_model.clone(),
+                        netns_path: netns_path.to_owned(),
+                        queues: self
+                            .hypervisor
+                            .hypervisor_config()
+                            .await
+                            .network_info
+                            .network_queues as usize,
+                        network_created: sandbox_config.network_env.network_created,
+                    });
+                    self.resource_manager
+                        .handle_network(network_resource)
+                        .await
+                        .context("set up device after start vm")?;
                 }
             }
-        });
 
-        // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
-        let (prestart_hooks, create_runtime_hooks) =
-            if let Some(hooks) = sandbox_config.hooks.as_ref() {
-                (
-                    hooks.prestart().clone().unwrap_or_default(),
-                    hooks.create_runtime().clone().unwrap_or_default(),
-                )
-            } else {
-                (Vec::new(), Vec::new())
+            // connect agent
+            // set agent socket
+            let address = self
+                .hypervisor
+                .get_agent_socket()
+                .await
+                .context("get agent socket")?;
+            self.agent
+                .start(&address)
+                .await
+                .context(format!("connect to address {:?}", &address))?;
+            self.set_agent_policy().await.context("set agent policy")?;
+
+            self.resource_manager
+                .setup_after_start_vm()
+                .await
+                .context("setup device after start vm")?;
+
+            // create sandbox in vm
+            let agent_config = self.agent.agent_config().await;
+            let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
+            let req = agent::CreateSandboxRequest {
+                hostname: sandbox_config.hostname.clone(),
+                dns: sandbox_config.dns.clone(),
+                storages: self
+                    .resource_manager
+                    .get_storage_for_sandbox(self.shm_size)
+                    .await
+                    .context("get storages for sandbox")?,
+                sandbox_pidns: false,
+                sandbox_id: id.to_string(),
+                guest_hook_path: self
+                    .hypervisor
+                    .hypervisor_config()
+                    .await
+                    .security_info
+                    .guest_hook_path,
+                kernel_modules,
             };
 
-        self.execute_oci_hook_functions(
-            &prestart_hooks,
-            &create_runtime_hooks,
-            &sandbox_config.state,
-        )
-        .await?;
+            self.agent
+                .create_sandbox(req)
+                .await
+                .context("create sandbox")?;
 
-        // 1. if there are pre-start hook functions, network config might have been changed.
-        //    We need to rescan the netns to handle the change.
-        // 2. Do not scan the netns if we want no network for the VM.
-        // TODO In case of vm factory, scan the netns to hotplug interfaces after the VM is started.
-        let config = self.resource_manager.config().await;
-        if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
-            && !config.runtime.disable_new_netns
-            && !dan_config_path(&config, &self.sid).exists()
-        {
-            if let Some(netns_path) = &sandbox_config.network_env.netns {
-                let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
-                    network_model: config.runtime.internetworking_model.clone(),
-                    netns_path: netns_path.to_owned(),
-                    queues: self
-                        .hypervisor
-                        .hypervisor_config()
-                        .await
-                        .network_info
-                        .network_queues as usize,
-                    network_created: sandbox_config.network_env.network_created,
-                });
-                self.resource_manager
-                    .handle_network(network_resource)
-                    .await
-                    .context("set up device after start vm")?;
-            }
+            Ok(())
+        }
+        .await;
+
+        if let Err(ref e) = start_result {
+            // CreateContainer returns Err without calling StopSandbox when start
+            // fails — previously that left a running/zombie QEMU behind. stop_vm
+            // now also reaps (fix5).
+            error!(
+                sl!(),
+                "sandbox start failed: {:#}; stopping QEMU to prevent zombie", e
+            );
+            let _ = self.hypervisor.stop_vm().await;
+            return start_result;
         }
 
-        // connect agent
-        // set agent socket
-        let address = self
-            .hypervisor
-            .get_agent_socket()
-            .await
-            .context("get agent socket")?;
-        self.agent
-            .start(&address)
-            .await
-            .context(format!("connect to address {:?}", &address))?;
-        self.set_agent_policy().await.context("set agent policy")?;
-
-        self.resource_manager
-            .setup_after_start_vm()
-            .await
-            .context("setup device after start vm")?;
-
-        // create sandbox in vm
-        let agent_config = self.agent.agent_config().await;
-        let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
-        let req = agent::CreateSandboxRequest {
-            hostname: sandbox_config.hostname.clone(),
-            dns: sandbox_config.dns.clone(),
-            storages: self
-                .resource_manager
-                .get_storage_for_sandbox(self.shm_size)
-                .await
-                .context("get storages for sandbox")?,
-            sandbox_pidns: false,
-            sandbox_id: id.to_string(),
-            guest_hook_path: self
-                .hypervisor
-                .hypervisor_config()
-                .await
-                .security_info
-                .guest_hook_path,
-            kernel_modules,
-        };
-
-        self.agent
-            .create_sandbox(req)
-            .await
-            .context("create sandbox")?;
-
-        inner.state = SandboxState::Running;
-        inner.created_at = Some(std::time::SystemTime::now());
+        {
+            let mut inner = self.inner.write().await;
+            if inner.state != SandboxState::Init {
+                warn!(sl!(), "sandbox left Init during start; skipping Running transition");
+                return Ok(());
+            }
+            inner.state = SandboxState::Running;
+            inner.created_at = Some(std::time::SystemTime::now());
+        }
 
         // get and store guest details
         self.store_guest_details()

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1156,11 +1156,20 @@ impl Sandbox for VirtSandbox {
             // fails — previously that left a running/zombie QEMU behind. stop_vm
             // now also reaps (fix5). Also release host taps (IFF_PERSIST) so a
             // retry does not hit TUNSETIFF EBUSY (fix7).
+            //
+            // fix12: use stop_vm_for_start_fail (bounded join) — non-blocking
+            // stop_vm (fix9, correct for Shutdown) races CreateContainer retries
+            // while QEMU still holds tap FDs → TUNSETIFF EBUSY.
             error!(
                 sl!(),
                 "sandbox start failed: {:#}; stopping QEMU and releasing network", e
             );
-            let _ = self.hypervisor.stop_vm().await;
+            const START_FAIL_REAP_TIMEOUT: std::time::Duration =
+                std::time::Duration::from_secs(60);
+            let _ = self
+                .hypervisor
+                .stop_vm_for_start_fail(START_FAIL_REAP_TIMEOUT)
+                .await;
             if let Err(net_err) = self.resource_manager.release_network().await {
                 warn!(
                     sl!(),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1377,9 +1377,16 @@ impl Sandbox for VirtSandbox {
             return Ok(());
         }
 
+        // fix9 (kata-containers#13564): stop_vm() only start_kill's QEMU and
+        // returns. Do NOT await wait() for the full reclaim of a large TDX/CC
+        // guest (can be many minutes) — that blocks Shutdown until containerd
+        // SIGKILLs the shim, orphaning a still-live QEMU under init. Mark
+        // Stopped now; the start_vm background wait_vm waiter reaps; QEMU's
+        // PR_SET_PDEATHSIG covers shim exit/death. Same pattern as the
+        // Init/Starting branch above.
         self.hypervisor.stop_vm().await.context("stop vm")?;
-        self.wait().await.context("wait for vm exit after stop")?;
-        info!(sl!(), "sandbox stopped");
+        self.record_stop(0, SystemTime::now()).await;
+        info!(sl!(), "sandbox stop signaled (not waiting for qemu exit)");
 
         Ok(())
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1381,9 +1381,10 @@ impl Sandbox for VirtSandbox {
         // returns. Do NOT await wait() for the full reclaim of a large TDX/CC
         // guest (can be many minutes) — that blocks Shutdown until containerd
         // SIGKILLs the shim, orphaning a still-live QEMU under init. Mark
-        // Stopped now; the start_vm background wait_vm waiter reaps; QEMU's
-        // PR_SET_PDEATHSIG covers shim exit/death. Same pattern as the
-        // Init/Starting branch above.
+        // Stopped now; QEMU's PR_SET_PDEATHSIG covers shim exit/death.
+        // fix10: stop_vm takes the Child and reaps on an OS thread (try_wait),
+        // so a cancelled tokio wait_vm cannot leave a zombie under an orphaned
+        // shim. Same non-blocking pattern as the Init/Starting branch above.
         self.hypervisor.stop_vm().await.context("stop vm")?;
         self.record_stop(0, SystemTime::now()).await;
         info!(sl!(), "sandbox stop signaled (not waiting for qemu exit)");

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -43,8 +43,6 @@ use hypervisor::HYPERVISOR_REMOTE;
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
-#[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
-use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
     utils::{get_hvsock_path, uses_native_ccw_bus},
@@ -97,6 +95,10 @@ pub struct SandboxRestoreArgs {
 #[derive(Clone, Copy, PartialEq, Debug, Display)]
 pub enum SandboxState {
     Init,
+    /// Bring-up in progress (network + QEMU + agent). Distinct from Init so
+    /// concurrent CreateContainer calls do not re-enter `start()` and hit
+    /// TUNSETIFF EBUSY on an already-created `tapN_kata`.
+    Starting,
     Running,
     Stopped,
 }
@@ -105,7 +107,9 @@ impl SandboxState {
     fn to_cri_state(self) -> &'static str {
         match self {
             SandboxState::Running => "SANDBOX_READY",
-            SandboxState::Init | SandboxState::Stopped => "SANDBOX_NOTREADY",
+            SandboxState::Init | SandboxState::Starting | SandboxState::Stopped => {
+                "SANDBOX_NOTREADY"
+            }
         }
     }
 }
@@ -137,6 +141,10 @@ pub struct VirtSandbox {
     sid: String,
     msg_sender: Arc<Mutex<Sender<Message>>>,
     inner: Arc<RwLock<SandboxInner>>,
+    /// Serializes `sandbox.start()` without holding `inner` write across the
+    /// long QEMU/agent bring-up (fix5). Concurrent CreateContainer retries wait
+    /// here instead of racing `prepare_before_start_vm` / tap creation.
+    start_mutex: Arc<Mutex<()>>,
     resource_manager: Arc<ResourceManager>,
     agent: Arc<dyn Agent>,
     hypervisor: Arc<dyn Hypervisor>,
@@ -183,6 +191,7 @@ impl VirtSandbox {
             sid: sid.to_string(),
             msg_sender: Arc::new(Mutex::new(msg_sender)),
             inner: Arc::new(RwLock::new(SandboxInner::new())),
+            start_mutex: Arc::new(Mutex::new(())),
             agent,
             hypervisor,
             resource_manager,
@@ -956,15 +965,48 @@ impl Sandbox for VirtSandbox {
         }
         let sandbox_config = self.sandbox_config.as_ref().unwrap();
 
-        // Only hold the sandbox lock for the Init check — NOT across start_vm /
-        // agent connect / device setup. Holding write across the whole bring-up
-        // blocked Task/State RPCs (StateProcess timed out) while QEMU was
-        // already dead, which is the wedge we hit on am-b200-38 (fix5).
+        // Fast path: already running — CreateContainer for the app container
+        // after the sandbox container brought the VM up.
         {
             let inner = self.inner.read().await;
-            if inner.state != SandboxState::Init {
-                warn!(sl!(), "sandbox is started");
-                return Ok(());
+            match inner.state {
+                SandboxState::Running => {
+                    warn!(sl!(), "sandbox is started");
+                    return Ok(());
+                }
+                SandboxState::Stopped => {
+                    return Err(anyhow!("sandbox already stopped"));
+                }
+                SandboxState::Init | SandboxState::Starting => {}
+            }
+        }
+
+        // Serialize bring-up. Do NOT hold `inner` write across QEMU/agent
+        // (fix5): that blocked Task/State RPCs. The start_mutex alone stops
+        // concurrent CreateContainer from racing tap creation (fix7 /
+        // kata-containers#13564 follow-up — TUNSETIFF EBUSY on tap0_kata).
+        let _start_guard = self.start_mutex.lock().await;
+
+        {
+            let mut inner = self.inner.write().await;
+            match inner.state {
+                SandboxState::Running => {
+                    warn!(sl!(), "sandbox is started");
+                    return Ok(());
+                }
+                SandboxState::Stopped => {
+                    return Err(anyhow!("sandbox already stopped"));
+                }
+                SandboxState::Starting => {
+                    // Should not happen under start_mutex; treat as in-progress
+                    // owner that somehow dropped the mutex — fail closed.
+                    return Err(anyhow!(
+                        "sandbox start already in progress (state=Starting)"
+                    ));
+                }
+                SandboxState::Init => {
+                    inner.state = SandboxState::Starting;
+                }
             }
         }
 
@@ -1112,19 +1154,36 @@ impl Sandbox for VirtSandbox {
         if let Err(ref e) = start_result {
             // CreateContainer returns Err without calling StopSandbox when start
             // fails — previously that left a running/zombie QEMU behind. stop_vm
-            // now also reaps (fix5).
+            // now also reaps (fix5). Also release host taps (IFF_PERSIST) so a
+            // retry does not hit TUNSETIFF EBUSY (fix7).
             error!(
                 sl!(),
-                "sandbox start failed: {:#}; stopping QEMU to prevent zombie", e
+                "sandbox start failed: {:#}; stopping QEMU and releasing network", e
             );
             let _ = self.hypervisor.stop_vm().await;
+            if let Err(net_err) = self.resource_manager.release_network().await {
+                warn!(
+                    sl!(),
+                    "failed to release network after start failure: {:#}", net_err
+                );
+            }
+            {
+                let mut inner = self.inner.write().await;
+                if inner.state == SandboxState::Starting {
+                    inner.state = SandboxState::Init;
+                }
+            }
             return start_result;
         }
 
         {
             let mut inner = self.inner.write().await;
-            if inner.state != SandboxState::Init {
-                warn!(sl!(), "sandbox left Init during start; skipping Running transition");
+            if inner.state != SandboxState::Starting {
+                warn!(
+                    sl!(),
+                    "sandbox left Starting during start (state={:?}); skipping Running transition",
+                    inner.state
+                );
                 return Ok(());
             }
             inner.state = SandboxState::Running;
@@ -1306,10 +1365,15 @@ impl Sandbox for VirtSandbox {
         self.cancel_token.cancel();
 
         info!(sl!(), "begin stop sandbox");
-        if state == SandboxState::Init {
+        if state == SandboxState::Init || state == SandboxState::Starting {
+            // Serialize with an in-flight start() so we don't race tap/QEMU teardown.
+            let _start_guard = self.start_mutex.lock().await;
             let _ = self.hypervisor.stop_vm().await;
+            if let Err(err) = self.resource_manager.release_network().await {
+                warn!(sl!(), "failed to release network during stop: {:#}", err);
+            }
             self.record_stop(0, SystemTime::now()).await;
-            info!(sl!(), "sandbox stopped during Init");
+            info!(sl!(), "sandbox stopped during {:?}", state);
             return Ok(());
         }
 
@@ -1524,8 +1588,6 @@ impl Persist for VirtSandbox {
                 HYPERVISOR_FIRECRACKER => Ok(Some(hypervisor_state)),
                 HYPERVISOR_QEMU => Ok(Some(hypervisor_state)),
                 HYPERVISOR_REMOTE => Ok(Some(hypervisor_state)),
-                #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
-                HYPERVISOR_NAME_OPENVMM => Ok(Some(hypervisor_state)),
                 _ => Err(anyhow!(
                     "Unsupported hypervisor {}",
                     hypervisor_state.hypervisor_type
@@ -1588,11 +1650,6 @@ impl Persist for VirtSandbox {
                 let hypervisor = Arc::new(Remote::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)
             }
-            #[cfg(all(feature = "openvmm", target_arch = "x86_64"))]
-            HYPERVISOR_NAME_OPENVMM => {
-                let hypervisor = Arc::new(OpenVmm::restore((), h).await?) as Arc<dyn Hypervisor>;
-                Ok(hypervisor)
-            }
             _ => Err(anyhow!("Unsupported hypervisor {}", &h.hypervisor_type)),
         }?;
         let agent = Arc::new(KataAgent::new(kata_types::config::Agent::default()));
@@ -1609,6 +1666,7 @@ impl Persist for VirtSandbox {
             sid: sid.to_string(),
             msg_sender: Arc::new(Mutex::new(sandbox_args.sender)),
             inner: Arc::new(RwLock::new(SandboxInner::new())),
+            start_mutex: Arc::new(Mutex::new(())),
             agent,
             hypervisor,
             resource_manager,


### PR DESCRIPTION
## Summary

Two tightly related production bugs in `runtime-rs` on slow confidential-compute (CC) GPU boots, plus a follow-up start-path hang that left zombie QEMU when QMP never came up:

### A. Zombie / orphan QEMU on `start_vm` failure — Fixes #13564

When `start_vm()` fails after the child is spawned, the Go runtime reaps via `LogAndWait`, but Rust left the process as a zombie and the shim stuck in `Task/State` timeouts (often requiring a node reboot / host kill).

**fix4** only cleaned up on QMP-init and `boot_from_template` errors — **insufficient in production** (HGX B200 + TDX).

**fix5**:
1. Cleanup guard on **any** `start_vm` `Err` after QEMU spawn → `stop_vm` + `wait_vm`
2. `Qemu::stop_vm` always attempts reap after kill
3. `sandbox.start()` releases the write lock during bring-up and calls `stop_vm` on failure (so `StateProcess` is not blocked)

**fix8–fix10** (teardown path on large TDX guests):
- fix8: `start_kill` without holding wait locks across multi-minute reclaim
- fix9: `PR_SET_PDEATHSIG(SIGKILL)` + non-blocking Shutdown (no await reclaim in stop path)
- fix10: `stop_vm`/`wait_vm` **take** the QEMU `Child` and reap on an **OS thread** (`try_wait` loop) so a cancelled tokio waiter cannot leave zombie QEMU under an orphaned live shim

### B. Concurrent `CreateContainer` → `TUNSETIFF EBUSY` — Fixes #13574 ⭐ breakthrough

fix5's write-lock release made a second race reachable: while the first start blocks for **minutes** on agent vsock (NVRC / 8×GPU CC), containerd retries `CreateContainer`, re-enters `sandbox.start()`, and races `TUNSETIFF` on the already-created **IFF_PERSIST** `tap0_kata` → `EBUSY: Device or resource busy`. Host ends with orphan shim + live TDX QEMU holding all GPUs.

**fix7**:
1. `start_mutex` + `SandboxState::Starting` — serialize bring-up; `Running` is a fast no-op
2. On start failure: `stop_vm` + **`release_network`** (delete persist taps) + reset to `Init`
3. `create_link`: reuse tap on `EBUSY`/`EEXIST`
4. veth detach deletes `tapN_kata`

Related: #13343 (slow / inconsistent VM-start timeouts widen the CreateContainer retry window).

### C. Unbounded QMP connect hang → Z QEMU on start — **fix11 (under production test)**

Even with fix5/fix10 cleanup, `Qmp::new` used unbounded `UnixStream::connect` while the parent still held the QMP listen FD (`unix:fd=`). When QEMU died (or never spoke QMP), connect could block forever — the 50s deadline never fired, Err-path cleanup never ran, and QEMU stayed **Z** under the shim (`Task/State` timeout loop). Hit on HGX B200 + TDX (glm-0).

**fix11** (latest commit on this PR):
1. Timed/nonblocking QMP `connect(2)` (hard per-attempt timeout)
2. `Child::try_wait` each retry → fail fast if QEMU already exited
3. Drop the parent's QMP listen FD after spawn so a dead QEMU yields `ECONNREFUSED` instead of a forever hang
4. Start-fail cleanup uses the fix10 OS-thread reaper (not a cancellable `wait_vm` await)

## Production verification (2026-08-08 → 2026-08-09)

Deployed via shim overlay on Intel TDX + NVIDIA GPU CC (HGX B200):

| Stage | Result |
|-------|--------|
| fix5 alone | Reap works; **new** EBUSY race on glm CC replicas |
| fix7 | **CreateContainer=1, EBUSY=0** on both replicas; both reached `Running` / container Started after ~8–9 min agent wait |
| fix10 | Stops cancelled-tokio-wait → Z under orphaned shim (teardown path) |
| **fix11** | **Currently under production test** on the same B200+TDX cluster (overlay rolled out; exercising start-path QMP hang / cleanup). Will report results here. |

Nodes: `am-b200-34`, `am-b200-38`. Workload: 8×GPU TDX guest, ~1.2 TiB memory.

## Test plan

- [x] fix5: after cold reboot of wedged node — 0 QEMU zombies
- [x] fix7: no TUNSETIFF EBUSY under concurrent CreateContainer during multi-minute agent connect
- [x] Both glm CC replicas Running with single CreateContainer
- [x] fix10: OS-thread reaper — no Z QEMU under orphaned shim after non-blocking stop
- [ ] **fix11: production test in progress** — confirm QMP connect cannot hang forever; start-fail path reaps via OS thread; no Z QEMU / `Task/State` wedge on QMP bring-up failure
- [ ] CI / unit coverage for Starting state + EBUSY reuse (happy to add)

## Out of scope (separate work)

- Configurable / longer VM-start deadline end-to-end (#13343) — fix11 bounds *connect*; overall agent/NVRC latency is separate
- Returning QEMU stderr in the startup error
- Broader sandbox resource cleanup (#13424)

Made with [Cursor](https://cursor.com)