### PR TITLE
runtime-rs: non-blocking large-guest QEMU teardown

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -428,6 +428,22 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
+        if let Err(e) = self
+            .finish_start_after_spawn(&mut cmdline, &console_socket_path)
+            .await
+        {
+            return Err(self.rollback_spawned_vm(e).await);
+        }
+
+        Ok(())
+    }
+
+    /// Post-spawn bring-up (QMP, virtio-mem, template boot, debug console).
+    async fn finish_start_after_spawn(
+        &mut self,
+        cmdline: &mut QemuCmdLine<'_>,
+        console_socket_path: &Path,
+    ) -> Result<()> {
         let qmp_socket_path = get_qmp_socket_path(self.id.as_str());
 
         match Qmp::new(&qmp_socket_path) {
@@ -487,6 +503,19 @@ impl QemuInner {
         }
 
         Ok(())
+    }
+
+    /// Kill and reap a QEMU that was spawned but whose start is returning Err.
+    /// Do not use this on the normal StopSandbox path: waiting for a large
+    /// guest can block teardown.
+    async fn rollback_spawned_vm(&mut self, start_err: anyhow::Error) -> anyhow::Error {
+        if let Err(e) = self.stop_vm().await {
+            warn!(sl!(), "start-fail rollback: stop_vm: {:#}", e);
+        }
+        if let Err(e) = self.wait_vm().await {
+            warn!(sl!(), "start-fail rollback: wait_vm: {:#}", e);
+        }
+        start_err
     }
 
     async fn boot_from_template(&mut self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -30,6 +30,8 @@ use kata_types::{
     capabilities::{Capabilities, CapabilityBits},
     config::KATA_PATH,
 };
+use nix::sys::signal::Signal;
+use nix::sys::prctl::set_pdeathsig;
 use nix::unistd::{setgid, setuid, Gid, Uid};
 use persist::sandbox_persist::Persist;
 use qapi_qmp::MigrationStatus;
@@ -60,6 +62,9 @@ pub struct QemuInner {
     id: String,
 
     qemu_process: Mutex<Option<Child>>,
+    /// Cached QEMU pid so stop_vm can signal even after wait_vm() has taken
+    /// the Child out of `qemu_process` (kata-containers#13564 fix8).
+    qemu_pid: Option<u32>,
     qmp: Option<Qmp>,
 
     config: HypervisorConfig,
@@ -74,6 +79,7 @@ impl QemuInner {
         QemuInner {
             id: "".to_string(),
             qemu_process: Mutex::new(None),
+            qemu_pid: None,
             qmp: None,
             config: Default::default(),
             devices: Vec::new(),
@@ -393,6 +399,17 @@ impl QemuInner {
         unsafe {
             let selinux_label = self.config.security_info.selinux_label.clone();
             let _pre_exec = command.pre_exec(move || {
+                // fix9 (kata-containers#13564): if the shim is SIGKILLed mid-
+                // teardown (or exits after Shutdown before QEMU finishes
+                // reclaiming a large TDX guest), the kernel must kill QEMU.
+                // Without this, QEMU is reparented to init as a live orphan and
+                // the Kubernetes pod stays Terminating. Set before exec; check
+                // getppid for the classic fork/PDEATHSIG race.
+                set_pdeathsig(Signal::SIGKILL).map_err(std::io::Error::from)?;
+                if nix::unistd::getppid().as_raw() == 1 {
+                    let _ = nix::sys::signal::raise(Signal::SIGKILL);
+                }
+
                 let _ = enter_netns(&netns);
                 if let Some(label) = selinux_label.as_ref() {
                     if let Err(e) = selinux::set_exec_label(label) {
@@ -417,9 +434,14 @@ impl QemuInner {
 
         let mut qemu_process = command.stderr(Stdio::piped()).spawn()?;
         let stderr = qemu_process.stderr.take().unwrap();
+        self.qemu_pid = qemu_process.id();
         self.qemu_process = Mutex::new(Some(qemu_process));
 
-        info!(sl!(), "qemu process started");
+        info!(
+            sl!(),
+            "qemu process started (pid={:?})",
+            self.qemu_pid
+        );
 
         let exit_notify: mpsc::Sender<()> = self
             .exit_notify
@@ -611,29 +633,72 @@ impl QemuInner {
     pub(crate) async fn stop_vm(&mut self) -> Result<()> {
         info!(sl!(), "Stopping QEMU VM");
 
-        let mut qemu_process = self.qemu_process.lock().await;
-        if let Some(qemu_process) = qemu_process.as_mut() {
-            let is_qemu_running = qemu_process.id().is_some();
-            if is_qemu_running {
-                info!(sl!(), "QemuInner::stop_vm(): kill()'ing qemu");
-                qemu_process.kill().await.map_err(anyhow::Error::from)
-            } else {
+        // CRITICAL (kata-containers#13564 fix8/fix9 / production B200+TDX):
+        // Do NOT use Child::kill().await while holding qemu_process — that
+        // waits for the process to exit under the mutex. On large confidential
+        // guests (e.g. 1.2 TiB TDX + 8×GPU) SIGKILL reclaim can take many
+        // minutes; containerd then SIGKILLs the shim mid-wait, the Child is
+        // never reaped, and QEMU becomes a zombie (or live orphan) under init
+        // — leaving the Kubernetes pod stuck Terminating.
+        //
+        // Use start_kill() (signal only). Reaping is done by Qemu::stop_vm /
+        // wait_vm via an OS-thread try_wait reaper (fix10) — never block
+        // stop_vm on exit. If the Child was already taken by a concurrent
+        // waiter, fall back to kill(2) on the cached pid. PR_SET_PDEATHSIG
+        // (fix9) covers the case where the shim dies before/during reclaim.
+        {
+            let mut qemu_process = self.qemu_process.lock().await;
+            if let Some(child) = qemu_process.as_mut() {
+                if let Some(pid) = child.id() {
+                    self.qemu_pid = Some(pid);
+                    info!(
+                        sl!(),
+                        "QemuInner::stop_vm(): start_kill() qemu pid={}", pid
+                    );
+                    // Signal only — do not await exit here (see comment above).
+                    child.start_kill().map_err(anyhow::Error::from)?;
+                    return Ok(());
+                }
                 info!(
                     sl!(),
-                    "QemuInner::stop_vm(): qemu process isn't running (likely stopped already)"
+                    "QemuInner::stop_vm(): qemu Child present but not running \
+                     (already exited); wait_vm will reap"
                 );
-                Ok(())
+                return Ok(());
             }
-        } else {
-            Err(anyhow!("qemu process has not been started yet"))
         }
+
+        if let Some(pid) = self.qemu_pid {
+            info!(
+                sl!(),
+                "QemuInner::stop_vm(): Child already taken; kill(2) pid={}", pid
+            );
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+            return Ok(());
+        }
+
+        Err(anyhow!("qemu process has not been started yet"))
+    }
+
+    /// Take ownership of the QEMU Child for reaping. Used by fix10 so stop_vm
+    /// (or wait_vm) can move the Child onto an OS thread that survives tokio
+    /// task cancellation.
+    pub(crate) async fn take_qemu_child(&self) -> Option<Child> {
+        let mut qemu_process = self.qemu_process.lock().await;
+        qemu_process.take()
     }
 
     pub(crate) async fn wait_vm(&self) -> Result<i32> {
-        let mut qemu_process = self.qemu_process.lock().await;
+        // Take the Child under the lock, then wait OUTSIDE it so stop_vm()
+        // can always start_kill() (fix8). Holding the mutex across
+        // Child::wait() was the teardown deadlock that produced zombies.
+        let child = self.take_qemu_child().await;
 
-        if let Some(mut qemu_process) = qemu_process.take() {
-            let status = qemu_process.wait().await?;
+        if let Some(mut child) = child {
+            let status = child.wait().await?;
             Ok(status.code().unwrap_or(0))
         } else {
             Err(anyhow!("the process has been reaped"))
@@ -705,13 +770,17 @@ impl QemuInner {
                     sl!(),
                     "QemuInner::get_vmm_master_tid(): returning {}", qemu_pid
                 );
-                Ok(qemu_pid)
-            } else {
-                Err(anyhow!("QemuInner::get_vmm_master_tid(): qemu process isn't running (likely stopped already)"))
+                return Ok(qemu_pid);
             }
-        } else {
-            Err(anyhow!("qemu process not running"))
         }
+        if let Some(qemu_pid) = self.qemu_pid {
+            info!(
+                sl!(),
+                "QemuInner::get_vmm_master_tid(): returning cached {}", qemu_pid
+            );
+            return Ok(qemu_pid);
+        }
+        Err(anyhow!("qemu process not running"))
     }
 
     pub(crate) async fn get_ns_path(&self) -> Result<String> {
@@ -1430,6 +1499,7 @@ impl Persist for QemuInner {
         Ok(QemuInner {
             id: hypervisor_state.id,
             qemu_process: Mutex::new(None),
+            qemu_pid: None,
             qmp: None,
             config: hypervisor_state.config,
             devices: Vec::new(),

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -21,13 +21,19 @@ use async_trait::async_trait;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tokio::process::Child;
 use tokio::sync::RwLock;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 
 #[derive(Debug)]
 pub struct Qemu {
     inner: Arc<RwLock<QemuInner>>,
     exit_waiter: Mutex<(mpsc::Receiver<()>, i32)>,
+    /// Exit code published by the sole OS-thread reaper (fix10).
+    /// `None` until QEMU has been reaped.
+    reaped_exit: watch::Sender<Option<i32>>,
 }
 
 impl Default for Qemu {
@@ -39,16 +45,69 @@ impl Default for Qemu {
 impl Qemu {
     pub fn new() -> Self {
         let (exit_notify, exit_waiter) = mpsc::channel(1);
+        let (reaped_exit, _) = watch::channel(None);
 
         Self {
             inner: Arc::new(RwLock::new(QemuInner::new(exit_notify))),
             exit_waiter: Mutex::new((exit_waiter, 0)),
+            reaped_exit,
         }
     }
 
     pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
+    }
+
+    /// Reap QEMU on a dedicated OS thread using sync `try_wait()`.
+    ///
+    /// fix10 (kata-containers#13564): a tokio task awaiting `Child::wait()` can
+    /// be cancelled when containerd SIGKILLs / abandons the shim after a
+    /// non-blocking Shutdown — Dropping the Child without a successful wait
+    /// leaves QEMU as a zombie under the (still-alive) orphaned shim. An OS
+    /// thread is not cancelled with the tokio task; `try_wait` reaps on Unix.
+    fn spawn_os_reaper(child: Child, reaped_exit: watch::Sender<Option<i32>>) {
+        let pid = child.id();
+        let _ = thread::Builder::new()
+            .name("qemu-reap".into())
+            .spawn(move || {
+                let mut child = child;
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            let code = status.code().unwrap_or(0);
+                            info!(
+                                sl!(),
+                                "fix10 OS reaper: qemu pid={:?} exited code={}", pid, code
+                            );
+                            let _ = reaped_exit.send(Some(code));
+                            return;
+                        }
+                        Ok(None) => thread::sleep(Duration::from_millis(200)),
+                        Err(e) => {
+                            // ECHILD if a racing reaper already collected the status.
+                            warn!(
+                                sl!(),
+                                "fix10 OS reaper: try_wait pid={:?} err={:?}", pid, e
+                            );
+                            let _ = reaped_exit.send(Some(0));
+                            return;
+                        }
+                    }
+                }
+            });
+    }
+
+    async fn wait_for_reaped_exit(&self) -> i32 {
+        let mut rx = self.reaped_exit.subscribe();
+        loop {
+            if let Some(code) = *rx.borrow_and_update() {
+                return code;
+            }
+            if rx.changed().await.is_err() {
+                return 0;
+            }
+        }
     }
 }
 
@@ -71,8 +130,35 @@ impl Hypervisor for Qemu {
     }
 
     async fn stop_vm(&self) -> Result<()> {
-        let mut inner = self.inner.write().await;
-        inner.stop_vm().await
+        // Signal under the write lock only (start_kill). Do not await QEMU
+        // exit here: large confidential guests can take minutes to reclaim,
+        // and containerd will SIGKILL the shim mid-wait.
+        // Take the Child and reap on an OS thread so a cancelled tokio
+        // waiter cannot leave a zombie.
+        let (kill_result, child) = {
+            let mut inner = self.inner.write().await;
+            let kill_result = inner.stop_vm().await;
+            let child = if kill_result.is_ok() {
+                inner.take_qemu_child().await
+            } else {
+                None
+            };
+            (kill_result, child)
+        };
+        if let Some(child) = child {
+            info!(
+                sl!(),
+                "stop_vm took qemu Child pid={:?}; spawning OS reaper",
+                child.id()
+            );
+            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+        } else if kill_result.is_ok() {
+            info!(
+                sl!(),
+                "stop_vm Child already taken; start_vm waiter / prior reaper owns wait"
+            );
+        }
+        kill_result
     }
 
     async fn wait_vm(&self) -> Result<i32> {
@@ -80,15 +166,33 @@ impl Hypervisor for Qemu {
 
         let mut waiter = self.exit_waiter.lock().await;
 
-        //wait until the qemu process exited.
+        // Wait until qemu stderr EOF (process exited / closed stderr).
         waiter.0.recv().await;
 
-        let inner = self.inner.read().await;
-        if let Ok(exit_code) = inner.wait_vm().await {
-            waiter.1 = exit_code;
+        // Already reaped by stop_vm's OS thread?
+        if let Some(code) = *self.reaped_exit.borrow() {
+            waiter.1 = code;
+            return Ok(code);
         }
 
-        Ok(waiter.1)
+        // Take Child for OS-thread reaping (same fix10 path as stop_vm).
+        // Do NOT Child::wait().await on this cancellable task.
+        let child = {
+            let inner = self.inner.read().await;
+            inner.take_qemu_child().await
+        };
+        if let Some(child) = child {
+            info!(
+                sl!(),
+                "fix10: wait_vm took qemu Child pid={:?}; spawning OS reaper",
+                child.id()
+            );
+            Self::spawn_os_reaper(child, self.reaped_exit.clone());
+        }
+
+        let code = self.wait_for_reaped_exit().await;
+        waiter.1 = code;
+        Ok(code)
     }
 
     async fn pause_vm(&self) -> Result<()> {
@@ -239,11 +343,13 @@ impl Persist for Qemu {
         hypervisor_state: Self::State,
     ) -> Result<Self> {
         let (exit_notify, exit_waiter) = mpsc::channel(1);
+        let (reaped_exit, _) = watch::channel(None);
 
         let inner = QemuInner::restore(exit_notify, hypervisor_state).await?;
         Ok(Self {
             inner: Arc::new(RwLock::new(inner)),
             exit_waiter: Mutex::new((exit_waiter, 0)),
+            reaped_exit,
         })
     }
 }

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -84,6 +84,13 @@ impl ResourceManager {
         inner.handle_network(network_config).await
     }
 
+    /// Detach endpoints and clear the cached network so a retry of
+    /// `sandbox.start()` can recreate them.
+    pub async fn release_network(&self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.release_network().await
+    }
+
     #[instrument]
     pub async fn setup_after_start_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -951,6 +951,15 @@ impl ResourceManagerInner {
         }
     }
 
+    pub async fn release_network(&mut self) -> Result<()> {
+        if let Some(network) = self.network.take() {
+            if let Err(err) = network.remove(self.hypervisor.as_ref()).await {
+                warn!(sl!(), "failed to remove network: {}", err);
+            }
+        }
+        Ok(())
+    }
+
     pub async fn cleanup(&self) -> Result<()> {
         // detach network endpoints (rebinds VFs from vfio-pci back to host driver)
         if let Some(network) = &self.network {

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -13,11 +13,25 @@ use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::DeviceType;
 use hypervisor::{Hypervisor, NetworkDevice};
+use scopeguard::defer;
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, VethEndpointState};
 use super::{attach_network_device, Endpoint};
+use crate::network::utils::link;
 use crate::network::{utils, NetworkPair};
+
+async fn delete_tap_device(name: &str) -> Result<()> {
+    let (connection, handle, _) = rtnetlink::new_connection().context("new connection")?;
+    let thread_handler = tokio::spawn(connection);
+    defer!({
+        thread_handler.abort();
+    });
+    link::delete_link(&handle, name)
+        .await
+        .with_context(|| format!("delete tap {name}"))?;
+    Ok(())
+}
 
 #[derive(Debug)]
 pub struct VethEndpoint {
@@ -99,6 +113,16 @@ impl Endpoint for VethEndpoint {
         }))
         .await
         .context("remove Veth endpoint device by hypervisor failed.")?;
+
+        // create_link sets IFF_PERSIST, so the tap survives FD close / QEMU exit.
+        // Delete it explicitly so a retry of sandbox.start() can recreate it
+        // (otherwise TUNSETIFF returns EBUSY).
+        if let Err(err) = delete_tap_device(&self.net_pair.tap.tap_iface.name).await {
+            warn!(
+                sl!(),
+                "failed to delete tap {}: {:#}", self.net_pair.tap.tap_iface.name, err
+            );
+        }
 
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -156,7 +156,16 @@ pub async fn create_link(
     name: &str,
     queues: usize,
 ) -> Result<Box<dyn link::Link>> {
-    link::create_link(name, link::LinkType::Tap, queues)?;
+    match link::create_link(name, link::LinkType::Tap, queues) {
+        Ok(()) => {}
+        Err(e) if link::is_busy_or_exist(&e) => {
+            // IFF_PERSIST leaves tapN_kata in the netns after a failed
+            // sandbox.start(); concurrent CreateContainer retries then hit
+            // TUNSETIFF EBUSY. Reuse the existing device instead of failing.
+            warn!(sl!(), "tap {} already exists ({}), reusing", name, e);
+        }
+        Err(e) => return Err(e).context("create tap device"),
+    }
 
     let link = get_link_by_name(handle, name)
         .await

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -16,6 +16,30 @@ use nix::ioctl_write_ptr;
 
 use super::macros::{get_name, set_name};
 
+/// True when TUNSETIFF failed because the named device already exists / is busy.
+/// Used to reuse a leftover `tapN_kata` after a failed sandbox start (IFF_PERSIST
+/// keeps the device alive after the creating FDs are dropped).
+pub fn is_busy_or_exist(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(ioe) = cause.downcast_ref::<io::Error>() {
+            match ioe.raw_os_error() {
+                Some(libc::EBUSY) | Some(libc::EEXIST) => return true,
+                _ => {}
+            }
+        }
+        if let Some(ne) = cause.downcast_ref::<nix::Error>() {
+            if *ne == nix::Error::EBUSY || *ne == nix::Error::EEXIST {
+                return true;
+            }
+        }
+    }
+    let s = format!("{err:#}");
+    s.contains("EBUSY")
+        || s.contains("EEXIST")
+        || s.contains("Device or resource busy")
+        || s.contains("File exists")
+}
+
 type IfName = [u8; libc::IFNAMSIZ];
 
 #[derive(Copy, Clone, Debug)]
@@ -128,23 +152,26 @@ fn create_queue(name: &str, flags: libc::c_int) -> Result<(File, String)> {
     Ok((file, req.get_name()?))
 }
 
-#[cfg(test)]
-pub mod net_test_utils {
+/// Delete a link by name (e.g. leftover `tap0_kata` after a failed start).
+pub async fn delete_link(handle: &rtnetlink::Handle, name: &str) -> Result<()> {
     use crate::network::network_model::tc_filter_model::fetch_index;
 
-    // remove a link by its name
-    #[allow(dead_code)]
-    pub async fn delete_link(
-        handle: &rtnetlink::Handle,
-        name: &str,
-    ) -> Result<(), rtnetlink::Error> {
-        let link_index = fetch_index(handle, name)
-            .await
-            .expect("failed to fetch index");
-        // the ifindex of a link will not change during its lifetime, so the index
-        // remains the same between the query above and the deletion below
-        handle.link().del(link_index).execute().await
-    }
+    let link_index = fetch_index(handle, name)
+        .await
+        .with_context(|| format!("fetch index for {name}"))?;
+    handle
+        .link()
+        .del(link_index)
+        .execute()
+        .await
+        .with_context(|| format!("delete link {name}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod net_test_utils {
+    // Back-compat for tests that imported delete_link from this module.
+    pub use super::delete_link;
 }
 
 #[cfg(test)]
@@ -157,6 +184,18 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_is_busy_or_exist() {
+        let busy = anyhow::Error::from(io::Error::from_raw_os_error(libc::EBUSY));
+        assert!(is_busy_or_exist(&busy));
+        let exist = anyhow::Error::from(io::Error::from_raw_os_error(libc::EEXIST));
+        assert!(is_busy_or_exist(&exist));
+        let other = anyhow::Error::from(io::Error::from_raw_os_error(libc::EINVAL));
+        assert!(!is_busy_or_exist(&other));
+        let nix_busy = anyhow::Error::from(nix::Error::EBUSY);
+        assert!(is_busy_or_exist(&nix_busy));
+    }
 
     #[actix_rt::test]
     async fn test_create_link() {

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -5,7 +5,7 @@
 //
 
 mod create;
-pub use create::{create_link, LinkType};
+pub use create::{create_link, delete_link, is_busy_or_exist, LinkType};
 mod driver_info;
 pub use driver_info::get_driver_info;
 mod macros;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -102,6 +102,7 @@ pub struct SandboxRestoreArgs {
 #[derive(Clone, Copy, PartialEq, Debug, Display)]
 pub enum SandboxState {
     Init,
+    Starting,
     Running,
     Stopped,
 }
@@ -110,7 +111,9 @@ impl SandboxState {
     fn to_cri_state(self) -> &'static str {
         match self {
             SandboxState::Running => "SANDBOX_READY",
-            SandboxState::Init | SandboxState::Stopped => "SANDBOX_NOTREADY",
+            SandboxState::Init | SandboxState::Starting | SandboxState::Stopped => {
+                "SANDBOX_NOTREADY"
+            }
         }
     }
 }
@@ -151,6 +154,7 @@ pub struct VirtSandbox {
     shm_size: u64,
     factory: Option<Factory>,
     cancel_token: CancellationToken,
+    start_mutex: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for VirtSandbox {
@@ -197,6 +201,7 @@ impl VirtSandbox {
             sandbox_config: Some(sandbox_config),
             factory: Some(factory),
             cancel_token,
+            start_mutex: Arc::new(Mutex::new(())),
         })
     }
 
@@ -213,8 +218,23 @@ impl VirtSandbox {
     }
 
     async fn record_stop(&self, exit_status: u32, exited_at: std::time::SystemTime) {
+        self.record_stop_inner(exit_status, exited_at, false).await;
+    }
+
+    /// Mark the sandbox Stopped. `force` is for an explicit StopSandbox
+    /// during Init/Starting. The background wait_vm task must not force:
+    /// a late QEMU exit during bring-up must not overwrite rollback to Init.
+    async fn record_stop_inner(
+        &self,
+        exit_status: u32,
+        exited_at: std::time::SystemTime,
+        force: bool,
+    ) {
         let mut inner = self.inner.write().await;
         if inner.state == SandboxState::Stopped {
+            return;
+        }
+        if !force && matches!(inner.state, SandboxState::Init | SandboxState::Starting) {
             return;
         }
 
@@ -962,6 +982,25 @@ impl VirtSandbox {
             network_created: false,
         })
     }
+
+    /// Stop the VMM, release host network, and return the sandbox to Init so
+    /// a later start() can retry. Preserves `start_err`; logs cleanup failures.
+    async fn rollback_failed_start(&self, start_err: &anyhow::Error) {
+        error!(
+            sl!(),
+            "sandbox start failed: {:#}; rolling back VMM and network", start_err
+        );
+        if let Err(e) = self.hypervisor.stop_vm().await {
+            warn!(sl!(), "start-fail rollback: stop_vm: {:#}", e);
+        }
+        if let Err(e) = self.resource_manager.release_network().await {
+            warn!(sl!(), "start-fail rollback: release_network: {:#}", e);
+        }
+        let mut inner = self.inner.write().await;
+        if inner.state == SandboxState::Starting {
+            inner.state = SandboxState::Init;
+        }
+    }
 }
 
 /// Collect VFIO character device nodes (e.g. /dev/vfio/devices/vfio0) that a CDI
@@ -998,162 +1037,197 @@ impl Sandbox for VirtSandbox {
         }
         let sandbox_config = self.sandbox_config.as_ref().unwrap();
 
-        // if sandbox is not in SandboxState::Init then return,
-        // otherwise try to create sandbox
-
-        let mut inner = self.inner.write().await;
-        if inner.state != SandboxState::Init {
-            warn!(sl!(), "sandbox is started");
-            return Ok(());
+        // Serialize bring-up. Do not hold `inner` write across QEMU/agent
+        // connect — that blocks Task/State RPCs for the whole boot.
+        let _start_guard = self.start_mutex.lock().await;
+        {
+            let mut inner = self.inner.write().await;
+            match inner.state {
+                SandboxState::Running => {
+                    warn!(sl!(), "sandbox is started");
+                    return Ok(());
+                }
+                SandboxState::Stopped => {
+                    return Err(anyhow!("sandbox already stopped"));
+                }
+                SandboxState::Starting => {
+                    return Err(anyhow!("sandbox start already in progress"));
+                }
+                SandboxState::Init => {
+                    inner.state = SandboxState::Starting;
+                }
+            }
         }
+
         let selinux_label = load_oci_spec().ok().and_then(|spec| {
             spec.process()
                 .as_ref()
                 .and_then(|process| process.selinux_label().clone())
         });
 
-        self.hypervisor
-            .prepare_vm(
-                id,
-                sandbox_config.network_env.netns.clone(),
-                &sandbox_config.annotations,
-                selinux_label,
-            )
-            .await
-            .context("prepare vm")?;
+        let start_result = async {
+            self.hypervisor
+                .prepare_vm(
+                    id,
+                    sandbox_config.network_env.netns.clone(),
+                    &sandbox_config.annotations,
+                    selinux_label,
+                )
+                .await
+                .context("prepare vm")?;
 
-        let defer_network = self.should_defer_network().await?;
+            let defer_network = self.should_defer_network().await?;
 
-        // generate device and setup before start vm
-        // should after hypervisor.prepare_vm
-        let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
+            // generate device and setup before start vm
+            // should after hypervisor.prepare_vm
+            let resources = self.prepare_for_start_sandbox(id, sandbox_config).await?;
 
-        self.resource_manager
-            .prepare_before_start_vm(resources)
-            .await
-            .context("set up device before start vm")?;
+            self.resource_manager
+                .prepare_before_start_vm(resources)
+                .await
+                .context("set up device before start vm")?;
 
-        // start vm
-        self.hypervisor.start_vm(10_000).await.context("start vm")?;
-        info!(sl!(), "start vm");
+            // start vm
+            self.hypervisor.start_vm(10_000).await.context("start vm")?;
+            info!(sl!(), "start vm");
 
-        let sandbox = self.clone();
-        // wait for vm exit in background, and record the exit status and time when vm exited.
-        tokio::spawn(async move {
-            match sandbox.hypervisor.wait_vm().await {
-                Ok(exit_code) => {
-                    sandbox
-                        .record_stop(exit_code as u32, SystemTime::now())
-                        .await;
+            let sandbox = self.clone();
+            // wait for vm exit in background, and record the exit status and time when vm exited.
+            tokio::spawn(async move {
+                match sandbox.hypervisor.wait_vm().await {
+                    Ok(exit_code) => {
+                        sandbox
+                            .record_stop(exit_code as u32, SystemTime::now())
+                            .await;
+                    }
+                    Err(err) => {
+                        warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
+                        sandbox.record_stop(255, SystemTime::now()).await;
+                    }
                 }
-                Err(err) => {
-                    warn!(sl!(), "failed waiting for sandbox VM exit: {:?}", err);
-                    sandbox.record_stop(255, SystemTime::now()).await;
+            });
+
+            // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
+            let (prestart_hooks, create_runtime_hooks) =
+                if let Some(hooks) = sandbox_config.hooks.as_ref() {
+                    (
+                        hooks.prestart().clone().unwrap_or_default(),
+                        hooks.create_runtime().clone().unwrap_or_default(),
+                    )
+                } else {
+                    (Vec::new(), Vec::new())
+                };
+
+            self.execute_oci_hook_functions(
+                &prestart_hooks,
+                &create_runtime_hooks,
+                &sandbox_config.state,
+            )
+            .await?;
+
+            // 1. if there are pre-start hook functions, network config might have been changed.
+            //    We need to rescan the netns to handle the change.
+            // 2. Do not scan the netns if we want no network for the VM.
+            // QEMU and Cloud Hypervisor advertise network hotplug support, so
+            // factory VMs using them defer network setup until after VM startup.
+            // Backends without this capability retain pre-start setup.
+            let config = self.resource_manager.config().await;
+            if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
+                && !defer_network
+                && !config.runtime.disable_new_netns
+                && !dan_config_path(&config, &self.sid).exists()
+            {
+                if let Some(netns_path) = &sandbox_config.network_env.netns {
+                    let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
+                        network_model: config.runtime.internetworking_model.clone(),
+                        netns_path: netns_path.to_owned(),
+                        queues: self
+                            .hypervisor
+                            .hypervisor_config()
+                            .await
+                            .network_info
+                            .network_queues as usize,
+                        network_created: sandbox_config.network_env.network_created,
+                    });
+                    self.resource_manager
+                        .handle_network(network_resource)
+                        .await
+                        .context("set up device after start vm")?;
                 }
             }
-        });
 
-        // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
-        let (prestart_hooks, create_runtime_hooks) =
-            if let Some(hooks) = sandbox_config.hooks.as_ref() {
-                (
-                    hooks.prestart().clone().unwrap_or_default(),
-                    hooks.create_runtime().clone().unwrap_or_default(),
-                )
-            } else {
-                (Vec::new(), Vec::new())
+            if defer_network {
+                self.setup_deferred_network_after_start(sandbox_config)
+                    .await?;
+            }
+
+            // connect agent
+            // set agent socket
+            let address = self
+                .hypervisor
+                .get_agent_socket()
+                .await
+                .context("get agent socket")?;
+            self.agent
+                .start(&address)
+                .await
+                .context(format!("connect to address {:?}", &address))?;
+            self.set_agent_policy().await.context("set agent policy")?;
+
+            self.resource_manager
+                .setup_after_start_vm()
+                .await
+                .context("setup device after start vm")?;
+
+            // create sandbox in vm
+            let agent_config = self.agent.agent_config().await;
+            let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
+            let req = agent::CreateSandboxRequest {
+                hostname: sandbox_config.hostname.clone(),
+                dns: sandbox_config.dns.clone(),
+                storages: self
+                    .resource_manager
+                    .get_storage_for_sandbox(self.shm_size)
+                    .await
+                    .context("get storages for sandbox")?,
+                sandbox_pidns: false,
+                sandbox_id: id.to_string(),
+                guest_hook_path: self
+                    .hypervisor
+                    .hypervisor_config()
+                    .await
+                    .security_info
+                    .guest_hook_path,
+                kernel_modules,
             };
 
-        self.execute_oci_hook_functions(
-            &prestart_hooks,
-            &create_runtime_hooks,
-            &sandbox_config.state,
-        )
-        .await?;
+            self.agent
+                .create_sandbox(req)
+                .await
+                .context("create sandbox")?;
 
-        // 1. if there are pre-start hook functions, network config might have been changed.
-        //    We need to rescan the netns to handle the change.
-        // 2. Do not scan the netns if we want no network for the VM.
-        // QEMU and Cloud Hypervisor advertise network hotplug support, so
-        // factory VMs using them defer network setup until after VM startup.
-        // Backends without this capability retain pre-start setup.
-        let config = self.resource_manager.config().await;
-        if self.has_prestart_hooks(&prestart_hooks, &create_runtime_hooks)
-            && !defer_network
-            && !config.runtime.disable_new_netns
-            && !dan_config_path(&config, &self.sid).exists()
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = start_result {
+            self.rollback_failed_start(&e).await;
+            return Err(e);
+        }
+
         {
-            if let Some(netns_path) = &sandbox_config.network_env.netns {
-                let network_resource = NetworkConfig::NetNs(NetworkWithNetNsConfig {
-                    network_model: config.runtime.internetworking_model.clone(),
-                    netns_path: netns_path.to_owned(),
-                    queues: self
-                        .hypervisor
-                        .hypervisor_config()
-                        .await
-                        .network_info
-                        .network_queues as usize,
-                    network_created: sandbox_config.network_env.network_created,
-                });
-                self.resource_manager
-                    .handle_network(network_resource)
-                    .await
-                    .context("set up device after start vm")?;
+            let mut inner = self.inner.write().await;
+            if inner.state != SandboxState::Starting {
+                warn!(
+                    sl!(),
+                    "sandbox left Starting during start (state={:?}); skipping Running transition",
+                    inner.state
+                );
+                return Ok(());
             }
+            inner.state = SandboxState::Running;
+            inner.created_at = Some(std::time::SystemTime::now());
         }
-
-        if defer_network {
-            self.setup_deferred_network_after_start(sandbox_config)
-                .await?;
-        }
-
-        // connect agent
-        // set agent socket
-        let address = self
-            .hypervisor
-            .get_agent_socket()
-            .await
-            .context("get agent socket")?;
-        self.agent
-            .start(&address)
-            .await
-            .context(format!("connect to address {:?}", &address))?;
-        self.set_agent_policy().await.context("set agent policy")?;
-
-        self.resource_manager
-            .setup_after_start_vm()
-            .await
-            .context("setup device after start vm")?;
-
-        // create sandbox in vm
-        let agent_config = self.agent.agent_config().await;
-        let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
-        let req = agent::CreateSandboxRequest {
-            hostname: sandbox_config.hostname.clone(),
-            dns: sandbox_config.dns.clone(),
-            storages: self
-                .resource_manager
-                .get_storage_for_sandbox(self.shm_size)
-                .await
-                .context("get storages for sandbox")?,
-            sandbox_pidns: false,
-            sandbox_id: id.to_string(),
-            guest_hook_path: self
-                .hypervisor
-                .hypervisor_config()
-                .await
-                .security_info
-                .guest_hook_path,
-            kernel_modules,
-        };
-
-        self.agent
-            .create_sandbox(req)
-            .await
-            .context("create sandbox")?;
-
-        inner.state = SandboxState::Running;
-        inner.created_at = Some(std::time::SystemTime::now());
 
         // get and store guest details
         self.store_guest_details()
@@ -1330,10 +1404,16 @@ impl Sandbox for VirtSandbox {
         self.cancel_token.cancel();
 
         info!(sl!(), "begin stop sandbox");
-        if state == SandboxState::Init {
-            let _ = self.hypervisor.stop_vm().await;
-            self.record_stop(0, SystemTime::now()).await;
-            info!(sl!(), "sandbox stopped during Init");
+        if state == SandboxState::Init || state == SandboxState::Starting {
+            let _start_guard = self.start_mutex.lock().await;
+            if let Err(e) = self.hypervisor.stop_vm().await {
+                warn!(sl!(), "stop during {:?}: stop_vm: {:#}", state, e);
+            }
+            if let Err(e) = self.resource_manager.release_network().await {
+                warn!(sl!(), "stop during {:?}: release_network: {:#}", state, e);
+            }
+            self.record_stop_inner(0, SystemTime::now(), true).await;
+            info!(sl!(), "sandbox stopped during {:?}", state);
             return Ok(());
         }
 
@@ -1668,6 +1748,20 @@ impl Persist for VirtSandbox {
             shm_size: DEFAULT_SHM_SIZE,
             factory: None,
             cancel_token: CancellationToken::default(),
+            start_mutex: Arc::new(Mutex::new(())),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SandboxState;
+
+    #[test]
+    fn cri_state_starting_is_not_ready() {
+        assert_eq!(SandboxState::Init.to_cri_state(), "SANDBOX_NOTREADY");
+        assert_eq!(SandboxState::Starting.to_cri_state(), "SANDBOX_NOTREADY");
+        assert_eq!(SandboxState::Stopped.to_cri_state(), "SANDBOX_NOTREADY");
+        assert_eq!(SandboxState::Running.to_cri_state(), "SANDBOX_READY");
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1428,9 +1428,17 @@ impl Sandbox for VirtSandbox {
             return Ok(());
         }
 
+        // fix9 (kata-containers#13564): stop_vm() only start_kill's QEMU and
+        // returns. Do NOT await wait() for the full reclaim of a large TDX/CC
+        // guest (can be many minutes) — that blocks Shutdown until containerd
+        // SIGKILLs the shim, orphaning a still-live QEMU under init. Mark
+        // Stopped now; QEMU's PR_SET_PDEATHSIG covers shim exit/death.
+        // fix10: stop_vm takes the Child and reaps on an OS thread (try_wait),
+        // so a cancelled tokio wait_vm cannot leave a zombie under an orphaned
+        // shim. Same non-blocking pattern as the Init/Starting branch above.
         self.hypervisor.stop_vm().await.context("stop vm")?;
-        self.wait().await.context("wait for vm exit after stop")?;
-        info!(sl!(), "sandbox stopped");
+        self.record_stop(0, SystemTime::now()).await;
+        info!(sl!(), "sandbox stop signaled (not waiting for qemu exit)");
 
         Ok(())
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -1405,7 +1405,18 @@ impl Sandbox for VirtSandbox {
 
         info!(sl!(), "begin stop sandbox");
         if state == SandboxState::Init || state == SandboxState::Starting {
-            let _start_guard = self.start_mutex.lock().await;
+            // Do not await start_mutex: start() holds it across start_vm +
+            // agent connect. If QEMU dies during bring-up, start() can wait
+            // until kubelet runtime-request-timeout (2h). Awaiting the same
+            // mutex here made Shutdown wait that long too (glm-0, 2026-08-13).
+            // try_lock: if start() holds it, still signal QEMU and proceed.
+            let _start_guard = self.start_mutex.try_lock();
+            if _start_guard.is_err() {
+                warn!(
+                    sl!(),
+                    "sandbox.stop: start in progress; signaling QEMU without waiting on start_mutex"
+                );
+            }
             if let Err(e) = self.hypervisor.stop_vm().await {
                 warn!(sl!(), "stop during {:?}: stop_vm: {:#}", state, e);
             }


### PR DESCRIPTION
## Summary

Large TDX guest teardown: `start_kill` without holding wait locks, PDEATHSIG, non-blocking stop, OS-thread QEMU reaper — avoids zombie / live-orphan QEMU when containerd SIGKILLs the shim mid-reclaim.

Related: #13564 (teardown path).

## Stack

**3/4** of the split from #13568. Depends on #13595 + #13596 (included until they merge — please review the tip commit only).

Does **not** change VMM start timeout policy (#13343).

## Test plan

- [ ] Large-guest (~TiB) stop leaves no zombie/orphan QEMU under init
- [ ] Pod terminates without stuck FailedKillPod

Made with [Cursor](https://cursor.com)