### PR TITLE
devkit: take the CUDA repository from versions.yaml

### DIFF
--- a/tools/osbuilder/rootfs-builder/devkit/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/devkit/Dockerfile.in
@@ -8,11 +8,13 @@ FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 
 # mmdebstrap builds the devkit rootfs; the extension ships no agent, so none of
 # the language toolchains the guest rootfs builder carries are needed here.
+# curl only bootstraps yq, which the build needs to read versions.yaml.
 # hadolint ignore=DL3009
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get --no-install-recommends -y install \
     ca-certificates \
+    curl \
     file \
     mmdebstrap \
     zstd && \

--- a/tools/osbuilder/rootfs-builder/devkit/devkit-add-nvidia-repos.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/devkit-add-nvidia-repos.sh
@@ -22,18 +22,20 @@ if [[ "${ID:-}" != "ubuntu" ]]; then
 	exit 1
 fi
 
-# NVIDIA publishes repos per distro tag (24.04 -> ubuntu2404) and per arch, with
-# 'sbsa' standing in for arm64.
-version_id="${VERSION_ID:-}"
-distro="ubuntu${version_id//./}"
-case "$(uname -m)" in
-	x86_64) repo_arch="x86_64" ;;
-	aarch64) repo_arch="sbsa" ;;
-	*) echo "add-nvidia-repos: unsupported arch $(uname -m)" >&2; exit 1 ;;
-esac
+# The repository NVIDIA publishes per distro tag (24.04 -> ubuntu2404) and per
+# arch ('sbsa' for arm64) is pinned in versions.yaml under
+# externals.nvidia.cuda.repo, the same entry the GPU rootfs builds consume. The
+# devkit shell has no versions.yaml to read, so the build bakes it in here.
+base_url="@CUDA_REPO_URL@"
+keyring_deb="@CUDA_REPO_PKG@"
 
-base_url="https://developer.download.nvidia.com/compute/cuda/repos/${distro}/${repo_arch}"
-keyring_deb="cuda-keyring_1.1-1_all.deb"
+if [[ -z "${base_url}" ]] || [[ "${base_url}" == @* ]] || [[ -z "${keyring_deb}" ]]; then
+	echo "add-nvidia-repos: no CUDA repository was baked into this devkit (see externals.nvidia.cuda.repo in versions.yaml)" >&2
+	exit 1
+fi
+
+# versions.yaml stores the repository URL with a trailing slash.
+base_url="${base_url%/}"
 
 echo "add-nvidia-repos: adding ${base_url}"
 tmpdir="$(mktemp -d)"

--- a/tools/osbuilder/rootfs-builder/devkit/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/rootfs_lib.sh
@@ -49,6 +49,22 @@ build_rootfs() {
 	done
 	ln -sf devkit-enter "${rootfs_dir}/usr/bin/devkit-sh"
 
+	# devkit-add-nvidia-repos runs inside the guest, where versions.yaml is not
+	# available, so resolve the pinned CUDA repository here and bake it in. Arches
+	# with no entry get the placeholders substituted away, which makes the helper
+	# refuse to run rather than reach for an unpinned URL.
+	local cuda_repo_url cuda_repo_pkg
+	# ARCH is exported by rootfs.sh.
+	# shellcheck disable=SC2154
+	cuda_repo_url=$(get_package_version_from_kata_yaml "externals.nvidia.cuda.repo.${ARCH}.url")
+	cuda_repo_pkg=$(get_package_version_from_kata_yaml "externals.nvidia.cuda.repo.${ARCH}.pkg")
+	[[ -n "${cuda_repo_url}" ]] \
+		|| info "no externals.nvidia.cuda.repo entry for ${ARCH}: devkit-add-nvidia-repos will be inert"
+	sed -i \
+		-e "s|@CUDA_REPO_URL@|${cuda_repo_url}|g" \
+		-e "s|@CUDA_REPO_PKG@|${cuda_repo_pkg}|g" \
+		"${rootfs_dir}/usr/bin/devkit-add-nvidia-repos"
+
 	# apt in the debug overlay runs as root: this is a single-user chroot and the
 	# _apt sandbox user cannot create its temp files (apt-key config, partials) on
 	# the tmpfs overlay, which otherwise breaks `apt-get update`. Keep /tmp sticky

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -864,12 +864,18 @@ install_image_devkit_extension() {
 	[[ "${os_name}" == "ubuntu" ]] || die "devkit extension expects an ubuntu base, got '${os_name}' for ${ARCH}"
 	[[ -n "${os_version}" ]] || die "assets.image.architecture.${ARCH}.version must be set in versions.yaml"
 
-	# Self-contained (Ubuntu release + guest scripts), so key the cache on the
-	# Ubuntu version and the devkit source directory.
+	# Self-contained (Ubuntu release + guest scripts + the CUDA repository baked
+	# into devkit-add-nvidia-repos), so key the cache on the Ubuntu version, the
+	# devkit source directory and that repository pin.
 	local devkit_last_commit
 	devkit_last_commit="$(git -C "${repo_root_dir}" log -1 --abbrev=9 --pretty=format:"%h" \
 		-- tools/osbuilder/rootfs-builder/devkit 2>/dev/null || echo "unknown")"
-	latest_artefact="$(get_kata_version)-devkit-extension-${os_version}-${devkit_last_commit}"
+	local cuda_repo_pin
+	cuda_repo_pin="$(printf '%s %s' \
+		"$(get_from_kata_deps ".externals.nvidia.cuda.repo.${ARCH}.url")" \
+		"$(get_from_kata_deps ".externals.nvidia.cuda.repo.${ARCH}.pkg")" \
+		| sha256sum | cut -c1-9)"
+	latest_artefact="$(get_kata_version)-devkit-extension-${os_version}-${devkit_last_commit}-${cuda_repo_pin}"
 	latest_builder_image=""
 
 	install_cached_tarball_component \


### PR DESCRIPTION
As done everywhere else, let's read those from versions.yaml.


Assisted-by: Cursor <cursoragent@cursor.com>