### PR TITLE
runtime-rs: serialize sandbox.start() and reclaim IFF_PERSIST taps (fix EBUSY)

### DIFF
--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -1,0 +1,112 @@
+name: Build & Publish Kata Shim Overlay (NVSwitch)
+
+on:
+  push:
+    branches:
+      - kubecon-staging
+    paths:
+      - 'src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs'
+      - '.github/workflows/build-shim-overlay.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
+  SHIM_TAG: v4.0.0-nvswitch-fix3
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout kata-containers fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        run: |
+          rustup default 1.88.0
+          rustup target add x86_64-unknown-linux-musl
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq musl-tools clang llvm protobuf-compiler libseccomp-dev
+
+      - name: Verify NVSwitch patch is present
+        run: |
+          echo "=== Checking for 0x0680 exception in core.rs ==="
+          grep -n "0x0680" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          echo "=== Current commit ==="
+          git log --oneline -1
+
+      - name: Build containerd-shim-kata-v2
+        working-directory: src/runtime-rs
+        run: |
+          cargo build --release --target x86_64-unknown-linux-musl --bin containerd-shim-kata-v2
+          echo "=== Build complete ==="
+          ls -la target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
+          sha256sum target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
+
+      - name: Stage binary for Docker build
+        run: |
+          mkdir -p overlay-image
+          cp src/runtime-rs/target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2 overlay-image/
+
+      - name: Create overlay.sh
+        run: |
+          cat > overlay-image/overlay.sh << 'OVERLAY_EOF'
+          #!/bin/sh
+          set -eu
+          SRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2
+          DST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2
+          MARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied
+          echo "[overlay] waiting for kata-deploy to install $DST ..."
+          while [ ! -f "$DST" ]; do sleep 5; done
+          echo "[overlay] $DST present"
+          apply() {
+            if cmp -s "$SRC" "$DST"; then
+              echo "[overlay] shim already patched (no-op)"
+            else
+              cp "$SRC" "$DST"
+              chmod 755 "$DST"
+              sha256sum "$SRC" | cut -d' ' -f1 > "$MARK"
+              echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"
+            fi
+          }
+          apply
+          echo "[overlay] entering watch loop (re-apply if kata-deploy re-installs)"
+          while true; do sleep 60; apply; done
+          OVERLAY_EOF
+          chmod 755 overlay-image/overlay.sh
+
+      - name: Create Dockerfile
+        run: |
+          cat > overlay-image/Dockerfile << 'DOCKERFILE_EOF'
+          FROM alpine:3.22
+          COPY containerd-shim-kata-v2 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2
+          COPY overlay.sh /overlay.sh
+          RUN chmod 755 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /overlay.sh
+          CMD ["/bin/sh", "/overlay.sh"]
+          DOCKERFILE_EOF
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push overlay image
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -f overlay-image/Dockerfile \
+            -t ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} \
+            --push \
+            overlay-image/
+          echo "=== Pushed ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} ==="
+
+      - name: Verify image
+        run: |
+          docker run --rm ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} sha256sum /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 || true

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -68,7 +68,8 @@ jobs:
         working-directory: src/runtime-rs
         run: |
           cargo build --release --target x86_64-unknown-linux-musl --bin containerd-shim-kata-v2
-          BIN=$(find /home/aph5nt/actions-runner-kubetee/_work -name 'containerd-shim-kata-v2' -type f 2>/dev/null | head -1)
+          BIN=target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
+          test -f "$BIN"
           echo "Binary found at: $BIN"
           cp "$BIN" ./containerd-shim-kata-v2
           ls -la ./containerd-shim-kata-v2

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -43,6 +43,31 @@ jobs:
           echo "=== Current commit ==="
           git log --oneline -1
 
+      - name: Generate config.rs (auto-generated, gitignored)
+        working-directory: src/runtime-rs
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          cat > crates/shim/src/config.rs << CONFIG_EOF
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//
+// WARNING: This file is auto-generated - DO NOT EDIT!
+//
+
+pub const PROJECT_NAME: &str = "Kata Containers";
+pub const RUNTIME_VERSION: &str = "4.0.0";
+pub const RUNTIME_GIT_COMMIT: &str = "${COMMIT}";
+pub const RUNTIME_NAME: &str = "containerd-shim-kata-v2";
+pub const CONTAINERD_RUNTIME_NAME: &str = "io.containerd.kata.v2";
+pub const RUNTIME_DIR: &str = "/usr/local/bin";
+pub const RUNTIME_PATH: &str = "/usr/local/bin/containerd-shim-kata-v2";
+CONFIG_EOF
+          echo "=== Generated config.rs ==="
+          cat crates/shim/src/config.rs
+
       - name: Build containerd-shim-kata-v2
         working-directory: src/runtime-rs
         run: |

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -15,7 +15,10 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
-  SHIM_TAG: v4.0.0-nvswitch-fix5
+  # fix6: replace local 0x0680 bitmask exception with upstream exact-class
+  # IOMMU filter + IOMMUFD single-device discover (410d12fe8 / 2c1c961bb,
+  # kata-containers#13430). Keeps fix5 QEMU reap (#13564).
+  SHIM_TAG: v4.0.0-nvswitch-fix6
 
 jobs:
   build-and-push:
@@ -41,8 +44,14 @@ jobs:
 
       - name: Verify patches are present
         run: |
-          echo "Checking for 0x0680 exception in core.rs"
-          grep -n "0x0680" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
+          grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          # Must NOT still use the old bitmask exception path
+          if grep -n 'if class_code == 0x0680' src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
+            echo "ERROR: old 0x0680 exception still present" >&2
+            exit 1
+          fi
           echo "Checking for zombie QEMU fix in inner.rs"
           grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
           git log --oneline -1

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -7,12 +7,13 @@ on:
       - kubecon-staging
     paths:
       - 'src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs'
+      - 'src/runtime-rs/crates/hypervisor/src/qemu/inner.rs'
       - '.github/workflows/build-shim-overlay.yaml'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
-  SHIM_TAG: v4.0.0-nvswitch-fix3
+  SHIM_TAG: v4.0.0-nvswitch-fix4
 
 jobs:
   build-and-push:
@@ -36,10 +37,12 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq musl-tools clang llvm protobuf-compiler libseccomp-dev
 
-      - name: Verify NVSwitch patch is present
+      - name: Verify patches are present
         run: |
           echo "Checking for 0x0680 exception in core.rs"
           grep -n "0x0680" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          echo "Checking for zombie QEMU fix in inner.rs"
+          grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
           git log --oneline -1
 
       - name: Generate config.rs

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Kata Shim Overlay NVSwitch
+name: Build and Publish Kata Shim Overlay
 
 on:
   workflow_dispatch:
@@ -15,10 +15,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
-  # fix6: replace local 0x0680 bitmask exception with upstream exact-class
-  # IOMMU filter + IOMMUFD single-device discover (410d12fe8 / 2c1c961bb,
-  # kata-containers#13430). Keeps fix5 QEMU reap (#13564).
-  SHIM_TAG: v4.0.0-nvswitch-fix6
 
 jobs:
   build-and-push:
@@ -26,11 +22,26 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # QEMU reap only (#13564 fix5). Tree after local 0x0680 revert, before
+          # upstream NVSwitch IOMMU cherry-picks. Deploy on Blackwell (gpu.family).
+          - shim_tag: v4.0.0-qemu-reap-fix5
+            checkout_ref: cf449bac1c719e3b22c745bc7e9e1299db114bac
+            variant: qemu-reap
+          # QEMU reap + upstream NVSwitch IOMMU (fix6). HEAD of kubecon-staging.
+          # Deploy on Hopper (gpu.family) only.
+          - shim_tag: v4.0.0-nvswitch-fix6
+            checkout_ref: ''
+            variant: nvswitch
     steps:
       - name: Checkout kata-containers fork
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ matrix.checkout_ref != '' && matrix.checkout_ref || github.sha }}
 
       - name: Install Rust toolchain
         run: |
@@ -44,17 +55,34 @@ jobs:
 
       - name: Verify patches are present
         run: |
-          echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
-          grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          # Must NOT still use the old bitmask exception path
+          set -eu
+          VARIANT="${{ matrix.variant }}"
+          echo "variant=$VARIANT commit=$(git rev-parse --short HEAD)"
+          git log --oneline -1
+
+          echo "Checking for zombie QEMU fix in inner.rs"
+          grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
+          if ! grep -q "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs; then
+            echo "ERROR: fix5 stop_vm reap missing from inner.rs" >&2
+            exit 1
+          fi
+          # Must NOT still use the old bitmask exception path in either variant
           if grep -n 'if class_code == 0x0680' src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
             echo "ERROR: old 0x0680 exception still present" >&2
             exit 1
           fi
-          echo "Checking for zombie QEMU fix in inner.rs"
-          grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
-          git log --oneline -1
+
+          if [ "$VARIANT" = "nvswitch" ]; then
+            echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
+            grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+            grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          else
+            echo "qemu-reap: upstream NVSwitch path must NOT be present"
+            if grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
+              echo "ERROR: IOMMU_IGNORE_CLASSES present in qemu-reap tree" >&2
+              exit 1
+            fi
+          fi
 
       - name: Generate config.rs
         working-directory: src/runtime-rs
@@ -79,7 +107,8 @@ jobs:
           mkdir -p overlay-image
           cp src/runtime-rs/containerd-shim-kata-v2 overlay-image/
 
-          printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied\necho "[overlay] waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' > overlay-image/overlay.sh
+          MARK_NAME=".shim-overlay-${{ matrix.variant }}-applied"
+          printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/%s\necho "[overlay] variant=%s waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' "$MARK_NAME" "${{ matrix.variant }}" > overlay-image/overlay.sh
           chmod 755 overlay-image/overlay.sh
 
           printf 'FROM alpine:3.22\nCOPY containerd-shim-kata-v2 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nCOPY overlay.sh /overlay.sh\nRUN chmod 755 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /overlay.sh\nCMD ["/bin/sh", "/overlay.sh"]\n' > overlay-image/Dockerfile
@@ -93,11 +122,11 @@ jobs:
         run: |
           docker buildx build --platform linux/amd64 \
             -f overlay-image/Dockerfile \
-            -t ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} \
+            -t ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }} \
             --push \
             overlay-image/
-          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG}"
+          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }}"
 
       - name: Verify image
         run: |
-          docker run --rm ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} sha256sum /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 || true
+          docker run --rm ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }} sha256sum /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 || true

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -1,13 +1,13 @@
-name: Build & Publish Kata Shim Overlay (NVSwitch)
+name: Build and Publish Kata Shim Overlay NVSwitch
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - kubecon-staging
     paths:
       - 'src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs'
       - '.github/workflows/build-shim-overlay.yaml'
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       packages: write
@@ -38,85 +38,34 @@ jobs:
 
       - name: Verify NVSwitch patch is present
         run: |
-          echo "=== Checking for 0x0680 exception in core.rs ==="
+          echo "Checking for 0x0680 exception in core.rs"
           grep -n "0x0680" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          echo "=== Current commit ==="
           git log --oneline -1
 
-      - name: Generate config.rs (auto-generated, gitignored)
+      - name: Generate config.rs
         working-directory: src/runtime-rs
         run: |
           COMMIT=$(git rev-parse --short HEAD)
-          cat > crates/shim/src/config.rs << CONFIG_EOF
-// Copyright (c) 2020 Intel Corporation
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-
-//
-// WARNING: This file is auto-generated - DO NOT EDIT!
-//
-
-pub const PROJECT_NAME: &str = "Kata Containers";
-pub const RUNTIME_VERSION: &str = "4.0.0";
-pub const RUNTIME_GIT_COMMIT: &str = "${COMMIT}";
-pub const RUNTIME_NAME: &str = "containerd-shim-kata-v2";
-pub const CONTAINERD_RUNTIME_NAME: &str = "io.containerd.kata.v2";
-pub const RUNTIME_DIR: &str = "/usr/local/bin";
-pub const RUNTIME_PATH: &str = "/usr/local/bin/containerd-shim-kata-v2";
-CONFIG_EOF
-          echo "=== Generated config.rs ==="
+          mkdir -p crates/shim/src
+          printf '// SPDX-License-Identifier: Apache-2.0\n// WARNING: auto-generated\n\npub const PROJECT_NAME: &str = "Kata Containers";\npub const RUNTIME_VERSION: &str = "4.0.0";\npub const RUNTIME_GIT_COMMIT: &str = "%s";\npub const RUNTIME_NAME: &str = "containerd-shim-kata-v2";\npub const CONTAINERD_RUNTIME_NAME: &str = "io.containerd.kata.v2";\npub const RUNTIME_DIR: &str = "/usr/local/bin";\npub const RUNTIME_PATH: &str = "/usr/local/bin/containerd-shim-kata-v2";\n' "$COMMIT" > crates/shim/src/config.rs
           cat crates/shim/src/config.rs
 
       - name: Build containerd-shim-kata-v2
         working-directory: src/runtime-rs
         run: |
           cargo build --release --target x86_64-unknown-linux-musl --bin containerd-shim-kata-v2
-          echo "=== Build complete ==="
           ls -la target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
           sha256sum target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
 
-      - name: Stage binary for Docker build
+      - name: Stage binary and create overlay image
         run: |
           mkdir -p overlay-image
           cp src/runtime-rs/target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2 overlay-image/
 
-      - name: Create overlay.sh
-        run: |
-          cat > overlay-image/overlay.sh << 'OVERLAY_EOF'
-          #!/bin/sh
-          set -eu
-          SRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2
-          DST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2
-          MARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied
-          echo "[overlay] waiting for kata-deploy to install $DST ..."
-          while [ ! -f "$DST" ]; do sleep 5; done
-          echo "[overlay] $DST present"
-          apply() {
-            if cmp -s "$SRC" "$DST"; then
-              echo "[overlay] shim already patched (no-op)"
-            else
-              cp "$SRC" "$DST"
-              chmod 755 "$DST"
-              sha256sum "$SRC" | cut -d' ' -f1 > "$MARK"
-              echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"
-            fi
-          }
-          apply
-          echo "[overlay] entering watch loop (re-apply if kata-deploy re-installs)"
-          while true; do sleep 60; apply; done
-          OVERLAY_EOF
+          printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied\necho "[overlay] waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' > overlay-image/overlay.sh
           chmod 755 overlay-image/overlay.sh
 
-      - name: Create Dockerfile
-        run: |
-          cat > overlay-image/Dockerfile << 'DOCKERFILE_EOF'
-          FROM alpine:3.22
-          COPY containerd-shim-kata-v2 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2
-          COPY overlay.sh /overlay.sh
-          RUN chmod 755 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /overlay.sh
-          CMD ["/bin/sh", "/overlay.sh"]
-          DOCKERFILE_EOF
+          printf 'FROM alpine:3.22\nCOPY containerd-shim-kata-v2 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nCOPY overlay.sh /overlay.sh\nRUN chmod 755 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /overlay.sh\nCMD ["/bin/sh", "/overlay.sh"]\n' > overlay-image/Dockerfile
 
       - name: Log in to GHCR
         env:
@@ -130,7 +79,7 @@ CONFIG_EOF
             -t ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} \
             --push \
             overlay-image/
-          echo "=== Pushed ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} ==="
+          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG}"
 
       - name: Verify image
         run: |

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -71,13 +71,20 @@ jobs:
       - name: Build containerd-shim-kata-v2
         working-directory: src/runtime-rs
         run: |
+          set -eux
           cargo build --release --target x86_64-unknown-linux-musl --bin containerd-shim-kata-v2
-          BIN=target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
-          test -f "$BIN"
+          # Workspace cargo target-dir is the repo root (not src/runtime-rs/target).
+          BIN="../../target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2"
+          if [ ! -f "$BIN" ]; then
+            echo "ERROR: expected binary missing at $BIN; searching..."
+            find ../.. -name 'containerd-shim-kata-v2' -type f 2>/dev/null | head -10 || true
+            exit 1
+          fi
           echo "Binary found at: $BIN"
           cp "$BIN" ./containerd-shim-kata-v2
           ls -la ./containerd-shim-kata-v2
           sha256sum ./containerd-shim-kata-v2
+          file ./containerd-shim-kata-v2
 
       - name: Stage binary and create overlay image
         run: |

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -8,12 +8,14 @@ on:
     paths:
       - 'src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs'
       - 'src/runtime-rs/crates/hypervisor/src/qemu/inner.rs'
+      - 'src/runtime-rs/crates/hypervisor/src/qemu/mod.rs'
+      - 'src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs'
       - '.github/workflows/build-shim-overlay.yaml'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
-  SHIM_TAG: v4.0.0-nvswitch-fix4
+  SHIM_TAG: v4.0.0-nvswitch-fix5
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -54,13 +54,16 @@ jobs:
         working-directory: src/runtime-rs
         run: |
           cargo build --release --target x86_64-unknown-linux-musl --bin containerd-shim-kata-v2
-          ls -la target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
-          sha256sum target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2
+          BIN=$(find /home/aph5nt/actions-runner-kubetee/_work -name 'containerd-shim-kata-v2' -type f 2>/dev/null | head -1)
+          echo "Binary found at: $BIN"
+          cp "$BIN" ./containerd-shim-kata-v2
+          ls -la ./containerd-shim-kata-v2
+          sha256sum ./containerd-shim-kata-v2
 
       - name: Stage binary and create overlay image
         run: |
           mkdir -p overlay-image
-          cp src/runtime-rs/target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2 overlay-image/
+          cp src/runtime-rs/containerd-shim-kata-v2 overlay-image/
 
           printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied\necho "[overlay] waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' > overlay-image/overlay.sh
           chmod 755 overlay-image/overlay.sh

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Log in to GHCR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GH_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u pamanseau --password-stdin
 
       - name: Build and push overlay image
         run: |

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Kata Shim Overlay
+name: Build and Publish Kata Shim Overlay NVSwitch
 
 on:
   workflow_dispatch:
@@ -15,6 +15,10 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
+  # fix6: replace local 0x0680 bitmask exception with upstream exact-class
+  # IOMMU filter + IOMMUFD single-device discover (410d12fe8 / 2c1c961bb,
+  # kata-containers#13430). Keeps fix5 QEMU reap (#13564).
+  SHIM_TAG: v4.0.0-nvswitch-fix6
 
 jobs:
   build-and-push:
@@ -22,26 +26,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # QEMU reap only (#13564 fix5). Tree after local 0x0680 revert, before
-          # upstream NVSwitch IOMMU cherry-picks. Deploy on Blackwell (gpu.family).
-          - shim_tag: v4.0.0-qemu-reap-fix5
-            checkout_ref: cf449bac1c719e3b22c745bc7e9e1299db114bac
-            variant: qemu-reap
-          # QEMU reap + upstream NVSwitch IOMMU (fix6). HEAD of kubecon-staging.
-          # Deploy on Hopper (gpu.family) only.
-          - shim_tag: v4.0.0-nvswitch-fix6
-            checkout_ref: ''
-            variant: nvswitch
     steps:
       - name: Checkout kata-containers fork
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ matrix.checkout_ref != '' && matrix.checkout_ref || github.sha }}
 
       - name: Install Rust toolchain
         run: |
@@ -55,34 +44,17 @@ jobs:
 
       - name: Verify patches are present
         run: |
-          set -eu
-          VARIANT="${{ matrix.variant }}"
-          echo "variant=$VARIANT commit=$(git rev-parse --short HEAD)"
-          git log --oneline -1
-
-          echo "Checking for zombie QEMU fix in inner.rs"
-          grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
-          if ! grep -q "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs; then
-            echo "ERROR: fix5 stop_vm reap missing from inner.rs" >&2
-            exit 1
-          fi
-          # Must NOT still use the old bitmask exception path in either variant
+          echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
+          grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+          # Must NOT still use the old bitmask exception path
           if grep -n 'if class_code == 0x0680' src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
             echo "ERROR: old 0x0680 exception still present" >&2
             exit 1
           fi
-
-          if [ "$VARIANT" = "nvswitch" ]; then
-            echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
-            grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-            grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          else
-            echo "qemu-reap: upstream NVSwitch path must NOT be present"
-            if grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
-              echo "ERROR: IOMMU_IGNORE_CLASSES present in qemu-reap tree" >&2
-              exit 1
-            fi
-          fi
+          echo "Checking for zombie QEMU fix in inner.rs"
+          grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
+          git log --oneline -1
 
       - name: Generate config.rs
         working-directory: src/runtime-rs
@@ -107,8 +79,7 @@ jobs:
           mkdir -p overlay-image
           cp src/runtime-rs/containerd-shim-kata-v2 overlay-image/
 
-          MARK_NAME=".shim-overlay-${{ matrix.variant }}-applied"
-          printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/%s\necho "[overlay] variant=%s waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' "$MARK_NAME" "${{ matrix.variant }}" > overlay-image/overlay.sh
+          printf '#!/bin/sh\nset -eu\nSRC=/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nDST=/host/opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nMARK=/host/opt/kata/runtime-rs/bin/.nvswitch-fix-applied\necho "[overlay] waiting for kata-deploy to install $DST ..."\nwhile [ ! -f "$DST" ]; do sleep 5; done\necho "[overlay] $DST present"\napply() {\n  if cmp -s "$SRC" "$DST"; then\n    echo "[overlay] shim already patched (no-op)"\n  else\n    cp "$SRC" "$DST"\n    chmod 755 "$DST"\n    sha256sum "$SRC" | cut -d" " -f1 > "$MARK"\n    echo "[overlay] patched shim applied: $(cut -c1-16 < "$MARK")"\n  fi\n}\napply\necho "[overlay] entering watch loop"\nwhile true; do sleep 60; apply; done\n' > overlay-image/overlay.sh
           chmod 755 overlay-image/overlay.sh
 
           printf 'FROM alpine:3.22\nCOPY containerd-shim-kata-v2 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2\nCOPY overlay.sh /overlay.sh\nRUN chmod 755 /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /overlay.sh\nCMD ["/bin/sh", "/overlay.sh"]\n' > overlay-image/Dockerfile
@@ -122,11 +93,11 @@ jobs:
         run: |
           docker buildx build --platform linux/amd64 \
             -f overlay-image/Dockerfile \
-            -t ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }} \
+            -t ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} \
             --push \
             overlay-image/
-          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }}"
+          echo "Pushed ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG}"
 
       - name: Verify image
         run: |
-          docker run --rm ${REGISTRY}/${IMAGE_NAME}:${{ matrix.shim_tag }} sha256sum /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 || true
+          docker run --rm ${REGISTRY}/${IMAGE_NAME}:${SHIM_TAG} sha256sum /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 || true

--- a/.github/workflows/build-shim-overlay.yaml
+++ b/.github/workflows/build-shim-overlay.yaml
@@ -10,15 +10,20 @@ on:
       - 'src/runtime-rs/crates/hypervisor/src/qemu/inner.rs'
       - 'src/runtime-rs/crates/hypervisor/src/qemu/mod.rs'
       - 'src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs'
+      - 'src/runtime-rs/crates/resource/src/network/**'
+      - 'src/runtime-rs/crates/resource/src/manager.rs'
+      - 'src/runtime-rs/crates/resource/src/manager_inner.rs'
       - '.github/workflows/build-shim-overlay.yaml'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kubetee-ai/kata-deploy-shim-overlay
-  # fix6: replace local 0x0680 bitmask exception with upstream exact-class
-  # IOMMU filter + IOMMUFD single-device discover (410d12fe8 / 2c1c961bb,
-  # kata-containers#13430). Keeps fix5 QEMU reap (#13564).
-  SHIM_TAG: v4.0.0-nvswitch-fix6
+  # fix7: serialize sandbox.start() (start_mutex + Starting state) + reuse/delete
+  # IFF_PERSIST tapN_kata on failure — fixes TUNSETIFF EBUSY when CreateContainer
+  # retries while agent connect is still in progress (glm CC on B200, #13564 follow-up).
+  # Restores fix5 VFIO discover (0x0680 exception); fix6 IOMMUFD single-device path
+  # was rolled back (guest agent "bridge … no pci_bus" on 8×B200).
+  SHIM_TAG: v4.0.0-nvswitch-fix7
 
 jobs:
   build-and-push:
@@ -44,16 +49,15 @@ jobs:
 
       - name: Verify patches are present
         run: |
-          echo "Checking for upstream IOMMU_IGNORE_CLASSES (exact match, NVSwitch absent)"
-          grep -n "IOMMU_IGNORE_CLASSES" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          grep -n "intentionally absent" src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
-          # Must NOT still use the old bitmask exception path
-          if grep -n 'if class_code == 0x0680' src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs; then
-            echo "ERROR: old 0x0680 exception still present" >&2
-            exit 1
-          fi
+          echo "Checking for NVSwitch 0x0680 exception (fix5 path — NOT fix6 IOMMUFD-only)"
+          grep -n 'class_code == 0x0680' src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
           echo "Checking for zombie QEMU fix in inner.rs"
           grep -n "stop_vm" src/runtime-rs/crates/hypervisor/src/qemu/inner.rs | head -5
+          echo "Checking for fix7 start_mutex / Starting state"
+          grep -n 'start_mutex' src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs | head -5
+          grep -n 'SandboxState::Starting' src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs | head -5
+          grep -n 'is_busy_or_exist' src/runtime-rs/crates/resource/src/network/utils/link/create.rs | head -3
+          grep -n 'release_network' src/runtime-rs/crates/resource/src/manager.rs | head -3
           git log --oneline -1
 
       - name: Generate config.rs

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -387,6 +387,17 @@ fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
         Some(cid_u32) => {
             // PCI class code is 24 bits, shift right 8 to get base+sub class
             let class_code = u64::from(cid_u32) >> 8;
+            // NVSwitches (PCI class 0x0680, "Bridge: Other") are passthrough-capable
+            // and required for NVLink in HGX/DGX confidential guests. They must
+            // NOT be filtered out: the 0x0600 bridge bitmask is a *subset* match
+            // (class_code & 0x0600 == 0x0600) that catches the whole 0x06 bridge
+            // base class — including 0x0680 — not just Host Bridges (0x0600) as
+            // the IOMMU_IGNORE comment implies. Without this exception, each
+            // NVSwitch (which sits in a singleton IOMMU group) is stripped, leaving
+            // an empty group -> "IOMMU group N has no passthrough-capable devices".
+            if class_code == 0x0680 {
+                return None;
+            }
             for &bitmask in bitmasks {
                 if class_code & bitmask == bitmask {
                     return Some(class_code);

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -346,7 +346,7 @@ fn validate_group_basic(devices: &[DeviceInfo]) -> bool {
             // filter host or PCI bridge
             let bdf_str = bdf.to_string();
             // Filter out devices that cannot be passed through (bridges, audio, etc.)
-            if filter_bridge_device(&bdf_str, IOMMU_IGNORE).is_some() {
+            if filter_bridge_device(&bdf_str, IOMMU_IGNORE_CLASSES).is_some() {
                 continue;
             }
         }
@@ -367,13 +367,20 @@ fn get_device_property(device_bdf: &str, property: &str) -> Result<String> {
     Ok(cfg_path.trim().to_string())
 }
 
-/// PCI class bitmasks for devices that must be ignored when enumerating an IOMMU group.
-/// Host Bridge: 0x0600, Audio device: 0x0403.
-const IOMMU_IGNORE: &[u64] = &[0x0600, 0x403];
+/// Exact (base+sub) PCI class codes for devices that must be ignored when enumerating
+/// a legacy IOMMU group: they share the group with a GPU but cannot be passed through.
+///
+/// 0x0600 = Host Bridge, 0x0604 = PCI-to-PCI Bridge, 0x0403 = Audio device.
+///
+/// NVSwitches (0x0680, Other Bridge) are intentionally absent: they are
+/// passthrough-capable and the device plugin binds them to vfio-pci on purpose.
+const IOMMU_IGNORE_CLASSES: &[u16] = &[0x0600, 0x0604, 0x0403];
 
-/// Filters for devices that cannot or should not be passed through within an IOMMU group
-/// (Host/PCI bridges, audio controllers that share the GPU's IOMMU group, etc.).
-fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
+/// Filters for devices that cannot or should not be passed through within a legacy
+/// IOMMU group (Host/PCI bridges, audio controllers that share the GPU's group).
+///
+/// Returns the base+sub class code if the device matches, None if it should be kept.
+fn filter_bridge_device(bdf: &str, ignored: &[u16]) -> Option<u16> {
     let device_class = get_device_property(bdf, "class").unwrap_or_default();
 
     if device_class.is_empty() {
@@ -383,18 +390,12 @@ fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
     // The sysfs `class` attribute is a hex string (e.g. "0x040300"), so it must
     // be parsed base-16. Parsing it as decimal always fails, which previously
     // caused every device to be treated as passthrough-capable.
-    match parse_class_code_u32(&device_class) {
-        Some(cid_u32) => {
-            // PCI class code is 24 bits, shift right 8 to get base+sub class
-            let class_code = u64::from(cid_u32) >> 8;
-            for &bitmask in bitmasks {
-                if class_code & bitmask == bitmask {
-                    return Some(class_code);
-                }
-            }
-            None
-        }
-        None => None,
+    let class_code = parse_class_code_u32(&device_class)? >> 8;
+    let class_u16 = class_code as u16;
+    if ignored.contains(&class_u16) {
+        Some(class_u16)
+    } else {
+        None
     }
 }
 
@@ -451,11 +452,6 @@ fn is_char_dev(p: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Extracts the IOMMU group ID from a PCI device's sysfs link.
-fn vfio_group_id_from_pci(bdf: &str) -> Option<u32> {
-    let link = fs::read_link(Path::new(SYS_PCI_DEVS).join(bdf).join("iommu_group")).ok()?;
-    link.file_name()?.to_string_lossy().parse::<u32>().ok()
-}
 
 /// Locates the VFIO character device (cdev) for a given PCI BDF.
 /// Path: /sys/bus/pci/devices/<bdf>/vfio-dev/vfioX
@@ -509,44 +505,96 @@ fn discover_vfio_cdev_by_name(
     })
 }
 
-/// Discovers the VFIO device context based on a /dev/vfio/devices/vfio<X> path.
+/// Discovers a VFIO device from an IOMMUFD per-device cdev (`/dev/vfio/devices/vfioX`).
+///
+/// IOMMUFD manages devices individually via `/dev/iommu`; there is no IOMMU group
+/// container.  The device plugin already chose this specific device by binding it to
+/// vfio-pci and handing us its cdev, so no class-based filtering is applied here.
 pub fn discover_vfio_device(vfio_device: &Path) -> Result<VfioDevice> {
-    if vfio_device.exists() && is_char_dev(vfio_device) {
-        let vfio_name = vfio_device
-            .file_name()
-            .ok_or_else(|| anyhow!("Invalid vfio device path"))?
-            .to_string_lossy()
-            .to_string();
-
-        // Resolve VFIO name to BDF via sysfs symlink
-        let dev_link = fs::read_link(
-            Path::new(SYS_CLASS_VFIO_DEV)
-                .join(&vfio_name)
-                .join("device"),
-        )
-        .with_context(|| format!("failed to read sysfs device link for {}", vfio_name))?;
-
-        let bdf = dev_link
-            .file_name()
-            .ok_or_else(|| anyhow!("Malformed vfio-dev symlink for {}", vfio_name))?
-            .to_string_lossy()
-            .to_string();
-
-        // Resolve BDF to IOMMU group. On iommufd-first hosts there is often no legacy
-        // /dev/vfio/<gid> node — only /dev/vfio/devices/vfioX cdevs exist — so use the
-        // cdev we were given as the group char dev when legacy is absent.
-        let gid = vfio_group_id_from_pci(&bdf)
-            .ok_or_else(|| anyhow!("could not resolve IOMMU group for {}", bdf))?;
-        let legacy = Path::new(DEV_VFIO).join(gid.to_string());
-        let group_devnode = if legacy.exists() && is_char_dev(&legacy) {
-            legacy
-        } else {
-            vfio_device.to_path_buf()
-        };
-        discover_vfio_device_for_iommu_group(gid, group_devnode)
-    } else {
-        Err(anyhow!("vfio device {} not found", vfio_device.display()))
+    if !vfio_device.exists() || !is_char_dev(vfio_device) {
+        return Err(anyhow!("vfio device {} not found", vfio_device.display()));
     }
+
+    let vfio_name = vfio_device
+        .file_name()
+        .ok_or_else(|| anyhow!("Invalid vfio device path"))?
+        .to_string_lossy()
+        .to_string();
+
+    // /sys/class/vfio-dev/<name>/device -> .../0000:01:00.0
+    let dev_link = fs::read_link(
+        Path::new(SYS_CLASS_VFIO_DEV)
+            .join(&vfio_name)
+            .join("device"),
+    )
+    .with_context(|| format!("failed to read sysfs device link for {}", vfio_name))?;
+
+    let bdf_str = dev_link
+        .file_name()
+        .ok_or_else(|| anyhow!("Malformed vfio-dev symlink for {}", vfio_name))?
+        .to_string_lossy()
+        .to_string();
+
+    let bdf = parse_bdf_str(&bdf_str)?;
+    let pci_path = Path::new(SYS_PCI_DEVS).join(&bdf_str);
+
+    let vendor_id = read_trim(pci_path.join("vendor"));
+    let device_id = read_trim(pci_path.join("device"));
+    let class_code = read_trim(pci_path.join("class"))
+        .as_deref()
+        .and_then(parse_class_code_u32);
+    let driver = driver_name(&pci_path);
+    let numa_node =
+        parse_i32(pci_path.join("numa_node")).and_then(|n| if n < 0 { None } else { Some(n) });
+
+    let cdev = discover_vfio_cdev_by_name(&vfio_name, Some(bdf_str.clone()), None);
+
+    let device_info = DeviceInfo {
+        addr: DeviceAddress::Pci(bdf),
+        vendor_id,
+        device_id,
+        class_code,
+        driver,
+        iommu_group_id: None,
+        numa_node,
+        sysfs_path: pci_path,
+        vfio_cdev: cdev.clone(),
+    };
+
+    let labels = build_group_labels(&[device_info.clone()]);
+    let primary = device_info.clone();
+
+    let iommufd_backend = {
+        let iommu_dev = PathBuf::from(DEV_IOMMU);
+        if is_char_dev(&iommu_dev) {
+            cdev.map(|c| VfioIommufdBackend {
+                iommufd_dev: iommu_dev,
+                cdevs: vec![c],
+            })
+        } else {
+            None
+        }
+    };
+
+    let health = if iommufd_backend.is_some() {
+        Health::Healthy
+    } else {
+        Health::Unhealthy
+    };
+
+    Ok(VfioDevice {
+        id: format!("vfio-iommufd-{}", vfio_name),
+        device_type: VfioDeviceType::Normal,
+        bus_mode: VfioBusMode::Pci,
+        iommu_group: None,
+        iommu_group_id: None,
+        iommufd: iommufd_backend,
+        devices: vec![device_info],
+        primary,
+        labels,
+        health,
+        ap_devices: Vec::new(),
+    })
 }
 
 fn parse_dev_vfio_group_id(s: &str) -> Option<u32> {
@@ -608,15 +656,15 @@ fn discover_vfio_device_for_iommu_group(gid: u32, group_devnode: PathBuf) -> Res
         }
     }
 
-    // Drop functions that only share the GPU's IOMMU group but must not be
-    // passed through (audio controllers, bridges), reusing the same
-    // IOMMU_IGNORE classification as validate_group_basic. Everything derived
-    // below (vfio_cdevs, the IOMMUFD backend cdevs and the primary device) is
-    // built from this filtered list. Passing such a function would otherwise
-    // emit an extra vfio-pci entry reusing the GPU's cold-plug root-port and
-    // IOMMUFD object ids, making QEMU abort with a duplicate-id error.
+    // Drop PCI functions that share the GPU's IOMMU group but must not be passed
+    // through (host bridges, PCI bridges, audio companions).  Everything derived
+    // below (vfio_cdevs and the primary device) is built from this filtered list.
+    // Passing such a function would otherwise emit an extra vfio-pci entry reusing
+    // the GPU's cold-plug root-port, making QEMU abort with a duplicate-id error.
     devices.retain(|d| match &d.addr {
-        DeviceAddress::Pci(bdf) => filter_bridge_device(&bdf.to_string(), IOMMU_IGNORE).is_none(),
+        DeviceAddress::Pci(bdf) => {
+            filter_bridge_device(&bdf.to_string(), IOMMU_IGNORE_CLASSES).is_none()
+        }
         _ => true,
     });
     if devices.is_empty() {

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -387,17 +387,6 @@ fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
         Some(cid_u32) => {
             // PCI class code is 24 bits, shift right 8 to get base+sub class
             let class_code = u64::from(cid_u32) >> 8;
-            // NVSwitches (PCI class 0x0680, "Bridge: Other") are passthrough-capable
-            // and required for NVLink in HGX/DGX confidential guests. They must
-            // NOT be filtered out: the 0x0600 bridge bitmask is a *subset* match
-            // (class_code & 0x0600 == 0x0600) that catches the whole 0x06 bridge
-            // base class — including 0x0680 — not just Host Bridges (0x0600) as
-            // the IOMMU_IGNORE comment implies. Without this exception, each
-            // NVSwitch (which sits in a singleton IOMMU group) is stripped, leaving
-            // an empty group -> "IOMMU group N has no passthrough-capable devices".
-            if class_code == 0x0680 {
-                return None;
-            }
             for &bitmask in bitmasks {
                 if class_code & bitmask == bitmask {
                     return Some(class_code);

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -390,7 +390,7 @@ fn filter_bridge_device(bdf: &str, ignored: &[u16]) -> Option<u16> {
     // The sysfs `class` attribute is a hex string (e.g. "0x040300"), so it must
     // be parsed base-16. Parsing it as decimal always fails, which previously
     // caused every device to be treated as passthrough-capable.
-    let class_code = parse_class_code_u32(&device_class)? >> 8;
+    let class_code = parse_class_code_u32(&device_class)? >> 8; // drop prog-if byte; yields base+sub class
     let class_u16 = class_code as u16;
     if ignored.contains(&class_u16) {
         Some(class_u16)
@@ -561,26 +561,22 @@ pub fn discover_vfio_device(vfio_device: &Path) -> Result<VfioDevice> {
         vfio_cdev: cdev.clone(),
     };
 
-    let labels = build_group_labels(&[device_info.clone()]);
+    let labels = build_group_labels(std::slice::from_ref(&device_info));
     let primary = device_info.clone();
 
-    let iommufd_backend = {
-        let iommu_dev = PathBuf::from(DEV_IOMMU);
-        if is_char_dev(&iommu_dev) {
-            cdev.map(|c| VfioIommufdBackend {
-                iommufd_dev: iommu_dev,
-                cdevs: vec![c],
-            })
-        } else {
-            None
-        }
-    };
-
-    let health = if iommufd_backend.is_some() {
-        Health::Healthy
-    } else {
-        Health::Unhealthy
-    };
+    let iommu_dev = PathBuf::from(DEV_IOMMU);
+    if !is_char_dev(&iommu_dev) {
+        return Err(anyhow!(
+            "{} not available; IOMMUFD passthrough requires it",
+            DEV_IOMMU
+        ));
+    }
+    let iommufd_backend =
+        cdev.map(|c| VfioIommufdBackend {
+            iommufd_dev: iommu_dev,
+            cdevs: vec![c],
+        })
+        .ok_or_else(|| anyhow!("no VFIO cdev found for {} (vfio-dev sysfs missing?)", vfio_name))?;
 
     Ok(VfioDevice {
         id: format!("vfio-iommufd-{}", vfio_name),
@@ -588,11 +584,11 @@ pub fn discover_vfio_device(vfio_device: &Path) -> Result<VfioDevice> {
         bus_mode: VfioBusMode::Pci,
         iommu_group: None,
         iommu_group_id: None,
-        iommufd: iommufd_backend,
+        iommufd: Some(iommufd_backend),
         devices: vec![device_info],
         primary,
         labels,
-        health,
+        health: Health::Healthy,
         ap_devices: Vec::new(),
     })
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio_device/core.rs
@@ -346,7 +346,7 @@ fn validate_group_basic(devices: &[DeviceInfo]) -> bool {
             // filter host or PCI bridge
             let bdf_str = bdf.to_string();
             // Filter out devices that cannot be passed through (bridges, audio, etc.)
-            if filter_bridge_device(&bdf_str, IOMMU_IGNORE_CLASSES).is_some() {
+            if filter_bridge_device(&bdf_str, IOMMU_IGNORE).is_some() {
                 continue;
             }
         }
@@ -367,20 +367,13 @@ fn get_device_property(device_bdf: &str, property: &str) -> Result<String> {
     Ok(cfg_path.trim().to_string())
 }
 
-/// Exact (base+sub) PCI class codes for devices that must be ignored when enumerating
-/// a legacy IOMMU group: they share the group with a GPU but cannot be passed through.
-///
-/// 0x0600 = Host Bridge, 0x0604 = PCI-to-PCI Bridge, 0x0403 = Audio device.
-///
-/// NVSwitches (0x0680, Other Bridge) are intentionally absent: they are
-/// passthrough-capable and the device plugin binds them to vfio-pci on purpose.
-const IOMMU_IGNORE_CLASSES: &[u16] = &[0x0600, 0x0604, 0x0403];
+/// PCI class bitmasks for devices that must be ignored when enumerating an IOMMU group.
+/// Host Bridge: 0x0600, Audio device: 0x0403.
+const IOMMU_IGNORE: &[u64] = &[0x0600, 0x403];
 
-/// Filters for devices that cannot or should not be passed through within a legacy
-/// IOMMU group (Host/PCI bridges, audio controllers that share the GPU's group).
-///
-/// Returns the base+sub class code if the device matches, None if it should be kept.
-fn filter_bridge_device(bdf: &str, ignored: &[u16]) -> Option<u16> {
+/// Filters for devices that cannot or should not be passed through within an IOMMU group
+/// (Host/PCI bridges, audio controllers that share the GPU's IOMMU group, etc.).
+fn filter_bridge_device(bdf: &str, bitmasks: &[u64]) -> Option<u64> {
     let device_class = get_device_property(bdf, "class").unwrap_or_default();
 
     if device_class.is_empty() {
@@ -390,12 +383,29 @@ fn filter_bridge_device(bdf: &str, ignored: &[u16]) -> Option<u16> {
     // The sysfs `class` attribute is a hex string (e.g. "0x040300"), so it must
     // be parsed base-16. Parsing it as decimal always fails, which previously
     // caused every device to be treated as passthrough-capable.
-    let class_code = parse_class_code_u32(&device_class)? >> 8; // drop prog-if byte; yields base+sub class
-    let class_u16 = class_code as u16;
-    if ignored.contains(&class_u16) {
-        Some(class_u16)
-    } else {
-        None
+    match parse_class_code_u32(&device_class) {
+        Some(cid_u32) => {
+            // PCI class code is 24 bits, shift right 8 to get base+sub class
+            let class_code = u64::from(cid_u32) >> 8;
+            // NVSwitches (PCI class 0x0680, "Bridge: Other") are passthrough-capable
+            // and required for NVLink in HGX/DGX confidential guests. They must
+            // NOT be filtered out: the 0x0600 bridge bitmask is a *subset* match
+            // (class_code & 0x0600 == 0x0600) that catches the whole 0x06 bridge
+            // base class — including 0x0680 — not just Host Bridges (0x0600) as
+            // the IOMMU_IGNORE comment implies. Without this exception, each
+            // NVSwitch (which sits in a singleton IOMMU group) is stripped, leaving
+            // an empty group -> "IOMMU group N has no passthrough-capable devices".
+            if class_code == 0x0680 {
+                return None;
+            }
+            for &bitmask in bitmasks {
+                if class_code & bitmask == bitmask {
+                    return Some(class_code);
+                }
+            }
+            None
+        }
+        None => None,
     }
 }
 
@@ -452,6 +462,11 @@ fn is_char_dev(p: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Extracts the IOMMU group ID from a PCI device's sysfs link.
+fn vfio_group_id_from_pci(bdf: &str) -> Option<u32> {
+    let link = fs::read_link(Path::new(SYS_PCI_DEVS).join(bdf).join("iommu_group")).ok()?;
+    link.file_name()?.to_string_lossy().parse::<u32>().ok()
+}
 
 /// Locates the VFIO character device (cdev) for a given PCI BDF.
 /// Path: /sys/bus/pci/devices/<bdf>/vfio-dev/vfioX
@@ -505,92 +520,44 @@ fn discover_vfio_cdev_by_name(
     })
 }
 
-/// Discovers a VFIO device from an IOMMUFD per-device cdev (`/dev/vfio/devices/vfioX`).
-///
-/// IOMMUFD manages devices individually via `/dev/iommu`; there is no IOMMU group
-/// container.  The device plugin already chose this specific device by binding it to
-/// vfio-pci and handing us its cdev, so no class-based filtering is applied here.
+/// Discovers the VFIO device context based on a /dev/vfio/devices/vfio<X> path.
 pub fn discover_vfio_device(vfio_device: &Path) -> Result<VfioDevice> {
-    if !vfio_device.exists() || !is_char_dev(vfio_device) {
-        return Err(anyhow!("vfio device {} not found", vfio_device.display()));
+    if vfio_device.exists() && is_char_dev(vfio_device) {
+        let vfio_name = vfio_device
+            .file_name()
+            .ok_or_else(|| anyhow!("Invalid vfio device path"))?
+            .to_string_lossy()
+            .to_string();
+
+        // Resolve VFIO name to BDF via sysfs symlink
+        let dev_link = fs::read_link(
+            Path::new(SYS_CLASS_VFIO_DEV)
+                .join(&vfio_name)
+                .join("device"),
+        )
+        .with_context(|| format!("failed to read sysfs device link for {}", vfio_name))?;
+
+        let bdf = dev_link
+            .file_name()
+            .ok_or_else(|| anyhow!("Malformed vfio-dev symlink for {}", vfio_name))?
+            .to_string_lossy()
+            .to_string();
+
+        // Resolve BDF to IOMMU group. On iommufd-first hosts there is often no legacy
+        // /dev/vfio/<gid> node — only /dev/vfio/devices/vfioX cdevs exist — so use the
+        // cdev we were given as the group char dev when legacy is absent.
+        let gid = vfio_group_id_from_pci(&bdf)
+            .ok_or_else(|| anyhow!("could not resolve IOMMU group for {}", bdf))?;
+        let legacy = Path::new(DEV_VFIO).join(gid.to_string());
+        let group_devnode = if legacy.exists() && is_char_dev(&legacy) {
+            legacy
+        } else {
+            vfio_device.to_path_buf()
+        };
+        discover_vfio_device_for_iommu_group(gid, group_devnode)
+    } else {
+        Err(anyhow!("vfio device {} not found", vfio_device.display()))
     }
-
-    let vfio_name = vfio_device
-        .file_name()
-        .ok_or_else(|| anyhow!("Invalid vfio device path"))?
-        .to_string_lossy()
-        .to_string();
-
-    // /sys/class/vfio-dev/<name>/device -> .../0000:01:00.0
-    let dev_link = fs::read_link(
-        Path::new(SYS_CLASS_VFIO_DEV)
-            .join(&vfio_name)
-            .join("device"),
-    )
-    .with_context(|| format!("failed to read sysfs device link for {}", vfio_name))?;
-
-    let bdf_str = dev_link
-        .file_name()
-        .ok_or_else(|| anyhow!("Malformed vfio-dev symlink for {}", vfio_name))?
-        .to_string_lossy()
-        .to_string();
-
-    let bdf = parse_bdf_str(&bdf_str)?;
-    let pci_path = Path::new(SYS_PCI_DEVS).join(&bdf_str);
-
-    let vendor_id = read_trim(pci_path.join("vendor"));
-    let device_id = read_trim(pci_path.join("device"));
-    let class_code = read_trim(pci_path.join("class"))
-        .as_deref()
-        .and_then(parse_class_code_u32);
-    let driver = driver_name(&pci_path);
-    let numa_node =
-        parse_i32(pci_path.join("numa_node")).and_then(|n| if n < 0 { None } else { Some(n) });
-
-    let cdev = discover_vfio_cdev_by_name(&vfio_name, Some(bdf_str.clone()), None);
-
-    let device_info = DeviceInfo {
-        addr: DeviceAddress::Pci(bdf),
-        vendor_id,
-        device_id,
-        class_code,
-        driver,
-        iommu_group_id: None,
-        numa_node,
-        sysfs_path: pci_path,
-        vfio_cdev: cdev.clone(),
-    };
-
-    let labels = build_group_labels(std::slice::from_ref(&device_info));
-    let primary = device_info.clone();
-
-    let iommu_dev = PathBuf::from(DEV_IOMMU);
-    if !is_char_dev(&iommu_dev) {
-        return Err(anyhow!(
-            "{} not available; IOMMUFD passthrough requires it",
-            DEV_IOMMU
-        ));
-    }
-    let iommufd_backend =
-        cdev.map(|c| VfioIommufdBackend {
-            iommufd_dev: iommu_dev,
-            cdevs: vec![c],
-        })
-        .ok_or_else(|| anyhow!("no VFIO cdev found for {} (vfio-dev sysfs missing?)", vfio_name))?;
-
-    Ok(VfioDevice {
-        id: format!("vfio-iommufd-{}", vfio_name),
-        device_type: VfioDeviceType::Normal,
-        bus_mode: VfioBusMode::Pci,
-        iommu_group: None,
-        iommu_group_id: None,
-        iommufd: Some(iommufd_backend),
-        devices: vec![device_info],
-        primary,
-        labels,
-        health: Health::Healthy,
-        ap_devices: Vec::new(),
-    })
 }
 
 fn parse_dev_vfio_group_id(s: &str) -> Option<u32> {
@@ -652,15 +619,15 @@ fn discover_vfio_device_for_iommu_group(gid: u32, group_devnode: PathBuf) -> Res
         }
     }
 
-    // Drop PCI functions that share the GPU's IOMMU group but must not be passed
-    // through (host bridges, PCI bridges, audio companions).  Everything derived
-    // below (vfio_cdevs and the primary device) is built from this filtered list.
-    // Passing such a function would otherwise emit an extra vfio-pci entry reusing
-    // the GPU's cold-plug root-port, making QEMU abort with a duplicate-id error.
+    // Drop functions that only share the GPU's IOMMU group but must not be
+    // passed through (audio controllers, bridges), reusing the same
+    // IOMMU_IGNORE classification as validate_group_basic. Everything derived
+    // below (vfio_cdevs, the IOMMUFD backend cdevs and the primary device) is
+    // built from this filtered list. Passing such a function would otherwise
+    // emit an extra vfio-pci entry reusing the GPU's cold-plug root-port and
+    // IOMMUFD object ids, making QEMU abort with a duplicate-id error.
     devices.retain(|d| match &d.addr {
-        DeviceAddress::Pci(bdf) => {
-            filter_bridge_device(&bdf.to_string(), IOMMU_IGNORE_CLASSES).is_none()
-        }
+        DeviceAddress::Pci(bdf) => filter_bridge_device(&bdf.to_string(), IOMMU_IGNORE).is_none(),
         _ => true,
     });
     if devices.is_empty() {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -432,28 +432,7 @@ impl QemuInner {
         // runtime reaps unconditionally via LogAndWait; runtime-rs historically
         // only cleaned up on the QMP-init / boot_from_template paths (fix4),
         // missing virtio-mem setup, resume_vm, console connect, and any future
-        // `?` after spawn. fix5: one cleanup guard covers all of them.
-        let result = self
-            .start_vm_after_spawn(cmdline, console_socket_path)
-            .await;
-        if let Err(ref e) = result {
-            error!(
-                sl!(),
-                "start_vm failed after QEMU spawn: {:?}; killing and reaping child to prevent zombie",
-                e
-            );
-            let _ = self.stop_vm().await;
-            let _ = self.wait_vm().await;
-        }
-        result
-    }
-
-    /// QMP handshake + post-spawn bring-up. Caller must kill+reap on Err.
-    async fn start_vm_after_spawn(
-        &mut self,
-        mut cmdline: QemuCmdLine<'_>,
-        console_socket_path: std::path::PathBuf,
-    ) -> Result<()> {
+        // `?` after spawn. fix5: cleanup on every failure path below.
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -472,13 +451,24 @@ impl QemuInner {
                 // "the configuration is not prepared for memory devices".
                 if self.config.memory_info.enable_virtio_mem {
                     if cmdline.has_memory_hotplug_region() {
-                        qmp.setup_virtio_mem(
-                            self.config.memory_info.default_memory,
-                            self.config.memory_info.default_maxmemory,
-                            &self.config.machine_info.machine_type,
-                            self.config.shared_fs.shared_fs.as_deref(),
-                        )
-                        .context("Failed to setup virtio-mem during VM initialization")?;
+                        if let Err(e) = qmp
+                            .setup_virtio_mem(
+                                self.config.memory_info.default_memory,
+                                self.config.memory_info.default_maxmemory,
+                                &self.config.machine_info.machine_type,
+                                self.config.shared_fs.shared_fs.as_deref(),
+                            )
+                            .context("Failed to setup virtio-mem during VM initialization")
+                        {
+                            error!(
+                                sl!(),
+                                "virtio-mem setup failed after QEMU spawn: {:?}; killing+reaping",
+                                e
+                            );
+                            let _ = self.stop_vm().await;
+                            let _ = self.wait_vm().await;
+                            return Err(e);
+                        }
                     } else {
                         info!(
                             sl!(),
@@ -494,22 +484,47 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            self.boot_from_template()
-                .await
-                .context("boot from template")?;
-            self.resume_vm().context("resume vm")?;
+            if let Err(e) = self.boot_from_template().await {
+                error!(sl!(), "boot from template failed: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e).context("boot from template");
+            }
+            if let Err(e) = self.resume_vm().context("resume vm") {
+                error!(
+                    sl!(),
+                    "resume_vm failed after QEMU spawn: {:?}; killing+reaping", e
+                );
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e);
+            }
         }
 
         // When hypervisor debug is enabled, output the kernel boot messages for debugging.
         if self.config.debug_info.enable_debug {
-            let stream = UnixStream::connect(console_socket_path.as_os_str()).await?;
-            tokio::spawn(log_qemu_console(stream));
+            match UnixStream::connect(console_socket_path.as_os_str()).await {
+                Ok(stream) => {
+                    tokio::spawn(log_qemu_console(stream));
+                }
+                Err(e) => {
+                    error!(
+                        sl!(),
+                        "console connect failed after QEMU spawn: {:?}; killing+reaping", e
+                    );
+                    let _ = self.stop_vm().await;
+                    let _ = self.wait_vm().await;
+                    return Err(e.into());
+                }
+            }
         }
 
         Ok(())

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -465,15 +465,25 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
+                // Kill and reap the spawned QEMU child to prevent a zombie process.
+                // Without this, the QEMU process is leaked when QMP init fails
+                // (e.g. the 50s QMP-connect deadline expires on slow CC/VFIO boots).
+                // The Go runtime reaps unconditionally via LogAndWait; the Rust
+                // runtime-rs had no equivalent on the failure path.
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            self.boot_from_template()
-                .await
-                .context("boot from template")?;
+            if let Err(e) = self.boot_from_template().await {
+                error!(sl!(), "boot from template failed: {:?}", e);
+                let _ = self.stop_vm().await;
+                let _ = self.wait_vm().await;
+                return Err(e).context("boot from template");
+            }
             self.resume_vm().context("resume vm")?;
         }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -425,6 +425,35 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
+        // Any failure AFTER spawn must kill+reap the Child. The sandbox only
+        // starts its background wait_vm() waiter once start_vm() returns Ok, so
+        // an Err return without cleanup leaks QEMU as a zombie and wedges the
+        // shim in a Task/State timeout loop (kata-containers#13564). The Go
+        // runtime reaps unconditionally via LogAndWait; runtime-rs historically
+        // only cleaned up on the QMP-init / boot_from_template paths (fix4),
+        // missing virtio-mem setup, resume_vm, console connect, and any future
+        // `?` after spawn. fix5: one cleanup guard covers all of them.
+        let result = self
+            .start_vm_after_spawn(cmdline, console_socket_path)
+            .await;
+        if let Err(ref e) = result {
+            error!(
+                sl!(),
+                "start_vm failed after QEMU spawn: {:?}; killing and reaping child to prevent zombie",
+                e
+            );
+            let _ = self.stop_vm().await;
+            let _ = self.wait_vm().await;
+        }
+        result
+    }
+
+    /// QMP handshake + post-spawn bring-up. Caller must kill+reap on Err.
+    async fn start_vm_after_spawn(
+        &mut self,
+        mut cmdline: QemuCmdLine<'_>,
+        console_socket_path: std::path::PathBuf,
+    ) -> Result<()> {
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -465,25 +494,15 @@ impl QemuInner {
             }
             Err(e) => {
                 error!(sl!(), "couldn't initialise QMP: {:?}", e);
-                // Kill and reap the spawned QEMU child to prevent a zombie process.
-                // Without this, the QEMU process is leaked when QMP init fails
-                // (e.g. the 50s QMP-connect deadline expires on slow CC/VFIO boots).
-                // The Go runtime reaps unconditionally via LogAndWait; the Rust
-                // runtime-rs had no equivalent on the failure path.
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
                 return Err(e);
             }
         }
 
         // Start the virtual machine by restoring it from a VM template if enabled.
         if self.config.vm_template.boot_from_template {
-            if let Err(e) = self.boot_from_template().await {
-                error!(sl!(), "boot from template failed: {:?}", e);
-                let _ = self.stop_vm().await;
-                let _ = self.wait_vm().await;
-                return Err(e).context("boot from template");
-            }
+            self.boot_from_template()
+                .await
+                .context("boot from template")?;
             self.resume_vm().context("resume vm")?;
         }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -72,7 +72,14 @@ impl Hypervisor for Qemu {
 
     async fn stop_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.stop_vm().await
+        let kill_result = inner.stop_vm().await;
+        // Always attempt to reap after stop. Init-state / failed-start teardown
+        // previously called stop_vm() without wait_vm(), leaving QEMU as a
+        // zombie when the background exit waiter was absent or blocked on
+        // exit_notify (kata-containers#13564 fix5). Double-reap is harmless:
+        // wait_vm returns Err("already reaped") which we ignore.
+        let _ = inner.wait_vm().await;
+        kill_result
     }
 
     async fn wait_vm(&self) -> Result<i32> {

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -84,6 +84,14 @@ impl ResourceManager {
         inner.handle_network(network_config).await
     }
 
+    /// Tear down network endpoints / taps and clear the cached network so a
+    /// retry of `sandbox.start()` can recreate them. See kata-containers#13564
+    /// follow-up (tap0_kata TUNSETIFF EBUSY on concurrent CreateContainer).
+    pub async fn release_network(&self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.release_network().await
+    }
+
     #[instrument]
     pub async fn setup_after_start_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -951,6 +951,17 @@ impl ResourceManagerInner {
         }
     }
 
+    /// Detach endpoints and delete host-side taps, then clear `self.network` so a
+    /// subsequent `handle_network` can recreate them (sandbox.start retry path).
+    pub async fn release_network(&mut self) -> Result<()> {
+        if let Some(network) = self.network.take() {
+            if let Err(err) = network.remove(self.hypervisor.as_ref()).await {
+                warn!(sl!(), "failed to remove network: {}", err);
+            }
+        }
+        Ok(())
+    }
+
     pub async fn cleanup(&self) -> Result<()> {
         // detach network endpoints (rebinds VFs from vfio-pci back to host driver)
         if let Some(network) = &self.network {

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -13,11 +13,25 @@ use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::DeviceType;
 use hypervisor::{Hypervisor, NetworkDevice};
+use scopeguard::defer;
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, VethEndpointState};
 use super::{attach_network_device, Endpoint};
+use crate::network::utils::link;
 use crate::network::{utils, NetworkPair};
+
+async fn delete_tap_device(name: &str) -> Result<()> {
+    let (connection, handle, _) = rtnetlink::new_connection().context("new connection")?;
+    let thread_handler = tokio::spawn(connection);
+    defer!({
+        thread_handler.abort();
+    });
+    link::delete_link(&handle, name)
+        .await
+        .with_context(|| format!("delete tap {name}"))?;
+    Ok(())
+}
 
 #[derive(Debug)]
 pub struct VethEndpoint {
@@ -99,6 +113,18 @@ impl Endpoint for VethEndpoint {
         }))
         .await
         .context("remove Veth endpoint device by hypervisor failed.")?;
+
+        // create_link sets IFF_PERSIST, so the tap survives FD close / QEMU exit.
+        // Delete it explicitly so a retry of sandbox.start() can recreate it
+        // (otherwise TUNSETIFF returns EBUSY).
+        if let Err(err) = delete_tap_device(&self.net_pair.tap.tap_iface.name).await {
+            warn!(
+                sl!(),
+                "failed to delete tap {}: {:#}",
+                self.net_pair.tap.tap_iface.name,
+                err
+            );
+        }
 
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -156,7 +156,21 @@ pub async fn create_link(
     name: &str,
     queues: usize,
 ) -> Result<Box<dyn link::Link>> {
-    link::create_link(name, link::LinkType::Tap, queues)?;
+    match link::create_link(name, link::LinkType::Tap, queues) {
+        Ok(()) => {}
+        Err(e) if link::is_busy_or_exist(&e) => {
+            // IFF_PERSIST leaves tapN_kata in the netns after a failed
+            // sandbox.start(); concurrent CreateContainer retries then hit
+            // TUNSETIFF EBUSY. Reuse the existing device instead of failing.
+            warn!(
+                sl!(),
+                "tap {} already exists ({}), reusing",
+                name,
+                e
+            );
+        }
+        Err(e) => return Err(e).context("create tap device"),
+    }
 
     let link = get_link_by_name(handle, name)
         .await

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -16,6 +16,30 @@ use nix::ioctl_write_ptr;
 
 use super::macros::{get_name, set_name};
 
+/// True when TUNSETIFF failed because the named device already exists / is busy.
+/// Used to reuse a leftover `tapN_kata` after a failed sandbox start (IFF_PERSIST
+/// keeps the device alive after the creating FDs are dropped).
+pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(ioe) = cause.downcast_ref::<io::Error>() {
+            match ioe.raw_os_error() {
+                Some(libc::EBUSY) | Some(libc::EEXIST) => return true,
+                _ => {}
+            }
+        }
+        if let Some(ne) = cause.downcast_ref::<nix::Error>() {
+            if *ne == nix::Error::EBUSY || *ne == nix::Error::EEXIST {
+                return true;
+            }
+        }
+    }
+    let s = format!("{err:#}");
+    s.contains("EBUSY")
+        || s.contains("EEXIST")
+        || s.contains("Device or resource busy")
+        || s.contains("File exists")
+}
+
 type IfName = [u8; libc::IFNAMSIZ];
 
 #[derive(Copy, Clone, Debug)]
@@ -128,23 +152,26 @@ fn create_queue(name: &str, flags: libc::c_int) -> Result<(File, String)> {
     Ok((file, req.get_name()?))
 }
 
-#[cfg(test)]
-pub mod net_test_utils {
+/// Delete a link by name (e.g. leftover `tap0_kata` after a failed start).
+pub async fn delete_link(handle: &rtnetlink::Handle, name: &str) -> Result<()> {
     use crate::network::network_model::tc_filter_model::fetch_index;
 
-    // remove a link by its name
-    #[allow(dead_code)]
-    pub async fn delete_link(
-        handle: &rtnetlink::Handle,
-        name: &str,
-    ) -> Result<(), rtnetlink::Error> {
-        let link_index = fetch_index(handle, name)
-            .await
-            .expect("failed to fetch index");
-        // the ifindex of a link will not change during its lifetime, so the index
-        // remains the same between the query above and the deletion below
-        handle.link().del(link_index).execute().await
-    }
+    let link_index = fetch_index(handle, name)
+        .await
+        .with_context(|| format!("fetch index for {name}"))?;
+    handle
+        .link()
+        .del(link_index)
+        .execute()
+        .await
+        .with_context(|| format!("delete link {name}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod net_test_utils {
+    // Back-compat for tests that imported delete_link from this module.
+    pub use super::delete_link;
 }
 
 #[cfg(test)]

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -5,7 +5,7 @@
 //
 
 mod create;
-pub use create::{create_link, LinkType};
+pub use create::{create_link, delete_link, is_busy_or_exist, LinkType};
 mod driver_info;
 pub use driver_info::get_driver_info;
 mod macros;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -235,6 +235,14 @@ impl RuntimeHandlerManagerInner {
             .setup_config(&mut config)
             .context("failed to setup static resource mgmt config")?;
 
+        // Re-apply the `io.katacontainers.config.hypervisor.default_vcpus` pod annotation
+        // override AFTER `setup_config`. setup_config (initial_size.rs:178) overwrites
+        // `default_vcpus` from the pod's CPU/memory resources whenever `mem_mb > 0` — e.g. a pod
+        // with a memory limit but no CPU limit resets it to `(overhead_vcpus + 0).max(1.0)` = 1,
+        // clobbering the override applied in `load_config` above. The annotation must win so
+        // qemu boots `-smp N` directly (no vCPU hotplug, kata-containers#13440).
+        apply_hypervisor_default_vcpus_annotation(&sandbox_config.annotations, &mut config)?;
+
         update_component_log_level(&config);
 
         let dan_path = dan_config_path(&config, &self.id);
@@ -856,6 +864,12 @@ fn load_config(an: &HashMap<String, String>, option: &Option<Vec<u8>>) -> Result
         TomlConfig::get_default_config_file_list()
     ))?;
     annotation.update_config_by_annotation(&mut toml_config)?;
+    // runtime-rs' update_config_by_annotation (external `annotations` crate) does not handle
+    // the `io.katacontainers.config.hypervisor.default_vcpus` annotation (kata-containers#13439),
+    // so CC guests always boot with the TOML `default_vcpus` (1) — a severe bottleneck for
+    // CPU-bound guest workloads. Apply it ourselves so qemu boots `-smp N` directly, with NO
+    // vCPU hotplug (sidestepping the unstable runtime-rs hotplug path, kata-containers#13440).
+    apply_hypervisor_default_vcpus_annotation(an, &mut toml_config)?;
     update_agent_kernel_params(&mut toml_config)?;
 
     // validate configuration and return the error
@@ -863,6 +877,60 @@ fn load_config(an: &HashMap<String, String>, option: &Option<Vec<u8>>) -> Result
 
     info!(logger, "get config content {:?}", &toml_config);
     Ok(toml_config)
+}
+
+// Apply the `io.katacontainers.config.hypervisor.default_vcpus` pod annotation override.
+//
+// runtime-rs' `Annotation::update_config_by_annotation` (external `annotations` crate) does
+// not handle the `default_vcpus` hypervisor annotation (kata-containers#13439): CC guests
+// always boot with the TOML `default_vcpus` (1), a severe bottleneck for CPU-bound guest
+// workloads (LLM weight load, DeepGEMM JIT, CUDA-graph capture). The pod annotation is
+// allowlisted in `enable_annotations` but silently dropped.
+//
+// This reads the annotation directly (respecting the per-hypervisor `enable_annotations`
+// regex allowlist via `SecurityInfo::is_annotation_enabled`) and sets `cpu_info.default_vcpus`
+// so qemu boots `-smp N` directly at sandbox creation — NO vCPU hotplug, sidestepping the
+// unstable runtime-rs hotplug path (kata-containers#13440). `default_maxvcpus` is capped at N
+// so no hotplug is triggered beyond it.
+//
+// Safe no-op when the annotation is absent or not allowlisted (preserves TOML default), so
+// pods without the annotation keep booting with the configured `default_vcpus`.
+fn apply_hypervisor_default_vcpus_annotation(
+    an: &HashMap<String, String>,
+    config: &mut TomlConfig,
+) -> Result<()> {
+    const DEFAULT_VCPUS_ANNOTATION: &str = "io.katacontainers.config.hypervisor.default_vcpus";
+
+    let hypervisor_name = config.runtime.hypervisor_name.clone();
+    let hv = config
+        .hypervisor
+        .get_mut(&hypervisor_name)
+        .context("failed to get hypervisor config for default_vcpus annotation")?;
+
+    // Respect the per-hypervisor `enable_annotations` regex allowlist (it lives on
+    // `security_info`, not on the top-level Hypervisor struct). Skip if `default_vcpus`
+    // is not allowlisted for this hypervisor.
+    if !hv.security_info.is_annotation_enabled(DEFAULT_VCPUS_ANNOTATION) {
+        return Ok(());
+    }
+
+    if let Some(val) = an.get(DEFAULT_VCPUS_ANNOTATION) {
+        if let Ok(n) = val.parse::<f32>() {
+            if n >= 1.0 {
+                hv.cpu_info.default_vcpus = n;
+                // Cap maxvcpus at default_vcpus so no vCPU hotplug is triggered beyond it
+                // (runtime-rs hotplug is unstable, kata-containers#13440).
+                hv.cpu_info.default_maxvcpus = n.ceil() as u32;
+                info!(
+                    sl!(),
+                    "applied {} annotation: default_vcpus={}",
+                    DEFAULT_VCPUS_ANNOTATION, n
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn is_shipped_kata_config_path(config_path: &str) -> bool {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -954,152 +954,180 @@ impl Sandbox for VirtSandbox {
         }
         let sandbox_config = self.sandbox_config.as_ref().unwrap();
 
-        // if sandbox is not in SandboxState::Init then return,
-        // otherwise try to create sandbox
-
-        let mut inner = self.inner.write().await;
-        if inner.state != SandboxState::Init {
-            warn!(sl!(), "sandbox is started");
-            return Ok(());
+        // Only hold the sandbox lock for the Init check — NOT across start_vm /
+        // agent connect / device setup. Holding write across the whole bring-up
+        // blocked Task/State RPCs (StateProcess timed out) while QEMU was
+        // already dead, which is the wedge we hit on am-b200-38 (fix5).
+        {
+            let inner = self.inner.read().await;
+            if inner.state != SandboxState::Init {
+                warn!(sl!(), "sandbox is started");
+                return Ok(());
+            }
         }
+
         let selinux_label = load_oci_spec().ok().and_then(|spec| {
             spec.process()
                 .as_ref()
                 .and_then(|process| process.selinux_label().clone())
         });
 
-        self.hypervisor
-            .prepare_vm(
-                id,
-                sandbox_config.network_env.netns.clone(),
-                &sandbox_config.annotations,
-                selinux_label,
-            )
-            .await
-            .context("prepare vm")?;
+        let start_result = async {
+            self.hypervisor
+                .prepare_vm(
+                    id,
+                    sandbox_config.network_env.netns.clone(),
+                    &sandbox_config.annotations,
+                    selinux_label,
+                )
+                .await
+                .context("prepare vm")?;
 
-        // generate device and setup before start vm
-        // should after hypervisor.prepare_vm
-        let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
+            // generate device and setup before start vm
+            // should after hypervisor.prepare_vm
+            let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
 
-        self.resource_manager
-            .prepare_before_start_vm(resources)
-            .await
-            .context("set up device before start vm")?;
+            self.resource_manager
+                .prepare_before_start_vm(resources)
+                .await
+                .context("set up device before start vm")?;
 
-        // start vm
-        self.hypervisor.start_vm(10_000).await.context("start vm")?;
-        info!(sl!(), "start vm");
+            // start vm
+            self.hypervisor.start_vm(10_000).await.context("start vm")?;
+            info!(sl!(), "start vm");
 
-        let sandbox = self.clone();
-        // wait for vm exit in background, and record the exit status and time when vm exited.
-        tokio::spawn(async move {
-            match sandbox.hypervisor.wait_vm().await {
-                Ok(exit_code) => {
-                    sandbox
-                        .record_stop(exit_code as u32, SystemTime::now())
-                        .await;
+            let sandbox = self.clone();
+            // wait for vm exit in background, and record the exit status and time when vm exited.
+            tokio::spawn(async move {
+                match sandbox.hypervisor.wait_vm().await {
+                    Ok(exit_code) => {
+                        sandbox
+                            .record_stop(exit_code as u32, SystemTime::now())
+                            .await;
+                    }
+                    Err(err) => {
+                        warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
+                        sandbox.record_stop(255, SystemTime::now()).await;
+                    }
                 }
-                Err(err) => {
-                    warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
-                    sandbox.record_stop(255, SystemTime::now()).await;
+            });
+
+            // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
+            let (prestart_hooks, create_runtime_hooks) =
+                if let Some(hooks) = sandbox_config.hooks.as_ref() {
+                    (
+                        hooks.prestart().clone().unwrap_or_default(),
+                        hooks.create_runtime().clone().unwrap_or_default(),
+                    )
+                } else {
+                    (Vec::new(), Vec::new())
+                };
+
+            self.execute_oci_hook_functions(
+                &prestart_hooks,
+                &create_runtime_hooks,
+                &sandbox_config.state,
+            )
+            .await?;
+
+            // 1. if there are pre-start hook functions, network config might have been changed.
+            //    We need to rescan the netns to handle the change.
+            // 2. Do not scan the netns if we want no network for the VM.
+            // TODO In case of vm factory, scan the netns to hotplug interfaces after the VM is started.
+            let config = self.resource_manager.config().await;
+            if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
+                && !config.runtime.disable_new_netns
+                && !dan_config_path(&config, &self.sid).exists()
+            {
+                if let Some(netns_path) = &sandbox_config.network_env.netns {
+                    let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
+                        network_model: config.runtime.internetworking_model.clone(),
+                        netns_path: netns_path.to_owned(),
+                        queues: self
+                            .hypervisor
+                            .hypervisor_config()
+                            .await
+                            .network_info
+                            .network_queues as usize,
+                        network_created: sandbox_config.network_env.network_created,
+                    });
+                    self.resource_manager
+                        .handle_network(network_resource)
+                        .await
+                        .context("set up device after start vm")?;
                 }
             }
-        });
 
-        // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
-        let (prestart_hooks, create_runtime_hooks) =
-            if let Some(hooks) = sandbox_config.hooks.as_ref() {
-                (
-                    hooks.prestart().clone().unwrap_or_default(),
-                    hooks.create_runtime().clone().unwrap_or_default(),
-                )
-            } else {
-                (Vec::new(), Vec::new())
+            // connect agent
+            // set agent socket
+            let address = self
+                .hypervisor
+                .get_agent_socket()
+                .await
+                .context("get agent socket")?;
+            self.agent
+                .start(&address)
+                .await
+                .context(format!("connect to address {:?}", &address))?;
+            self.set_agent_policy().await.context("set agent policy")?;
+
+            self.resource_manager
+                .setup_after_start_vm()
+                .await
+                .context("setup device after start vm")?;
+
+            // create sandbox in vm
+            let agent_config = self.agent.agent_config().await;
+            let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
+            let req = agent::CreateSandboxRequest {
+                hostname: sandbox_config.hostname.clone(),
+                dns: sandbox_config.dns.clone(),
+                storages: self
+                    .resource_manager
+                    .get_storage_for_sandbox(self.shm_size)
+                    .await
+                    .context("get storages for sandbox")?,
+                sandbox_pidns: false,
+                sandbox_id: id.to_string(),
+                guest_hook_path: self
+                    .hypervisor
+                    .hypervisor_config()
+                    .await
+                    .security_info
+                    .guest_hook_path,
+                kernel_modules,
             };
 
-        self.execute_oci_hook_functions(
-            &prestart_hooks,
-            &create_runtime_hooks,
-            &sandbox_config.state,
-        )
-        .await?;
+            self.agent
+                .create_sandbox(req)
+                .await
+                .context("create sandbox")?;
 
-        // 1. if there are pre-start hook functions, network config might have been changed.
-        //    We need to rescan the netns to handle the change.
-        // 2. Do not scan the netns if we want no network for the VM.
-        // TODO In case of vm factory, scan the netns to hotplug interfaces after the VM is started.
-        let config = self.resource_manager.config().await;
-        if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
-            && !config.runtime.disable_new_netns
-            && !dan_config_path(&config, &self.sid).exists()
-        {
-            if let Some(netns_path) = &sandbox_config.network_env.netns {
-                let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
-                    network_model: config.runtime.internetworking_model.clone(),
-                    netns_path: netns_path.to_owned(),
-                    queues: self
-                        .hypervisor
-                        .hypervisor_config()
-                        .await
-                        .network_info
-                        .network_queues as usize,
-                    network_created: sandbox_config.network_env.network_created,
-                });
-                self.resource_manager
-                    .handle_network(network_resource)
-                    .await
-                    .context("set up device after start vm")?;
-            }
+            Ok(())
+        }
+        .await;
+
+        if let Err(ref e) = start_result {
+            // CreateContainer returns Err without calling StopSandbox when start
+            // fails — previously that left a running/zombie QEMU behind. stop_vm
+            // now also reaps (fix5).
+            error!(
+                sl!(),
+                "sandbox start failed: {:#}; stopping QEMU to prevent zombie", e
+            );
+            let _ = self.hypervisor.stop_vm().await;
+            return start_result;
         }
 
-        // connect agent
-        // set agent socket
-        let address = self
-            .hypervisor
-            .get_agent_socket()
-            .await
-            .context("get agent socket")?;
-        self.agent
-            .start(&address)
-            .await
-            .context(format!("connect to address {:?}", &address))?;
-        self.set_agent_policy().await.context("set agent policy")?;
-
-        self.resource_manager
-            .setup_after_start_vm()
-            .await
-            .context("setup device after start vm")?;
-
-        // create sandbox in vm
-        let agent_config = self.agent.agent_config().await;
-        let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
-        let req = agent::CreateSandboxRequest {
-            hostname: sandbox_config.hostname.clone(),
-            dns: sandbox_config.dns.clone(),
-            storages: self
-                .resource_manager
-                .get_storage_for_sandbox(self.shm_size)
-                .await
-                .context("get storages for sandbox")?,
-            sandbox_pidns: false,
-            sandbox_id: id.to_string(),
-            guest_hook_path: self
-                .hypervisor
-                .hypervisor_config()
-                .await
-                .security_info
-                .guest_hook_path,
-            kernel_modules,
-        };
-
-        self.agent
-            .create_sandbox(req)
-            .await
-            .context("create sandbox")?;
-
-        inner.state = SandboxState::Running;
-        inner.created_at = Some(std::time::SystemTime::now());
+        {
+            let mut inner = self.inner.write().await;
+            if inner.state != SandboxState::Init {
+                warn!(sl!(), "sandbox left Init during start; skipping Running transition");
+                return Ok(());
+            }
+            inner.state = SandboxState::Running;
+            inner.created_at = Some(std::time::SystemTime::now());
+        }
 
         // get and store guest details
         self.store_guest_details()

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -95,6 +95,10 @@ pub struct SandboxRestoreArgs {
 #[derive(Clone, Copy, PartialEq, Debug, Display)]
 pub enum SandboxState {
     Init,
+    /// Bring-up in progress (network + QEMU + agent). Distinct from Init so
+    /// concurrent CreateContainer calls do not re-enter `start()` and hit
+    /// TUNSETIFF EBUSY on an already-created `tapN_kata`.
+    Starting,
     Running,
     Stopped,
 }
@@ -103,7 +107,9 @@ impl SandboxState {
     fn to_cri_state(self) -> &'static str {
         match self {
             SandboxState::Running => "SANDBOX_READY",
-            SandboxState::Init | SandboxState::Stopped => "SANDBOX_NOTREADY",
+            SandboxState::Init | SandboxState::Starting | SandboxState::Stopped => {
+                "SANDBOX_NOTREADY"
+            }
         }
     }
 }
@@ -135,6 +141,10 @@ pub struct VirtSandbox {
     sid: String,
     msg_sender: Arc<Mutex<Sender<Message>>>,
     inner: Arc<RwLock<SandboxInner>>,
+    /// Serializes `sandbox.start()` without holding `inner` write across the
+    /// long QEMU/agent bring-up (fix5). Concurrent CreateContainer retries wait
+    /// here instead of racing `prepare_before_start_vm` / tap creation.
+    start_mutex: Arc<Mutex<()>>,
     resource_manager: Arc<ResourceManager>,
     agent: Arc<dyn Agent>,
     hypervisor: Arc<dyn Hypervisor>,
@@ -181,6 +191,7 @@ impl VirtSandbox {
             sid: sid.to_string(),
             msg_sender: Arc::new(Mutex::new(msg_sender)),
             inner: Arc::new(RwLock::new(SandboxInner::new())),
+            start_mutex: Arc::new(Mutex::new(())),
             agent,
             hypervisor,
             resource_manager,
@@ -954,15 +965,48 @@ impl Sandbox for VirtSandbox {
         }
         let sandbox_config = self.sandbox_config.as_ref().unwrap();
 
-        // Only hold the sandbox lock for the Init check — NOT across start_vm /
-        // agent connect / device setup. Holding write across the whole bring-up
-        // blocked Task/State RPCs (StateProcess timed out) while QEMU was
-        // already dead, which is the wedge we hit on am-b200-38 (fix5).
+        // Fast path: already running — CreateContainer for the app container
+        // after the sandbox container brought the VM up.
         {
             let inner = self.inner.read().await;
-            if inner.state != SandboxState::Init {
-                warn!(sl!(), "sandbox is started");
-                return Ok(());
+            match inner.state {
+                SandboxState::Running => {
+                    warn!(sl!(), "sandbox is started");
+                    return Ok(());
+                }
+                SandboxState::Stopped => {
+                    return Err(anyhow!("sandbox already stopped"));
+                }
+                SandboxState::Init | SandboxState::Starting => {}
+            }
+        }
+
+        // Serialize bring-up. Do NOT hold `inner` write across QEMU/agent
+        // (fix5): that blocked Task/State RPCs. The start_mutex alone stops
+        // concurrent CreateContainer from racing tap creation (fix7 /
+        // kata-containers#13564 follow-up — TUNSETIFF EBUSY on tap0_kata).
+        let _start_guard = self.start_mutex.lock().await;
+
+        {
+            let mut inner = self.inner.write().await;
+            match inner.state {
+                SandboxState::Running => {
+                    warn!(sl!(), "sandbox is started");
+                    return Ok(());
+                }
+                SandboxState::Stopped => {
+                    return Err(anyhow!("sandbox already stopped"));
+                }
+                SandboxState::Starting => {
+                    // Should not happen under start_mutex; treat as in-progress
+                    // owner that somehow dropped the mutex — fail closed.
+                    return Err(anyhow!(
+                        "sandbox start already in progress (state=Starting)"
+                    ));
+                }
+                SandboxState::Init => {
+                    inner.state = SandboxState::Starting;
+                }
             }
         }
 
@@ -1110,19 +1154,36 @@ impl Sandbox for VirtSandbox {
         if let Err(ref e) = start_result {
             // CreateContainer returns Err without calling StopSandbox when start
             // fails — previously that left a running/zombie QEMU behind. stop_vm
-            // now also reaps (fix5).
+            // now also reaps (fix5). Also release host taps (IFF_PERSIST) so a
+            // retry does not hit TUNSETIFF EBUSY (fix7).
             error!(
                 sl!(),
-                "sandbox start failed: {:#}; stopping QEMU to prevent zombie", e
+                "sandbox start failed: {:#}; stopping QEMU and releasing network", e
             );
             let _ = self.hypervisor.stop_vm().await;
+            if let Err(net_err) = self.resource_manager.release_network().await {
+                warn!(
+                    sl!(),
+                    "failed to release network after start failure: {:#}", net_err
+                );
+            }
+            {
+                let mut inner = self.inner.write().await;
+                if inner.state == SandboxState::Starting {
+                    inner.state = SandboxState::Init;
+                }
+            }
             return start_result;
         }
 
         {
             let mut inner = self.inner.write().await;
-            if inner.state != SandboxState::Init {
-                warn!(sl!(), "sandbox left Init during start; skipping Running transition");
+            if inner.state != SandboxState::Starting {
+                warn!(
+                    sl!(),
+                    "sandbox left Starting during start (state={:?}); skipping Running transition",
+                    inner.state
+                );
                 return Ok(());
             }
             inner.state = SandboxState::Running;
@@ -1304,10 +1365,15 @@ impl Sandbox for VirtSandbox {
         self.cancel_token.cancel();
 
         info!(sl!(), "begin stop sandbox");
-        if state == SandboxState::Init {
+        if state == SandboxState::Init || state == SandboxState::Starting {
+            // Serialize with an in-flight start() so we don't race tap/QEMU teardown.
+            let _start_guard = self.start_mutex.lock().await;
             let _ = self.hypervisor.stop_vm().await;
+            if let Err(err) = self.resource_manager.release_network().await {
+                warn!(sl!(), "failed to release network during stop: {:#}", err);
+            }
             self.record_stop(0, SystemTime::now()).await;
-            info!(sl!(), "sandbox stopped during Init");
+            info!(sl!(), "sandbox stopped during {:?}", state);
             return Ok(());
         }
 
@@ -1600,6 +1666,7 @@ impl Persist for VirtSandbox {
             sid: sid.to_string(),
             msg_sender: Arc::new(Mutex::new(sandbox_args.sender)),
             inner: Arc::new(RwLock::new(SandboxInner::new())),
+            start_mutex: Arc::new(Mutex::new(())),
             agent,
             hypervisor,
             resource_manager,

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
@@ -211,6 +211,19 @@ func (dv *directVolume) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeR
 				klog.Infof("Removed backing file %s for volume %s", backingFile, volId)
 			}
 		}
+	} else {
+		// Non-SPDK directvol: release the upper storage directory
+		// that holds the rawdisk backing file. This is the CSI-spec
+		// place for backing-storage teardown; NodeUnstage must not
+		// do it because that would silently turn every PV into an
+		// ephemeral one (ignoring reclaimPolicy: Retain).
+		if storagePath, err := utils.GetStoragePath(dv.config.StoragePath, volId); err != nil {
+			klog.Warningf("Failed to resolve storage path for volume %s: %v", volId, err)
+		} else if err := os.RemoveAll(storagePath); err != nil {
+			klog.Warningf("Failed to remove storage path %s for volume %s: %v", storagePath, volId, err)
+		} else {
+			klog.Infof("Removed storage path %s for volume %s", storagePath, volId)
+		}
 	}
 
 	if err := dv.deleteVolume(volId); err != nil {

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
@@ -115,7 +115,13 @@ func (dv *directVolume) CreateVolume(ctx context.Context, req *csi.CreateVolumeR
 	} else {
 		vol, err = dv.createVolume(volumeID, req.GetName(), capacity, kind)
 		if err != nil {
-			klog.Errorf("created volume %s at path %s failed with error: %v", vol.VolID, vol.VolPath, err.Error())
+			// createVolume returns (nil, err) on every error path (size limit,
+			// capacity tracking, mkdir, state update). Dereferencing vol here
+			// panics with a nil-pointer dereference that masks the real error
+			// and crashes the driver -> CrashLoopBackOff blocks ALL kata-direct
+			// provisioning on the node. Log the non-nil fields + err instead of
+			// vol.VolID/vol.VolPath (which are "" / unreachable when vol==nil).
+			klog.Errorf("createVolume %s (name %q, capacity %d) failed: %v", volumeID, req.GetName(), capacity, err)
 			return nil, err
 		}
 		klog.Infof("created volume %s at path %s", vol.VolID, vol.VolPath)

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
@@ -281,14 +281,10 @@ func (dv *directVolume) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnst
 		}
 	}
 
-	if deviceUpperPath, err := utils.GetStoragePath(dv.config.StoragePath, volumeID); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("get device UpperPath %s failed: %v", deviceUpperPath, err))
-	} else {
-		if err = os.RemoveAll(deviceUpperPath); err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("remove device upper path: %s failed %v", deviceUpperPath, err.Error()))
-		}
-		klog.Infof("direct volume %s has been removed.", deviceUpperPath)
-	}
+	// NB: do not delete the raw disk here. The CSI spec reserves backing
+	// storage teardown for ControllerDeleteVolume; deleting it on
+	// NodeUnstage makes the volume effectively ephemeral, ignoring
+	// reclaimPolicy: Retain and losing any data the workload wrote.
 
 	if err := os.RemoveAll(stagingTargetPath); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("remove staging target path: %v", err))


### PR DESCRIPTION
## Summary

Follow-up to #13564 / #13568. After fix5 released the sandbox write-lock during bring-up, concurrent `CreateContainer` retries re-entered `sandbox.start()` while agent connect was still in progress (slow CC GPU guest boot), racing `TUNSETIFF` on an already-created `tap0_kata` → **EBUSY**.

Seen in production on HGX B200 + TDX with large CC GPU pods (orphan QEMU holding all GPUs; pods CrashLoop / Terminating stuck).

## Changes

- `start_mutex` + `SandboxState::Starting` — serialize bring-up without re-holding `inner` write across QEMU/agent
- On start failure: `stop_vm` + `release_network` (delete persist taps) + reset to `Init`
- `create_link`: reuse existing tap on EBUSY/EEXIST
- veth `detach`: delete `tapN_kata` (IFF_PERSIST survives FD close)

## Test plan

- [ ] Unit / existing runtime-rs network tests
- [ ] Deploy CC GPU pod with slow agent connect; confirm concurrent CreateContainer does not return EBUSY
- [ ] Confirm failed start leaves no orphan `tapN_kata` in the pod netns
- [ ] Confirm Task/State still responds during bring-up (fix5 lock-release preserved)

Related: https://github.com/kata-containers/kata-containers/issues/13564#issuecomment-5228200050

Made with [Cursor](https://cursor.com)