### PR TITLE
agent: reject cwd outside the container root

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -653,6 +653,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     if !oci_process.cwd().as_os_str().is_empty() {
         unistd::chdir(oci_process.cwd().display().to_string().as_str())?;
     }
+    verify_cwd()?;
     // Create new session for init/exec process rather than inheriting parent's session
     // This ensures the init/exec process owns independent session ID, which aligns with runc behavior.
     unistd::setsid().context("create a new session")?;
@@ -831,6 +832,18 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     }
 
     do_exec(&args);
+}
+
+// Verify that chdir did not follow a procfs magic link outside the container
+// mount namespace. libc reports ENOENT when cwd is unreachable from root.
+fn verify_cwd() -> Result<()> {
+    match unistd::getcwd() {
+        Err(Errno::ENOENT) => Err(anyhow!(
+            "current working directory is outside the container mount namespace root"
+        )),
+        Err(e) => Err(anyhow!("failed to verify current working directory: {e}")),
+        Ok(_) => Ok(()),
+    }
 }
 
 // set_stdio_permissions fixes the permissions of PID 1's STDIO


### PR DESCRIPTION
## Summary

Prevent an exec process from retaining a working directory outside its container root.

After resolving the OCI-requested cwd, call `getcwd()` and reject process startup when it returns `ENOENT`. Linux reports this when the cwd is unreachable from the process root, including when `chdir()` followed a procfs magic link into the guest root.

This is a minimal, runc-style post-`chdir()` verification and requires no dependency changes.

## Security impact

Without this check, one container exec helper can be stopped and referenced through `/proc/<pid>/root` by another exec. The second process can then retain the Kata guest root as its cwd after dropping capabilities, exposing files outside the container root filesystem through relative paths.

## Validation

- `rustfmt` passed.
- `cargo check --manifest-path src/agent/rustjail/Cargo.toml --lib` passed.
- An end-to-end cross-helper `/proc/<pid>/root` reproducer was blocked by `rustjail::container::verify_cwd`.
- A normal exec control continued to succeed.
- The observed rejection was: `current working directory is outside the container mount namespace root`.
