### PR TITLE
docs: make runtime-rs the default for ppc64le

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -65,13 +65,12 @@ defaultShim:
   amd64: qemu-runtime-rs
   arm64: qemu-runtime-rs
   s390x: qemu-runtime-rs
-  ppc64le: qemu
+  ppc64le: qemu-runtime-rs
 ```
 
 Since the Kata Containers **4.0 release**, the default is the **Rust runtime**
 (`runtime-rs`, `qemu-runtime-rs`) on every architecture that ships a
-`runtime-rs` build (x86_64, aarch64, s390x). ppc64le has no `runtime-rs` build
-yet and stays on the Go runtime (`qemu`). The Go runtime remains selectable
+`runtime-rs` build (x86_64, aarch64, s390x and ppc64le). The Go runtime remains selectable
 (e.g. via the `kata-qemu` RuntimeClass) but is
 [deprecated](migrating-config-go-runtime-to-runtime-rs.md#go-runtime-deprecation).
 See the [config migration guide](migrating-config-go-runtime-to-runtime-rs.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -221,13 +221,11 @@ case "$(uname -m)" in
     ;;
 esac
 
-if [[ "${ARCH}" != "ppc64le" ]]; then
-  curl -fsSL -o kata-static.tar.zst \
-    "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-${ARCH}.tar.zst"
+curl -fsSL -o kata-static.tar.zst \
+  "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-${ARCH}.tar.zst"
 
-  # The archive uses an /opt/kata/ prefix.
-  sudo tar -xvf kata-static.tar.zst -C /
-fi
+# The archive uses an /opt/kata/ prefix.
+sudo tar -xvf kata-static.tar.zst -C /
 ```
 
 The `kata-static` archive contains runtime-rs, its configurations, composable
@@ -244,8 +242,7 @@ and `configuration-dragonball.toml` selects the built-in Dragonball VMM.
 
 !!! warning "The Go runtime is deprecated"
     Users who still require the Go runtime or monolithic guest images must
-    install the separate `kata-go-static` archive. This is also the only release
-    tarball available for `ppc64le`, where runtime-rs is not supported.
+    install the separate `kata-go-static` archive.
 
 ```sh
 curl -fsSL -o kata-go-static.tar.zst \

--- a/docs/migrating-config-go-runtime-to-runtime-rs.md
+++ b/docs/migrating-config-go-runtime-to-runtime-rs.md
@@ -4,10 +4,9 @@
 
 Starting with the **4.0.0 release**, the **Rust runtime (`runtime-rs`)** is the
 **default** runtime shipped by `kata-deploy` on every architecture that has a
-`runtime-rs` build (x86_64, aarch64 and s390x). The default RuntimeClass
+`runtime-rs` build (x86_64, aarch64, s390x and ppc64le). The default RuntimeClass
 therefore resolves to `qemu-runtime-rs` rather than the Go runtime's
-`kata-qemu`. ppc64le has no `runtime-rs` build yet and stays on the Go
-runtime.
+`kata-qemu`.
 
 **The Go runtime is deprecated, but it is not removed.** It remains supported
 (no new features are being added) and selectable — for example via the


### PR DESCRIPTION
Switch the default shim for ppc64le from the Go runtime ("qemu") to the Rust runtime ("qemu-runtime-rs"), bringing it in line with other archs.

Dependent on #12552