### PR TITLE
runtime-rs: fix mem-agent startup lock panic

### DIFF
--- a/src/libs/mem-agent/src/agent.rs
+++ b/src/libs/mem-agent/src/agent.rs
@@ -42,7 +42,10 @@ async fn handle_agent_cmd(
 
     let need_reset_mas = match cmd {
         AgentCmd::MemcgStatus => {
-            ret_msg = AgentReturn::MemcgStatus(memcg.get_status().await);
+            ret_msg = match memcg.get_status().await {
+                Ok(status) => AgentReturn::MemcgStatus(status),
+                Err(e) => AgentReturn::Err(e),
+            };
             false
         }
         AgentCmd::MemcgSet(opt) => match memcg.set_config(opt).await {
@@ -55,7 +58,13 @@ async fn handle_agent_cmd(
                 false
             }
         },
-        AgentCmd::CompactSet(opt) => comp.set_config(opt).await,
+        AgentCmd::CompactSet(opt) => match comp.set_config(opt).await {
+            Ok(reset) => reset,
+            Err(e) => {
+                ret_msg = AgentReturn::Err(e);
+                false
+            }
+        },
     };
 
     ret_tx

--- a/src/libs/mem-agent/src/compact.rs
+++ b/src/libs/mem-agent/src/compact.rs
@@ -17,10 +17,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
-use tokio::sync::RwLock;
 use tokio::time::Duration as TokioDuration;
 
 const PAGE_REPORTING_MIN_ORDER: u8 = 9;
@@ -263,7 +262,7 @@ impl Compact {
         let file = File::open("/proc/pagetypeinfo")?;
         let reader = BufReader::new(file);
 
-        let order_limit = self.core.blocking_read().config.compact_order as usize;
+        let order_limit = self.core.read().unwrap().config.compact_order as usize;
 
         let mut total_free_movable_pages = 0;
 
@@ -303,7 +302,8 @@ impl Compact {
         };
 
         self.core
-            .blocking_read()
+            .read()
+            .unwrap()
             .check_compact_threshold(memfree_kb, free_movable_pages)
     }
 
@@ -315,16 +315,17 @@ impl Compact {
             .map_err(|e| anyhow!("calculate_free_movable_pages failed: {e}"))?;
 
         self.core
-            .blocking_write()
+            .write()
+            .unwrap()
             .set_prev(memfree_kb, free_movable_pages);
 
         Ok(())
     }
 
     fn do_compact(&self) -> Result<()> {
-        let compact_psi_percent_limit = self.core.blocking_read().config.compact_psi_percent_limit;
-        let mut compact_psi = self.core.blocking_read().get_special_psi();
-        let mut rest_sec = self.core.blocking_read().config.compact_sec_max;
+        let compact_psi_percent_limit = self.core.read().unwrap().config.compact_psi_percent_limit;
+        let mut compact_psi = self.core.read().unwrap().get_special_psi();
+        let mut rest_sec = self.core.read().unwrap().config.compact_sec_max;
 
         if let Err(e) = sched_yield() {
             error!("sched_yield failed: {:?}", e);
@@ -395,25 +396,28 @@ impl Compact {
     }
 
     pub fn need_work(&self) -> bool {
-        self.core.blocking_read().need_work()
+        self.core.read().unwrap().need_work()
     }
 
     pub fn reset_timer(&mut self) {
-        self.core.blocking_write().timeout.reset();
+        self.core.write().unwrap().timeout.reset();
     }
 
     pub fn get_remaining_tokio_duration(&self) -> TokioDuration {
-        self.core.blocking_read().get_remaining_tokio_duration()
+        self.core.read().unwrap().get_remaining_tokio_duration()
     }
 
     pub async fn async_get_remaining_tokio_duration(&self) -> TokioDuration {
-        self.core.read().await.get_remaining_tokio_duration()
+        let core = self.core.clone();
+        tokio::task::spawn_blocking(move || core.read().unwrap().get_remaining_tokio_duration())
+            .await
+            .unwrap_or_else(|_| TokioDuration::from_secs(0))
     }
 
     pub fn work(&mut self) -> Result<()> {
-        let mut can_work = self.core.blocking_write().psi_ok();
+        let mut can_work = self.core.write().unwrap().psi_ok();
         if can_work {
-            if !self.core.blocking_read().need_force_compact() {
+            if !self.core.read().unwrap().need_force_compact() {
                 if !self.check_compact_threshold() {
                     trace!("not enough free movable pages");
                     can_work = false;
@@ -429,16 +433,19 @@ impl Compact {
 
             self.set_prev()?;
 
-            self.core.blocking_write().force_counter = 0;
+            self.core.write().unwrap().force_counter = 0;
         } else {
-            self.core.blocking_write().force_counter += 1;
+            self.core.write().unwrap().force_counter += 1;
         }
 
         Ok(())
     }
 
-    pub async fn set_config(&mut self, new_config: OptionConfig) -> bool {
-        self.core.write().await.set_config(new_config)
+    pub async fn set_config(&mut self, new_config: OptionConfig) -> Result<bool> {
+        let core = self.core.clone();
+        tokio::task::spawn_blocking(move || core.write().unwrap().set_config(new_config))
+            .await
+            .map_err(|e| anyhow!("tokio::task::spawn_blocking failed: {e:?}"))
     }
 }
 

--- a/src/libs/mem-agent/src/memcg.rs
+++ b/src/libs/mem-agent/src/memcg.rs
@@ -15,8 +15,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use tokio::time::Duration as TokioDuration;
 
 /* If last_inc_time to current_time small than IDLE_FRESH_IGNORE_SECS,
@@ -1002,7 +1001,7 @@ impl MemCG {
         let mg_hash = mglru::host_memcgs_get(target_paths, true, self.is_cg_v2)
             .map_err(|e| anyhow!("lru_gen_parse::file_parse failed: {e}"))?;
 
-        let mut mgs = self.memcgs.blocking_write();
+        let mut mgs = self.memcgs.write().unwrap();
 
         if target_paths.is_empty() {
             mgs.remove_changed(&mg_hash);
@@ -1050,7 +1049,7 @@ impl MemCG {
             }
         });
 
-        self.memcgs.blocking_write().inc_run_aging_count(infov);
+        self.memcgs.write().unwrap().inc_run_aging_count(infov);
     }
 
     fn swap_not_available(&self) -> Result<bool> {
@@ -1098,7 +1097,7 @@ impl MemCG {
             swap = false;
         }
 
-        let psi_path = self.memcgs.blocking_read().config.psi_path.clone();
+        let psi_path = self.memcgs.read().unwrap().config.psi_path.clone();
         for info in infov.iter_mut() {
             info.eviction = Some(EvictionInfo {
                 psi: psi::Period::new(&psi_path.join(info.path.trim_start_matches('/')), false),
@@ -1291,7 +1290,7 @@ impl MemCG {
             }
         }
 
-        let mut mgs = self.memcgs.blocking_write();
+        let mut mgs = self.memcgs.write().unwrap();
         mgs.record_eviction(infov);
         mgs.record_eviction(&removed_infov);
 
@@ -1299,35 +1298,44 @@ impl MemCG {
     }
 
     fn check_psi_get_infos(&mut self, sec: u64) -> Vec<(SingleConfig, Vec<Info>)> {
-        self.memcgs.blocking_write().check_psi_get_infos(sec)
+        self.memcgs.write().unwrap().check_psi_get_infos(sec)
     }
 
     fn update_info(&self, infov: &mut Vec<Info>) {
-        self.memcgs.blocking_read().update_info(infov);
+        self.memcgs.read().unwrap().update_info(infov);
     }
 
     pub fn get_timeout_list(&self) -> Vec<u64> {
-        self.memcgs.blocking_read().get_timeout_list()
+        self.memcgs.read().unwrap().get_timeout_list()
     }
 
     pub fn reset_timers(&mut self, work_list: &Vec<u64>) {
-        self.memcgs.blocking_write().reset_timers(work_list);
+        self.memcgs.write().unwrap().reset_timers(work_list);
     }
 
     pub fn get_remaining_tokio_duration(&self) -> TokioDuration {
-        self.memcgs.blocking_read().get_remaining_tokio_duration()
+        self.memcgs.read().unwrap().get_remaining_tokio_duration()
     }
 
     pub async fn async_get_remaining_tokio_duration(&self) -> TokioDuration {
-        self.memcgs.read().await.get_remaining_tokio_duration()
+        let memcgs = self.memcgs.clone();
+        tokio::task::spawn_blocking(move || memcgs.read().unwrap().get_remaining_tokio_duration())
+            .await
+            .unwrap_or_else(|_| TokioDuration::from_secs(0))
     }
 
     pub async fn set_config(&mut self, new_config: OptionConfig) -> Result<bool> {
-        self.memcgs.write().await.set_config(new_config)
+        let memcgs = self.memcgs.clone();
+        tokio::task::spawn_blocking(move || memcgs.write().unwrap().set_config(new_config))
+            .await
+            .map_err(|e| anyhow!("tokio::task::spawn_blocking failed: {e:?}"))?
     }
 
-    pub async fn get_status(&self) -> HashMap<String, MemCgroup> {
-        self.memcgs.read().await.cgroups.clone()
+    pub async fn get_status(&self) -> Result<HashMap<String, MemCgroup>> {
+        let memcgs = self.memcgs.clone();
+        tokio::task::spawn_blocking(move || memcgs.read().unwrap().cgroups.clone())
+            .await
+            .map_err(|e| anyhow!("tokio::task::spawn_blocking failed: {e:?}"))
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the mem-agent's internal Tokio read-write locks with standard library
read-write locks so its synchronous paths can access state without calling
Tokio's blocking lock APIs from inside the runtime.

Async accessors run their blocking lock operations through
`tokio::task::spawn_blocking`.

## Problem

When runtime-rs starts the agent with `mem_agent_enable = true`, synchronous
mem-agent paths can execute within a Tokio runtime and call
`tokio::sync::RwLock::blocking_read` or `blocking_write`.

Tokio's blocking lock methods panic when called from an asynchronous execution
context. This can make the agent panic during startup and leave the workload
stuck during container creation, as reported in
[issue #12278](https://github.com/kata-containers/kata-containers/issues/12278).

## Fix

Use `std::sync::RwLock` for the shared state accessed by the synchronous
compaction and memory-cgroup paths. The synchronous methods use normal
`read`/`write` operations.

For the small number of asynchronous accessors, clone the shared state and run
the lock operation with `tokio::task::spawn_blocking`. This avoids blocking a
Tokio worker while keeping the primarily synchronous mem-agent interface
unchanged.

Propagate failures from the blocking tasks through the existing mem-agent error
response path rather than reporting a successful configuration update or an
empty memory-cgroup status.

This is based on the original fix proposed by @Cloudzp in
[PR #12281](https://github.com/kata-containers/kata-containers/pull/12281),
which this PR supersedes at a maintainer's request.

## Testing

The equivalent downstream change passed its full CI pipeline, including:

```text
make check LIBC=gnu
```

After rebasing onto current upstream `main`, the affected package passed focused
formatting, lint, and unit-test validation:

```text
cargo fmt -- --check
CARGO_BUILD_JOBS=4 cargo clippy -p mem-agent --all-targets --release --locked -- -D warnings
cargo test -p mem-agent --locked
```

The mem-agent test suite completed with 17 tests passed and no failures.
