### PR TITLE
build: key CoCo caches on consumed content

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -58,7 +58,6 @@ jobs:
           - ovmf
           - ovmf-sev
           - ovmf-tdx
-          - pause-image
           - qemu
           - qemu-no-shared-fs
           - qemu-snp-experimental
@@ -294,7 +293,6 @@ jobs:
           - busybox
           - coco-guest-components
           - kernel-nvidia-gpu-modules
-          - pause-image
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -55,7 +55,6 @@ jobs:
           - kernel-nvidia-gpu
           - nydus
           - ovmf
-          - pause-image
           - qemu
           - qemu-no-shared-fs
           - virtiofsd
@@ -280,7 +279,6 @@ jobs:
         asset:
           - busybox
           - coco-guest-components
-          - pause-image
           - kernel-nvidia-gpu-modules
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm-${{ toJSON(matrix) }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -48,7 +48,6 @@ jobs:
           - fake-boot-image-se
           - fake-boot-image-se-runtime-rs
           - kernel
-          - pause-image
           - qemu
           - virtiofsd
     concurrency:
@@ -262,7 +261,6 @@ jobs:
         asset:
           - agent
           - coco-guest-components
-          - pause-image
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-s390x-${{ toJSON(matrix) }}
       cancel-in-progress: true

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -111,7 +111,6 @@ NVGPU_BASE_TARBALLS = \
 	ovmf-sev-tarball \
 	ovmf-tdx-tarball \
 	ovmf-tarball \
-	pause-image-tarball \
 	qemu-no-shared-fs-tarball \
 	qemu-snp-experimental-tarball \
 	qemu-tdx-experimental-tarball \
@@ -126,7 +125,6 @@ NVGPU_BASE_TARBALLS = \
 	$(PUBLISH_COMPONENT_TARBALLS) \
 	kernel-nvidia-gpu-tarball \
 	ovmf-tarball \
-	pause-image-tarball \
 	qemu-no-shared-fs-tarball \
 	qemu-tarball \
 	virtiofsd-tarball \
@@ -142,7 +140,6 @@ NVGPU_FINAL_TARBALL_INPUTS = \
 	kata-static-ovmf-sev.tar.zst \
 	kata-static-ovmf-tdx.tar.zst \
 	kata-static-ovmf.tar.zst \
-	kata-static-pause-image.tar.zst \
 	kata-static-qemu-no-shared-fs.tar.zst \
 	kata-static-qemu-snp-experimental.tar.zst \
 	kata-static-qemu-tdx-experimental.tar.zst \
@@ -339,7 +336,7 @@ DEPS := agent-tarball
 rootfs-image-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball pause-image-tarball coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball coco-guest-components-tarball kernel-tarball
 rootfs-image-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -356,7 +353,7 @@ DEPS := agent-tarball
 rootfs-image-mariner-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball pause-image-tarball coco-guest-components-tarball kernel-tarball
+DEPS := agent-tarball coco-guest-components-tarball kernel-tarball
 rootfs-initrd-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 
@@ -368,7 +365,7 @@ DEPS := agent-tarball busybox-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-tarball: $(DEPS)
 	${MAKE} $@-build
 
-DEPS := agent-tarball busybox-tarball pause-image-tarball coco-guest-components-tarball kernel-nvidia-gpu-tarball
+DEPS := agent-tarball busybox-tarball coco-guest-components-tarball kernel-nvidia-gpu-tarball
 rootfs-image-nvidia-gpu-confidential-tarball: $(DEPS)
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -355,8 +355,16 @@ get_coco_guest_components_tarball_path() {
 	echo "${coco_guest_components_local_build_dir}/${coco_guest_components_tarball_name}"
 }
 
+get_coco_guest_components_tarball_checksum() {
+	local tarball
+	tarball="$(get_coco_guest_components_tarball_path)"
+	[[ -f "${tarball}" ]] || die "CoCo guest components tarball not found: ${tarball}"
+
+	sha256sum "${tarball}" | cut -d' ' -f1
+}
+
 get_latest_coco_guest_components_artefact_and_builder_image_version() {
-	echo "$(get_from_kata_deps ".externals.coco-guest-components.version")-$(get_coco_extension_oci_arch)"
+	echo "$(get_from_kata_deps ".externals.coco-guest-components.version")-$(get_coco_extension_oci_arch)-$(get_coco_guest_components_container_image_digest)"
 }
 
 get_coco_extension_oci_arch() {
@@ -374,6 +382,17 @@ get_coco_guest_components_container_image_ref() {
 	[[ -n "${image}" ]] || die "Failed to get coco-guest-components container_image from versions.yaml"
 
 	echo "${image}:${version}"
+}
+
+get_coco_guest_components_container_image_digest() {
+	ensure_oras_installed >&2
+
+	local image_ref go_arch
+	image_ref="$(get_coco_guest_components_container_image_ref)"
+	go_arch="$(get_coco_extension_oci_arch)"
+
+	oras resolve --platform "linux/${go_arch}" "${image_ref}" \
+		|| die "Failed to resolve ${image_ref} for linux/${go_arch}; bump .externals.coco-guest-components.version in versions.yaml once guest-components has published the image"
 }
 
 # The extension disk image is published as a multi-arch OCI index tagged with the
@@ -474,15 +493,12 @@ verify_guest_components_oci_provenance() {
 # Pull the published scratch OCI container image (coco-extension), verify its
 # provenance, and export the rootfs into destdir for monolithic confidential images.
 install_coco_guest_components_from_oci() {
-	ensure_oras_installed
-
 	local image_ref image go_arch digest cid
 	image_ref="$(get_coco_guest_components_container_image_ref)"
 	image="${image_ref%%:*}"
 	go_arch="$(get_coco_extension_oci_arch)"
 
-	digest="$(oras resolve --platform "linux/${go_arch}" "${image_ref}")" \
-		|| die "Failed to resolve ${image_ref} for linux/${go_arch}; bump .externals.coco-guest-components.version in versions.yaml once guest-components has published the image"
+	digest="$(get_coco_guest_components_container_image_digest)"
 
 	verify_guest_components_oci_provenance "${image}" "${digest}"
 
@@ -656,6 +672,7 @@ install_image() {
 		# Both the standard and NVIDIA confidential images bake the CoCo
 		# guest components (including the pause bundle) into the rootfs.
 		latest_artefact+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_coco_guest_components_tarball_checksum)"
 	fi
 
 	if [[ "${variant}" == "nvidia-gpu" ]]; then
@@ -990,6 +1007,7 @@ install_initrd() {
 			latest_artefact+="-$(get_latest_kernel_artefact_and_builder_image_version)"
 		fi
 		latest_artefact+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_coco_guest_components_tarball_checksum)"
 	fi
 
 	if [[ "${variant}" == "nvidia-gpu" ]]; then


### PR DESCRIPTION
Confidential rootfs caches tracked the CoCo version rather than the downloaded CoCo component tarball, allowing a stale artifact without the bundled pause image into published kata-deploy images.

Include the per-architecture CoCo OCI digest in the component cache key and the CoCo tarball checksum in confidential rootfs and initrd keys.

Drop redundant standalone pause-image builds (again).