### PR TITLE
runtime-rs: honour enable_hugepages on the QEMU command line

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -67,14 +67,10 @@ const VM_ROOTFS_ROOT_PMEM: &str = "/dev/pmem0p1";
 // mkdir -p /dev/hugepages
 // mount -t hugetlbfs none /dev/hugepages
 pub const HUGETLBFS: &str = "hugetlbfs";
+const DEV_HUGEPAGES: &str = "/dev/hugepages";
 // Constants required for Dragonball VMM when enabled.
 // Gated on both feature and arch so they activate together with `pub mod
 // dragonball;` above (the dragonball crate only builds on x86_64/aarch64).
-#[cfg(all(
-    feature = "dragonball",
-    any(target_arch = "x86_64", target_arch = "aarch64")
-))]
-const DEV_HUGEPAGES: &str = "/dev/hugepages";
 #[cfg(all(
     feature = "dragonball",
     any(target_arch = "x86_64", target_arch = "aarch64")

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -10,7 +10,7 @@ use crate::utils::{
     SocketAddress,
 };
 
-use crate::{kernel_param::KernelParams, Address, HypervisorConfig};
+use crate::{kernel_param::KernelParams, Address, HypervisorConfig, DEV_HUGEPAGES};
 use std::borrow::Cow;
 
 use anyhow::{anyhow, Context, Result};
@@ -2836,9 +2836,27 @@ impl<'a> QemuCmdLine<'a> {
             ccw_subchannel,
         };
 
-        // add_virtiofs_share() installs the file-backed memory backend when
-        // filesystem sharing is enabled.
-        if matches!(config.shared_fs.shared_fs.as_deref(), None | Some("none")) {
+        // With huge pages the whole of the guest RAM comes out of the hugetlbfs
+        // pool, so that backend replaces both the plain RAM one and the
+        // /dev/shm one that add_virtiofs_share() would otherwise install.  This
+        // is the order getMemArgs() uses in the Go runtime
+        // (src/runtime/virtcontainers/qemu.go).
+        let shared_fs_enabled =
+            !matches!(config.shared_fs.shared_fs.as_deref(), None | Some("none"));
+        if config.memory_info.enable_hugepages {
+            // The Go runtime also pre-allocates when huge pages are combined
+            // with filesystem sharing, so a pool that cannot satisfy the
+            // reservation fails the boot instead of the first guest fault.
+            qemu_cmd_line.add_file_memory_backend(
+                "entire-guest-memory",
+                DEV_HUGEPAGES,
+                true,
+                false,
+                config.memory_info.enable_mem_prealloc || shared_fs_enabled,
+            );
+        } else if !shared_fs_enabled {
+            // add_virtiofs_share() installs the file-backed memory backend when
+            // filesystem sharing is enabled.
             qemu_cmd_line.add_ram_memory_backend(config.memory_info.enable_mem_prealloc);
         }
 
@@ -3074,13 +3092,18 @@ impl<'a> QemuCmdLine<'a> {
 
         // don't put the /dev/shm memory backend file into the anonymous container,
         // there has to be at most one of those so keep it by name in Memory instead
-        self.add_file_memory_backend(
-            "entire-guest-memory-share",
-            "/dev/shm",
-            true,
-            false,
-            self.config.memory_info.enable_mem_prealloc,
-        );
+        //
+        // Huge pages are shared as well, and QemuCmdLine::new() has already
+        // installed that backend, so there is nothing left to do here.
+        if !self.config.memory_info.enable_hugepages {
+            self.add_file_memory_backend(
+                "entire-guest-memory-share",
+                "/dev/shm",
+                true,
+                false,
+                self.config.memory_info.enable_mem_prealloc,
+            );
+        }
     }
 
     pub fn add_vsock(&mut self, vhostfd: tokio::fs::File, guest_cid: u32) -> Result<()> {
@@ -3851,6 +3874,49 @@ mod tests {
             args[0] == "-machine"
                 && contains_param(&args[1..2], "memory-backend=entire-guest-memory")
         }));
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    async fn test_qemu_hugepages_backend_without_shared_fs() {
+        let mut config = test_qemu_config(Some("none"), false);
+        config.memory_info.enable_hugepages = true;
+        let params = build_test_cmdline("hugepages-no-shared-fs", &config).await;
+
+        assert!(has_qemu_arg(
+            &params,
+            "-object",
+            "memory-backend-file,id=entire-guest-memory,mem-path=/dev/hugepages,size=2G,share=on,prealloc=off,readonly=off"
+        ));
+        assert!(!params.iter().any(|arg| arg.contains("memory-backend-ram")));
+
+        assert!(params.windows(2).any(|args| {
+            args[0] == "-machine"
+                && contains_param(&args[1..2], "memory-backend=entire-guest-memory")
+        }));
+    }
+
+    #[actix_rt::test]
+    #[serial]
+    async fn test_qemu_hugepages_take_precedence_over_virtiofs_shm() {
+        let mut config = test_qemu_config(Some("virtio-fs"), false);
+        config.memory_info.enable_hugepages = true;
+
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+        let mut cmdline = QemuCmdLine::new("hugepages-virtiofs", &config).unwrap();
+        cmdline.add_virtiofs_share("/run/virtiofsd.sock", "kataShared", 1024);
+        let params = cmdline.build().await.unwrap();
+        drop(cmdline);
+        let _ = std::fs::remove_file(QMP_SOCKET_FILE);
+
+        // Sharing the guest memory over virtio-fs still has to come from the
+        // huge page pool, and it is pre-allocated, as in the Go runtime.
+        assert!(has_qemu_arg(
+            &params,
+            "-object",
+            "memory-backend-file,id=entire-guest-memory,mem-path=/dev/hugepages,size=2G,share=on,prealloc=on,readonly=off"
+        ));
+        assert!(!params.iter().any(|arg| arg.contains("mem-path=/dev/shm")));
     }
 
     #[actix_rt::test]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2840,9 +2840,11 @@ impl<'a> QemuCmdLine<'a> {
         // sharing is enabled.
         if matches!(config.shared_fs.shared_fs.as_deref(), None | Some("none")) {
             if config.memory_info.enable_hugepages {
-                // The whole of the guest RAM comes out of the hugetlbfs pool,
-                // as getMemArgs() does it in the Go runtime
-                // (src/runtime/virtcontainers/qemu.go).
+                // Binding the whole of the guest RAM to the hugetlbfs mount is
+                // what takes it from the huge page pool.  qemu then refuses to
+                // start when the pool is not mounted or cannot cover the
+                // sandbox, instead of the guest silently running on ordinary
+                // pages.
                 qemu_cmd_line.add_file_memory_backend(
                     "entire-guest-memory",
                     DEV_HUGEPAGES,
@@ -3089,10 +3091,9 @@ impl<'a> QemuCmdLine<'a> {
         // there has to be at most one of those so keep it by name in Memory instead
         if self.config.memory_info.enable_hugepages {
             // Huge pages are shared too, so they replace the /dev/shm backend
-            // rather than adding to it.  The Go runtime pre-allocates when the
-            // two are combined (qemu.go sets Knobs.MemPrealloc), so a pool that
-            // cannot satisfy the reservation fails the boot instead of the
-            // first guest fault.
+            // rather than adding to it.  Pre-allocating makes a pool too small
+            // for the sandbox fail the boot, rather than surfacing as a fault
+            // at an arbitrary point once the guest is running.
             self.add_file_memory_backend("entire-guest-memory", DEV_HUGEPAGES, true, false, true);
         } else {
             self.add_file_memory_backend(
@@ -3909,7 +3910,7 @@ mod tests {
         let _ = std::fs::remove_file(QMP_SOCKET_FILE);
 
         // Sharing the guest memory over virtio-fs still has to come from the
-        // huge page pool, and it is pre-allocated, as in the Go runtime.
+        // huge page pool, and it is pre-allocated.
         assert!(has_qemu_arg(
             &params,
             "-object",

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2836,28 +2836,23 @@ impl<'a> QemuCmdLine<'a> {
             ccw_subchannel,
         };
 
-        // With huge pages the whole of the guest RAM comes out of the hugetlbfs
-        // pool, so that backend replaces both the plain RAM one and the
-        // /dev/shm one that add_virtiofs_share() would otherwise install.  This
-        // is the order getMemArgs() uses in the Go runtime
-        // (src/runtime/virtcontainers/qemu.go).
-        let shared_fs_enabled =
-            !matches!(config.shared_fs.shared_fs.as_deref(), None | Some("none"));
-        if config.memory_info.enable_hugepages {
-            // The Go runtime also pre-allocates when huge pages are combined
-            // with filesystem sharing, so a pool that cannot satisfy the
-            // reservation fails the boot instead of the first guest fault.
-            qemu_cmd_line.add_file_memory_backend(
-                "entire-guest-memory",
-                DEV_HUGEPAGES,
-                true,
-                false,
-                config.memory_info.enable_mem_prealloc || shared_fs_enabled,
-            );
-        } else if !shared_fs_enabled {
-            // add_virtiofs_share() installs the file-backed memory backend when
-            // filesystem sharing is enabled.
-            qemu_cmd_line.add_ram_memory_backend(config.memory_info.enable_mem_prealloc);
+        // add_virtiofs_share() installs the memory backend when filesystem
+        // sharing is enabled.
+        if matches!(config.shared_fs.shared_fs.as_deref(), None | Some("none")) {
+            if config.memory_info.enable_hugepages {
+                // The whole of the guest RAM comes out of the hugetlbfs pool,
+                // as getMemArgs() does it in the Go runtime
+                // (src/runtime/virtcontainers/qemu.go).
+                qemu_cmd_line.add_file_memory_backend(
+                    "entire-guest-memory",
+                    DEV_HUGEPAGES,
+                    true,
+                    false,
+                    config.memory_info.enable_mem_prealloc,
+                );
+            } else {
+                qemu_cmd_line.add_ram_memory_backend(config.memory_info.enable_mem_prealloc);
+            }
         }
 
         if config.device_info.enable_iommu {
@@ -3090,12 +3085,16 @@ impl<'a> QemuCmdLine<'a> {
         }
         self.devices.push(Box::new(virtiofs_device));
 
-        // don't put the /dev/shm memory backend file into the anonymous container,
+        // don't put the memory backend file into the anonymous container,
         // there has to be at most one of those so keep it by name in Memory instead
-        //
-        // Huge pages are shared as well, and QemuCmdLine::new() has already
-        // installed that backend, so there is nothing left to do here.
-        if !self.config.memory_info.enable_hugepages {
+        if self.config.memory_info.enable_hugepages {
+            // Huge pages are shared too, so they replace the /dev/shm backend
+            // rather than adding to it.  The Go runtime pre-allocates when the
+            // two are combined (qemu.go sets Knobs.MemPrealloc), so a pool that
+            // cannot satisfy the reservation fails the boot instead of the
+            // first guest fault.
+            self.add_file_memory_backend("entire-guest-memory", DEV_HUGEPAGES, true, false, true);
+        } else {
             self.add_file_memory_backend(
                 "entire-guest-memory-share",
                 "/dev/shm",


### PR DESCRIPTION
## What this fixes

`enable_hugepages` is accepted, parsed into `memory_info.enable_hugepages`, and then never read by the
QEMU hypervisor in runtime-rs. `grep -r hugepage crates/hypervisor/src/qemu/` returns nothing. A sandbox
configured for huge pages boots on ordinary memory and takes nothing from the host pool.

Two sites drop it:

- `QemuCmdLine::new()` installs a `memory-backend-ram` object whenever no filesystem sharing is
  configured, passing only `enable_mem_prealloc`.
- `add_virtiofs_share()` installs a `memory-backend-file` whose `mem-path` is hardcoded to `/dev/shm`.

## The fix

Install a `memory-backend-file` on `/dev/hugepages` with `share=on`, and let it take precedence over the
`/dev/shm` backend.

The Go runtime in this same tree is the reference. `getMemArgs()` in `src/runtime/virtcontainers/qemu.go`
picks `/dev/hugepages` + `memory-backend-file` + `share=true` when huge pages are on, and only falls back
to the shared-memory dir otherwise; `appendMemoryKnobs()` in `src/runtime/pkg/govmm/qemu/qemu.go` emits
the same object. The pre-allocation in the combined huge-pages-plus-shared-fs case also comes from there
(`qemu.go` sets `knobs.MemPrealloc = true` for it), so a pool that cannot satisfy the reservation fails
the boot rather than the first guest fault.

`DEV_HUGEPAGES` already existed but was gated behind the `dragonball` feature. The `qemu` module is built
unconditionally, so the gate comes off rather than a second copy of the constant being added.

This also removes the silence the issue describes. Once `mem-path` reaches the command line, qemu itself
refuses to start when `/dev/hugepages` is not mounted or the pool is too small, so a misconfigured host
gets an error instead of a guest quietly running on ordinary pages.

## Behaviour change worth a look

Huge pages without filesystem sharing now go through `add_file_memory_backend()`, which zeroes `maxmem`
and `slots` unless the rootfs is nvdimm/virtio-pmem or virtio-mem is enabled. That is the existing rule
for any guest whose entire RAM is bound through `-machine memory-backend=`, and it disables pc-dimm
hotplug for huge-page sandboxes that previously had it. Keeping it consistent seemed better than the
alternative, since `hotplug_pc_dimm()` in `qemu/qmp.rs` hardcodes `/dev/shm`, so hotplugged memory would
have come from ordinary pages anyway. Happy to change this if you would rather preserve hotplug here.

## Testing

Three tests already covered the generated memory-backend objects in `cmdline_generator.rs`. Two more in
the same style:

- `test_qemu_hugepages_backend_without_shared_fs`
- `test_qemu_hugepages_take_precedence_over_virtiofs_shm`

Both fail on the assertion before the change and pass after it. Full crate suite:

```
cargo test -p hypervisor --lib
...
test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo clippy -p hypervisor --all-targets` is clean, and both touched files are rustfmt-clean.

## Not addressed here

Two more places have the same shape. Deliberately left out to keep this focused on the reported bug, but
happy to follow up on either:

- Cloud Hypervisor ignores `enable_hugepages` as well. `ch-config/src/convert.rs` builds `MemoryConfig`
  with `prefault: mem.enable_mem_prealloc` and never sets the `hugepages` field that
  `ch-config/src/lib.rs` already declares.
- Hot-plugged memory never comes from the pool even once boot memory does. `hotplug_pc_dimm()` in
  `qemu/qmp.rs` hardcodes `mem_path: "/dev/shm"`, and the s390x virtio-mem setup picks its backend from
  `shared_fs` alone.

Fixes: #13580
