### PR TITLE
agent: return sealed environment unseal errors

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -163,3 +163,24 @@ results in:
 ```bash
 {"msg":"announce","level":"INFO","subsystem":"root","version":"0.1.0","pid":"214","source":"agent","name":"kata-agent","config":"AgentConfig { debug_console: true, dev_mode: false, log_level: Debug, hotplug_timeout: 10s, debug_console_vport: 0, log_vport: 0, container_pipe_size: 0, server_addr: "vsock://-1:1024", passfd_listener_port: 0, unified_cgroup_hierarchy: false, tracing: false, supports_seccomp: true }","agent-version":"3.3.0-alpha0"}
 ```
+
+## Confidential Containers
+
+### Sealed environment variables
+
+When the Confidential Data Hub (CDH) is running, the Kata agent treats an
+environment variable value beginning with `sealed.` as a
+[CoCo sealed secret](https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/docs/SEALED_SECRET.md).
+The agent asks CDH to unseal the value before it creates the container. If CDH
+cannot unseal the value, container creation fails and the agent logs the error.
+
+When CDH is not running, the agent leaves all environment variable values
+unchanged. This keeps sealed-secret handling opt-in through
+`agent.guest_components_procs`.
+
+This only defines how the agent handles an unseal error. It does not verify
+that the host supplied the complete intended environment. For host request
+validation, `genpolicy` can generate an Agent Policy from the pod YAML and add
+it to `cc_init_data`; see [Kata Agent Policy](../../docs/how-to/how-to-use-the-kata-agent-policy.md).
+The current Agent Policy permits the host to omit an expected environment
+variable.

--- a/src/agent/src/confidential_data_hub/mod.rs
+++ b/src/agent/src/confidential_data_hub/mod.rs
@@ -319,8 +319,15 @@ mod tests {
         async fn unseal_secret(
             &self,
             _ctx: &::ttrpc::asynchronous::TtrpcContext,
-            _req: confidential_data_hub::UnsealSecretInput,
+            req: confidential_data_hub::UnsealSecretInput,
         ) -> ttrpc::error::Result<confidential_data_hub::UnsealSecretOutput> {
+            if req.secret == b"sealed.fail" {
+                return Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
+                    ttrpc::Code::INTERNAL,
+                    "injected unseal failure".to_string(),
+                )));
+            }
+
             let mut output = confidential_data_hub::UnsealSecretOutput::new();
             output.set_plaintext("unsealed".into());
             Ok(output)
@@ -398,6 +405,7 @@ mod tests {
         let normal_env = String::from("key=testdata");
         let unchanged_env = unseal_env(&normal_env).await.unwrap();
         assert_eq!(unchanged_env, String::from("key=testdata"));
+        assert!(unseal_env("key=sealed.fail").await.is_err());
 
         // Test sealed secret as files
         let sealed_dir = test_dir_path.join("..test");

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2651,9 +2651,10 @@ async fn cdh_handler_sealed_secrets(oci: &mut Spec) -> Result<()> {
     if let Some(envs) = process.env_mut().as_mut() {
         for env in envs.iter_mut() {
             match confidential_data_hub::unseal_env(env).await {
-                Ok(unsealed_env) => *env = unsealed_env.to_string(),
+                Ok(unsealed_env) => *env = unsealed_env,
                 Err(e) => {
-                    warn!(sl(), "Failed to unseal secret: {}", e)
+                    error!(sl(), "Failed to unseal sealed environment variable: {}", e);
+                    return Err(e).context("failed to process a sealed environment variable");
                 }
             }
         }

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -64,14 +64,10 @@ setup() {
 	fi
 }
 
-@test "Cannot Unseal Env Secrets with CDH without key" {
-	k8s_create_pod "${K8S_TEST_ENV_YAML}"
-
-	logs=$(kubectl logs secret-test-pod-cc)
-	echo "$logs"
-	grep -q "UNPROTECTED_SECRET = not_sealed_secret" <<< "$logs"
-	run grep -q "PROTECTED_SECRET = unsealed_secret" <<< "$logs"
-	[ "$status" -eq 1 ]
+@test "Reject Env Secrets with CDH without key" {
+	assert_pod_fail "${K8S_TEST_ENV_YAML}"
+	assert_logs_contain "${node}" kata "${node_start_time}" \
+		"Failed to unseal sealed environment variable"
 }
 
 

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -66,8 +66,8 @@ setup() {
 
 @test "Reject Env Secrets with CDH without key" {
 	assert_pod_fail "${K8S_TEST_ENV_YAML}"
-	assert_logs_contain "${node}" kata "${node_start_time}" \
-		"Failed to unseal sealed environment variable"
+	kubectl describe pod/secret-test-pod-cc | \
+		grep -F "failed to handle sealed secrets: failed to process a sealed environment variable"
 }
 
 


### PR DESCRIPTION
## Why

When CDH is active, an environment value beginning with `sealed.` asks the
guest to resolve a sealed secret before container startup. Kata-agent currently
logs an unseal error and continues with the encoded value, so the caller cannot
tell that setup failed.

This PR returns that error to the caller. It does not guarantee that the host
supplied the complete intended environment. Current Agent Policy rules still
allow an expected environment variable to be omitted.

## What changed

- return CDH failures while resolving sealed environment values
- keep values unchanged when CDH is not running
- retain the agent-side error log
- update the existing CoCo test to require startup failure when the key is absent
- document the behavior and Agent Policy limitation in a CoCo section

Sealed-secret mount handling is unchanged. Those mounts are found by scanning
candidate volume contents rather than by an explicit marker.

## Validation

- focused `kata-agent` sealed-secret unit test on Linux: passed
- `kata-agent` clippy with `init-data`, all targets, warnings denied: passed
- `kata-agent` formatting: passed
- Bats script error-level shellcheck: passed
- Kubernetes CoCo scenario: updated, but not run locally because it requires a
  confidential Kata runtime and KBS

**AI was used in the making of this PR**
