### PR TITLE
osbuilder: devkit: put the mounted extensions' tools in PATH 

### DIFF
--- a/tests/integration/kubernetes/k8s-devkit-debug-console.bats
+++ b/tests/integration/kubernetes/k8s-devkit-debug-console.bats
@@ -33,7 +33,25 @@ devkit_runtimeclass() {
 # unambiguous proof that a debug console shell actually executed. The /real_root
 # symlink is created only by devkit-init when the overlay is set up, so it tells
 # the devkit chroot apart from the (also Ubuntu-based) NVIDIA base rootfs.
-DEVKIT_PROBE='echo "SHELL_OK=$((6*7))"; . /etc/os-release 2>/dev/null; echo "GUEST_ID=${ID}"; test -L /real_root && echo "DEVKIT_OVERLAY=yes" || true'
+#
+# It also reports the PATH the shell runs with, plus one EXT_BIN line per tool
+# directory the mounted extensions ship, which assert_extension_dirs_in_path()
+# then cross-checks on this side.
+#
+# One complete command per element, joined by newlines below: the guest reads
+# these from a PTY, so nothing is spread over continuation lines. Single quotes
+# cannot appear either - run_debug_console() feeds the result through a
+# single-quoted printf on the node.
+DEVKIT_PROBE_COMMANDS=(
+	'echo "SHELL_OK=$((6*7))"'
+	'. /etc/os-release 2>/dev/null; echo "GUEST_ID=${ID}"'
+	'test -L /real_root && echo "DEVKIT_OVERLAY=yes" || true'
+	'echo "DEVKIT_PATH=${PATH}"'
+	# Symlinked directories are skipped for the same reason devkit-init does
+	# not list them (the GPU extension's usr/bin -> ../bin).
+	'for d in /real_root/run/kata-extensions/*/bin; do test -d "${d}" && ! test -L "${d}" && echo "EXT_BIN=${d#/real_root}"; done'
+)
+DEVKIT_PROBE="$(printf '%s\n' "${DEVKIT_PROBE_COMMANDS[@]}")"
 
 check_and_skip() {
 	if ! devkit_supported; then
@@ -94,6 +112,41 @@ rm -f \"\${fifo}\"
 	exec_host "${node}" "${remote}" || true
 }
 
+# Every tool directory the probe found under /run/kata-extensions must be in the
+# PATH the devkit shell runs with, under the name the *guest* root uses: that is
+# what `chroot /real_root <tool>` resolves against, so without it an extension's
+# tools (e.g. the GPU extension's nvidia-smi) are only reachable by full path.
+#
+# A reported value is told apart from the probe text the PTY echoes back by
+# where it sits and what it holds: at the start of a line, with a path for a
+# value, while the echo carries `${PATH}` and `${d#/real_root}` unexpanded and
+# behind a shell prompt.
+#
+# Passes vacuously where the devkit is the only extension cold-plugged, which is
+# the case on the CPU-only class this test runs on today.
+assert_extension_dirs_in_path() {
+	local output="$1"
+	local clean guest_path ext_dir missing=""
+
+	# Readline brackets every line it accepts in paste-mode escapes, and the
+	# closing one is written just before the command's output: on a PTY the
+	# values only begin a line once the control sequences are dropped.
+	clean="$(printf '%s\n' "${output}" | tr -d '\r' | sed $'s/\033\\[[0-9;?]*[A-Za-z]//g')"
+
+	guest_path="$(printf '%s\n' "${clean}" | sed -n 's|^DEVKIT_PATH=\(/.*\)$|\1|p' | head -1)"
+	[[ -n "${guest_path}" ]] || die "devkit debug console did not report its PATH"
+
+	# The devkit's own bin/ is the chroot's root, not something PATH should
+	# point at: its dynamic binaries cannot run on the guest base anyway.
+	for ext_dir in $(printf '%s\n' "${clean}" | sed -n 's|^EXT_BIN=\(/.*\)$|\1|p'); do
+		[[ "${ext_dir}" == */devkit/bin ]] && continue
+		[[ ":${guest_path}:" == *":${ext_dir}:"* ]] && continue
+		missing+=" ${ext_dir}"
+	done
+
+	[[ -z "${missing}" ]] || die "devkit shell PATH lacks extension tools at:${missing} (PATH=${guest_path})"
+}
+
 setup() {
 	check_and_skip
 
@@ -121,6 +174,8 @@ setup() {
 		|| die "devkit debug console did not report an Ubuntu guest"
 	echo "${output}" | grep -q 'DEVKIT_OVERLAY=yes' \
 		|| die "devkit debug console shell lacks /real_root; not the devkit overlay"
+
+	assert_extension_dirs_in_path "${output}"
 }
 
 teardown() {

--- a/tools/osbuilder/rootfs-builder/devkit/devkit-init.sh
+++ b/tools/osbuilder/rootfs-builder/devkit/devkit-init.sh
@@ -23,7 +23,8 @@
 
 DEVKIT_INIT_VERSION=1
 
-DEVKIT="${DEVKIT:-/run/kata-extensions/devkit}"
+EXTENSIONS_ROOT="${EXTENSIONS_ROOT:-/run/kata-extensions}"
+DEVKIT="${DEVKIT:-${EXTENSIONS_ROOT}/devkit}"
 WRITABLE="${WRITABLE:-/run/kata-devkit-writable}"
 BB="${BB:-${DEVKIT}/bin/busybox.static}"
 
@@ -31,8 +32,64 @@ UPPER="${WRITABLE}/upper"
 WORK="${WRITABLE}/work"
 MERGED="${WRITABLE}/merged"
 
+# The agent execs the debug console shell with the environment PID 1 happens to
+# have, which on a minimal guest may carry no PATH at all, so the chroot starts
+# from an explicit one rather than whatever the shell falls back to.
+DEVKIT_BASE_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Tool directories an extension may ship, relative to its mount root. The GPU
+# extension keeps its binaries in bin/sbin, the CoCo one under usr/local; list
+# both layouts so no extension needs to know about this file.
+DEVKIT_EXTENSION_BIN_DIRS="bin sbin usr/bin usr/sbin usr/local/bin usr/local/sbin"
+
 devkit_is_mounted() {
 	"${BB}" grep -q "[[:space:]]${1}[[:space:]]" /proc/mounts 2>/dev/null
+}
+
+# Colon-separated tool directories of the extensions mounted in this sandbox,
+# named as the *guest* root sees them (/run/kata-extensions/<name>/...).
+#
+# Those are the paths that matter for the common debug move of reaching into the
+# guest from the devkit shell: `chroot /real_root <tool>` resolves <tool> with
+# execvp() *after* switching root, i.e. against the guest's filesystem, using the
+# PATH it inherits from us. Without these entries an extension's tools are only
+# reachable by full path ("chroot: failed to run command 'nvidia-smi'").
+#
+# The devkit extension itself is skipped: it is already the chroot's own root,
+# and its dynamically linked binaries cannot run on the shell-less guest base.
+devkit_extension_path() {
+	local path="" ext sub dir
+	for ext in "${EXTENSIONS_ROOT}"/*; do
+		"${BB}" test -d "${ext}" || continue
+		"${BB}" test "${ext}" = "${DEVKIT}" && continue
+
+		# An extension name is a mount point the runtime created from the
+		# hypervisor config, but PATH has no quoting: anything that could
+		# split an entry has no business in it.
+		case "${ext##*/}" in
+			*[!A-Za-z0-9._-]*) continue ;;
+		esac
+
+		for sub in ${DEVKIT_EXTENSION_BIN_DIRS}; do
+			dir="${ext}/${sub}"
+			"${BB}" test -d "${dir}" || continue
+			# A symlinked directory (the GPU extension's usr/bin ->
+			# ../bin) is just a second name for one already listed.
+			"${BB}" test -L "${dir}" && continue
+			path="${path:+${path}:}${dir}"
+		done
+	done
+	"${BB}" echo "${path}"
+}
+
+# Seed the PATH the chroot (and anything it execs, including `chroot /real_root`)
+# runs with. Ubuntu's /etc/profile only sources /etc/profile.d, it does not reset
+# PATH, so a login shell keeps what we export here.
+devkit_export_path() {
+	local extension_path
+	extension_path="$(devkit_extension_path)"
+	PATH="${DEVKIT_BASE_PATH}${extension_path:+:${extension_path}}"
+	export PATH
 }
 
 # Mount an exec-enabled tmpfs at ${WRITABLE}: /run is typically noexec, so the
@@ -101,13 +158,16 @@ devkit_link_real_root() {
 	"${BB}" ln -s /proc/1/root "${MERGED}/real_root" 2>/dev/null || true
 }
 
-# Idempotent: safe to call from every devkit-* invocation.
+# Idempotent: safe to call from every devkit-* invocation. Also exports the PATH
+# the caller then hands to the chroot, so mounting an extension is all it takes
+# for its tools to be reachable by name.
 devkit_setup_chroot() {
 	devkit_mount_writable || return 1
 	devkit_mount_root || return 1
 	devkit_bind_mounts || return 1
 	devkit_seed_resolv_conf
 	devkit_link_real_root
+	devkit_export_path
 	"${BB}" echo "${DEVKIT_INIT_VERSION}" > "${WRITABLE}/.initialized" 2>/dev/null || true
 	return 0
 }


### PR DESCRIPTION
The devkit debug shell ran with whatever environment the agent's PID 1
happened to have, which never lists the extension mount points, so reaching
into the guest for a tool an extension provides failed:

```sh
    root@devkit:/# chroot /real_root nvidia-smi -L
    chroot: failed to run command 'nvidia-smi': No such file or directory
    root@devkit:/# chroot /real_root /run/kata-extensions/gpu/bin/nvidia-smi -L
    GPU 0: NVIDIA H100 80GB HBM3 (UUID: GPU-50802db5-...)
```

chroot(1) resolves the command with execvp() *after* switching root, i.e.
against the guest's filesystem using the PATH it inherits from us, so the
guest's own view of the extension directories is exactly what is missing.

Build PATH from the extensions actually mounted in the sandbox: scan
/run/kata-extensions/* for the tool directories an extension may ship (bin,
sbin, usr/bin, usr/sbin, usr/local/bin, usr/local/sbin - the GPU extension
uses the first two, the CoCo one usr/local) and append them to an explicit
base PATH, since a minimal guest may hand us no PATH at all. Ubuntu's
/etc/profile only sources /etc/profile.d and does not reset PATH, so the
login shell keeps this.

devkit_setup_chroot() does it, so devkit-enter and devkit_chroot_exec both
get it and mounting an extension is all it takes for its tools to be
reachable by name.

Three details worth noting:

- The devkit extension itself is skipped: it is already the chroot's own
  root, and its dynamically linked binaries cannot run on the shell-less
  guest base anyway.
- Symlinked directories are skipped, because the GPU extension's usr/bin is
  a symlink to ../bin and would otherwise be listed twice.
- Extension names outside [A-Za-z0-9._-] are skipped: PATH has no quoting
  for entries that could split.

The directories are appended rather than prepended, so the devkit's own
tooling still wins for names that exist in both.

This makes the tools reachable **through** `chroot /real_root`, not from
inside the devkit chroot itself, where /run/kata-extensions is not mounted
and the extension binaries would find no libraries: bind-mounting them plus
an LD_LIBRARY_PATH risks the extension's own libc shadowing the devkit's.
