### PR TITLE
kata-ctl: add cp, and let exec run a single command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,12 +605,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -3679,7 +3673,7 @@ version = "0.0.1"
 dependencies = [
  "agent",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes 1.11.1",
  "chrono",
  "clap",
@@ -3715,6 +3709,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "sys-info",
+ "tar",
  "tempfile",
  "test-utils",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ slog-term = "2.9.0"
 strum = { version = "0.24.0", features = ["derive"] }
 strum_macros = "0.26.2"
 sysinfo = "0.39.5"
+tar = "0.4.46"
 tdx = "0.1.1"
 tempfile = "3.19.1"
 thiserror = "2.0.18"

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -22,7 +22,8 @@ strum_macros = "0.24.3"
 serde.workspace = true
 url.workspace = true
 futures.workspace = true
-base64 = "0.13.0"
+base64.workspace = true
+tar.workspace = true
 toml.workspace = true
 sys-info = "0.9.1"
 

--- a/src/tools/kata-ctl/src/args.rs
+++ b/src/tools/kata-ctl/src/args.rs
@@ -49,6 +49,9 @@ pub enum Commands {
     /// Test if system can run Kata Containers
     Check(CheckArgument),
 
+    /// Copy files and directories between the host and a guest VM
+    Cp(CpArguments),
+
     /// Directly assign a volume to Kata Containers to manage
     DirectVolume(DirectVolumeCommand),
 
@@ -219,6 +222,28 @@ pub struct ExecArguments {
     /// debug console carries a single stream, so the command's stderr arrives
     /// interleaved on stdout; kata-ctl exits with the command's exit status.
     pub command: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+#[clap(
+    after_help = "Copies travel over the agent debug console, so the sandbox has to have been \
+started with it enabled, and the guest needs the devkit extension for the \
+shell, tar and base64 a copy drives there. A kata-<shim>-devkit RuntimeClass \
+gives you both.
+
+EXAMPLES:
+    kata-ctl cp ./tool <sandbox-id>:/tmp/tool
+    kata-ctl cp <sandbox-id>:/var/log ./guest-logs"
+)]
+pub struct CpArguments {
+    /// Source: either a host path, or <sandbox-id>:<absolute-guest-path>.
+    pub src: String,
+    /// Destination: either a host path, or <sandbox-id>:<absolute-guest-path>.
+    /// An existing directory is copied into, anything else names the copy.
+    pub dst: String,
+    #[clap(short = 'p', long = "kata-debug-port", default_value_t = 1026)]
+    /// kata debug console vport same as configuration, default is 1026.
+    pub vport: u32,
 }
 
 #[derive(Args, Debug)]

--- a/src/tools/kata-ctl/src/args.rs
+++ b/src/tools/kata-ctl/src/args.rs
@@ -55,7 +55,7 @@ pub enum Commands {
     /// Display settings
     Env(EnvArgument),
 
-    /// Enter into guest VM by debug console
+    /// Enter into guest VM by debug console, or run a single command there
     Exec(ExecArguments),
 
     /// Manage VM factory
@@ -213,6 +213,12 @@ pub struct ExecArguments {
     #[clap(short = 'p', long = "kata-debug-port", default_value_t = 1026)]
     /// kata debug console vport same as configuration, default is 1026.
     pub vport: u32,
+    #[clap(last = true)]
+    /// Command to run in the guest, e.g. `kata-ctl exec <sandbox-id> -- ls -l /`.
+    /// Without one, a terminal is attached to the console shell instead. The
+    /// debug console carries a single stream, so the command's stderr arrives
+    /// interleaved on stdout; kata-ctl exits with the command's exit status.
+    pub command: Vec<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/tools/kata-ctl/src/debug_console.rs
+++ b/src/tools/kata-ctl/src/debug_console.rs
@@ -1,0 +1,642 @@
+// Copyright (c) 2022 Ant Group
+// Copyright (c) Kata Containers Community
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description:
+// Client side of the kata-agent debug console: the vsock / hybrid vsock
+// transport, and a request/response protocol layered on top of the PTY-backed
+// shell the agent execs there, so a caller can run one command and collect its
+// output and exit status instead of only attaching a terminal to the console.
+
+use std::{
+    io::{self, BufRead, BufReader, Read, Write},
+    os::unix::{
+        io::{AsRawFd, FromRawFd, IntoRawFd},
+        net::UnixStream,
+    },
+    process,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use http_body_util::BodyExt;
+use hyper::StatusCode;
+use nix::sys::socket::{
+    connect as vsock_connect, socket, AddressFamily, SockFlag, SockType, VsockAddr,
+};
+use slog::{debug, o};
+
+use shim_interface::shim_mgmt::{client::MgmtClient, AGENT_URL};
+
+use crate::utils::TIMEOUT;
+
+const CMD_CONNECT: &str = "CONNECT";
+const CMD_OK: &str = "OK";
+const SCHEME_VSOCK: &str = "VSOCK";
+const SCHEME_HYBRID_VSOCK: &str = "HVSOCK";
+
+const KATA_AGENT_VSOCK_TIMEOUT: u64 = 5;
+
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "debug_console"))
+    };
+}
+
+trait SockHandler {
+    fn setup_sock(&self) -> Result<UnixStream>;
+}
+
+struct VsockConfig {
+    sock_cid: u32,
+    sock_port: u32,
+}
+
+impl VsockConfig {
+    fn new(sock_cid: u32, sock_port: u32) -> VsockConfig {
+        VsockConfig {
+            sock_cid,
+            sock_port,
+        }
+    }
+}
+
+impl SockHandler for VsockConfig {
+    fn setup_sock(&self) -> Result<UnixStream> {
+        let sock_addr = VsockAddr::new(self.sock_cid, self.sock_port);
+
+        // Create socket fd
+        let vsock_fd = socket(
+            AddressFamily::Vsock,
+            SockType::Stream,
+            SockFlag::SOCK_CLOEXEC,
+            None,
+        )
+        .context("create vsock socket")?;
+
+        // Wrap the socket fd in UnixStream, so that it is closed
+        // when anything fails.
+        let stream = unsafe { UnixStream::from_raw_fd(vsock_fd.into_raw_fd()) };
+        // Connect the socket to vsock server.
+        vsock_connect(stream.as_raw_fd(), &sock_addr)
+            .with_context(|| format!("failed to connect to server {:?}", &sock_addr))?;
+
+        Ok(stream)
+    }
+}
+
+struct HvsockConfig {
+    sock_addr: String,
+    sock_port: u32,
+}
+
+impl HvsockConfig {
+    fn new(sock_addr: String, sock_port: u32) -> Self {
+        HvsockConfig {
+            sock_addr,
+            sock_port,
+        }
+    }
+}
+
+impl SockHandler for HvsockConfig {
+    fn setup_sock(&self) -> Result<UnixStream> {
+        let mut stream = match UnixStream::connect(self.sock_addr.clone()) {
+            Ok(s) => s,
+            Err(e) => return Err(anyhow!(e).context("failed to create UNIX Stream socket")),
+        };
+
+        // Ensure the Unix Stream directly connects to the real VSOCK server which
+        // the Kata agent is listening to in the VM.
+        {
+            let test_msg = format!("{} {}\n", CMD_CONNECT, self.sock_port);
+
+            stream.set_read_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
+            stream.set_write_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
+
+            stream.write_all(test_msg.as_bytes())?;
+            // Now, see if we get the expected response
+            let stream_reader = stream.try_clone()?;
+            let mut reader = BufReader::new(&stream_reader);
+            let mut msg = String::new();
+
+            reader.read_line(&mut msg)?;
+            if msg.is_empty() {
+                return Err(anyhow!(
+                    "stream reader get message is empty with port: {:?}",
+                    self.sock_port
+                ));
+            }
+
+            // Expected response message returned was successful.
+            if msg.starts_with(CMD_OK) {
+                let response = msg
+                    .strip_prefix(CMD_OK)
+                    .ok_or(format!("invalid response: {msg:?}"))
+                    .map_err(|e| anyhow!(e))?
+                    .trim();
+                debug!(sl!(), "Hybrid Vsock host-side port: {:?}", response);
+                // Unset the timeout in order to turn the sokect to bloking mode.
+                stream.set_read_timeout(None)?;
+                stream.set_write_timeout(None)?;
+            } else {
+                return Err(anyhow!(
+                    "failed to setup Hybrid Vsock connection: {:?}",
+                    msg
+                ));
+            }
+        }
+
+        Ok(stream)
+    }
+}
+
+fn setup_client(server_url: String, dbg_console_port: u32) -> Result<UnixStream> {
+    // server address format: scheme://[cid|/x/domain.sock]:port
+    let url_fields: Vec<&str> = server_url.split("://").collect();
+    if url_fields.len() != 2 {
+        return Err(anyhow!("invalid URI"));
+    }
+
+    let scheme = url_fields[0].to_uppercase();
+    let sock_addr: Vec<&str> = url_fields[1].split(':').collect();
+    if sock_addr.len() != 2 {
+        return Err(anyhow!("invalid VSOCK server address URI"));
+    }
+
+    match scheme.as_str() {
+        // Hybrid Vsock: hvsock://<path>:<port>.
+        // Example: "hvsock:///x/y/z/kata.hvsock:port"
+        // Firecracker/Dragonball/CLH implements the hybrid vsock device model.
+        SCHEME_HYBRID_VSOCK => {
+            let hvsock_path = sock_addr[0].to_string();
+            if hvsock_path.is_empty() {
+                return Err(anyhow!("hvsock path cannot be empty"));
+            }
+
+            let hvsock = HvsockConfig::new(hvsock_path, dbg_console_port);
+            hvsock.setup_sock().context("set up hvsock")
+        }
+        // Vsock: vsock://<cid>:<port>
+        // Example: "vsock://31513974:1024"
+        // Qemu using the Vsock device model.
+        SCHEME_VSOCK => {
+            let sock_cid: u32 = match sock_addr[0] {
+                "-1" | "" => libc::VMADDR_CID_ANY,
+                _ => match sock_addr[0].parse::<u32>() {
+                    Ok(cid) => cid,
+                    Err(e) => return Err(anyhow!("vsock addr CID is INVALID: {:?}", e)),
+                },
+            };
+
+            let vsock = VsockConfig::new(sock_cid, dbg_console_port);
+            vsock.setup_sock().context("set up vsock")
+        }
+        // Others will be INVALID URI.
+        _ => Err(anyhow!("invalid URI scheme: {:?}", scheme)),
+    }
+}
+
+async fn get_agent_socket(sandbox_id: &str) -> Result<String> {
+    let shim_client = MgmtClient::new(sandbox_id, Some(TIMEOUT))?;
+
+    // get agent sock from body when status code is OK.
+    let response = shim_client.get(AGENT_URL).await?;
+    let status = response.status();
+    if status != StatusCode::OK {
+        return Err(anyhow!("shim client get connection failed: {:?} ", status));
+    }
+
+    let body = response.into_body().collect().await?.to_bytes();
+    let agent_sock = String::from_utf8(body.to_vec())?;
+
+    Ok(agent_sock)
+}
+
+fn get_server_socket(sandbox_id: &str) -> Result<String> {
+    let server_url = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(get_agent_socket(sandbox_id))
+        .context("get connection vsock")?;
+
+    Ok(server_url)
+}
+
+/// Connect to the debug console the agent of `sandbox_id` serves on `vport`.
+pub fn connect(sandbox_id: &str, vport: u32) -> Result<UnixStream> {
+    let server_url = get_server_socket(sandbox_id).context("get debug console socket URL")?;
+    if server_url.is_empty() {
+        return Err(anyhow!("server url is empty."));
+    }
+
+    setup_client(server_url, vport)
+}
+
+/// Appended to the marker to frame the output of a command. Neither is ever
+/// spelled out in what we write to the shell - both are only ever produced by
+/// expanding the variable holding the marker - so a terminal that echoes our
+/// input back can never be mistaken for the real thing.
+const BEGIN: &str = "-BEGIN";
+const END: &str = "-END:";
+
+/// How long to wait for a command to start before giving up. Only covers the
+/// round trip to the shell, never the command itself, so it can be generous:
+/// the devkit console shell assembles an overlay before it is reachable.
+const START_TIMEOUT: Duration = Duration::from_secs(300);
+
+const READ_CHUNK: usize = 8 * 1024;
+
+/// Quote `arg` so the console shell passes it on as a single word.
+pub fn shell_quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', r"'\''"))
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Undo the terminal's NL -> CR NL output translation.
+fn strip_cr(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut i = 0;
+
+    while i < data.len() {
+        if data[i] == b'\r' && data.get(i + 1) == Some(&b'\n') {
+            i += 1;
+            continue;
+        }
+        out.push(data[i]);
+        i += 1;
+    }
+
+    out
+}
+
+/// A non-interactive session on the console shell.
+///
+/// The console offers a shell on a pseudo-terminal and nothing else: no exit
+/// status, no framing, and no way to tell the shell's own chatter from what a
+/// command printed. So each command is wrapped in a pair of markers that only
+/// the guest can produce, and the status is printed after the second one.
+pub struct Session {
+    stream: UnixStream,
+    marker: String,
+    buf: Vec<u8>,
+    /// The guest is still translating NL to CR NL on output, so undo it.
+    crlf: bool,
+    prepared: bool,
+}
+
+impl Session {
+    pub fn new(stream: UnixStream) -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+
+        Session {
+            stream,
+            marker: format!("KATACTL{:x}{:x}", process::id(), nanos),
+            buf: Vec::new(),
+            crlf: false,
+            prepared: false,
+        }
+    }
+
+    /// Run `cmd` to completion, relaying its output to `sink`, and report the
+    /// exit status. The console is one stream, so this is stdout and stderr
+    /// interleaved.
+    pub fn run(&mut self, cmd: &str, sink: &mut dyn Write) -> Result<i32> {
+        self.begin(cmd)?;
+        self.finish(sink)
+    }
+
+    /// Send `cmd` and return once it is running, so the caller may then write
+    /// to its stdin over the same connection.
+    fn begin(&mut self, cmd: &str) -> Result<()> {
+        self.prepare()?;
+
+        let marker = self.marker.clone();
+        self.send(&format!(
+            "__kc_m={marker}; printf '%s\\n' \"${{__kc_m}}{BEGIN}\"; {cmd}; __kc_rc=$?; \
+             printf '%s%s\\n' \"${{__kc_m}}{END}\" \"${{__kc_rc}}\""
+        ))?;
+
+        // Anything ahead of the marker is the shell's own noise: a prompt, a
+        // login banner, or our command echoed back.
+        self.stream.set_read_timeout(Some(START_TIMEOUT))?;
+        let begin = format!("{marker}{BEGIN}");
+        self.scan(begin.as_bytes(), &mut io::sink())?;
+        self.crlf = self.consume_eol()?;
+        self.stream.set_read_timeout(None)?;
+
+        Ok(())
+    }
+
+    /// Relay the output of the command started by [`Session::begin`] to
+    /// `sink`, and report its exit status.
+    fn finish(&mut self, sink: &mut dyn Write) -> Result<i32> {
+        let end = format!("{}{END}", self.marker);
+        self.scan(end.as_bytes(), sink)?;
+
+        self.read_status()
+    }
+
+    /// Leave the shell, so the guest side tears the session down promptly.
+    pub fn close(mut self) {
+        let _ = self.send("exit");
+    }
+
+    /// Put the guest terminal in a shape we can parse: no echo of what we
+    /// write, which would otherwise be indistinguishable from command output,
+    /// and no NL -> CR NL translation, so output arrives byte for byte. Best
+    /// effort - a guest with no stty still works, [`Session::begin`] infers
+    /// the translation from how the marker line ends.
+    fn prepare(&mut self) -> Result<()> {
+        if self.prepared {
+            return Ok(());
+        }
+
+        self.send("stty -opost -echo 2>/dev/null")?;
+        self.prepared = true;
+
+        Ok(())
+    }
+
+    fn send(&mut self, line: &str) -> Result<()> {
+        self.stream
+            .write_all(format!("{line}\n").as_bytes())
+            .context("write to debug console")?;
+
+        self.stream.flush().context("flush debug console")
+    }
+
+    fn fill(&mut self) -> Result<()> {
+        let mut chunk = [0u8; READ_CHUNK];
+
+        let n = self.stream.read(&mut chunk).map_err(|e| {
+            if matches!(
+                e.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+            ) {
+                anyhow!(
+                    "timed out after {}s waiting for the guest debug console shell",
+                    START_TIMEOUT.as_secs()
+                )
+            } else {
+                anyhow!(e).context("read from debug console")
+            }
+        })?;
+
+        if n == 0 {
+            bail!("debug console closed the connection");
+        }
+
+        self.buf.extend_from_slice(&chunk[..n]);
+
+        Ok(())
+    }
+
+    fn take(&mut self, n: usize) {
+        self.buf.drain(..n);
+    }
+
+    /// Consume input up to and including `needle`, relaying everything ahead
+    /// of it to `sink`.
+    fn scan(&mut self, needle: &[u8], sink: &mut dyn Write) -> Result<()> {
+        loop {
+            if let Some(at) = find(&self.buf, needle) {
+                self.emit(at, sink)?;
+                self.take(needle.len());
+                return Ok(());
+            }
+
+            // Hand over everything that cannot still turn out to be the head
+            // of the marker, or the CR of a CR LF whose LF has yet to arrive.
+            let hold = needle.len() - 1;
+            if self.buf.len() > hold {
+                let mut upto = self.buf.len() - hold;
+                if self.crlf && self.buf[upto - 1] == b'\r' {
+                    upto -= 1;
+                }
+                self.emit(upto, sink)?;
+            }
+
+            self.fill()?;
+        }
+    }
+
+    fn emit(&mut self, n: usize, sink: &mut dyn Write) -> Result<()> {
+        if n == 0 {
+            return Ok(());
+        }
+
+        let chunk: Vec<u8> = self.buf.drain(..n).collect();
+        let chunk = if self.crlf { strip_cr(&chunk) } else { chunk };
+
+        sink.write_all(&chunk).context("relay debug console output")
+    }
+
+    /// Consume the end of the marker line, reporting whether it was CR LF.
+    fn consume_eol(&mut self) -> Result<bool> {
+        let crlf = self.peek()? == b'\r';
+        if crlf {
+            self.take(1);
+        }
+
+        if self.peek()? != b'\n' {
+            bail!("unexpected data after the debug console marker");
+        }
+        self.take(1);
+
+        Ok(crlf)
+    }
+
+    fn peek(&mut self) -> Result<u8> {
+        while self.buf.is_empty() {
+            self.fill()?;
+        }
+
+        Ok(self.buf[0])
+    }
+
+    /// Read the exit status the wrapper prints right after the end marker.
+    fn read_status(&mut self) -> Result<i32> {
+        let mut line = Vec::new();
+
+        loop {
+            if let Some(at) = self.buf.iter().position(|b| *b == b'\n') {
+                line.extend_from_slice(&self.buf[..at]);
+                self.take(at + 1);
+                break;
+            }
+
+            line.extend_from_slice(&self.buf);
+            self.buf.clear();
+            self.fill()?;
+        }
+
+        let status = String::from_utf8_lossy(&line);
+        let status = status.trim();
+
+        status
+            .parse::<i32>()
+            .with_context(|| format!("parse exit status {status:?} from the debug console"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use micro_http::HttpServer;
+    use std::thread;
+
+    #[test]
+    fn test_setup_hvsock_failed() {
+        let kata_hybrid_addr = "/tmp/kata_hybrid_vsock02.hvsock";
+        let hybrid_sock_addr = "hvsock:///tmp/kata_hybrid_vsock02.hvsock:1024";
+        std::fs::remove_file(kata_hybrid_addr).unwrap_or_default();
+        let dbg_console_port: u32 = 1026;
+        let mut server = HttpServer::new(kata_hybrid_addr).unwrap();
+        server.start_server().unwrap();
+
+        let stream = setup_client(hybrid_sock_addr.to_string(), dbg_console_port);
+        assert!(stream.is_err());
+        std::fs::remove_file(kata_hybrid_addr).unwrap_or_default();
+    }
+
+    #[test]
+    fn test_setup_vsock_client_failed() {
+        let hybrid_sock_addr = "hvsock://8:1024";
+        let dbg_console_port: u32 = 1026;
+        let stream = setup_client(hybrid_sock_addr.to_string(), dbg_console_port);
+        assert!(stream.is_err());
+    }
+
+    #[test]
+    fn test_shell_quote() {
+        assert_eq!(shell_quote("ls"), "'ls'");
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote("it's"), r"'it'\''s'");
+        assert_eq!(shell_quote("$(id)"), "'$(id)'");
+    }
+
+    #[test]
+    fn test_strip_cr() {
+        assert_eq!(strip_cr(b"a\r\nb\r\n"), b"a\nb\n");
+        // A CR that is not part of a line ending belongs to the payload.
+        assert_eq!(strip_cr(b"a\rb"), b"a\rb");
+        assert_eq!(strip_cr(b"\r"), b"\r");
+    }
+
+    #[test]
+    fn test_find() {
+        assert_eq!(find(b"hello", b"ll"), Some(2));
+        assert_eq!(find(b"hello", b"xx"), None);
+        assert_eq!(find(b"hi", b"longer"), None);
+        assert_eq!(find(b"hello", b""), None);
+    }
+
+    /// Stand in for the guest: read the wrapper command line, echo the markers
+    /// back around `output`, then report `status`.
+    fn fake_shell(mut sock: UnixStream, output: &'static [u8], status: i32, crlf: bool) {
+        thread::spawn(move || {
+            let peer = sock.try_clone().unwrap();
+            let mut reader = BufReader::new(peer);
+            let eol: &[u8] = if crlf { b"\r\n" } else { b"\n" };
+
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    return;
+                }
+
+                // Only the wrapper carries a marker; skip the stty prelude.
+                let marker = match line.split_once("__kc_m=") {
+                    Some((_, rest)) => rest.split(';').next().unwrap().to_string(),
+                    None => continue,
+                };
+
+                sock.write_all(b"noise from the shell prompt").unwrap();
+                sock.write_all(format!("{marker}{BEGIN}").as_bytes())
+                    .unwrap();
+                sock.write_all(eol).unwrap();
+                sock.write_all(output).unwrap();
+                sock.write_all(format!("{marker}{END}{status}").as_bytes())
+                    .unwrap();
+                sock.write_all(eol).unwrap();
+                sock.flush().unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn test_session_relays_output() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        fake_shell(theirs, b"hello\n", 0, false);
+
+        let mut session = Session::new(ours);
+        let mut out = Vec::new();
+        let status = session.run("echo hello", &mut out).unwrap();
+
+        assert_eq!(status, 0);
+        assert_eq!(out, b"hello\n");
+    }
+
+    #[test]
+    fn test_session_reports_exit_status() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        fake_shell(theirs, b"", 42, false);
+
+        let mut session = Session::new(ours);
+
+        assert_eq!(session.run("false", &mut io::sink()).unwrap(), 42);
+    }
+
+    /// A guest with no stty leaves the NL -> CR NL translation on.
+    #[test]
+    fn test_session_undoes_crlf() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        fake_shell(theirs, b"one\r\ntwo\r\n", 0, true);
+
+        let mut session = Session::new(ours);
+        let mut out = Vec::new();
+        session.run("cat", &mut out).unwrap();
+
+        assert_eq!(out, b"one\ntwo\n");
+    }
+
+    /// Output that does not end in a newline must not gain or lose bytes, even
+    /// though the end marker is then glued to the last line.
+    #[test]
+    fn test_session_output_is_verbatim() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        fake_shell(theirs, b"no trailing newline", 0, false);
+
+        let mut session = Session::new(ours);
+        let mut out = Vec::new();
+        session.run("printf x", &mut out).unwrap();
+
+        assert_eq!(out, b"no trailing newline");
+    }
+
+    /// Successive commands share one connection, and one shell.
+    #[test]
+    fn test_session_runs_several_commands() {
+        let (ours, theirs) = UnixStream::pair().unwrap();
+        fake_shell(theirs, b"out\n", 0, false);
+
+        let mut session = Session::new(ours);
+        for _ in 0..3 {
+            let mut out = Vec::new();
+            assert_eq!(session.run("echo out", &mut out).unwrap(), 0);
+            assert_eq!(out, b"out\n");
+        }
+    }
+}

--- a/src/tools/kata-ctl/src/debug_console.rs
+++ b/src/tools/kata-ctl/src/debug_console.rs
@@ -234,6 +234,10 @@ pub fn connect(sandbox_id: &str, vport: u32) -> Result<UnixStream> {
     setup_client(server_url, vport)
 }
 
+/// End-of-transmission. The guest terminal stays in canonical mode, so this at
+/// the start of a line is what closes the stdin of a running command.
+pub const EOT: u8 = 0x04;
+
 /// Appended to the marker to frame the output of a command. Neither is ever
 /// spelled out in what we write to the shell - both are only ever produced by
 /// expanding the variable holding the marker - so a terminal that echoes our
@@ -309,6 +313,14 @@ impl Session {
         }
     }
 
+    /// A second handle on the connection, so a command's stdin can be fed
+    /// while its output is being read.
+    pub fn writer(&self) -> Result<UnixStream> {
+        self.stream
+            .try_clone()
+            .context("clone debug console socket")
+    }
+
     /// Run `cmd` to completion, relaying its output to `sink`, and report the
     /// exit status. The console is one stream, so this is stdout and stderr
     /// interleaved.
@@ -317,9 +329,22 @@ impl Session {
         self.finish(sink)
     }
 
+    /// Run `cmd` for its output, trimmed, as text.
+    pub fn capture(&mut self, cmd: &str) -> Result<(i32, String)> {
+        let mut out = Vec::new();
+        let status = self.run(cmd, &mut out)?;
+
+        Ok((status, String::from_utf8_lossy(&out).trim().to_string()))
+    }
+
+    /// Run `cmd` purely for its exit status, e.g. a `test` probe.
+    pub fn probe(&mut self, cmd: &str) -> Result<bool> {
+        Ok(self.run(cmd, &mut io::sink())? == 0)
+    }
+
     /// Send `cmd` and return once it is running, so the caller may then write
     /// to its stdin over the same connection.
-    fn begin(&mut self, cmd: &str) -> Result<()> {
+    pub fn begin(&mut self, cmd: &str) -> Result<()> {
         self.prepare()?;
 
         let marker = self.marker.clone();
@@ -341,7 +366,7 @@ impl Session {
 
     /// Relay the output of the command started by [`Session::begin`] to
     /// `sink`, and report its exit status.
-    fn finish(&mut self, sink: &mut dyn Write) -> Result<i32> {
+    pub fn finish(&mut self, sink: &mut dyn Write) -> Result<i32> {
         let end = format!("{}{END}", self.marker);
         self.scan(end.as_bytes(), sink)?;
 

--- a/src/tools/kata-ctl/src/main.rs
+++ b/src/tools/kata-ctl/src/main.rs
@@ -16,6 +16,7 @@ mod debug_console;
 mod log_parser;
 mod monitor;
 mod ops;
+mod progress;
 mod types;
 mod utils;
 

--- a/src/tools/kata-ctl/src/main.rs
+++ b/src/tools/kata-ctl/src/main.rs
@@ -12,6 +12,7 @@ extern crate slog;
 mod arch;
 mod args;
 mod check;
+mod debug_console;
 mod log_parser;
 mod monitor;
 mod ops;
@@ -41,7 +42,9 @@ macro_rules! sl {
     };
 }
 
-fn real_main() -> Result<()> {
+// Returns the exit status to leave with: zero for every command but `exec`,
+// which reports the status of what ran in the guest.
+fn real_main() -> Result<i32> {
     let args = KataCtlCli::parse();
 
     if args.show_default_config_paths {
@@ -49,7 +52,7 @@ fn real_main() -> Result<()> {
             .iter()
             .for_each(|p| println!("{}", p.display()));
 
-        return Ok(());
+        return Ok(0);
     }
 
     let log_level = args.log_level.unwrap_or(slog::Level::Info);
@@ -64,16 +67,16 @@ fn real_main() -> Result<()> {
 
     let res = if let Some(command) = args.command {
         match command {
-            Commands::Check(args) => handle_check(args),
-            Commands::DirectVolume(args) => handle_direct_volume(args),
+            Commands::Check(args) => handle_check(args).map(|_| 0),
+            Commands::DirectVolume(args) => handle_direct_volume(args).map(|_| 0),
             Commands::Exec(args) => handle_exec(args),
-            Commands::Env(args) => handle_env(args),
-            Commands::Factory(args) => handle_factory(args),
-            Commands::Iptables(args) => handle_iptables(args),
-            Commands::Metrics(args) => handle_metrics(args),
-            Commands::Monitor(args) => handle_monitor(args),
-            Commands::Version => handle_version(),
-            Commands::LogParser(args) => log_parser(args),
+            Commands::Env(args) => handle_env(args).map(|_| 0),
+            Commands::Factory(args) => handle_factory(args).map(|_| 0),
+            Commands::Iptables(args) => handle_iptables(args).map(|_| 0),
+            Commands::Metrics(args) => handle_metrics(args).map(|_| 0),
+            Commands::Monitor(args) => handle_monitor(args).map(|_| 0),
+            Commands::Version => handle_version().map(|_| 0),
+            Commands::LogParser(args) => log_parser(args).map(|_| 0),
         }
     } else {
         // The user specified an option, but not a subcommand. We've already
@@ -103,7 +106,8 @@ fn real_main() -> Result<()> {
 }
 
 fn main() {
-    if let Err(_e) = real_main() {
-        exit(1);
+    match real_main() {
+        Ok(status) => exit(status),
+        Err(_e) => exit(1),
     }
 }

--- a/src/tools/kata-ctl/src/main.rs
+++ b/src/tools/kata-ctl/src/main.rs
@@ -30,6 +30,7 @@ use std::process::exit;
 use ops::check_ops::{
     handle_check, handle_iptables, handle_metrics, handle_monitor, handle_version,
 };
+use ops::cp_ops::handle_cp;
 use ops::env_ops::handle_env;
 use ops::exec_ops::handle_exec;
 use ops::factory_ops::handle_factory;
@@ -68,6 +69,7 @@ fn real_main() -> Result<i32> {
     let res = if let Some(command) = args.command {
         match command {
             Commands::Check(args) => handle_check(args).map(|_| 0),
+            Commands::Cp(args) => handle_cp(args).map(|_| 0),
             Commands::DirectVolume(args) => handle_direct_volume(args).map(|_| 0),
             Commands::Exec(args) => handle_exec(args),
             Commands::Env(args) => handle_env(args).map(|_| 0),

--- a/src/tools/kata-ctl/src/ops.rs
+++ b/src/tools/kata-ctl/src/ops.rs
@@ -4,6 +4,7 @@
 //
 
 pub mod check_ops;
+pub mod cp_ops;
 pub mod env_ops;
 pub mod exec_ops;
 pub mod factory_ops;

--- a/src/tools/kata-ctl/src/ops/cp_ops.rs
+++ b/src/tools/kata-ctl/src/ops/cp_ops.rs
@@ -1,0 +1,892 @@
+// Copyright (c) Kata Containers Community
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description:
+// Copying files and directories between the host and a guest VM, tunnelled
+// through the agent debug console.
+
+use std::{
+    fs,
+    io::{self, BufWriter, Read, Write},
+    net::Shutdown,
+    os::unix::net::UnixStream,
+    path::{Path, PathBuf},
+    process,
+    sync::mpsc::{sync_channel, Receiver, SyncSender},
+    thread,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+use crate::args::CpArguments;
+use crate::debug_console::{self, shell_quote, Session, EOT};
+
+/// Where the devkit guest extension is mounted, and where the console shell can
+/// still see the guest's real root once devkit-init has chrooted it into the
+/// devkit overlay.
+const DEVKIT_ROOT: &str = "/run/kata-extensions/devkit";
+const REAL_ROOT: &str = "/real_root";
+
+/// Where the guest parks the stderr of a command whose stdout we are reading.
+/// The console carries one stream, so anything written there would otherwise
+/// land in the middle of the payload. `$$` is the console shell's own pid, so
+/// two sessions never pick the same file.
+const GUEST_STDERR: &str = "/tmp/.kata-ctl-cp.$$.err";
+
+/// base64 wraps at 76 characters, which keeps every line we push at the guest
+/// well inside what its terminal accepts unbroken. 57 bytes is that much input,
+/// and a multiple of 3, so each line encodes on its own with no padding until
+/// the last one.
+const B64_LINE_BYTES: usize = 57;
+
+/// How much of a failed command's output to keep for the error message.
+const DIAGNOSTIC_BYTES: usize = 4 * 1024;
+
+/// Archive chunks in flight between the thread reading the console and the one
+/// extracting, so neither runs ahead of the other by more than a little.
+const PIPE_DEPTH: usize = 16;
+
+// kata-ctl handle cp command starts here.
+pub fn handle_cp(cp_args: CpArguments) -> Result<()> {
+    let src = Endpoint::parse(&cp_args.src)?;
+    let dst = Endpoint::parse(&cp_args.dst)?;
+
+    let (sandbox_id, copy) = match (src, dst) {
+        (Endpoint::Guest { sandbox_id, path }, Endpoint::Host(local)) => {
+            (sandbox_id, Copy::Out { path, local })
+        }
+        (Endpoint::Host(local), Endpoint::Guest { sandbox_id, path }) => {
+            (sandbox_id, Copy::In { local, path })
+        }
+        (Endpoint::Host(_), Endpoint::Host(_)) => {
+            bail!("neither side names a sandbox: write one of them as <sandbox-id>:<path>")
+        }
+        (Endpoint::Guest { .. }, Endpoint::Guest { .. }) => {
+            bail!("copying straight from one sandbox to another is not supported")
+        }
+    };
+
+    let sock_stream = debug_console::connect(&sandbox_id, cp_args.vport)?;
+    let mut session = Session::new(sock_stream);
+
+    require_devkit(&mut session)?;
+
+    let res = match copy {
+        Copy::In { local, path } => copy_in(&mut session, &local, &path),
+        Copy::Out { path, local } => copy_out(&mut session, &path, &local),
+    };
+
+    session.close();
+
+    res
+}
+
+/// One side of a copy: a path on this host, or a path inside a sandbox.
+#[derive(Debug, PartialEq)]
+enum Endpoint {
+    Host(PathBuf),
+    Guest { sandbox_id: String, path: String },
+}
+
+enum Copy {
+    In { local: PathBuf, path: String },
+    Out { path: String, local: PathBuf },
+}
+
+impl Endpoint {
+    /// `<sandbox-id>:<absolute-guest-path>` names a guest, anything else is a
+    /// host path. As in docker, a colon only separates the two when what comes
+    /// before it could be an id, so host paths containing one still work.
+    fn parse(spec: &str) -> Result<Self> {
+        let (sandbox_id, path) = match spec.split_once(':') {
+            Some((id, path)) if !id.is_empty() && !id.contains('/') => (id, path),
+            _ => return Ok(Endpoint::Host(PathBuf::from(spec))),
+        };
+
+        // The console shell's working directory is an implementation detail of
+        // the devkit overlay, so a relative guest path would land somewhere the
+        // caller cannot predict.
+        if !path.starts_with('/') {
+            bail!("guest path {path:?} in {spec:?} must be absolute");
+        }
+
+        Ok(Endpoint::Guest {
+            sandbox_id: sandbox_id.to_string(),
+            path: path.to_string(),
+        })
+    }
+}
+
+/// `cp` leans on what the devkit extension brings into the guest - a shell, tar
+/// and base64 - none of which a minimal guest rootfs is required to have, and
+/// several of which ship none of. Refuse up front rather than fail halfway
+/// through a copy.
+///
+/// A precondition, then, and not a permission check. It cannot be one: it runs
+/// on this side, so a patched kata-ctl drops it, and nothing is kept out by it
+/// anyway. What carries a copy is the agent debug console, and that console is
+/// a root shell in the guest - whoever can open one can already move bytes in
+/// both directions in a handful of lines, with no kata-ctl involved. The
+/// boundary is that console existing at all: the agent opens it only for a
+/// guest booted with `agent.debug_console`, which the runtime passes only for
+/// `debug_console_enabled`, and which a confidential guest measures. Turning it
+/// on is deliberate, and it is visible to attestation.
+///
+/// The console shell chroots into the devkit overlay, where the extension's own
+/// mount point is out of view but the guest's real root is reachable through
+/// the /real_root symlink devkit-init leaves behind. Look in both places, so
+/// this holds whether or not that chroot happened.
+fn require_devkit(session: &mut Session) -> Result<()> {
+    let probe = format!("test -d {DEVKIT_ROOT} || test -d {REAL_ROOT}{DEVKIT_ROOT}");
+
+    if session.probe(&probe)? {
+        return Ok(());
+    }
+
+    bail!(
+        "this sandbox has no devkit guest extension, and `kata-ctl cp` needs the \
+         tooling it brings into the guest; run the workload under a \
+         kata-<shim>-devkit RuntimeClass, which kata-deploy creates when it is \
+         installed with both `debug` and `devkit` enabled"
+    )
+}
+
+/// Host to guest. The archive is built here and unpacked there.
+fn copy_in(session: &mut Session, local: &Path, remote: &str) -> Result<()> {
+    if !local.exists() {
+        bail!("{} does not exist", local.display());
+    }
+
+    // As in docker cp, an existing directory is copied *into*; anything else
+    // names the copy.
+    let (dir, name) = if session.probe(&format!("test -d {}", shell_quote(remote)))? {
+        (remote.to_string(), host_basename(local)?)
+    } else {
+        (guest_dirname(remote)?, guest_basename(remote)?)
+    };
+
+    if !session.probe(&format!("test -d {}", shell_quote(&dir)))? {
+        bail!("guest directory {dir:?} does not exist");
+    }
+
+    // The host's uids mean nothing in the guest, where the console runs as
+    // root, so let the archive's modes through but not its ownership. tar's own
+    // stderr can go straight into the framed output: nothing else comes back
+    // this way, so there is no payload for it to corrupt.
+    session.begin(&format!(
+        "base64 -d | tar -C {} --no-same-owner -xf -",
+        shell_quote(&dir)
+    ))?;
+
+    let sink = session.writer()?;
+    let feeder = {
+        let src = local.to_path_buf();
+        let entry = name.clone();
+
+        thread::spawn(move || {
+            let res = send_archive(&sink, &src, &entry);
+            if res.is_err() {
+                // Let the guest see the end of its input, so it stops waiting
+                // for an archive that is never going to arrive.
+                let _ = sink.shutdown(Shutdown::Write);
+            }
+            res
+        })
+    };
+
+    let mut diagnostic = Diagnostic::default();
+    let status = session.finish(&mut diagnostic)?;
+
+    if status != 0 {
+        // The guest has stopped reading, so the feeder may still be blocked
+        // partway through the archive. Close the writing side to let it go.
+        if let Ok(sock) = session.writer() {
+            let _ = sock.shutdown(Shutdown::Write);
+        }
+        let _ = feeder.join();
+
+        bail!(
+            "unpacking into {dir:?} in the guest failed{}",
+            diagnostic.detail()
+        );
+    }
+
+    feeder
+        .join()
+        .map_err(|_| anyhow!("the thread writing the archive panicked"))?
+}
+
+/// Guest to host. The archive is built there and unpacked here.
+fn copy_out(session: &mut Session, remote: &str, local: &Path) -> Result<()> {
+    let dir = guest_dirname(remote)?;
+    let name = guest_basename(remote)?;
+
+    if !session.probe(&format!("test -e {}", shell_quote(remote)))? {
+        bail!("{remote:?} does not exist in the guest");
+    }
+
+    // As in docker cp, an existing directory is copied *into*; anything else
+    // names the copy.
+    let (root, rename) = if local.is_dir() {
+        (local.to_path_buf(), None)
+    } else {
+        (host_parent(local), Some(local.to_path_buf()))
+    };
+
+    if !root.is_dir() {
+        bail!("{} is not a directory", root.display());
+    }
+
+    // base64 is last in the pipeline, so without pipefail a tar that died would
+    // still be reported as a clean exit.
+    session.begin(&format!(
+        "set -o pipefail 2>/dev/null; tar -C {} -cf - {} 2>{GUEST_STDERR} | base64",
+        shell_quote(&dir),
+        shell_quote(&name),
+    ))?;
+
+    let (tx, rx) = pipe();
+    let unpacker = {
+        let dest = rename.clone();
+        let root = root.clone();
+
+        thread::spawn(move || unpack(rx, root, dest))
+    };
+
+    let mut decoder = Base64Decoder::new(tx);
+    let status = session.finish(&mut decoder)?;
+    // Dropping the decoder closes the pipe, which is what ends the extraction.
+    decoder.finish()?;
+
+    let unpacked = unpacker
+        .join()
+        .map_err(|_| anyhow!("the thread extracting the archive panicked"))?;
+
+    let (_, stderr) = session.capture(&format!(
+        "cat {GUEST_STDERR} 2>/dev/null; rm -f {GUEST_STDERR}"
+    ))?;
+
+    if status != 0 {
+        bail!(
+            "archiving {remote:?} in the guest failed{}",
+            detail(&stderr)
+        );
+    }
+
+    unpacked
+}
+
+/// Tar `src` under the name `entry`, base64 it, and push it at the command
+/// waiting on the other end of `sink`, then close that command's stdin.
+fn send_archive(sink: &UnixStream, src: &Path, entry: &str) -> Result<()> {
+    let mut out = Base64Lines::new(BufWriter::new(sink));
+
+    {
+        let mut archive = tar::Builder::new(&mut out);
+        let meta = fs::symlink_metadata(src).with_context(|| format!("stat {}", src.display()))?;
+
+        if meta.is_dir() {
+            archive
+                .append_dir_all(entry, src)
+                .with_context(|| format!("archive {}", src.display()))?;
+        } else {
+            archive
+                .append_path_with_name(src, entry)
+                .with_context(|| format!("archive {}", src.display()))?;
+        }
+
+        archive.finish().context("finish the archive")?;
+    }
+
+    let mut sink = out.finish()?;
+    sink.write_all(&[b'\n', EOT])
+        .context("close the guest command's stdin")?;
+    sink.flush().context("flush to the guest")?;
+
+    Ok(())
+}
+
+/// Extract the archive `reader` carries into `root`. With `rename`, the
+/// archive's single top-level entry is put there under that name instead.
+fn unpack(reader: PipeReader, root: PathBuf, rename: Option<PathBuf>) -> Result<()> {
+    // Unpack whole-archive rather than entry by entry: the guest chose these
+    // names, and that is what rejects the ones that would write outside the
+    // directory we picked.
+    let mut archive = tar::Archive::new(reader);
+    archive.set_overwrite(true);
+    archive.set_preserve_permissions(true);
+
+    let Some(dest) = rename else {
+        return archive
+            .unpack(&root)
+            .with_context(|| format!("extract into {}", root.display()));
+    };
+
+    // A rename only happens when the destination does not exist yet, so stage
+    // the archive next to it and move the one thing it holds into place. That
+    // keeps the extraction itself inside a directory of our own making.
+    let staging = Staging::new(&root)?;
+
+    archive
+        .unpack(staging.path())
+        .with_context(|| format!("extract into {}", staging.path().display()))?;
+
+    let mut top = fs::read_dir(staging.path())
+        .with_context(|| format!("read {}", staging.path().display()))?;
+
+    let entry = top
+        .next()
+        .transpose()?
+        .ok_or_else(|| anyhow!("the guest sent an empty archive"))?;
+
+    if top.next().transpose()?.is_some() {
+        bail!("the guest sent an archive holding more than one top-level entry");
+    }
+
+    fs::rename(entry.path(), &dest)
+        .with_context(|| format!("move the copy into place at {}", dest.display()))
+}
+
+/// A scratch directory that goes away with the value.
+struct Staging(PathBuf);
+
+impl Staging {
+    fn new(parent: &Path) -> Result<Self> {
+        let path = parent.join(format!(".kata-ctl-cp.{}", process::id()));
+
+        fs::create_dir(&path).with_context(|| format!("create {}", path.display()))?;
+
+        Ok(Staging(path))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for Staging {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Wraps a writer so what is written reaches it as base64, in lines short
+/// enough for the guest's terminal to take unbroken.
+struct Base64Lines<W: Write> {
+    inner: W,
+    pending: Vec<u8>,
+}
+
+impl<W: Write> Base64Lines<W> {
+    fn new(inner: W) -> Self {
+        Base64Lines {
+            inner,
+            pending: Vec::with_capacity(B64_LINE_BYTES * 2),
+        }
+    }
+
+    /// Emit the remainder, the only line that carries padding, and hand the
+    /// underlying writer back.
+    fn finish(mut self) -> Result<W> {
+        if !self.pending.is_empty() {
+            let line = BASE64.encode(&self.pending);
+            self.pending.clear();
+            self.inner.write_all(line.as_bytes())?;
+            self.inner.write_all(b"\n")?;
+        }
+
+        self.inner.flush()?;
+
+        Ok(self.inner)
+    }
+}
+
+impl<W: Write> Write for Base64Lines<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(buf);
+
+        let full = self.pending.len() / B64_LINE_BYTES * B64_LINE_BYTES;
+        if full > 0 {
+            let mut lines = String::with_capacity(full / B64_LINE_BYTES * 77);
+            for chunk in self.pending[..full].chunks(B64_LINE_BYTES) {
+                lines.push_str(&BASE64.encode(chunk));
+                lines.push('\n');
+            }
+
+            self.pending.drain(..full);
+            self.inner.write_all(lines.as_bytes())?;
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Wraps a writer so base64 written to it reaches the writer decoded.
+struct Base64Decoder<W: Write> {
+    inner: W,
+    pending: Vec<u8>,
+}
+
+impl<W: Write> Base64Decoder<W> {
+    fn new(inner: W) -> Self {
+        Base64Decoder {
+            inner,
+            pending: Vec::new(),
+        }
+    }
+
+    fn finish(mut self) -> Result<()> {
+        let rest = std::mem::take(&mut self.pending);
+        self.decode_line(&rest)?;
+        self.inner.flush()?;
+
+        Ok(())
+    }
+
+    fn decode_line(&mut self, line: &[u8]) -> io::Result<()> {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if line.is_empty() {
+            return Ok(());
+        }
+
+        let data = BASE64.decode(line).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("the guest sent something that is not base64: {e}"),
+            )
+        })?;
+
+        self.inner.write_all(&data)
+    }
+}
+
+impl<W: Write> Write for Base64Decoder<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(buf);
+
+        while let Some(at) = self.pending.iter().position(|b| *b == b'\n') {
+            let line: Vec<u8> = self.pending.drain(..=at).collect();
+            self.decode_line(&line[..at])?;
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// A `Write` end and a `Read` end joined by a bounded queue, so bytes being
+/// pushed out of the console can feed a reader that wants to pull them.
+fn pipe() -> (PipeWriter, PipeReader) {
+    let (tx, rx) = sync_channel(PIPE_DEPTH);
+
+    (
+        PipeWriter(tx),
+        PipeReader {
+            rx,
+            chunk: Vec::new(),
+            at: 0,
+        },
+    )
+}
+
+struct PipeWriter(SyncSender<Vec<u8>>);
+
+impl Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // A reader that gave up took its error with it, and that error says far
+        // more than a broken pipe would. Keep draining the console so the
+        // command's own status still comes back, and let the caller report it.
+        let _ = self.0.send(buf.to_vec());
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct PipeReader {
+    rx: Receiver<Vec<u8>>,
+    chunk: Vec<u8>,
+    at: usize,
+}
+
+impl Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        while self.at == self.chunk.len() {
+            match self.rx.recv() {
+                Ok(chunk) => {
+                    self.chunk = chunk;
+                    self.at = 0;
+                }
+                Err(_) => return Ok(0),
+            }
+        }
+
+        let n = std::cmp::min(buf.len(), self.chunk.len() - self.at);
+        buf[..n].copy_from_slice(&self.chunk[self.at..self.at + n]);
+        self.at += n;
+
+        Ok(n)
+    }
+}
+
+/// Keeps only the tail of what a failing command printed.
+#[derive(Default)]
+struct Diagnostic(Vec<u8>);
+
+impl Diagnostic {
+    fn detail(&self) -> String {
+        detail(&String::from_utf8_lossy(&self.0))
+    }
+}
+
+impl Write for Diagnostic {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.extend_from_slice(buf);
+        if self.0.len() > DIAGNOSTIC_BYTES {
+            self.0.drain(..self.0.len() - DIAGNOSTIC_BYTES);
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn detail(msg: &str) -> String {
+    match msg.trim() {
+        "" => String::new(),
+        msg => format!(": {msg}"),
+    }
+}
+
+fn guest_basename(path: &str) -> Result<String> {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("{path:?} names nothing inside the guest"))
+}
+
+fn guest_dirname(path: &str) -> Result<String> {
+    Path::new(path)
+        .parent()
+        .and_then(|dir| dir.to_str())
+        .filter(|dir| !dir.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("{path:?} has no parent directory inside the guest"))
+}
+
+fn host_basename(path: &Path) -> Result<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("{} names nothing", path.display()))
+}
+
+fn host_parent(path: &Path) -> PathBuf {
+    match path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => dir.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Command, Stdio};
+
+    use nix::pty::openpty;
+    use tempfile::tempdir;
+
+    /// A stand-in for the guest side of the console: a real shell on a real
+    /// pseudo-terminal, reachable over a socket, which is what the agent
+    /// offers. Yields nothing where the machine cannot provide one, so the
+    /// suite still runs somewhere without a pty or without the guest tools.
+    fn console() -> Option<(UnixStream, Child)> {
+        for tool in ["bash", "tar", "base64", "stty"] {
+            let found = Command::new("sh")
+                .arg("-c")
+                .arg(format!("command -v {tool}"))
+                .stdout(Stdio::null())
+                .status()
+                .ok()?
+                .success();
+
+            if !found {
+                return None;
+            }
+        }
+
+        let pty = openpty(None, None).ok()?;
+        let slave = pty.slave;
+
+        let child = unsafe {
+            Command::new("bash")
+                .args(["--noprofile", "--norc"])
+                .stdin(Stdio::from(slave.try_clone().ok()?))
+                .stdout(Stdio::from(slave.try_clone().ok()?))
+                .stderr(Stdio::from(slave.try_clone().ok()?))
+                .pre_exec(|| {
+                    // Same shape as the agent's console: session leader, with
+                    // the pty as its controlling terminal.
+                    nix::unistd::setsid()?;
+                    libc::ioctl(0, libc::TIOCSCTTY, 0);
+                    Ok(())
+                })
+                .spawn()
+                .ok()?
+        };
+        drop(slave);
+
+        let (ours, theirs) = UnixStream::pair().ok()?;
+        let master = fs::File::from(pty.master);
+        let mut to_shell = master.try_clone().ok()?;
+        let mut from_shell = master;
+        let mut sock_out = theirs.try_clone().ok()?;
+        let mut sock_in = theirs;
+
+        thread::spawn(move || io::copy(&mut from_shell, &mut sock_out));
+        thread::spawn(move || io::copy(&mut sock_in, &mut to_shell));
+
+        Some((ours, child))
+    }
+
+    fn read(path: &Path) -> Vec<u8> {
+        fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
+
+    /// Drive both directions against a real shell, so the whole tunnel is
+    /// exercised: terminal setup, framing, base64 lines, the end-of-input the
+    /// upload closes with, and tar on either side.
+    #[test]
+    fn test_copy_round_trip_over_a_real_shell() {
+        let Some((sock, mut shell)) = console() else {
+            eprintln!("skipping: no pty-backed shell with tar and base64 here");
+            return;
+        };
+
+        let mut session = Session::new(sock);
+
+        let host = tempdir().unwrap();
+        let guest = tempdir().unwrap();
+
+        // A file big enough to span many base64 lines, and to make the writer
+        // and the reader overlap rather than fit in a socket buffer.
+        let payload: Vec<u8> = (0..300_000).map(|i| (i % 251) as u8).collect();
+        let src = host.path().join("payload.bin");
+        fs::write(&src, &payload).unwrap();
+
+        // Host to guest, onto a name of its own.
+        let remote = guest.path().join("copied.bin");
+        copy_in(&mut session, &src, remote.to_str().unwrap()).unwrap();
+        assert_eq!(read(&remote), payload);
+
+        // Host to guest again, this time into an existing directory.
+        copy_in(&mut session, &src, guest.path().to_str().unwrap()).unwrap();
+        assert_eq!(read(&guest.path().join("payload.bin")), payload);
+
+        // A directory, back out to a name of its own.
+        let tree = guest.path().join("tree");
+        fs::create_dir(&tree).unwrap();
+        fs::write(tree.join("one"), b"first").unwrap();
+        fs::create_dir(tree.join("nested")).unwrap();
+        fs::write(tree.join("nested/two"), b"second").unwrap();
+
+        let out = host.path().join("pulled");
+        copy_out(&mut session, tree.to_str().unwrap(), &out).unwrap();
+        assert_eq!(read(&out.join("one")), b"first");
+        assert_eq!(read(&out.join("nested/two")), b"second");
+
+        // And a single file back out, into an existing directory.
+        copy_out(&mut session, remote.to_str().unwrap(), host.path()).unwrap();
+        assert_eq!(read(&host.path().join("copied.bin")), payload);
+
+        session.close();
+        let _ = shell.kill();
+        let _ = shell.wait();
+    }
+
+    /// Nothing here is a devkit guest, so the gate has to hold, and say why.
+    #[test]
+    fn test_require_devkit_refuses_a_guest_without_it() {
+        let Some((sock, mut shell)) = console() else {
+            eprintln!("skipping: no pty-backed shell with tar and base64 here");
+            return;
+        };
+
+        let mut session = Session::new(sock);
+        let err = require_devkit(&mut session).unwrap_err().to_string();
+
+        assert!(err.contains("devkit"), "unhelpful error: {}", err);
+
+        session.close();
+        let _ = shell.kill();
+        let _ = shell.wait();
+    }
+
+    /// A guest-side failure has to surface as the guest's own complaint, not as
+    /// a decoding error from the stderr that leaked into the payload.
+    #[test]
+    fn test_copy_out_reports_the_guest_error() {
+        let Some((sock, mut shell)) = console() else {
+            eprintln!("skipping: no pty-backed shell with tar and base64 here");
+            return;
+        };
+
+        let mut session = Session::new(sock);
+        let host = tempdir().unwrap();
+
+        let err = copy_out(
+            &mut session,
+            "/nonexistent-a4f2/thing",
+            &host.path().join("out"),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("does not exist in the guest"),
+            "unhelpful error: {}",
+            err
+        );
+
+        session.close();
+        let _ = shell.kill();
+        let _ = shell.wait();
+    }
+
+    #[test]
+    fn test_endpoint_parse() {
+        assert_eq!(
+            Endpoint::parse("abc123:/var/log").unwrap(),
+            Endpoint::Guest {
+                sandbox_id: "abc123".to_string(),
+                path: "/var/log".to_string(),
+            }
+        );
+
+        // No colon, so a host path.
+        assert_eq!(
+            Endpoint::parse("/tmp/out").unwrap(),
+            Endpoint::Host(PathBuf::from("/tmp/out"))
+        );
+        assert_eq!(
+            Endpoint::parse("out").unwrap(),
+            Endpoint::Host(PathBuf::from("out"))
+        );
+
+        // A colon behind a path separator belongs to the host path.
+        assert_eq!(
+            Endpoint::parse("/tmp/a:b").unwrap(),
+            Endpoint::Host(PathBuf::from("/tmp/a:b"))
+        );
+
+        // A sandbox id with a relative path is too ambiguous to accept.
+        assert!(Endpoint::parse("abc123:var/log").is_err());
+    }
+
+    #[test]
+    fn test_path_helpers() {
+        assert_eq!(guest_basename("/var/log/kata.log").unwrap(), "kata.log");
+        assert_eq!(guest_basename("/var/log/").unwrap(), "log");
+        assert!(guest_basename("/").is_err());
+
+        assert_eq!(guest_dirname("/var/log/kata.log").unwrap(), "/var/log");
+        assert_eq!(guest_dirname("/kata.log").unwrap(), "/");
+        assert!(guest_dirname("/").is_err());
+
+        assert_eq!(host_parent(Path::new("out.tar")), PathBuf::from("."));
+        assert_eq!(
+            host_parent(Path::new("/tmp/out.tar")),
+            PathBuf::from("/tmp")
+        );
+    }
+
+    /// What goes out as base64 lines has to come back byte for byte, including
+    /// the payload sizes that do not land on a line boundary.
+    #[test]
+    fn test_base64_round_trip() {
+        for len in [0usize, 1, 56, 57, 58, 4096] {
+            let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+
+            let mut wire = Vec::new();
+            let mut encoder = Base64Lines::new(&mut wire);
+            // Write in awkward slices, so a line boundary falls mid-write.
+            for chunk in payload.chunks(13) {
+                encoder.write_all(chunk).unwrap();
+            }
+            encoder.finish().unwrap();
+
+            for line in wire.split(|b| *b == b'\n').filter(|l| !l.is_empty()) {
+                assert!(line.len() <= 76, "line of {} chars is too long", line.len());
+            }
+
+            let mut back = Vec::new();
+            let mut decoder = Base64Decoder::new(&mut back);
+            for chunk in wire.chunks(7) {
+                decoder.write_all(chunk).unwrap();
+            }
+            decoder.finish().unwrap();
+
+            assert_eq!(back, payload, "round trip of {len} bytes");
+        }
+    }
+
+    /// The guest's stderr can end up in the stream we are decoding.
+    #[test]
+    fn test_base64_decoder_rejects_junk() {
+        let mut out = Vec::new();
+        let mut decoder = Base64Decoder::new(&mut out);
+
+        assert!(decoder.write_all(b"tar: /nope: Cannot stat\n").is_err());
+    }
+
+    #[test]
+    fn test_pipe_carries_everything() {
+        let (mut tx, mut rx) = pipe();
+        let payload: Vec<u8> = (0..10_000).map(|i| (i % 251) as u8).collect();
+
+        let expected = payload.clone();
+        let writer = thread::spawn(move || {
+            for chunk in payload.chunks(101) {
+                tx.write_all(chunk).unwrap();
+            }
+        });
+
+        let mut back = Vec::new();
+        rx.read_to_end(&mut back).unwrap();
+        writer.join().unwrap();
+
+        assert_eq!(back, expected);
+    }
+
+    #[test]
+    fn test_diagnostic_keeps_the_tail() {
+        let mut diagnostic = Diagnostic::default();
+        diagnostic
+            .write_all(&vec![b'x'; DIAGNOSTIC_BYTES * 2])
+            .unwrap();
+
+        assert_eq!(diagnostic.0.len(), DIAGNOSTIC_BYTES);
+
+        let mut empty = Diagnostic::default();
+        empty.write_all(b"  \n ").unwrap();
+        assert_eq!(empty.detail(), "");
+    }
+}

--- a/src/tools/kata-ctl/src/ops/cp_ops.rs
+++ b/src/tools/kata-ctl/src/ops/cp_ops.rs
@@ -22,6 +22,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 use crate::args::CpArguments;
 use crate::debug_console::{self, shell_quote, Session, EOT};
+use crate::progress::{Meter, Progress};
 
 /// Where the devkit guest extension is mounted, and where the console shell can
 /// still see the guest's real root once devkit-init has chrooted it into the
@@ -47,6 +48,11 @@ const DIAGNOSTIC_BYTES: usize = 4 * 1024;
 /// Archive chunks in flight between the thread reading the console and the one
 /// extracting, so neither runs ahead of the other by more than a little.
 const PIPE_DEPTH: usize = 16;
+
+/// tar lays an entry out as a 512-byte header followed by its contents padded
+/// out to the next multiple of that, and closes the archive with two empty
+/// ones.
+const TAR_BLOCK: u64 = 512;
 
 // kata-ctl handle cp command starts here.
 pub fn handle_cp(cp_args: CpArguments) -> Result<()> {
@@ -184,9 +190,10 @@ fn copy_in(session: &mut Session, local: &Path, remote: &str) -> Result<()> {
     let feeder = {
         let src = local.to_path_buf();
         let entry = name.clone();
+        let progress = Progress::new(format!("sending {name}"), archive_size(local).ok());
 
         thread::spawn(move || {
-            let res = send_archive(&sink, &src, &entry);
+            let res = send_archive(&sink, &src, &entry, progress);
             if res.is_err() {
                 // Let the guest see the end of its input, so it stops waiting
                 // for an archive that is never going to arrive.
@@ -239,6 +246,8 @@ fn copy_out(session: &mut Session, remote: &str, local: &Path) -> Result<()> {
         bail!("{} is not a directory", root.display());
     }
 
+    let total = guest_archive_size(session, &dir, &name);
+
     // base64 is last in the pipeline, so without pipefail a tar that died would
     // still be reported as a clean exit.
     session.begin(&format!(
@@ -255,7 +264,8 @@ fn copy_out(session: &mut Session, remote: &str, local: &Path) -> Result<()> {
         thread::spawn(move || unpack(rx, root, dest))
     };
 
-    let mut decoder = Base64Decoder::new(tx);
+    let progress = Progress::new(format!("receiving {name}"), total);
+    let mut decoder = Base64Decoder::new(Meter::new(tx, progress));
     let status = session.finish(&mut decoder)?;
     // Dropping the decoder closes the pipe, which is what ends the extraction.
     decoder.finish()?;
@@ -280,11 +290,16 @@ fn copy_out(session: &mut Session, remote: &str, local: &Path) -> Result<()> {
 
 /// Tar `src` under the name `entry`, base64 it, and push it at the command
 /// waiting on the other end of `sink`, then close that command's stdin.
-fn send_archive(sink: &UnixStream, src: &Path, entry: &str) -> Result<()> {
+///
+/// `progress` is metered on the archive rather than on the base64 leaving the
+/// socket, so what it counts is the copy the caller asked for and not the
+/// third again that encoding it costs.
+fn send_archive(sink: &UnixStream, src: &Path, entry: &str, progress: Progress) -> Result<()> {
     let mut out = Base64Lines::new(BufWriter::new(sink));
 
     {
-        let mut archive = tar::Builder::new(&mut out);
+        let mut metered = Meter::new(&mut out, progress);
+        let mut archive = tar::Builder::new(&mut metered);
         let meta = fs::symlink_metadata(src).with_context(|| format!("stat {}", src.display()))?;
 
         if meta.is_dir() {
@@ -306,6 +321,55 @@ fn send_archive(sink: &UnixStream, src: &Path, entry: &str) -> Result<()> {
     sink.flush().context("flush to the guest")?;
 
     Ok(())
+}
+
+/// What the archive of `path` will come to once tar has laid it out, so the
+/// meter has something to count against. An estimate, in that a path too long
+/// to sit in a header costs an entry of its own that this does not add up, so
+/// the meter treats a total as a bound rather than a promise.
+fn archive_size(path: &Path) -> Result<u64> {
+    fn walk(path: &Path, total: &mut u64) -> Result<()> {
+        let meta =
+            fs::symlink_metadata(path).with_context(|| format!("stat {}", path.display()))?;
+
+        *total += TAR_BLOCK;
+
+        if meta.is_file() {
+            *total += meta.len().div_ceil(TAR_BLOCK) * TAR_BLOCK;
+        } else if meta.is_dir() {
+            for entry in fs::read_dir(path).with_context(|| format!("read {}", path.display()))? {
+                walk(&entry?.path(), total)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    let mut total = 2 * TAR_BLOCK;
+    walk(path, &mut total)?;
+
+    Ok(total)
+}
+
+/// The same for an archive only the guest can measure, by building it there
+/// and throwing it away. That reads the tree twice, but the second pass is
+/// over the guest's own disk and costs nothing beside the console the copy
+/// itself has to cross. Best effort: without a total the meter still counts
+/// bytes, it just cannot say out of how many.
+fn guest_archive_size(session: &mut Session, dir: &str, name: &str) -> Option<u64> {
+    let (status, out) = session
+        .capture(&format!(
+            "set -o pipefail 2>/dev/null; tar -C {} -cf - {} 2>/dev/null | wc -c",
+            shell_quote(dir),
+            shell_quote(name),
+        ))
+        .ok()?;
+
+    if status != 0 {
+        return None;
+    }
+
+    out.parse().ok()
 }
 
 /// Extract the archive `reader` carries into `root`. With `rename`, the
@@ -765,6 +829,66 @@ mod tests {
             "unhelpful error: {}",
             err
         );
+
+        session.close();
+        let _ = shell.kill();
+        let _ = shell.wait();
+    }
+
+    /// The meter counts the archive, so the total it counts against has to be
+    /// the archive too, not the bytes that went into it.
+    #[test]
+    fn test_archive_size_matches_the_archive() {
+        let dir = tempdir().unwrap();
+
+        let file = dir.path().join("one");
+        fs::write(&file, vec![b'x'; 1000]).unwrap();
+
+        let mut built = Vec::new();
+        let mut builder = tar::Builder::new(&mut built);
+        builder.append_path_with_name(&file, "one").unwrap();
+        builder.finish().unwrap();
+        drop(builder);
+
+        assert_eq!(archive_size(&file).unwrap(), built.len() as u64);
+
+        // A tree, where the headers of everything under it count too.
+        let tree = dir.path().join("tree");
+        fs::create_dir(&tree).unwrap();
+        fs::write(tree.join("a"), b"aaa").unwrap();
+        fs::create_dir(tree.join("sub")).unwrap();
+        fs::write(tree.join("sub/b"), vec![b'b'; 700]).unwrap();
+
+        let mut built = Vec::new();
+        let mut builder = tar::Builder::new(&mut built);
+        builder.append_dir_all("tree", &tree).unwrap();
+        builder.finish().unwrap();
+        drop(builder);
+
+        assert_eq!(archive_size(&tree).unwrap(), built.len() as u64);
+    }
+
+    /// Sizing runs in the guest, so it has to survive a guest that cannot do
+    /// it rather than hand the meter a total of nothing.
+    #[test]
+    fn test_guest_archive_size() {
+        let Some((sock, mut shell)) = console() else {
+            eprintln!("skipping: no pty-backed shell with tar and base64 here");
+            return;
+        };
+
+        let mut session = Session::new(sock);
+        let dir = tempdir().unwrap();
+        let tree = dir.path().join("tree");
+        fs::create_dir(&tree).unwrap();
+        fs::write(tree.join("one"), vec![b'x'; 5000]).unwrap();
+
+        let root = dir.path().to_str().unwrap();
+        let size = guest_archive_size(&mut session, root, "tree")
+            .expect("the guest could not size its own archive");
+
+        assert!(size >= 5000, "implausible archive size {}", size);
+        assert_eq!(guest_archive_size(&mut session, root, "missing"), None);
 
         session.close();
         let _ = shell.kill();

--- a/src/tools/kata-ctl/src/ops/exec_ops.rs
+++ b/src/tools/kata-ctl/src/ops/exec_ops.rs
@@ -8,33 +8,21 @@
 // set in the configuration.
 
 use std::{
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{self, Read, Write},
     os::unix::{
-        io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+        io::{AsRawFd, RawFd},
         net::UnixStream,
     },
-    time::Duration,
 };
 
-use anyhow::{anyhow, Context};
-use http_body_util::BodyExt;
-use hyper::StatusCode;
-use nix::sys::socket::{connect, socket, AddressFamily, SockFlag, SockType, VsockAddr};
-use slog::{debug, error, o};
+use anyhow::Context;
+use slog::{error, o};
 use vmm_sys_util::terminal::Terminal;
 
 use crate::args::ExecArguments;
-use shim_interface::shim_mgmt::{client::MgmtClient, AGENT_URL};
-
-use crate::utils::TIMEOUT;
-
-const CMD_CONNECT: &str = "CONNECT";
-const CMD_OK: &str = "OK";
-const SCHEME_VSOCK: &str = "VSOCK";
-const SCHEME_HYBRID_VSOCK: &str = "HVSOCK";
+use crate::debug_console::{self, Session};
 
 const EPOLL_EVENTS_LEN: usize = 16;
-const KATA_AGENT_VSOCK_TIMEOUT: u64 = 5;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -179,193 +167,7 @@ impl EpollContext {
     }
 }
 
-trait SockHandler {
-    fn setup_sock(&self) -> anyhow::Result<UnixStream>;
-}
-
-struct VsockConfig {
-    sock_cid: u32,
-    sock_port: u32,
-}
-
-impl VsockConfig {
-    fn new(sock_cid: u32, sock_port: u32) -> VsockConfig {
-        VsockConfig {
-            sock_cid,
-            sock_port,
-        }
-    }
-}
-
-impl SockHandler for VsockConfig {
-    fn setup_sock(&self) -> anyhow::Result<UnixStream> {
-        let sock_addr = VsockAddr::new(self.sock_cid, self.sock_port);
-
-        // Create socket fd
-        let vsock_fd = socket(
-            AddressFamily::Vsock,
-            SockType::Stream,
-            SockFlag::SOCK_CLOEXEC,
-            None,
-        )
-        .context("create vsock socket")?;
-
-        // Wrap the socket fd in UnixStream, so that it is closed
-        // when anything fails.
-        let stream = unsafe { UnixStream::from_raw_fd(vsock_fd.into_raw_fd()) };
-        // Connect the socket to vsock server.
-        connect(stream.as_raw_fd(), &sock_addr)
-            .with_context(|| format!("failed to connect to server {:?}", &sock_addr))?;
-
-        Ok(stream)
-    }
-}
-
-struct HvsockConfig {
-    sock_addr: String,
-    sock_port: u32,
-}
-
-impl HvsockConfig {
-    fn new(sock_addr: String, sock_port: u32) -> Self {
-        HvsockConfig {
-            sock_addr,
-            sock_port,
-        }
-    }
-}
-
-impl SockHandler for HvsockConfig {
-    fn setup_sock(&self) -> anyhow::Result<UnixStream> {
-        let mut stream = match UnixStream::connect(self.sock_addr.clone()) {
-            Ok(s) => s,
-            Err(e) => return Err(anyhow!(e).context("failed to create UNIX Stream socket")),
-        };
-
-        // Ensure the Unix Stream directly connects to the real VSOCK server which
-        // the Kata agent is listening to in the VM.
-        {
-            let test_msg = format!("{} {}\n", CMD_CONNECT, self.sock_port);
-
-            stream.set_read_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
-            stream.set_write_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
-
-            stream.write_all(test_msg.as_bytes())?;
-            // Now, see if we get the expected response
-            let stream_reader = stream.try_clone()?;
-            let mut reader = BufReader::new(&stream_reader);
-            let mut msg = String::new();
-
-            reader.read_line(&mut msg)?;
-            if msg.is_empty() {
-                return Err(anyhow!(
-                    "stream reader get message is empty with port: {:?}",
-                    self.sock_port
-                ));
-            }
-
-            // Expected response message returned was successful.
-            if msg.starts_with(CMD_OK) {
-                let response = msg
-                    .strip_prefix(CMD_OK)
-                    .ok_or(format!("invalid response: {msg:?}"))
-                    .map_err(|e| anyhow!(e))?
-                    .trim();
-                debug!(sl!(), "Hybrid Vsock host-side port: {:?}", response);
-                // Unset the timeout in order to turn the sokect to bloking mode.
-                stream.set_read_timeout(None)?;
-                stream.set_write_timeout(None)?;
-            } else {
-                return Err(anyhow!(
-                    "failed to setup Hybrid Vsock connection: {:?}",
-                    msg
-                ));
-            }
-        }
-
-        Ok(stream)
-    }
-}
-
-fn setup_client(server_url: String, dbg_console_port: u32) -> anyhow::Result<UnixStream> {
-    // server address format: scheme://[cid|/x/domain.sock]:port
-    let url_fields: Vec<&str> = server_url.split("://").collect();
-    if url_fields.len() != 2 {
-        return Err(anyhow!("invalid URI"));
-    }
-
-    let scheme = url_fields[0].to_uppercase();
-    let sock_addr: Vec<&str> = url_fields[1].split(':').collect();
-    if sock_addr.len() != 2 {
-        return Err(anyhow!("invalid VSOCK server address URI"));
-    }
-
-    match scheme.as_str() {
-        // Hybrid Vsock: hvsock://<path>:<port>.
-        // Example: "hvsock:///x/y/z/kata.hvsock:port"
-        // Firecracker/Dragonball/CLH implements the hybrid vsock device model.
-        SCHEME_HYBRID_VSOCK => {
-            let hvsock_path = sock_addr[0].to_string();
-            if hvsock_path.is_empty() {
-                return Err(anyhow!("hvsock path cannot be empty"));
-            }
-
-            let hvsock = HvsockConfig::new(hvsock_path, dbg_console_port);
-            hvsock.setup_sock().context("set up hvsock")
-        }
-        // Vsock: vsock://<cid>:<port>
-        // Example: "vsock://31513974:1024"
-        // Qemu using the Vsock device model.
-        SCHEME_VSOCK => {
-            let sock_cid: u32 = match sock_addr[0] {
-                "-1" | "" => libc::VMADDR_CID_ANY,
-                _ => match sock_addr[0].parse::<u32>() {
-                    Ok(cid) => cid,
-                    Err(e) => return Err(anyhow!("vsock addr CID is INVALID: {:?}", e)),
-                },
-            };
-
-            let vsock = VsockConfig::new(sock_cid, dbg_console_port);
-            vsock.setup_sock().context("set up vsock")
-        }
-        // Others will be INVALID URI.
-        _ => Err(anyhow!("invalid URI scheme: {:?}", scheme)),
-    }
-}
-
-async fn get_agent_socket(sandbox_id: &str) -> anyhow::Result<String> {
-    let shim_client = MgmtClient::new(sandbox_id, Some(TIMEOUT))?;
-
-    // get agent sock from body when status code is OK.
-    let response = shim_client.get(AGENT_URL).await?;
-    let status = response.status();
-    if status != StatusCode::OK {
-        return Err(anyhow!("shim client get connection failed: {:?} ", status));
-    }
-
-    let body = response.into_body().collect().await?.to_bytes();
-    let agent_sock = String::from_utf8(body.to_vec())?;
-
-    Ok(agent_sock)
-}
-
-fn get_server_socket(sandbox_id: &str) -> anyhow::Result<String> {
-    let server_url = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?
-        .block_on(get_agent_socket(sandbox_id))
-        .context("get connection vsock")?;
-
-    Ok(server_url)
-}
-
-fn do_run_exec(sandbox_id: &str, dbg_console_vport: u32) -> anyhow::Result<()> {
-    let server_url = get_server_socket(sandbox_id).context("get debug console socket URL")?;
-    if server_url.is_empty() {
-        return Err(anyhow!("server url is empty."));
-    }
-    let sock_stream = setup_client(server_url, dbg_console_vport)?;
-
+fn do_run_exec(sock_stream: UnixStream) -> anyhow::Result<()> {
     let mut epoll_context = EpollContext::new().expect("create epoll context");
     epoll_context
         .enable_stdin_event()
@@ -385,11 +187,38 @@ fn do_run_exec(sandbox_id: &str, dbg_console_vport: u32) -> anyhow::Result<()> {
     Ok(())
 }
 
-// kata-ctl handle exec command starts here.
-pub fn handle_exec(exec_args: ExecArguments) -> anyhow::Result<()> {
-    do_run_exec(exec_args.sandbox_id.as_str(), exec_args.vport)?;
+// Run a single command in the guest and relay what it printed, rather than
+// handing the console shell a terminal. The console carries one stream, so the
+// command's stderr arrives interleaved on stdout.
+fn do_run_command(sock_stream: UnixStream, argv: &[String]) -> anyhow::Result<i32> {
+    let cmd = argv
+        .iter()
+        .map(|arg| debug_console::shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ");
 
-    Ok(())
+    let mut session = Session::new(sock_stream);
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let status = session.run(&cmd, &mut out)?;
+    out.flush().context("flush stdout")?;
+
+    session.close();
+
+    Ok(status)
+}
+
+// kata-ctl handle exec command starts here.
+pub fn handle_exec(exec_args: ExecArguments) -> anyhow::Result<i32> {
+    let sock_stream = debug_console::connect(&exec_args.sandbox_id, exec_args.vport)?;
+
+    if exec_args.command.is_empty() {
+        do_run_exec(sock_stream)?;
+        return Ok(0);
+    }
+
+    do_run_command(sock_stream, &exec_args.command)
 }
 
 #[cfg(test)]
@@ -418,27 +247,5 @@ mod tests {
         assert_eq!(epoll_ctx.dispatch_table[1], EpollDispatch::Stdin);
         assert_eq!(epoll_ctx.dispatch_table.len(), 2);
         std::fs::remove_file(kata_hybrid_addr).unwrap_or_default();
-    }
-
-    #[test]
-    fn test_setup_hvsock_failed() {
-        let kata_hybrid_addr = "/tmp/kata_hybrid_vsock02.hvsock";
-        let hybrid_sock_addr = "hvsock:///tmp/kata_hybrid_vsock02.hvsock:1024";
-        std::fs::remove_file(kata_hybrid_addr).unwrap_or_default();
-        let dbg_console_port: u32 = 1026;
-        let mut server = HttpServer::new(kata_hybrid_addr).unwrap();
-        server.start_server().unwrap();
-
-        let stream = setup_client(hybrid_sock_addr.to_string(), dbg_console_port);
-        assert!(stream.is_err());
-        std::fs::remove_file(kata_hybrid_addr).unwrap_or_default();
-    }
-
-    #[test]
-    fn test_setup_vsock_client_failed() {
-        let hybrid_sock_addr = "hvsock://8:1024";
-        let dbg_console_port: u32 = 1026;
-        let stream = setup_client(hybrid_sock_addr.to_string(), dbg_console_port);
-        assert!(stream.is_err());
     }
 }

--- a/src/tools/kata-ctl/src/progress.rs
+++ b/src/tools/kata-ctl/src/progress.rs
@@ -1,0 +1,260 @@
+// Copyright (c) Kata Containers Community
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description:
+// A byte meter, for transfers slow enough that the caller needs telling they
+// are still moving.
+
+use std::{
+    io::{self, IsTerminal, Write},
+    time::{Duration, Instant},
+};
+
+/// How often the meter may redraw: often enough to look continuous, rarely
+/// enough that drawing it costs nothing next to what it is measuring.
+const TICK: Duration = Duration::from_millis(100);
+
+const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+/// Whether a meter is worth drawing. Redrawing a line a few times a second
+/// only reads as progress on a terminal; anywhere else it is noise in
+/// somebody's log. The test harness owns the terminal while the suite runs,
+/// so it does not count as one either.
+fn interactive() -> bool {
+    !cfg!(test) && io::stderr().is_terminal()
+}
+
+/// Bytes moved so far, drawn over a single line of the terminal and wiped off
+/// it once the transfer ends.
+pub struct Progress {
+    label: String,
+    total: Option<u64>,
+    done: u64,
+    started: Instant,
+    drawn: Instant,
+    /// Width of the line last drawn, so a shorter one wipes what it replaces.
+    width: usize,
+    live: bool,
+}
+
+impl Progress {
+    /// Start metering. `total` is what the transfer is expected to come to,
+    /// where that is knowable; without it the meter counts but cannot say out
+    /// of how much.
+    pub fn new(label: impl Into<String>, total: Option<u64>) -> Self {
+        let now = Instant::now();
+        let mut progress = Progress {
+            label: label.into(),
+            total,
+            done: 0,
+            started: now,
+            drawn: now,
+            width: 0,
+            live: interactive(),
+        };
+
+        // Draw once before anything has moved: the far end can be slow to
+        // produce a first byte, and until it does this is the only sign that
+        // something is happening.
+        progress.draw(false);
+
+        progress
+    }
+
+    pub fn add(&mut self, n: u64) {
+        self.done += n;
+
+        if self.drawn.elapsed() >= TICK {
+            self.drawn = Instant::now();
+            self.draw(false);
+        }
+    }
+
+    fn line(&self) -> String {
+        let rate = format!("{}/s", human(self.rate()));
+
+        match self.total {
+            Some(total) if total > 0 => {
+                // An estimate can be beaten, and a meter reading 103% looks
+                // like a bug rather than a rounding error.
+                let pct = std::cmp::min(100, self.done.saturating_mul(100) / total);
+
+                format!(
+                    "{}  {} / {}  {pct:>3}%  {rate}",
+                    self.label,
+                    human(self.done),
+                    human(total)
+                )
+            }
+            _ => format!("{}  {}  {rate}", self.label, human(self.done)),
+        }
+    }
+
+    fn rate(&self) -> u64 {
+        let secs = self.started.elapsed().as_secs_f64();
+        if secs <= 0.0 {
+            return 0;
+        }
+
+        (self.done as f64 / secs) as u64
+    }
+
+    /// The next reading, back at the start of the line and padded out to
+    /// whatever the last one occupied, so no tail of it shows past the end of
+    /// this one.
+    fn frame(&mut self) -> String {
+        let line = self.line();
+        let width = line.chars().count();
+        let pad = self.width.saturating_sub(width);
+        self.width = width;
+
+        format!("\r{line}{blank:pad$}", blank = "")
+    }
+
+    fn draw(&mut self, last: bool) {
+        if !self.live {
+            return;
+        }
+
+        let frame = self.frame();
+        let mut err = io::stderr().lock();
+
+        let _ = err.write_all(frame.as_bytes());
+        if last {
+            let _ = err.write_all(b"\n");
+        }
+        let _ = err.flush();
+    }
+}
+
+impl Drop for Progress {
+    /// Whether the transfer finished or gave up partway, the last thing drawn
+    /// should be where it got to, on a line of its own so that what comes next
+    /// - a shell prompt, or the error that ended it - starts on a clean one.
+    fn drop(&mut self) {
+        self.draw(true);
+    }
+}
+
+/// A writer that meters what passes through it on its way to another.
+pub struct Meter<W: Write> {
+    inner: W,
+    progress: Progress,
+}
+
+impl<W: Write> Meter<W> {
+    pub fn new(inner: W, progress: Progress) -> Self {
+        Meter { inner, progress }
+    }
+}
+
+impl<W: Write> Write for Meter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.progress.add(n as u64);
+
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Bytes as a size someone can take in at a glance.
+fn human(bytes: u64) -> String {
+    let mut size = bytes as f64;
+    let mut unit = 0;
+
+    while size >= 1024.0 && unit + 1 < UNITS.len() {
+        size /= 1024.0;
+        unit += 1;
+    }
+
+    match unit {
+        0 => format!("{bytes} B"),
+        _ => format!("{size:.1} {}", UNITS[unit]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_human() {
+        assert_eq!(human(0), "0 B");
+        assert_eq!(human(1023), "1023 B");
+        assert_eq!(human(1024), "1.0 KiB");
+        assert_eq!(human(1536), "1.5 KiB");
+        assert_eq!(human(10 * 1024 * 1024), "10.0 MiB");
+        assert_eq!(human(3 * 1024 * 1024 * 1024), "3.0 GiB");
+        // Nothing scales past the last unit, however big.
+        assert_eq!(human(2 * 1024 * 1024 * 1024 * 1024 * 1024), "2048.0 TiB");
+    }
+
+    #[test]
+    fn test_line_with_a_total() {
+        let mut progress = Progress::new("sending payload.bin", Some(4096));
+        progress.add(1024);
+
+        let line = progress.line();
+        assert!(line.starts_with("sending payload.bin  1.0 KiB / 4.0 KiB   25%"));
+    }
+
+    #[test]
+    fn test_line_without_a_total() {
+        let mut progress = Progress::new("receiving tree", None);
+        progress.add(2048);
+
+        let line = progress.line();
+        assert!(line.starts_with("receiving tree  2.0 KiB"), "{}", line);
+        // Nothing to be a percentage of.
+        assert!(!line.contains('%'), "{}", line);
+    }
+
+    /// A total is an estimate on both sides, so beating it must not read as a
+    /// bug, and a total too small to take a percentage of must not divide by
+    /// zero.
+    #[test]
+    fn test_percentage_is_bounded() {
+        let mut progress = Progress::new("sending x", Some(100));
+        progress.add(400);
+        assert!(progress.line().contains("100%"));
+
+        let mut tiny = Progress::new("sending x", Some(1));
+        tiny.add(1);
+        assert!(tiny.line().contains("100%"));
+    }
+
+    /// A shorter reading has to cover the longer one it replaces, or the tail
+    /// of the old line is left showing past the end of the new one.
+    #[test]
+    fn test_a_frame_covers_the_one_before_it() {
+        let mut progress = Progress::new("sending a-long-name.bin", None);
+
+        let first = progress.frame();
+        assert!(first.starts_with('\r'));
+        assert!(!first.ends_with(' '));
+
+        progress.label = "sending x".to_string();
+        let second = progress.frame();
+
+        assert_eq!(second.chars().count(), first.chars().count());
+        assert!(second.ends_with(' '));
+    }
+
+    #[test]
+    fn test_meter_counts_what_it_passes_on() {
+        let mut out = Vec::new();
+        let mut meter = Meter::new(&mut out, Progress::new("sending x", None));
+
+        meter.write_all(b"hello").unwrap();
+        meter.write_all(b" world").unwrap();
+        assert_eq!(meter.progress.done, 11);
+
+        drop(meter);
+        assert_eq!(out, b"hello world");
+    }
+}

--- a/src/tools/kata-ctl/src/utils.rs
+++ b/src/tools/kata-ctl/src/utils.rs
@@ -159,14 +159,43 @@ pub fn supports_vsocks(vsock_path: &str) -> Result<bool> {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::env;
     use std::io::Write;
+    use std::process::Command;
     use tempfile::tempdir;
 
+    /// Set on the copy of the test binary that does the dropping, so it knows
+    /// to do it rather than start another one.
+    const DROP_PRIVS_CHILD: &str = "KATA_CTL_TEST_DROP_PRIVS_CHILD";
+
+    /// Dropping privileges cannot be undone and applies to the whole process,
+    /// and every test here runs in a thread of one. Dropping in place would
+    /// take root away from whatever else is running, which under `sudo make
+    /// test` leaves the longer tests unable to touch the files they created.
+    /// So run the real thing in a fresh copy of this binary and go by what it
+    /// exits with. A new process rather than a fork of this one: looking a
+    /// user up in the child of a process this threaded is a way to deadlock.
     #[test]
     #[serial]
     fn test_drop_privs() {
-        let res = drop_privs();
-        assert!(res.is_ok());
+        if env::var_os(DROP_PRIVS_CHILD).is_some() {
+            drop_privs().unwrap();
+            return;
+        }
+
+        let before = nix::unistd::Uid::effective();
+        let status = Command::new(env::current_exe().unwrap())
+            .args(["utils::tests::test_drop_privs", "--exact", "--nocapture"])
+            .env(DROP_PRIVS_CHILD, "1")
+            .status()
+            .unwrap();
+
+        assert!(status.success(), "dropping privileges failed: {}", status);
+        assert_eq!(
+            nix::unistd::Uid::effective(),
+            before,
+            "the suite dropped its own privileges"
+        );
     }
 
     #[test]

--- a/tests/integration/kubernetes/k8s-devkit-debug-console.bats
+++ b/tests/integration/kubernetes/k8s-devkit-debug-console.bats
@@ -38,10 +38,10 @@ devkit_runtimeclass() {
 # directory the mounted extensions ship, which assert_extension_dirs_in_path()
 # then cross-checks on this side.
 #
-# One complete command per element, joined by newlines below: the guest reads
-# these from a PTY, so nothing is spread over continuation lines. Single quotes
-# cannot appear either - run_debug_console() feeds the result through a
-# single-quoted printf on the node.
+# One complete command per element, joined into a single line below: kata-ctl
+# hands the probe to the console shell as one line, so nothing is spread over
+# continuation lines. Single quotes cannot appear either - run_debug_console()
+# single-quotes the probe for the shell on the node.
 DEVKIT_PROBE_COMMANDS=(
 	'echo "SHELL_OK=$((6*7))"'
 	'. /etc/os-release 2>/dev/null; echo "GUEST_ID=${ID}"'
@@ -51,7 +51,8 @@ DEVKIT_PROBE_COMMANDS=(
 	# not list them (the GPU extension's usr/bin -> ../bin).
 	'for d in /real_root/run/kata-extensions/*/bin; do test -d "${d}" && ! test -L "${d}" && echo "EXT_BIN=${d#/real_root}"; done'
 )
-DEVKIT_PROBE="$(printf '%s\n' "${DEVKIT_PROBE_COMMANDS[@]}")"
+DEVKIT_PROBE="$(printf '%s; ' "${DEVKIT_PROBE_COMMANDS[@]}")"
+DEVKIT_PROBE="${DEVKIT_PROBE%; }"
 
 check_and_skip() {
 	if ! devkit_supported; then
@@ -93,22 +94,17 @@ launch_pod() {
 	echo "sandbox id: ${sandbox_id}"
 }
 
-# Drive the interactive agent debug console for sandbox_id with DEVKIT_PROBE and
-# echo the combined output.
+# Run DEVKIT_PROBE on the agent debug console for sandbox_id and echo what it
+# printed. `kata-ctl exec ... -- <cmd>` waits for the console shell to be ready
+# on its own, so no terminal has to be faked and no sleeps have to be guessed.
 #
-# The console is an interactive PTY, so a bare pipe races the guest login shell
-# startup and loses the input. Drive it with a real terminal via `script`
-# (util-linux), feeding commands through a FIFO whose writer stays open long
-# enough for the shell to be ready before input arrives and to flush output
-# before we send `exit`.
+# DEVKIT_PROBE carries no single quotes, so it survives being single-quoted here
+# for the remote shell.
 run_debug_console() {
 	local sandbox_id="$1"
-	local remote="
-fifo=\$(mktemp -u); mkfifo \"\${fifo}\"
-( sleep 2; printf '%s\\n' '${DEVKIT_PROBE}'; sleep 3; printf 'exit\\n'; sleep 1 ) > \"\${fifo}\" &
-timeout 120 script -qec \"nsenter --mount=/proc/1/ns/mnt /opt/kata/bin/kata-ctl exec ${sandbox_id}\" /dev/null < \"\${fifo}\" 2>&1
-rm -f \"\${fifo}\"
-"
+	local remote="timeout 120 nsenter --mount=/proc/1/ns/mnt \
+/opt/kata/bin/kata-ctl exec ${sandbox_id} -- sh -c '${DEVKIT_PROBE}' 2>&1"
+
 	exec_host "${node}" "${remote}" || true
 }
 

--- a/tests/integration/kubernetes/k8s-devkit-debug-console.bats
+++ b/tests/integration/kubernetes/k8s-devkit-debug-console.bats
@@ -174,6 +174,35 @@ setup() {
 	assert_extension_dirs_in_path "${output}"
 }
 
+@test "kata-ctl cp moves a file in and out of the devkit guest" {
+	launch_pod "$(devkit_runtimeclass)"
+
+	local token="devkit-cp-${RANDOM}${RANDOM}"
+	local src="/tmp/kata-ctl-cp-src"
+	local dst="/tmp/kata-ctl-cp-dst"
+	local guest="/tmp/kata-ctl-cp-payload"
+
+	# All of this runs in PID 1's mount namespace: that is where the shim
+	# socket kata-ctl needs lives, and it also keeps the host paths below
+	# meaning the same thing to the shell that writes them and to kata-ctl.
+	# Nothing interpolated here carries a single quote, so the script survives
+	# being single-quoted for the remote shell.
+	local script="set -e"
+	script+="; printf %s ${token} > ${src}"
+	script+="; /opt/kata/bin/kata-ctl cp ${src} ${sandbox_id}:${guest}"
+	script+="; /opt/kata/bin/kata-ctl cp ${sandbox_id}:${guest} ${dst}"
+	script+="; cat ${dst}"
+	script+="; rm -f ${src} ${dst}"
+
+	local output
+	output="$(exec_host "${node}" "timeout 120 nsenter --mount=/proc/1/ns/mnt sh -c '${script}'")"
+	echo "kata-ctl cp output:"
+	echo "${output}"
+
+	echo "${output}" | grep -q "${token}" \
+		|| die "kata-ctl cp did not round-trip the payload through the guest"
+}
+
 teardown() {
 	check_and_skip
 

--- a/tests/integration/kubernetes/k8s-devkit-debug-console.bats
+++ b/tests/integration/kubernetes/k8s-devkit-debug-console.bats
@@ -88,8 +88,8 @@ launch_pod() {
 	kubectl create -f "${pod_config}"
 	kubectl wait --for=condition=Ready --timeout="${timeout}" "pod/${pod_name}"
 
-	sandbox_id="$(get_node_kata_sandbox_id "${node}")"
-	[[ -n "${sandbox_id}" ]] || die "Failed to resolve kata sandbox id on node ${node}"
+	sandbox_id="$(get_pod_sandbox_id "${pod_name}")"
+	[[ -n "${sandbox_id}" ]] || die "Failed to resolve the sandbox id of pod ${pod_name}"
 	echo "sandbox id: ${sandbox_id}"
 }
 

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -168,6 +168,28 @@ exec_host() {
 	kubectl exec -qi -n kube-system "${pod_name}" -- chroot /host bash -c "${command}" | tr -d '\r'
 }
 
+# Return the sandbox id of a pod, as the container runtime knows it. For Kata
+# that is also the id the shim, the guest and kata-ctl go by.
+#
+# Only ready sandboxes count: a pod name can be reused once the pod that had it
+# is gone, and the runtime remembers the dead sandbox for a while afterwards.
+#
+# Parameters:
+#	$1 - pod name in the current Kubernetes namespace
+get_pod_sandbox_id() {
+	local pod_name="$1"
+	local node
+
+	node="$(kubectl get pod "${pod_name}" -o jsonpath='{.spec.nodeName}')"
+	[[ -n "${node}" ]] || die "No node found for pod ${pod_name}"
+	exec_host "${node}" "command -v crictl >/dev/null" || \
+		die "crictl is required on Kubernetes node ${node}"
+
+	exec_host "${node}" \
+		"crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
+		pods --name \"${pod_name}\" --state ready -q | head -1"
+}
+
 # Return the QEMU PID for a running pod.
 #
 # Parameters:
@@ -178,15 +200,11 @@ get_qemu_pid_for_pod() {
 	local qemu_pid
 	local sandbox_id
 
+	sandbox_id="$(get_pod_sandbox_id "${pod_name}")"
+	[[ -n "${sandbox_id}" ]] || die "No sandbox ID found for pod ${pod_name}"
+
 	node="$(kubectl get pod "${pod_name}" -o jsonpath='{.spec.nodeName}')"
 	[[ -n "${node}" ]] || die "No node found for pod ${pod_name}"
-	exec_host "${node}" "command -v crictl >/dev/null" || \
-		die "crictl is required on Kubernetes node ${node}"
-
-	sandbox_id="$(exec_host "${node}" \
-		"crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-		pods --name \"${pod_name}\" -q | head -1")"
-	[[ -n "${sandbox_id}" ]] || die "No sandbox ID found for pod ${pod_name}"
 
 	qemu_pid="$(exec_host "${node}" \
 		"pgrep -f \"qemu.*${sandbox_id}\" | head -1")"
@@ -500,30 +518,4 @@ set_node() {
   yq -i \
     "${spec} = \"${node}\"" \
     "${yaml}"
-}
-
-# Get the sandbox id for kata container from a worker node
-#
-# Parameters:
-#	$1 - the k8s worker node name
-#
-get_node_kata_sandbox_id() {
-	local node="$1"
-	local kata_sandbox_id=""
-	local local_wait_time="${wait_time}"
-	# Max loop 3 times to get kata_sandbox_id
-	while [[ "${local_wait_time}" -gt 0 ]];
-	do
-		kata_sandbox_id=$(exec_host "${node}" "ps -ef |\
-		  grep containerd-shim-kata-v2" |\
-		  grep -oP '(?<=-id\s)[a-f0-9]+' |\
-		  tail -1)
-		if [[ -n "${kata_sandbox_id}" ]]; then
-			break
-		else
-			sleep "${sleep_time}"
-			local_wait_time=$((local_wait_time-sleep_time))
-		fi
-	done
-	echo "${kata_sandbox_id}"
 }


### PR DESCRIPTION
Some guests are hard to debug. With `shared_fs=none` and a read-only, measured
rootfs, there is no host directory you can drop a file into. The only way in is
the agent debug console.

Right now `kata-ctl exec` can only attach a terminal to that console. That is
fine if you are sitting at a keyboard, but useless from a script, and it cannot
move files at all. This PR fixes both.

### Run one command

```
    kata-ctl exec <sandbox-id> -- cat /proc/cmdline
```

With no command, exec attaches a terminal as before. With one, you get the
output on stdout and kata-ctl exits with the command's exit code.

This needed some plumbing. The console is just a shell on a pseudo-terminal. It
does not say where output starts or stops, and it does not report exit codes. So
each command is wrapped in two markers that only the guest can print, and the
exit code is printed after the second one. We also turn off echo and CRNL
translation so output comes back byte for byte. Guests without `stty` still
work.

One caveat: the console is a single stream, so stderr comes back mixed into
stdout.

### Copy files

```
    kata-ctl cp ./tool <sandbox-id>:/tmp/tool
    kata-ctl cp <sandbox-id>:/var/log ./guest-logs
```

Same addressing as `docker cp`. If the destination is a directory that already
exists, the copy goes inside it. Otherwise the destination is the new name.

Files travel as a tar stream, so directories keep their layout and permissions.
The tar is base64'd, because a terminal cannot carry raw binary or very long
lines. One thread moves the archive while another drains the console, so neither
side can block the other, and nothing is written to a temp file first.

Copies are slow, so there is a progress meter. It only shows when stderr is a
terminal:

```
    sending payload.bin  4.0 MiB / 40.0 MiB   10%  1.2 MiB/s
```

### Why cp needs devkit

`cp` checks for the devkit extension first, and tells you which RuntimeClass to
use if it is missing. Devkit is where the shell, tar and base64 come from, and
minimal guest images have none of them. Checking early gives a clear error
instead of a failure halfway through a copy.

To be clear, **this check is not a security control**, and it should not be one. The
debug console is a root shell. Anyone who can open it can already copy files in
and out with a short script and no kata-ctl at all.

**The real control is whether the console exists: the agent only serves one if the
guest booted with `agent.debug_console`, which only happens with
`debug_console_enabled`, and a confidential guest measures that kernel
command line.**