### PR TITLE
 runtime: Use host CPU model for SNP guests instead of EPYC-v4

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -3290,7 +3290,7 @@ impl<'a> QemuCmdLine<'a> {
             .set_confidential_guest_support("snp")
             .set_nvdimm(false);
 
-        self.cpu.set_type("EPYC-v4");
+        self.cpu.set_type("host");
     }
 
     pub fn add_tdx_protection_device(

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -235,18 +235,8 @@ func nestedPCIeBridges(number uint32) []types.Bridge {
 }
 
 func (q *qemuAmd64) cpuModel() string {
-	var err error
-	cpuModel := defaultCPUModel
-
-	// Temporary until QEMU cpu model 'host' supports AMD SEV-SNP
-	protection, err := availableGuestProtection()
-	if err == nil {
-		if protection == snpProtection && q.snpGuest {
-			cpuModel = "EPYC-v4"
-		}
-	}
-
-	return cpuModel
+	// returning the default CPU model for AMD64 architecture, which is "host"
+	return defaultCPUModel
 }
 
 func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {


### PR DESCRIPTION
Remove hardcoded EPYC-v4 CPU model for AMD SEV-SNP VMs and use host CPU model instead to support newer AMD processor generations with advanced instruction sets.

Changes:
- Go runtime: Simplified cpuModel() to return defaultCPUModel ("host")
- Rust runtime: Changed SNP CPU type from "EPYC-v4" to "host"

This allows SNP VMs on Turin and other newer processors to access
AVX-512, AVX-VNNI, and other instruction sets beyond EPYC-v4 (Naples).