### PR TITLE
kata-deploy: give job mode's per-node pods no API credentials at all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,10 +3759,12 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger 0.10.2",
+ "humantime",
  "k8s-openapi",
  "kube",
  "log",
  "rstest",
+ "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "tokio",
 ]

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -162,27 +162,69 @@ top-level `deploymentMode` value:
   pipeline as ordered `initContainers` and then exits:
 
   ```
-  host-check -> artifacts -> cri   (initContainers)  ->  label (main)
+  host-check -> artifacts   (initContainers)  ->  cri (main)
   ```
 
   On `helm uninstall`, a `pre-delete` dispatcher fans out per-node Jobs that run
-  the pipeline in reverse (`unlabel -> revert-cri -> remove-artifacts`). Unlike
+  the pipeline in reverse (`revert-cri -> remove-artifacts`). Unlike
   the DaemonSet, **nothing keeps running on the node after installation
   completes**, and the dispatcher itself only ever talks to the API server — it
   never touches the host (so it ships as a separate, minimal image,
   `job.dispatcherImage`).
 
-  The privilege split is explicit: the dispatcher pod runs **fully unprivileged**
-  (`runAsNonRoot`, all capabilities dropped, no privilege escalation, read-only
-  root filesystem, `RuntimeDefault` seccomp) under a **dedicated minimal
-  ServiceAccount** whose only rights are `nodes: list` (cluster-scoped) and
-  managing Jobs in the release namespace. All privileged, host-mutating work
-  stays in the per-node Jobs, which continue to use the `kata-deploy`
-  ServiceAccount.
+  The privilege split is explicit, and it is what `job` mode buys you over the
+  DaemonSet: **the privileged pods hold no API credentials at all**. Everything
+  that needs the API server is done by the dispatcher, which runs **fully
+  unprivileged** (`runAsNonRoot`, all capabilities dropped, no privilege
+  escalation, read-only root filesystem, `RuntimeDefault` seccomp), never touches
+  the host, and can be confined to nodes you trust.
 
 ```yaml title="values.yaml"
 deploymentMode: job
 ```
+
+#### Where the credentials live
+
+Only **one** identity exists in `job` mode, and it is not the one that runs on
+your nodes. This matters because root on a node can read the ServiceAccount token
+of any pod running there — so the per-node Jobs are rendered with
+`automountServiceAccountToken: false` and no ServiceAccount of their own.
+
+| | runs where | privileged on the host | API rights |
+|---|---|---|---|
+| dispatcher (install, uninstall) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; Jobs in the release namespace; `nodes/proxy: get` only when guest pull or image conversion is configured |
+| per-node Jobs | every node Kata is installed on | yes | **none — no token is mounted** |
+
+Getting there moved three things out of the per-node Jobs:
+
+- **Labelling the node and lifting its taints.** The dispatcher applies
+  `katacontainers.io/kata-runtime` once a node's Job has succeeded *and* the node
+  reports `Ready` again (`job.waitNodeReadySeconds`), then lifts the configured
+  `startupTaints`. This is also a stronger guarantee than before: the label can no
+  longer appear on a node whose install pipeline failed halfway, and it is removed
+  *before* an uninstall Job starts taking the node apart.
+- **The one node fact the install cannot work out locally** — the node's container
+  runtime version — is read by the dispatcher off the `Node` objects it already
+  listed, and passed down as an environment variable. Everything else it needs
+  about the node, the Kubernetes flavour included, it establishes by asking the
+  host.
+- **The cluster-scoped objects**: the `RuntimeClass`es and the `NodeFeatureRule`
+  advertising TEE key counts are rendered by the chart (see
+  [TEE key advertisement](#tee-key-advertisement)) rather than applied at run time
+  from a root-on-the-host container. `helm uninstall` removes them for free.
+
+!!! note "How this compares to `daemonset` mode"
+
+    Installing Kata means writing to the host and restarting the CRI runtime, so
+    something privileged has to run on each node in either mode. Two things differ.
+    The DaemonSet pod carries the `kata-deploy` ServiceAccount, which can patch any
+    node in the cluster and read any node's kubelet configuration, and it stays on
+    the node — token and all — for the life of the release. A per-node Job carries
+    no token and exits when it is done.
+
+    So in `job` mode a compromised worker node yields no cluster credentials, and
+    the one component that does hold them can be kept on the control plane. In
+    `daemonset` mode that token is, by construction, on every node Kata runs on.
 
 #### Why a dispatcher instead of Helm-rendered per-node Jobs
 
@@ -226,17 +268,15 @@ the dispatcher's placement. When `job.dispatcherTolerations` is empty it falls
 back to the top-level `tolerations`, so the dispatcher stays schedulable on a
 cluster whose every node is tainted.
 
-!!! warning "What this does, and what it leaves alone"
+!!! tip "Pinning covers every credential in the release"
 
-    Pinning moves one credential, not all of them. The per-node Jobs still run
-    under the `kata-deploy` ServiceAccount on every node Kata is installed on,
-    so a worker still hosts a token that can patch nodes and RuntimeClasses.
-    What it takes off those workers is the credential that reaches the *whole*
-    cluster: node enumeration, and the ability to create privileged Jobs
-    anywhere.
+    The dispatcher holds the only token `job` mode has, so keeping it off your
+    workers leaves no Kubernetes credential on them at all — the privileged
+    per-node Jobs mount none (see
+    [Where the credentials live](#where-the-credentials-live)).
 
-    That much is a boundary `daemonset` mode cannot draw at all, since the pod
-    holding its token has to run on every node by definition.
+    That is a boundary `daemonset` mode cannot draw, since the pod holding its
+    token has to run on every node by definition.
 
 ### Adding nodes in `job` mode
 
@@ -783,3 +823,38 @@ no manual `runtimeClass.nodeSelector` is set for that shim.
 **Note**: NFD detection requires cluster access. During `helm template` (dry-run without a
 cluster), external NFD is not seen, so auto-injected labels are not added. Manual
 `runtimeClass.nodeSelector` values are still applied in all cases.
+
+## TEE key advertisement
+
+A confidential VM consumes a *hardware key slot* — an encrypted-state ID on AMD
+SEV-SNP, a key ID on Intel TDX — and a node has a small, fixed number of them. The chart models that
+as an extended resource so the scheduler stops placing confidential pods on a node
+whose slots are all taken, instead of letting the VM fail to start:
+
+- a `NodeFeatureRule` tells node-feature-discovery to advertise the per-node counts
+  as `sev-snp.amd.com/esids` and `tdx.intel.com/keys`
+- the matching `RuntimeClass`es request one of them in `overhead.podFixed`, so every
+  pod that uses the class consumes a slot
+
+Both halves are one switch, because requesting a resource nothing advertises would
+leave confidential pods `Pending` forever:
+
+```yaml title="values.yaml"
+nodeFeatureRules:
+  create: auto   # auto | true | false
+```
+
+`auto` renders them when NFD is in the picture: installed by this chart
+(`node-feature-discovery.enabled=true`), already present in the cluster, or its CRD
+is registered. `true` and `false` decide outright — `false` is the escape hatch for
+a cluster that manages the rule itself.
+
+!!! note "This used to be the install binary's job"
+    The rule and the `RuntimeClass` patching were applied at run time by the
+    privileged pod on each node, which meant granting cluster-wide write access to
+    `nodefeaturerules` and `runtimeclasses` to a container running as root on the
+    host — once per node, for a pair of cluster-scoped objects. Rendering them in
+    the chart drops that grant, does it once per release, and removes them on
+    `helm uninstall`. The rule is named `kata-tee-keys` (suffixed with
+    `env.multiInstallSuffix` when set); a rule left behind by an older release is
+    called `amd64-tee-keys` and can be deleted once every release has been upgraded.

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -123,6 +123,30 @@ found [here](runtime-configuration.md#drop-in-files).
 You can also use the `customRuntimes.runtimes.[name].dropIn` configuration in the helm
 chart to achieve the same results.
 
+### k8sDistribution
+
+Different Kubernetes distributions keep containerd's configuration in different
+places, so the chart needs to be told which one this cluster is. The value picks the
+host directory that gets mounted into the install:
+
+```yaml title="values.yaml"
+k8sDistribution: k8s   # k8s | k3s | rke2 | k0s | microk8s
+```
+
+Any other value means the default location, `/etc/containerd/` — so `kubeadm` and
+`vanilla` are as good as `k8s`. Set `containerd.configDir` instead if your
+containerd matches none of the presets.
+
+!!! warning "A wrong value fails the install rather than misconfiguring the node"
+
+    Which *file* to write is worked out on the node itself, from the CRI runtime
+    actually running there — so declaring `k8s` on a `k3s` cluster used to produce a
+    perfectly good `k3s` configuration inside a directory `k3s` does not read, with
+    nothing to show for it afterwards but a node that never runs a Kata workload.
+    The install now compares the two and stops before writing anything, naming the
+    value to set. An explicit `containerd.configDir` overrides the derivation this
+    check is about, so it does not apply in that case.
+
 ## Deployment Modes (DaemonSet vs Job)
 
 The chart can install Kata on nodes in one of two ways, selected with the

--- a/tests/functional/kata-deploy/kata-deploy-distribution.bats
+++ b/tests/functional/kata-deploy/kata-deploy-distribution.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for k8sDistribution reaching the install. No cluster
+# required.
+#
+# The value picks which host directory is mounted at /etc/containerd, while the
+# install detects the node's CRI runtime itself and picks the file to write inside
+# that mount. The install can only refuse a disagreement between the two if it is
+# told what was declared, so these tests cover that it is.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+render() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@"
+}
+
+@test "Helm template: the declared distribution reaches the install, in both modes" {
+	local mode rendered
+	for mode in job daemonset; do
+		rendered=$(render --set "deploymentMode=${mode}" --set k8sDistribution=k3s)
+
+		echo "${rendered}" | grep -q 'name: K8S_DISTRIBUTION'
+		echo "${rendered}" | grep -A1 'name: K8S_DISTRIBUTION' | grep -q 'value: "k3s"'
+	done
+}
+
+@test "Helm template: pinning the containerd directory takes the check out of the way" {
+	# containerd.configDir overrides the very derivation the install would be
+	# checking, so an operator who set it is taken at their word.
+	local rendered
+	rendered=$(render --set deploymentMode=job \
+		--set 'containerd.configDir=/etc/my-containerd/')
+
+	if echo "${rendered}" | grep -q 'name: K8S_DISTRIBUTION'; then
+		echo "K8S_DISTRIBUTION was passed despite an explicit containerd.configDir" >&2
+		return 1
+	fi
+}

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for who holds which credentials. No cluster required.
+#
+# Job mode's claim over the DaemonSet is that the privileged pods - the ones that
+# run on every node Kata is installed on, root on the host, next to whatever else
+# that node runs - hold no API credentials at all. Everything that needs the
+# apiserver is done by the unprivileged dispatcher, which an operator can pin to
+# trusted nodes.
+#
+# That claim is only worth as much as the rendered manifests, and it is easy to
+# undo by accident: adding a ServiceAccount to a per-node Job, or reintroducing a
+# stage that talks to the apiserver, would both look harmless in review. These
+# tests fail when that happens.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+# Render one template of the chart in job mode.
+render_job_mode() {
+	local template="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		--set deploymentMode=job \
+		--show-only "templates/${template}" \
+		"$@"
+}
+
+# The per-node Job templates the dispatcher reads, as one YAML stream.
+per_node_jobs() {
+	render_job_mode kata-deploy-job-templates.yaml "$@"
+}
+
+# Assert that rendered output does NOT contain a pattern. `! grep ...` would be
+# exempt from set -e, so as anything but the last line of a test it could never
+# fail one.
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
+@test "Helm template (job mode): the pods that run on every node carry no token" {
+	local jobs
+	jobs=$(per_node_jobs)
+
+	# A ServiceAccount here would be readable by root on the node, and these pods
+	# are privileged on purpose - so there is deliberately nothing to read.
+	refute_match "${jobs}" 'serviceAccountName'
+	# Kubernetes mounts the namespace's default ServiceAccount unless told not to,
+	# so omitting serviceAccountName is not by itself enough.
+	[[ "$(echo "${jobs}" | grep -c 'automountServiceAccountToken: false')" -eq 2 ]]
+}
+
+@test "Helm template (job mode): no stage inside a per-node Job talks to the apiserver" {
+	local jobs
+	jobs=$(per_node_jobs)
+
+	# The label/unlabel stages are the API-using ones; they now happen in the
+	# dispatcher. Anything reintroducing them here would need a token again.
+	refute_match "${jobs}" 'install-stage-label'
+	refute_match "${jobs}" 'cleanup-stage-unlabel'
+
+	# The stages that are left, in order. Install ends with the CRI restart, which
+	# is why it is the main container rather than an init container.
+	echo "${jobs}" | grep -q 'install-stage-host-check'
+	echo "${jobs}" | grep -q 'install-stage-artifacts'
+	echo "${jobs}" | grep -q 'install-stage-cri'
+	echo "${jobs}" | grep -q 'cleanup-stage-revert-cri'
+	echo "${jobs}" | grep -q 'cleanup-stage-remove-artifacts'
+}
+
+@test "Helm template (job mode): the privileged ServiceAccount is not created at all" {
+	local rbac
+	rbac=$(render_job_mode kata-rbac.yaml)
+
+	# kata-deploy-sa can patch any node in the cluster and read any node's kubelet
+	# configuration. In job mode nothing needs it, so it does not exist.
+	refute_match "${rbac}" 'name: kata-deploy-sa$'
+	refute_match "${rbac}" 'name: kata-deploy-role$'
+	refute_match "${rbac}" 'name: kata-deploy-rb$'
+
+	# Daemonset mode still needs it: that pod does the node-level work itself.
+	local ds_rbac
+	ds_rbac=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--show-only templates/kata-rbac.yaml)
+	echo "${ds_rbac}" | grep -qE 'name: kata-deploy-sa$'
+}
+
+@test "Helm template (job mode): the dispatcher does the node-level work" {
+	local install cleanup
+	install=$(render_job_mode kata-deploy-install-job.yaml \
+		--set 'startupTaints[0]=kata/installing:NoSchedule')
+	cleanup=$(render_job_mode kata-deploy-cleanup-job.yaml)
+
+	# Labelling last, and only once the node is Ready again: the install restarts
+	# the node's CRI runtime, and the label is what admits workloads.
+	echo "${install}" | grep -q -- '--node-label=true'
+	echo "${install}" | grep -q -- '--wait-node-ready-secs=300'
+	echo "${install}" | grep -q -- '--remove-node-taints=kata/installing:NoSchedule'
+
+	# Cleanup goes the other way: unlabel before the node is taken apart.
+	echo "${cleanup}" | grep -q -- '--remove-node-label'
+	refute_match "${cleanup}" '--node-label='
+}
+
+@test "Helm template (job mode): the dispatcher may patch nodes, and nothing else may" {
+	local rbac
+	rbac=$(render_job_mode kata-rbac.yaml)
+
+	# Exactly one rule over nodes, on the dispatcher's own ClusterRole.
+	echo "${rbac}" | grep -q 'verbs: \["list", "get", "patch"\]'
+	[[ "$(echo "${rbac}" | grep -c 'resources: \["nodes"\]')" -eq 1 ]]
+}
+
+@test "Helm template (job mode): kubelet config is only read when it matters" {
+	local rbac install
+	rbac=$(render_job_mode kata-rbac.yaml)
+	install=$(render_job_mode kata-deploy-install-job.yaml)
+
+	# The default enables the confidential shims, which pull images inside
+	# CreateContainer - the one thing slow enough to hit runtimeRequestTimeout.
+	echo "${rbac}" | grep -q 'resources: \["nodes/proxy"\]'
+	echo "${install}" | grep -q -- '--kubelet-timeout-warn-secs=600'
+
+	# Without guest pull or image conversion the warning is pointless, and the
+	# grant that goes with it - reading any node's kubelet configuration - is not
+	# asked for.
+	local plain_rbac plain_install
+	plain_rbac=$(render_job_mode kata-rbac.yaml \
+		--set shims.disableAll=true \
+		--set shims.qemu.enabled=true \
+		--set snapshotter.setup=null)
+	plain_install=$(render_job_mode kata-deploy-install-job.yaml \
+		--set shims.disableAll=true \
+		--set shims.qemu.enabled=true \
+		--set snapshotter.setup=null)
+
+	refute_match "${plain_rbac}" 'nodes/proxy'
+	refute_match "${plain_install}" '--kubelet-timeout-warn-secs'
+
+	# A custom runtime asking for guest pull brings it back. Worth its own case:
+	# customRuntimes.runtimes is a map, not a list, so the check that walks it is
+	# easy to write in a way that silently matches nothing.
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+shims:
+  disableAll: true
+  qemu:
+    enabled: true
+snapshotter:
+  setup: null
+customRuntimes:
+  enabled: true
+  runtimes:
+    guest-pulling-workload:
+      baseConfig: "qemu"
+      crio:
+        pullType: "guest-pull"
+EOF
+
+	render_job_mode kata-deploy-install-job.yaml -f "${values_file}" |
+		grep -q -- '--kubelet-timeout-warn-secs=600'
+	render_job_mode kata-rbac.yaml -f "${values_file}" | grep -q 'nodes/proxy'
+	rm -f "${values_file}"
+}
+
+@test "Helm template: neither mode grants the cluster-scoped rights the install shed" {
+	# Advertising TEE keys and adjusting RuntimeClass overhead is the chart's job,
+	# so no pod needs to write these any more, in either mode.
+	local mode rbac
+	for mode in job daemonset; do
+		rbac=$(helm template kata-deploy "${CHART_PATH}" \
+			--set "deploymentMode=${mode}" \
+			--show-only templates/kata-rbac.yaml)
+
+		refute_match "${rbac}" 'nodefeaturerules'
+		refute_match "${rbac}" 'runtimeclasses'
+		refute_match "${rbac}" 'customresourcedefinitions'
+	done
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -25,6 +25,7 @@ else
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \
 		"kata-deploy-privileges.bats" \
+		"kata-deploy-distribution.bats" \
 	)
 fi
 

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -24,6 +24,7 @@ else
 		"kata-deploy-lifecycle.bats" \
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \
+		"kata-deploy-privileges.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -2470,6 +2470,7 @@ mod tests {
             erofs_snapshotter_mode: None,
             erofs_dmverity: false,
             startup_taints: vec![],
+            container_runtime_version: None,
         };
 
         let without_debug = generate_kernel_params_drop_in(&config, "qemu", false).unwrap();

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -2471,6 +2471,7 @@ mod tests {
             erofs_dmverity: false,
             startup_taints: vec![],
             container_runtime_version: None,
+            k8s_distribution: None,
         };
 
         let without_debug = generate_kernel_params_drop_in(&config, "qemu", false).unwrap();

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -227,6 +227,15 @@ pub struct Config {
     /// removes the taint as its final install step, closing the window in which a
     /// pod could land on a not-yet-ready node.
     pub startup_taints: Vec<String>,
+    /// This node's `status.nodeInfo.containerRuntimeVersion`, supplied by
+    /// whoever launched this process (`CONTAINER_RUNTIME_VERSION`).
+    ///
+    /// The job-mode dispatcher already holds every Node object it selected, so it
+    /// passes this down to the per-node Job. That is what lets those Jobs run
+    /// without a ServiceAccount token: they are the privileged, host-mutating part
+    /// of the install, and the less they can reach the better. Absent (the
+    /// DaemonSet), the value is read from the Node.
+    pub container_runtime_version: Option<String>,
 }
 
 impl Config {
@@ -420,6 +429,13 @@ impl Config {
             .filter(|s| !s.is_empty())
             .collect();
 
+        // Empty is treated as absent, so a template that renders the env var
+        // unconditionally still means "look it up".
+        let container_runtime_version = env::var("CONTAINER_RUNTIME_VERSION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let config = Config {
             node_name,
             debug,
@@ -452,6 +468,7 @@ impl Config {
             erofs_snapshotter_mode,
             erofs_dmverity,
             startup_taints,
+            container_runtime_version,
         };
 
         // Validate the configuration
@@ -724,6 +741,22 @@ impl Config {
         log::debug!("Resolved kata-deploy configuration:\n{:#?}", self);
     }
 
+    /// This node's container runtime version, e.g. `containerd://2.1.5-k3s1`.
+    ///
+    /// Every caller goes through here so there is a single place where the value
+    /// can come from the environment (job mode, where the dispatcher passes it in
+    /// and the pod holds no credentials) instead of from the Node object.
+    pub async fn resolve_container_runtime_version(&self) -> Result<String> {
+        match self.container_runtime_version.as_deref() {
+            Some(version) => Ok(version.to_string()),
+            None => k8s::get_container_runtime_version(self).await.context(
+                "could not read this node's container runtime version from the apiserver. In job \
+                 mode the dispatcher passes it in CONTAINER_RUNTIME_VERSION precisely because \
+                 these pods hold no credentials, so reaching this means it did not",
+            ),
+        }
+    }
+
     /// Get containerd configuration file paths based on runtime type and containerd version
     pub async fn get_containerd_paths(&self, runtime: &str) -> Result<ContainerdPaths> {
         use crate::runtime::manager;
@@ -733,7 +766,7 @@ impl Config {
         let container_runtime_version = if matches!(runtime, "k0s-worker" | "k0s-controller") {
             None
         } else {
-            Some(k8s::get_container_runtime_version(self).await?)
+            Some(self.resolve_container_runtime_version().await?)
         };
         let use_drop_in = manager::is_containerd_capable_of_drop_in(
             runtime,

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -236,6 +236,12 @@ pub struct Config {
     /// of the install, and the less they can reach the better. Absent (the
     /// DaemonSet), the value is read from the Node.
     pub container_runtime_version: Option<String>,
+    /// The Kubernetes flavour the chart was configured for (`K8S_DISTRIBUTION`),
+    /// which is what chose the host directory mounted at /etc/containerd.
+    ///
+    /// Absent when the operator pinned that directory themselves, or when this
+    /// process was not started by the chart.
+    pub k8s_distribution: Option<String>,
 }
 
 impl Config {
@@ -436,6 +442,11 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        let k8s_distribution = env::var("K8S_DISTRIBUTION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let config = Config {
             node_name,
             debug,
@@ -469,6 +480,7 @@ impl Config {
             erofs_dmverity,
             startup_taints,
             container_runtime_version,
+            k8s_distribution,
         };
 
         // Validate the configuration

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -418,6 +418,8 @@ async fn install_stage_host_check(
         ));
     }
 
+    runtime::validate_declared_distribution(config, runtime)?;
+
     if runtime != "crio" {
         runtime::containerd::containerd_snapshotter_version_check(config).await?;
         runtime::containerd::snapshotter_handler_mapping_validation_check(config)?;

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -305,7 +305,7 @@ async fn main() -> Result<()> {
         // path does not use these directly; it goes through `install` above,
         // which composes the same stage functions.
         Action::InstallStageHostCheck => {
-            install_stage_host_check(&config, &runtime).await?;
+            install_stage_host_check(&config, &runtime, true).await?;
             info!("Install host-check stage completed, exiting");
         }
         Action::InstallStageArtifacts => {
@@ -329,7 +329,7 @@ async fn main() -> Result<()> {
             info!("Cleanup unlabel stage completed, exiting");
         }
         Action::CleanupStageRevertCri => {
-            cleanup_stage_revert_cri(&config, &runtime).await?;
+            cleanup_stage_revert_cri(&config, &runtime, true).await?;
             info!("Cleanup revert-cri stage completed, exiting");
         }
         Action::CleanupStageRemoveArtifacts => {
@@ -370,7 +370,7 @@ fn reexec_into_post_install_wait(
 async fn install(config: &config::Config, runtime: &str) -> Result<()> {
     info!("Installing Kata Containers");
 
-    install_stage_host_check(config, runtime).await?;
+    install_stage_host_check(config, runtime, false).await?;
     install_stage_artifacts(config, runtime).await?;
     install_stage_cri(config, runtime, false).await?;
     install_stage_label(config).await?;
@@ -395,7 +395,16 @@ const SUPPORTED_RUNTIMES: &[&str] = &[
 /// installation before any host mutation happens. This is read-only and safe
 /// to run repeatedly; it fails fast with actionable diagnostics so a staged
 /// JobSet can abort the per-node pipeline before the privileged stages run.
-async fn install_stage_host_check(config: &config::Config, runtime: &str) -> Result<()> {
+///
+/// `staged` marks the job-mode pipeline, whose containers hold no Kubernetes
+/// credentials: the one check that needs the apiserver (reading the kubelet's
+/// `runtimeRequestTimeout` out of `/configz`, which is advisory) is left to the
+/// dispatcher, which runs it per node before dispatching.
+async fn install_stage_host_check(
+    config: &config::Config,
+    runtime: &str,
+    staged: bool,
+) -> Result<()> {
     info!("install (host-check): validating node prerequisites for runtime {runtime}");
 
     if !SUPPORTED_RUNTIMES.contains(&runtime) {
@@ -440,7 +449,7 @@ async fn install_stage_host_check(config: &config::Config, runtime: &str) -> Res
                 for s in &non_empty_snapshotters {
                     match s.as_str() {
                         "erofs" => {
-                            validate_erofs_prerequisites(config).await?;
+                            validate_erofs_prerequisites(config, staged).await?;
                         }
                         "nydus" => {}
                         _ => {
@@ -454,7 +463,7 @@ async fn install_stage_host_check(config: &config::Config, runtime: &str) -> Res
         }
     }
 
-    if config_uses_guest_pull(config) {
+    if config_uses_guest_pull(config) && !staged {
         validate_kubelet_runtime_request_timeout(config, "guest pull").await?;
     }
 
@@ -462,7 +471,7 @@ async fn install_stage_host_check(config: &config::Config, runtime: &str) -> Res
     Ok(())
 }
 
-async fn validate_erofs_prerequisites(config: &config::Config) -> Result<()> {
+async fn validate_erofs_prerequisites(config: &config::Config, staged: bool) -> Result<()> {
     info!("Validating EROFS snapshotter prerequisites");
 
     runtime::containerd::containerd_erofs_snapshotter_version_check(config).await?;
@@ -494,7 +503,9 @@ async fn validate_erofs_prerequisites(config: &config::Config) -> Result<()> {
     // the backing filesystem's fs-verity feature. Keep this check warning-only.
     warn_if_erofs_fsverity_may_be_unavailable();
 
-    validate_kubelet_runtime_request_timeout(config, "EROFS layer conversion").await?;
+    if !staged {
+        validate_kubelet_runtime_request_timeout(config, "EROFS layer conversion").await?;
+    }
 
     Ok(())
 }
@@ -1199,7 +1210,7 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     // server process, which kills this (terminating) pod. By doing it after
     // all other cleanup, we ensure config and artifacts are already gone.
     info!("Restarting CRI runtime");
-    runtime::restart_and_wait_for_ready(config, runtime).await?;
+    runtime::restart_and_wait_for_ready(config, runtime, false).await?;
     info!("CRI runtime restarted successfully");
 
     info!("Kata Containers cleanup completed successfully");
@@ -1233,7 +1244,11 @@ async fn cleanup_stage_unlabel(config: &config::Config) -> Result<()> {
 /// privileged, node-disrupting cleanup stage and is kept short-lived. Skips
 /// entirely when the CRI drop-ins are already absent, avoiding an unnecessary
 /// runtime restart.
-async fn cleanup_stage_revert_cri(config: &config::Config, runtime: &str) -> Result<()> {
+async fn cleanup_stage_revert_cri(
+    config: &config::Config,
+    runtime: &str,
+    staged: bool,
+) -> Result<()> {
     info!("cleanup (revert-cri): reverting CRI configuration");
 
     if !cri_drop_in_present(config, runtime).await {
@@ -1253,7 +1268,7 @@ async fn cleanup_stage_revert_cri(config: &config::Config, runtime: &str) -> Res
     runtime::cleanup_cri_runtime_config(config, runtime).await?;
 
     info!("cleanup (revert-cri): restarting runtime");
-    runtime::restart_and_wait_for_ready(config, runtime).await?;
+    runtime::restart_and_wait_for_ready(config, runtime, staged).await?;
     info!("cleanup (revert-cri): runtime restarted");
 
     Ok(())

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -72,13 +72,18 @@ enum Action {
     /// runtime, and wait for node readiness.
     #[clap(name = "install-stage-cri")]
     InstallStageCri,
-    /// Stage 3 of a staged (JobSet) install: apply the kata-runtime node label.
-    /// Unprivileged, Kubernetes API only.
+    /// Apply the kata-runtime node label. Unprivileged, Kubernetes API only.
+    ///
+    /// No longer part of the staged pipeline: the dispatcher labels the node
+    /// itself, once the node's Job as a whole succeeded, which is what lets those
+    /// Jobs run with no ServiceAccount token. Kept because a chart from before
+    /// that change still invokes it.
     #[clap(name = "install-stage-label")]
     InstallStageLabel,
-    /// Cleanup stage 1 of a staged (JobSet) uninstall: remove the kata-runtime
-    /// node label first so the scheduler stops placing kata workloads here.
-    /// Unprivileged, Kubernetes API only.
+    /// Remove the kata-runtime node label. Unprivileged, Kubernetes API only.
+    ///
+    /// As with install-stage-label, the dispatcher does this now; kept for older
+    /// charts.
     #[clap(name = "cleanup-stage-unlabel")]
     CleanupStageUnlabel,
     /// Cleanup stage 2 of a staged (JobSet) uninstall: remove CRI drop-ins,

--- a/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
@@ -5,7 +5,6 @@
 
 use crate::config;
 use crate::config::{Config, ContainerdPaths, CustomRuntime, NYDUS_FOR_KATA_TEE};
-use crate::k8s;
 use crate::utils;
 use crate::utils::toml as toml_utils;
 use anyhow::{Context, Result};
@@ -688,7 +687,7 @@ pub async fn setup_containerd_config_files(runtime: &str, config: &Config) -> Re
         "containerd" if !Path::new(&config.containerd_conf_file).exists() => {
             if let Some(parent) = Path::new(&config.containerd_conf_file).parent() {
                 if parent.exists() {
-                    let runtime_version = k8s::get_container_runtime_version(config).await?;
+                    let runtime_version = config.resolve_container_runtime_version().await?;
                     let schema = schema_version_for_containerd_release(&runtime_version)?;
                     fs::write(
                         &config.containerd_conf_file,
@@ -750,7 +749,7 @@ fn check_containerd_snapshotter_version_support(
 }
 
 pub async fn containerd_snapshotter_version_check(config: &Config) -> Result<()> {
-    let container_runtime_version = k8s::get_container_runtime_version(config).await?;
+    let container_runtime_version = config.resolve_container_runtime_version().await?;
 
     let has_snapshotter_mapping = config
         .snapshotter_handler_mapping_for_arch
@@ -795,7 +794,7 @@ fn check_containerd_erofs_version_support(container_runtime_version: &str) -> Re
 }
 
 pub async fn containerd_erofs_snapshotter_version_check(config: &Config) -> Result<()> {
-    let container_runtime_version = k8s::get_container_runtime_version(config).await?;
+    let container_runtime_version = config.resolve_container_runtime_version().await?;
 
     check_containerd_erofs_version_support(&container_runtime_version)
 }

--- a/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
@@ -94,6 +94,76 @@ pub async fn get_container_runtime(config: &Config) -> Result<String> {
     Ok(runtime)
 }
 
+/// Distributions keeping containerd's configuration somewhere of their own, and
+/// the runtimes each can turn out to be. More than one apiece because a single
+/// Helm value covers a whole cluster while the runtime differs per node role.
+const DISTRIBUTION_RUNTIMES: &[(&str, &[&str])] = &[
+    ("k3s", &["k3s", "k3s-agent"]),
+    ("rke2", &["rke2-server", "rke2-agent"]),
+    ("k0s", &["k0s-controller", "k0s-worker"]),
+    ("microk8s", &["microk8s"]),
+];
+
+/// Runtimes reading their configuration from the default location.
+const VANILLA_RUNTIMES: &[&str] = &["containerd", "crio"];
+
+/// Unrecognised values answer with the vanilla runtimes rather than with nothing,
+/// because that is what the chart does with them: `containerdConfPath` falls
+/// through to /etc/containerd for everything it does not know, so "kubeadm" and
+/// "vanilla" describe the same mount as "k8s" and can be checked just as well.
+fn runtimes_for_distribution(distribution: &str) -> &'static [&'static str] {
+    DISTRIBUTION_RUNTIMES
+        .iter()
+        .find(|(name, _)| *name == distribution)
+        .map(|(_, runtimes)| *runtimes)
+        .unwrap_or(VANILLA_RUNTIMES)
+}
+
+/// The `k8sDistribution` a node running `runtime` should have been declared as,
+/// or `None` when any of the values meaning "vanilla" would have done.
+fn distribution_for_runtime(runtime: &str) -> Option<&'static str> {
+    DISTRIBUTION_RUNTIMES
+        .iter()
+        .find(|(_, runtimes)| runtimes.contains(&runtime))
+        .map(|(name, _)| *name)
+}
+
+/// Refuse to continue when the Kubernetes flavour the chart was configured for is
+/// not the one this node turns out to run.
+///
+/// Neither value corrects the other: the declared one chose which host directory
+/// is mounted at /etc/containerd, while the detected runtime chooses the file
+/// written inside that mount. Disagreeing writes a valid configuration into a
+/// directory this node's CRI runtime never reads, and the install can then go on
+/// to restart the runtime and advertise the node as Kata-capable regardless.
+pub fn validate_declared_distribution(config: &Config, runtime: &str) -> Result<()> {
+    check_declared_distribution(config.k8s_distribution.as_deref(), runtime)
+}
+
+fn check_declared_distribution(declared: Option<&str>, runtime: &str) -> Result<()> {
+    let Some(declared) = declared else {
+        return Ok(());
+    };
+
+    if runtimes_for_distribution(declared).contains(&runtime) {
+        return Ok(());
+    }
+
+    let advice = match distribution_for_runtime(runtime) {
+        Some(distribution) => format!("set k8sDistribution to {distribution:?}"),
+        // Nothing to name: this runtime keeps its configuration where the chart
+        // already mounts by default, so the declared value is the odd one out.
+        None => "set k8sDistribution to \"k8s\"".to_string(),
+    };
+
+    anyhow::bail!(
+        "this node runs {runtime}, but the chart was configured for k8sDistribution \
+         {declared:?}, so the directory mounted at /etc/containerd is not the one \
+         {runtime} reads its configuration from. Kata would be configured where nothing \
+         looks for it: {advice}, or override containerd.configDir directly."
+    )
+}
+
 /// Returns the systemd unit that runs the node's CRI runtime.
 ///
 /// For most runtimes the detected runtime name doubles as the unit name, but k3s,
@@ -459,6 +529,51 @@ mod tests {
     #[case::unknown_runtime_falls_back_to_its_own_name("something-else", "something-else.service")]
     fn test_cri_systemd_unit(#[case] runtime: &str, #[case] expected: &str) {
         assert_eq!(cri_systemd_unit(runtime), expected, "runtime: {}", runtime);
+    }
+
+    // --- check_declared_distribution ---
+
+    /// Every runtime a flavour can present as is accepted, since one Helm value
+    /// covers a whole cluster while the runtime differs per node role: declaring
+    /// k3s and finding an agent is right, finding cri-o is not.
+    #[rstest]
+    #[case::vanilla_containerd(Some("k8s"), "containerd", true)]
+    #[case::crio_is_also_vanilla_k8s(Some("k8s"), "crio", true)]
+    #[case::k3s_server(Some("k3s"), "k3s", true)]
+    #[case::k3s_agent(Some("k3s"), "k3s-agent", true)]
+    #[case::rke2_agent(Some("rke2"), "rke2-agent", true)]
+    #[case::k0s_worker(Some("k0s"), "k0s-worker", true)]
+    #[case::microk8s(Some("microk8s"), "microk8s", true)]
+    #[case::k3s_node_left_at_the_default(Some("k8s"), "k3s", false)]
+    #[case::k8s_node_declared_as_k3s(Some("k3s"), "containerd", false)]
+    #[case::k3s_and_rke2_are_not_interchangeable(Some("k3s"), "rke2-agent", false)]
+    // The chart mounts /etc/containerd for any value it does not recognise, so
+    // these mean the same as "k8s" and are held to the same answer.
+    #[case::kubeadm_is_vanilla(Some("kubeadm"), "containerd", true)]
+    #[case::vanilla_on_a_k3s_node(Some("vanilla"), "k3s", false)]
+    // Not started by the chart, so there is nothing to check against.
+    #[case::unset(None, "k3s", true)]
+    fn test_check_declared_distribution(
+        #[case] declared: Option<&str>,
+        #[case] runtime: &str,
+        #[case] accepted: bool,
+    ) {
+        assert_eq!(
+            check_declared_distribution(declared, runtime).is_ok(),
+            accepted,
+            "declared: {declared:?}, runtime: {runtime}"
+        );
+    }
+
+    /// The error has to say which value to change, since the two names differ
+    /// (`k0s-worker` is not a k8sDistribution) and only one of them is a knob.
+    #[test]
+    fn a_mismatch_names_the_value_to_set() {
+        let err = check_declared_distribution(Some("k8s"), "k0s-worker")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("k0s-worker"), "{err}");
+        assert!(err.contains(r#"set k8sDistribution to "k0s""#), "{err}");
     }
 
     // --- is_containerd_capable_of_drop_in (pure version) ---

--- a/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;
-use crate::k8s;
 use crate::utils;
 use anyhow::{Context, Result};
 use regex::Regex;
@@ -45,15 +44,16 @@ async fn is_unit_active(unit: &str) -> bool {
 }
 
 pub async fn get_container_runtime(config: &Config) -> Result<String> {
-    let runtime_version = k8s::get_container_runtime_version(config)
+    let runtime_version = config
+        .resolve_container_runtime_version()
         .await
         .context("Failed to get container runtime version")?;
 
-    let microk8s = k8s::get_node_label(config, "microk8s.io/cluster")
-        .await
-        .ok()
-        .flatten();
-    if microk8s.as_deref() == Some("true") {
+    // Asked of the host rather than of the `microk8s.io/cluster` node label, so
+    // that a pod holding no Kubernetes credentials can still tell: microk8s runs
+    // containerd as a snap daemon, and the version string kubelet reports says
+    // only "containerd".
+    if is_unit_active(&cri_systemd_unit("microk8s")).await {
         return Ok("microk8s".to_string());
     }
 
@@ -188,7 +188,7 @@ pub async fn is_containerd_capable_of_using_drop_in_files(
     let runtime_version = if runtime == "k0s-worker" || runtime == "k0s-controller" {
         None
     } else {
-        Some(k8s::get_container_runtime_version(config).await?)
+        Some(config.resolve_container_runtime_version().await?)
     };
 
     Ok(is_containerd_capable_of_drop_in(
@@ -299,11 +299,28 @@ pub async fn cleanup_cri_runtime_config(config: &Config, runtime: &str) -> Resul
     Ok(())
 }
 
-/// Restart the CRI runtime and wait for the node to become ready.
-pub async fn restart_and_wait_for_ready(config: &Config, runtime: &str) -> Result<()> {
+/// Restart the CRI runtime and wait for it to come back.
+///
+/// `staged` picks the wait: a staged per-node Job has no Kubernetes credentials
+/// and waits on the systemd unit, the DaemonSet waits for the node to go Ready.
+pub async fn restart_and_wait_for_ready(
+    config: &Config,
+    runtime: &str,
+    staged: bool,
+) -> Result<()> {
     log::info!("restart_and_wait_for_ready: Restarting runtime");
     lifecycle::restart_cri_runtime(config, runtime).await?;
     log::info!("restart_and_wait_for_ready: Successfully restarted runtime");
+
+    if staged {
+        if !matches!(runtime, "k0s-worker" | "k0s-controller") {
+            log::info!(
+                "restart_and_wait_for_ready: Waiting for the CRI runtime unit (timeout: 300s)"
+            );
+            lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
+        }
+        return Ok(());
+    }
 
     log::info!("restart_and_wait_for_ready: Waiting for node to become ready (timeout: 300s)");
     lifecycle::wait_till_node_is_ready_timeout(config, Some(300)).await?;

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -748,6 +748,72 @@ Returns the comma-joined selector string (possibly empty, meaning "all nodes").
 {{- end -}}
 
 {{/*
+Flags handing the node-level API work to the dispatcher, for the stage named in
+`stage` ("install" or "cleanup").
+
+This is what the per-node Jobs used to do themselves, in a `label` / `unlabel`
+stage holding the kata-deploy ServiceAccount token. Moving it up here is what
+allows those Jobs to mount no token at all - see kata-deploy.perNodeJob.
+
+Install labels only once the node reports Ready again, its CRI runtime having just
+been restarted, and lifts the start-up taints after that. Cleanup goes the other
+way round, so the scheduler stops sending Kata workloads to a node that is about
+to lose its runtime.
+
+Arguments (dict): root, stage. Emitted at column 0; `nindent` at the call site.
+*/}}
+{{- define "kata-deploy.dispatcherNodeWorkFlags" -}}
+{{- $root := .root -}}
+{{- if eq .stage "cleanup" }}
+- "--remove-node-label"
+{{- else }}
+- "--node-label=true"
+- "--wait-node-ready-secs={{ $root.Values.job.waitNodeReadySeconds | default 300 }}"
+{{- with $root.Values.startupTaints }}
+- "--remove-node-taints={{ join "," . }}"
+{{- end }}
+{{- with include "kata-deploy.kubeletTimeoutWarnSecs" $root | trim }}
+- "--kubelet-timeout-warn-secs={{ . }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Seconds below which a node's kubelet `runtimeRequestTimeout` is worth warning
+about, or EMPTY when this configuration has no reason to care.
+
+Only pulling or converting an image inside `CreateContainer` can run long enough
+to hit that timeout, which is why the warning is asked for exactly when guest pull
+or EROFS conversion is configured - every cluster would trip a 10 minute
+expectation otherwise, since the kubelet default is 2 minutes.
+
+The check itself lives in the dispatcher because it needs the apiserver
+(`nodes/proxy`), and the per-node Jobs deliberately hold no credentials.
+*/}}
+{{- define "kata-deploy.kubeletTimeoutWarnSecs" -}}
+{{- $needed := false -}}
+{{- range $arch := list "amd64" "arm64" "s390x" "ppc64le" -}}
+{{- if include "kata-deploy.getForceGuestPullForArch" (dict "root" $ "arch" $arch) | trim -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- if contains "guest-pull" (include "kata-deploy.getPullTypeMappingForArch" (dict "root" $ "arch" $arch) | trim) -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- end -}}
+{{- if contains "erofs" (include "kata-deploy.getSnapshotterSetup" . | trim) -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- if .Values.customRuntimes.enabled -}}
+{{- range $runtime := (.Values.customRuntimes.runtimes | default list) -}}
+{{- if eq (dig "crio" "pullType" "" $runtime) "guest-pull" -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $needed -}}600{{- end -}}
+{{- end -}}
+
+{{/*
 Whether to render the NFD-derived resources: the `NodeFeatureRule` that advertises
 TEE key counts, and the matching `overhead.podFixed` entries that make Kata's
 confidential RuntimeClasses consume one of those keys per pod.
@@ -792,11 +858,11 @@ true
 Where a dispatcher pod may run: `nodeSelector` and `tolerations` blocks for the
 install and cleanup dispatchers.
 
-This is about the dispatcher pod, not about which nodes get Kata. The dispatcher
-holds the one token that reaches the whole cluster - it enumerates every node and
-creates the privileged per-node Jobs - and root on the node it lands on can read
-it; confining it to trusted nodes is a hardening step a DaemonSet cannot offer,
-having to run everywhere by definition.
+This is about the dispatcher pod, not about which nodes get Kata. The distinction
+matters because the dispatcher is the only part of job mode that holds
+credentials, and root on the node it lands on can read them; confining it to
+trusted nodes is a hardening step a DaemonSet cannot offer. The per-node Jobs,
+which do run on every target node, hold no token at all.
 
 Tolerations fall back to the top-level `tolerations` so the dispatcher stays
 schedulable wherever the per-node Jobs are allowed to run - without that, a
@@ -952,8 +1018,12 @@ Arguments (dict):
   root  - top-level context (.)
   stage - "install" | "cleanup"
 
-install pipeline:  host-check -> artifacts -> cri (initContainers) ; label (main)
-cleanup pipeline:  unlabel -> revert-cri    (initContainers) ; remove-artifacts (main)
+install pipeline:  host-check -> artifacts (initContainers) ; cri (main)
+cleanup pipeline:  revert-cri              (initContainer)  ; remove-artifacts (main)
+
+The node label is not a stage here: the dispatcher sets it once the Job as a whole
+has succeeded (and removes it before a cleanup Job runs), which is what lets these
+pods run without a ServiceAccount token.
 
 Emitted at column 0 (a standalone Job document); embed with `indent` at the call
 site under a ConfigMap data key.
@@ -990,7 +1060,14 @@ spec:
       imagePullSecrets:
 {{- toYaml . | nindent 8 }}
 {{- end }}
-      serviceAccountName: {{ include "kata-deploy.serviceAccountName" $root }}
+      {{- /* No ServiceAccount, and no token mounted: these pods write to the host
+             (install dir, CRI configuration, systemd) on every node Kata is
+             installed on, so anything mounted here is within reach on a node that
+             may also run untrusted workloads. Everything that needs the apiserver
+             - labelling the node, lifting its start-up taints, reading its kubelet
+             config - is done by the dispatcher instead, which can be pinned to
+             trusted nodes (job.dispatcherNodeSelector). */}}
+      automountServiceAccountToken: false
       restartPolicy: Never
 {{- with $root.Values.tolerations }}
       tolerations:
@@ -1003,12 +1080,10 @@ spec:
       initContainers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "host-check" "action" "install-stage-host-check" "privileged" false "mountHost" true) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "artifacts" "action" "install-stage-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "cri" "action" "install-stage-cri" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "label" "action" "install-stage-label" "privileged" false "mountHost" false) | nindent 8 }}
+{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "cri" "action" "install-stage-cri" "privileged" false "mountHost" true) | nindent 8 }}
 {{- else }}
       initContainers:
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "unlabel" "action" "cleanup-stage-unlabel" "privileged" false "mountHost" false) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "revert-cri" "action" "cleanup-stage-revert-cri" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "remove-artifacts" "action" "cleanup-stage-remove-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
@@ -1018,8 +1093,10 @@ spec:
 {{- end -}}
 
 {{/*
-Service account name (honoring multiInstallSuffix), shared by all kata-deploy
-workloads (DaemonSet and staged Jobs).
+Service account name (honoring multiInstallSuffix) for the DaemonSet, the only
+workload that carries the privileged host-mutation rights. Job mode's per-node
+Jobs deliberately have no ServiceAccount; its dispatcher uses
+kata-deploy.dispatcherServiceAccountName.
 */}}
 {{- define "kata-deploy.serviceAccountName" -}}
 {{- if .Values.env.multiInstallSuffix -}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -684,6 +684,14 @@ e.g. `{{- include "kata-deploy.commonEnv" . | nindent 8 }}`.
 - name: CONTAINERD_CONFIG_FILE_NAME
   value: {{ .Values.containerd.configFileName | trim | quote }}
 {{- end }}
+{{- if not (.Values.containerd.configDir | trim) }}
+{{- /* This value picks the host directory mounted at /etc/containerd, while the
+       install detects the runtime itself and picks the file written within it, so
+       the install needs it to refuse a directory its runtime does not read.
+       Omitted when configDir overrides the derivation being checked. */}}
+- name: K8S_DISTRIBUTION
+  value: {{ .Values.k8sDistribution | quote }}
+{{- end }}
 {{- if .Values.containerd.userDropIn | trim }}
 - name: CONTAINERD_USER_DROP_IN_SOURCE_FILE
   value: "/custom-containerd-config/containerd-user-dropin.toml"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -92,6 +92,7 @@ spec:
             - "--name-prefix={{ $base }}-cleanup"
             - "--owner-job-name={{ $dispatcherName }}"
             - "--parallelism={{ $root.Values.job.parallelism }}"
+{{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "cleanup") | nindent 12 }}
 {{- if $cNodes }}
             - "--nodes={{ join "," $cNodes }}"
 {{- else }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -110,6 +110,7 @@ job.nodes list, which names nodes outright and needs no discovery.
 */}}
             - "--wait-for-nodes-secs={{ $root.Values.job.waitForNodesSeconds | default 0 }}"
 {{- end }}
+{{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "install") | nindent 12 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -60,11 +60,7 @@ spec:
       imagePullSecrets:
 {{- toYaml . | nindent 6 }}
 {{- end }}
-{{- if .Values.env.multiInstallSuffix }}
-      serviceAccountName: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
-{{- else }}
-      serviceAccountName: {{ .Chart.Name }}-sa
-{{- end }}
+      serviceAccountName: {{ include "kata-deploy.serviceAccountName" . }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{- toYaml . | nindent 8 }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -1,3 +1,10 @@
+{{- if eq (.Values.deploymentMode | default "daemonset") "daemonset" }}
+{{- /*
+  The privileged host-mutation identity, and DaemonSet-only: that pod is what
+  needs to label its node and read its kubelet config. In job mode no such
+  identity is created at all - the per-node Jobs mount no token, and the
+  dispatcher's own (far smaller) rights are further down this file.
+*/}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -61,14 +68,14 @@ subjects:
   name: {{ .Chart.Name }}-sa
 {{- end }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if eq (.Values.deploymentMode | default "daemonset") "job" }}
 ---
-# Dedicated, least-privilege identity for the job-mode dispatcher
-# (kata-deploy-job-dispatcher). It is a pure control-plane client: it lists nodes
-# (cluster-scoped) and manages per-node Jobs in the release namespace
-# (namespace-scoped). It deliberately does NOT get the privileged kata-deploy
-# host-mutation rights (node patch, runtimeclasses, NFD, etc.); those stay on
-# kata-deploy-sa, which only the per-node Jobs use.
+# The job-mode dispatcher's identity, and in job mode the ONLY identity in play:
+# the per-node Jobs it creates mount no token at all. It is unprivileged, never
+# touches the host, and can be confined to trusted nodes with
+# job.dispatcherNodeSelector - which is the point of concentrating the node-level
+# API work here rather than in a privileged pod on every node.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -80,10 +87,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Chart.Name }}-dispatcher-noderole{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
 rules:
-# Enumerating nodes is inherently cluster-scoped.
+# Enumerating nodes is inherently cluster-scoped. `get` re-reads one node (its
+# readiness, and the label back after patching it); `patch` sets the
+# katacontainers.io/kata-runtime label and lifts start-up taints, which is the
+# work the per-node Jobs used to do with a token of their own.
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["list", "get", "patch"]
+{{- if include "kata-deploy.kubeletTimeoutWarnSecs" . | trim }}
+# Only granted when this configuration pulls or converts images inside
+# CreateContainer: reading the kubelet's runtimeRequestTimeout from /configz to
+# warn when it is too low for that to finish.
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -184,6 +184,15 @@ monitor:
       cpu: 200m
       memory: 300Mi
 
+# Which Kubernetes flavour this cluster runs. It picks the host directory that
+# holds containerd's configuration, which is mounted into the install.
+#
+# Getting it wrong used to pass unnoticed: the install detects the runtime on the
+# node itself, so it would write a correct configuration into whichever directory
+# was mounted - and if that is not the one this node's containerd reads, Kata is
+# configured where nothing looks for it. The install now refuses to continue when
+# the two disagree, naming the value to set. Setting containerd.configDir takes
+# that check out of the way, being an explicit override of this derivation.
 k8sDistribution: "k8s"  # k8s, k3s, rke2, k0s, microk8s
 
 # Containerd configuration overrides

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -37,11 +37,11 @@ job:
   # to do with which nodes get Kata - that is the top-level `nodeSelector` /
   # `affinity` / `tolerations`.
   #
-  # Worth setting: the dispatcher is the component that holds Kubernetes
-  # credentials, and root on whatever node it lands on can read them.
-  # Confining it to nodes you trust - typically the control plane - means a
-  # compromised worker cannot reach them, something a DaemonSet can never offer
-  # because it must run everywhere.
+  # Worth setting: the dispatcher is the one component that holds credentials, and
+  # root on whatever node it lands on can read them. Confining it to nodes you
+  # trust - typically the control plane - means a compromised worker cannot reach
+  # them, something a DaemonSet can never offer because it must run everywhere.
+  # The per-node Jobs need no such care: they carry no ServiceAccount token at all.
   #
   # Example (control plane only; the toleration is required because those nodes are
   # normally tainted):
@@ -98,6 +98,17 @@ job:
   # this alone just trades a dispatcher error that names the selectors it tried
   # for Helm's opaque "timed out waiting for the condition".
   waitForNodesSeconds: 120
+  # How long to wait for a node to report Ready again after its install Job
+  # finished, before advertising it as Kata-capable.
+  #
+  # The last thing that install does is restart the node's CRI runtime, which
+  # takes the node NotReady for a moment. Labeling it (and lifting its
+  # startupTaints) only once it is Ready again is what keeps the scheduler from
+  # sending the first Kata workload to a node whose runtime is still coming back.
+  #
+  # A node that never recovers fails its own install and nothing else: it stays
+  # unlabeled, so no workload is sent there, and a later run retries it.
+  waitNodeReadySeconds: 300
   # Node selection for the UNINSTALL (pre-delete hook) dispatcher.
   #
   # Deliberately independent of the install selection: uninstall has to reach

--- a/tools/packaging/kata-deploy/job-dispatcher/Cargo.toml
+++ b/tools/packaging/kata-deploy/job-dispatcher/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 env_logger = "0.10"
+# Parses the kubelet's runtimeRequestTimeout, which /configz reports Go-style
+# ("2m0s"), for the advisory pre-flight warning.
+humantime = "2.1.0"
 k8s-openapi = { version = "0.26", default-features = false, features = [
     "v1_33",
 ] }
@@ -27,6 +30,7 @@ kube = { version = "2.0", default-features = false, features = [
     "ring",
 ] }
 log.workspace = true
+serde_json.workspace = true
 serde_yaml = "0.9"
 tokio = { workspace = true, features = [
     "rt-multi-thread",

--- a/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::nodes::NodeFacts;
 use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::{EnvVar, PodSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
+
+/// Carries `.status.nodeInfo.containerRuntimeVersion` into the per-node Job, so it
+/// need not read the Node object to detect the runtime.
+pub const CONTAINER_RUNTIME_VERSION_ENV: &str = "CONTAINER_RUNTIME_VERSION";
 
 /// Label applied to every per-node Job, set to the dispatcher's name prefix.
 /// Used as a server-side selector so the dispatcher only ever sees the Jobs it
@@ -111,6 +117,8 @@ pub fn job_owned_by(job: &Job, owner_value: &str) -> bool {
 ///   - set a unique `metadata.name`,
 ///   - pin the pod to `node` via `spec.template.spec.nodeName`,
 ///   - add owner/node tracking labels (+ a full-name annotation),
+///   - pass down the node facts in `facts`, so the containers do not have to read
+///     them from the apiserver themselves,
 ///   - optionally attach an `ownerReference` for garbage collection.
 ///
 /// `owner_value` is the dispatcher's name prefix, recorded in [`OWNER_LABEL`] so
@@ -121,6 +129,7 @@ pub fn build_node_job(
     node: &str,
     owner_value: &str,
     owner: Option<&OwnerReference>,
+    facts: &NodeFacts,
 ) -> Job {
     let mut job = template.clone();
 
@@ -151,7 +160,45 @@ pub fn build_node_job(
     let pod_spec = spec.template.spec.get_or_insert_with(Default::default);
     pod_spec.node_name = Some(node.to_string());
 
+    inject_node_facts(pod_spec, facts);
+
     job
+}
+
+/// Each stage container runs the same binary and resolves the node's CRI runtime
+/// on its own, which normally means reading the Node object. Handing the one
+/// cluster-sourced fact down here is what lets the per-node Jobs run without a
+/// ServiceAccount token: the dispatcher already holds the Node objects it
+/// selected, so this costs nothing.
+///
+/// Set on every container rather than just the first: the stages are independent
+/// processes, any of them may need the runtime, and an existing value is left
+/// alone so an explicit override in the chart still wins.
+fn inject_node_facts(pod_spec: &mut PodSpec, facts: &NodeFacts) {
+    let Some(version) = facts.container_runtime_version.as_deref() else {
+        return;
+    };
+
+    let containers = pod_spec
+        .init_containers
+        .iter_mut()
+        .flatten()
+        .chain(pod_spec.containers.iter_mut());
+
+    for container in containers {
+        let env = container.env.get_or_insert_with(Vec::new);
+        if env
+            .iter()
+            .any(|var| var.name == CONTAINER_RUNTIME_VERSION_ENV)
+        {
+            continue;
+        }
+        env.push(EnvVar {
+            name: CONTAINER_RUNTIME_VERSION_ENV.to_string(),
+            value: Some(version.to_string()),
+            value_from: None,
+        });
+    }
 }
 
 /// Interpret a Job's `.status` into a coarse outcome. Prefers the explicit
@@ -287,12 +334,18 @@ spec:
             block_owner_deletion: Some(false),
         };
 
+        let facts = NodeFacts {
+            name: "node1".to_string(),
+            container_runtime_version: Some("containerd://2.1.5".to_string()),
+        };
+
         let job = build_node_job(
             &template,
             "kata-deploy-install-node1",
             "node1",
             "kata-deploy-install",
             Some(&owner),
+            &facts,
         );
 
         assert_eq!(
@@ -313,6 +366,98 @@ spec:
         assert_eq!(job.metadata.owner_references.unwrap().len(), 1);
         let pod_spec = job.spec.unwrap().template.spec.unwrap();
         assert_eq!(pod_spec.node_name.as_deref(), Some("node1"));
+
+        // The fact has to reach the containers, or they would try to read it from
+        // the apiserver with a token they no longer have.
+        let env = pod_spec.containers[0].env.as_ref().unwrap();
+        assert_eq!(
+            env.iter()
+                .find(|var| var.name == CONTAINER_RUNTIME_VERSION_ENV)
+                .and_then(|var| var.value.clone())
+                .as_deref(),
+            Some("containerd://2.1.5")
+        );
+    }
+
+    /// Nothing is injected for a node whose facts are unknown, so the install
+    /// falls back to looking them up rather than seeing an empty value.
+    #[test]
+    fn unknown_facts_inject_nothing() {
+        let template: Job = serde_yaml::from_str(
+            r#"apiVersion: batch/v1
+kind: Job
+metadata:
+  name: t
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: i
+          image: busybox
+      containers:
+        - name: c
+          image: busybox
+"#,
+        )
+        .unwrap();
+
+        let job = build_node_job(
+            &template,
+            "j",
+            "node1",
+            "owner",
+            None,
+            &NodeFacts::name_only("node1"),
+        );
+
+        let pod_spec = job.spec.unwrap().template.spec.unwrap();
+        assert!(pod_spec.containers[0].env.is_none());
+        assert!(pod_spec.init_containers.unwrap()[0].env.is_none());
+    }
+
+    /// Init containers run the same stages, so they need the fact too.
+    #[test]
+    fn facts_reach_init_containers() {
+        let template: Job = serde_yaml::from_str(
+            r#"apiVersion: batch/v1
+kind: Job
+metadata:
+  name: t
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: host-check
+          image: busybox
+      containers:
+        - name: cri
+          image: busybox
+"#,
+        )
+        .unwrap();
+
+        let facts = NodeFacts {
+            name: "node1".to_string(),
+            container_runtime_version: Some("cri-o://1.31.0".to_string()),
+        };
+        let job = build_node_job(&template, "j", "node1", "owner", None, &facts);
+        let pod_spec = job.spec.unwrap().template.spec.unwrap();
+
+        for env in [
+            pod_spec.init_containers.as_ref().unwrap()[0].env.as_ref(),
+            pod_spec.containers[0].env.as_ref(),
+        ] {
+            let env = env.unwrap();
+            assert_eq!(
+                env.iter()
+                    .find(|var| var.name == CONTAINER_RUNTIME_VERSION_ENV)
+                    .and_then(|var| var.value.clone())
+                    .as_deref(),
+                Some("cri-o://1.31.0")
+            );
+        }
     }
 
     fn job_with_status(status_yaml: &str) -> Job {

--- a/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
@@ -18,6 +18,7 @@
 
 mod job;
 mod node_filter;
+mod nodes;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
@@ -30,8 +31,9 @@ use k8s_openapi::api::core::v1::{Node, Toleration};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{Api, ListParams, PostParams};
 use kube::Client;
-use log::{error, info};
+use log::{error, info, warn};
 use node_filter::{describe_taint, partition_by_tolerations, suggested_toleration, SkippedNode};
+use nodes::{NodeFacts, NodeOps};
 use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
@@ -113,6 +115,48 @@ struct Args {
     #[arg(long)]
     owner_job_name: Option<String>,
 
+    /// Label a node `katacontainers.io/kata-runtime=<value>` once its Job
+    /// succeeded, then lift any --remove-node-taints.
+    ///
+    /// The label is what admits Kata workloads to a node, and setting it from
+    /// here rather than from a final stage inside the per-node Job is what allows
+    /// those Jobs to carry no credentials at all. It also tightens the contract:
+    /// the label goes on only after the Job as a whole succeeded AND the node
+    /// reported Ready again, never from inside a pipeline that might still fail.
+    #[arg(long)]
+    node_label: Option<String>,
+
+    /// Remove `katacontainers.io/kata-runtime` from a node before creating its
+    /// Job, so the scheduler stops sending Kata workloads there before anything on
+    /// the node is taken apart. For cleanup runs.
+    #[arg(long, default_value_t = false)]
+    remove_node_label: bool,
+
+    /// Comma-separated taints to lift after labelling a node, as `key` (any
+    /// effect) or `key:effect`. These are the start-up taints that keep workloads
+    /// off a node until Kata is actually installed on it.
+    #[arg(long)]
+    remove_node_taints: Option<String>,
+
+    /// Seconds to wait for a node to report Ready after its install Job finished,
+    /// before labelling it. 0 disables the wait.
+    ///
+    /// The install restarts the node's CRI runtime, and the Job can only report on
+    /// the runtime's own unit; waiting for the kubelet to report Ready here is
+    /// what keeps a node from being advertised as Kata-capable while it is still
+    /// coming back.
+    #[arg(long, default_value_t = 0)]
+    wait_node_ready_secs: u64,
+
+    /// Warn when a node's kubelet `runtimeRequestTimeout` is below this many
+    /// seconds. 0 disables the check.
+    ///
+    /// Advisory: a timeout well below the time a large image needs can abort
+    /// CreateContainer mid-pull, which is why the chart only asks for this when
+    /// guest pull or image conversion is configured.
+    #[arg(long, default_value_t = 0)]
+    kubelet_timeout_warn_secs: u64,
+
     /// Seconds between status polls.
     #[arg(long, default_value_t = 5)]
     poll_interval_secs: u64,
@@ -146,11 +190,15 @@ async fn main() -> Result<()> {
     let template: Job = serde_yaml::from_str(&template_raw)
         .with_context(|| format!("failed to parse job template {}", args.job_template))?;
 
+    let node_ops = node_ops_from_args(&client, &args)?;
+
     let nodes = resolve_nodes(&client, &args, &template_tolerations(&template)).await?;
     if nodes.is_empty() {
         info!("no target nodes matched the selection; nothing to do");
         return Ok(());
     }
+
+    let facts = collect_node_facts(&node_ops, &nodes).await;
 
     let owner = match args.owner_job_name.as_deref() {
         Some(name) => Some(owner_ref_for_job(&client, &namespace, name).await?),
@@ -174,8 +222,77 @@ async fn main() -> Result<()> {
         &namespace,
         parallelism,
         owner.as_ref(),
+        &node_ops,
+        &facts,
     )
     .await
+}
+
+fn node_ops_from_args(client: &Client, args: &Args) -> Result<NodeOps> {
+    let mut ops = NodeOps::new(client);
+
+    ops.label_value = args.node_label.clone();
+    ops.remove_label = args.remove_node_label;
+    ops.remove_taints = args
+        .remove_node_taints
+        .as_deref()
+        .unwrap_or_default()
+        .split(',')
+        .map(|taint| taint.trim().to_string())
+        .filter(|taint| !taint.is_empty())
+        .collect();
+    if args.wait_node_ready_secs > 0 {
+        ops.wait_ready = Some(Duration::from_secs(args.wait_node_ready_secs));
+    }
+    if args.kubelet_timeout_warn_secs > 0 {
+        ops.kubelet_timeout_warn = Some(Duration::from_secs(args.kubelet_timeout_warn_secs));
+    }
+
+    if !ops.remove_taints.is_empty() && ops.label_value.is_none() {
+        bail!(
+            "--remove-node-taints needs --node-label: a start-up taint may only be lifted once \
+             the node is labelled Kata-capable, otherwise workloads reach it before the label \
+             that is supposed to gate them"
+        );
+    }
+
+    Ok(ops)
+}
+
+/// Nodes resolved from a selector were already listed in full, so their facts are
+/// free; explicitly named nodes (`--nodes`) are fetched here. A node whose facts
+/// cannot be read is not fatal: the Job falls back to looking them up, which is
+/// what it does under the DaemonSet anyway.
+async fn collect_node_facts(ops: &NodeOps, nodes: &[Node]) -> HashMap<String, NodeFacts> {
+    let mut facts = HashMap::new();
+
+    for node in nodes {
+        let Some(name) = node.metadata.name.clone() else {
+            continue;
+        };
+        // A node the selector produced carries its full object; a named one is a
+        // stub holding just the name.
+        let known = node.status.is_some() || node.metadata.labels.is_some();
+        if known {
+            facts.insert(name.clone(), NodeFacts::from_node(node));
+            continue;
+        }
+
+        match ops.get(&name).await {
+            Ok(fetched) => {
+                facts.insert(name.clone(), NodeFacts::from_node(&fetched));
+            }
+            Err(err) => {
+                warn!(
+                    "could not read node {name} to pass its runtime details to the per-node Job \
+                     ({err:#}); the Job will look them up itself"
+                );
+                facts.insert(name.clone(), NodeFacts::name_only(&name));
+            }
+        }
+    }
+
+    facts
 }
 
 /// Resolve the namespace to create Jobs in: explicit flag, then $POD_NAMESPACE,
@@ -238,7 +355,7 @@ async fn resolve_nodes(
     client: &Client,
     args: &Args,
     tolerations: &[Toleration],
-) -> Result<Vec<String>> {
+) -> Result<Vec<Node>> {
     if let Some(list) = args.nodes.as_deref() {
         let mut names: Vec<String> = list
             .split(',')
@@ -247,7 +364,9 @@ async fn resolve_nodes(
             .collect();
         names.sort();
         names.dedup();
-        return Ok(names);
+        // Named nodes are taken at face value - naming a node is unambiguous - so
+        // these are stubs; whatever else is needed about them is fetched later.
+        return Ok(names.into_iter().map(node_stub).collect());
     }
 
     let api: Api<Node> = Api::all(client.clone());
@@ -294,23 +413,57 @@ async fn select_nodes(
     api: &Api<Node>,
     args: &Args,
     tolerations: &[Toleration],
-) -> Result<(Vec<String>, Vec<SkippedNode>)> {
+) -> Result<(Vec<Node>, Vec<SkippedNode>)> {
     let mut matched: Vec<Node> = Vec::new();
     for selector in selector_passes(&args.node_selector) {
         matched.extend(list_nodes(api, args, selector).await?);
     }
 
     if args.ignore_node_taints {
-        let mut names: Vec<String> = matched
-            .iter()
-            .filter_map(|node| node.metadata.name.clone())
-            .collect();
-        names.sort();
-        names.dedup();
-        return Ok((names, Vec::new()));
+        return Ok((dedup_by_name(matched, None), Vec::new()));
     }
 
-    Ok(partition_by_tolerations(&matched, tolerations))
+    let (admitted, skipped) = partition_by_tolerations(&matched, tolerations);
+    Ok((dedup_by_name(matched, Some(&admitted)), skipped))
+}
+
+/// Collapse the per-selector duplicates a union produces, keeping the objects
+/// themselves so the facts they carry can be handed to the per-node Jobs. With
+/// `keep`, only those nodes survive.
+fn dedup_by_name(nodes: Vec<Node>, keep: Option<&[String]>) -> Vec<Node> {
+    let mut seen: Vec<String> = Vec::new();
+    let mut unique: Vec<Node> = Vec::new();
+
+    for node in nodes {
+        let Some(name) = node.metadata.name.clone() else {
+            continue;
+        };
+        if let Some(keep) = keep {
+            if !keep.contains(&name) {
+                continue;
+            }
+        }
+        if seen.contains(&name) {
+            continue;
+        }
+        seen.push(name);
+        unique.push(node);
+    }
+
+    unique.sort_by(|a, b| a.metadata.name.cmp(&b.metadata.name));
+    unique
+}
+
+/// A Node carrying nothing but its name, for nodes named explicitly rather than
+/// selected (and therefore never listed).
+fn node_stub(name: String) -> Node {
+    Node {
+        metadata: kube::core::ObjectMeta {
+            name: Some(name),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
 }
 
 /// Decide what "nothing is eligible" means once we have stopped looking.
@@ -320,7 +473,7 @@ async fn select_nodes(
 /// Nothing matched at all is only a no-op when the caller never asked us to
 /// wait: having waited means nodes were expected, and exiting 0 there would
 /// leave the whole fleet uninstalled with nothing to show for it.
-fn no_eligible_nodes(args: &Args, skipped: &[SkippedNode]) -> Result<Vec<String>> {
+fn no_eligible_nodes(args: &Args, skipped: &[SkippedNode]) -> Result<Vec<Node>> {
     let waited = if args.wait_for_nodes_secs > 0 {
         format!(" after waiting {}s", args.wait_for_nodes_secs)
     } else {
@@ -426,16 +579,28 @@ async fn owner_ref_for_job(client: &Client, namespace: &str, name: &str) -> Resu
 
 /// Create and watch per-node Jobs, keeping at most `parallelism` in flight.
 /// Returns an error listing the nodes whose Jobs failed, if any.
+///
+/// `node_ops` brackets each node's Job with the node-level API work the Job
+/// itself is deliberately not credentialed to do: unlabelling before a cleanup
+/// Job, and - once a Job has actually succeeded - waiting for the node to report
+/// Ready, labelling it Kata-capable and lifting its start-up taints.
+#[allow(clippy::too_many_arguments)]
 async fn run_fanout(
     jobs: &Api<Job>,
     template: &Job,
-    nodes: &[String],
+    nodes: &[Node],
     args: &Args,
     namespace: &str,
     parallelism: usize,
     owner: Option<&OwnerReference>,
+    node_ops: &NodeOps,
+    facts: &HashMap<String, NodeFacts>,
 ) -> Result<()> {
-    let mut queue: VecDeque<&String> = nodes.iter().collect();
+    let names: Vec<String> = nodes
+        .iter()
+        .filter_map(|node| node.metadata.name.clone())
+        .collect();
+    let mut queue: VecDeque<&String> = names.iter().collect();
     // job name -> node name
     let mut in_flight: HashMap<String, String> = HashMap::new();
     let mut succeeded = 0usize;
@@ -454,8 +619,21 @@ async fn run_fanout(
             let Some(node) = queue.pop_front() else {
                 break;
             };
+
+            // A failure here fails the node rather than proceeding: for cleanup
+            // that would mean dismantling Kata on a node still advertising it.
+            if let Err(err) = node_ops.before_dispatch(node).await {
+                error!("node {node}: {err:#}");
+                failed.push(node.clone());
+                continue;
+            }
+
             let name = job_name(&owner_value, node);
-            let node_job = build_node_job(template, &name, node, &owner_value, owner);
+            let node_facts = facts
+                .get(node)
+                .cloned()
+                .unwrap_or_else(|| NodeFacts::name_only(node));
+            let node_job = build_node_job(template, &name, node, &owner_value, owner, &node_facts);
             match jobs.create(&post, &node_job).await {
                 Ok(_) => info!("created job {name} (node {node})"),
                 // A Job with this name already exists (e.g. left over from a
@@ -510,9 +688,18 @@ async fn run_fanout(
             };
             match interpret_status(&j) {
                 JobOutcome::Succeeded => {
-                    succeeded += 1;
                     finished.push(name.clone());
                     info!("node {node}: job {name} succeeded");
+                    // The install is only complete once the node is labelled, so a
+                    // node that cannot be labelled counts as failed even though
+                    // its Job passed - a later run comes back to it.
+                    match node_ops.after_success(node).await {
+                        Ok(()) => succeeded += 1,
+                        Err(err) => {
+                            error!("node {node}: install finished but {err:#}");
+                            failed.push(node.clone());
+                        }
+                    }
                 }
                 JobOutcome::Failed => {
                     failed.push(node.clone());

--- a/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
@@ -1,0 +1,495 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Everything the dispatcher does *to* a node, and everything it reads *from* one
+//! on the per-node Jobs' behalf.
+//!
+//! This exists so the per-node Jobs can run with no ServiceAccount token at all.
+//! They are the privileged, host-mutating half of the install and they run on
+//! every node Kata is installed on, including nodes that also run untrusted
+//! workloads; root there can read any token mounted into a pod on that node. The
+//! dispatcher, by contrast, is one unprivileged pod that an operator can pin to
+//! trusted nodes, so the node-scoped API work belongs here.
+
+use anyhow::{Context, Result};
+use k8s_openapi::api::core::v1::{Node, Taint};
+use kube::api::{Api, GetParams, Patch, PatchParams, Request};
+use kube::Client;
+use log::{info, warn};
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+/// The RuntimeClasses select on this label, so it is the switch that admits Kata
+/// workloads to a node.
+pub const KATA_RUNTIME_LABEL: &str = "katacontainers.io/kata-runtime";
+
+/// The facts about a node that the per-node Job would otherwise have to read from
+/// the apiserver itself.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NodeFacts {
+    pub name: String,
+    /// `.status.nodeInfo.containerRuntimeVersion`, e.g. `containerd://2.1.5-k3s1`.
+    pub container_runtime_version: Option<String>,
+}
+
+impl NodeFacts {
+    pub fn from_node(node: &Node) -> Self {
+        let name = node.metadata.name.clone().unwrap_or_default();
+        let container_runtime_version = node
+            .status
+            .as_ref()
+            .and_then(|status| status.node_info.as_ref())
+            .map(|info| info.container_runtime_version.clone())
+            .filter(|version| !version.is_empty());
+
+        Self {
+            name,
+            container_runtime_version,
+        }
+    }
+
+    /// Reached when a node was named explicitly and the GET for it failed; the
+    /// install is left to look the rest up itself.
+    pub fn name_only(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+/// The node-level work the dispatcher performs around each per-node Job.
+pub struct NodeOps {
+    api: Api<Node>,
+    client: Client,
+    pub label_value: Option<String>,
+    pub remove_label: bool,
+    /// Matchers, each `key` (any effect) or `key:effect`.
+    pub remove_taints: Vec<String>,
+    pub wait_ready: Option<Duration>,
+    pub kubelet_timeout_warn: Option<Duration>,
+}
+
+impl NodeOps {
+    pub fn new(client: &Client) -> Self {
+        Self {
+            api: Api::all(client.clone()),
+            client: client.clone(),
+            label_value: None,
+            remove_label: false,
+            remove_taints: Vec::new(),
+            wait_ready: None,
+            kubelet_timeout_warn: None,
+        }
+    }
+
+    pub async fn get(&self, node: &str) -> Result<Node> {
+        self.api
+            .get(node)
+            .await
+            .with_context(|| format!("failed to get node {node}"))
+    }
+
+    /// Unlabelling first is what makes cleanup safe: the scheduler stops placing
+    /// Kata workloads on the node before anything on it is taken apart.
+    pub async fn before_dispatch(&self, node: &str) -> Result<()> {
+        if self.remove_label {
+            self.set_label(node, None).await?;
+        }
+        if let Some(threshold) = self.kubelet_timeout_warn {
+            self.warn_on_low_kubelet_timeout(node, threshold).await;
+        }
+        Ok(())
+    }
+
+    /// Order matters: the node has to be Ready (its CRI runtime was just
+    /// restarted) before it is advertised as Kata-capable, and the start-up
+    /// taints may only be lifted once that advertisement is in place - they are
+    /// what keeps workloads off the node until then.
+    pub async fn after_success(&self, node: &str) -> Result<()> {
+        let Some(value) = self.label_value.clone() else {
+            return Ok(());
+        };
+
+        if let Some(timeout) = self.wait_ready {
+            self.wait_till_ready(node, timeout).await?;
+        }
+
+        self.set_label(node, Some(&value)).await?;
+        self.verify_label(node, &value).await?;
+        self.lift_taints(node).await;
+
+        Ok(())
+    }
+
+    /// Set (or, with `None`, remove) the Kata runtime label on `node`.
+    async fn set_label(&self, node: &str, value: Option<&str>) -> Result<()> {
+        // A JSON merge patch removes a key by setting it to null; omitting it
+        // would leave it untouched.
+        let patch = match value {
+            Some(value) => json!({"metadata": {"labels": {KATA_RUNTIME_LABEL: value}}}),
+            None => json!({"metadata": {"labels": {KATA_RUNTIME_LABEL: serde_json::Value::Null}}}),
+        };
+
+        self.api
+            .patch(node, &PatchParams::default(), &Patch::Merge(&patch))
+            .await
+            .with_context(|| match value {
+                Some(value) => format!("failed to label node {node} {KATA_RUNTIME_LABEL}={value}"),
+                None => format!("failed to remove label {KATA_RUNTIME_LABEL} from node {node}"),
+            })?;
+
+        match value {
+            Some(value) => info!("node {node}: labelled {KATA_RUNTIME_LABEL}={value}"),
+            None => info!("node {node}: removed label {KATA_RUNTIME_LABEL}"),
+        }
+        Ok(())
+    }
+
+    /// Read the label back, so a silently dropped patch (a mutating webhook, say)
+    /// fails the node instead of leaving it advertised-but-unlabelled.
+    async fn verify_label(&self, node: &str, expected: &str) -> Result<()> {
+        let observed = self
+            .get(node)
+            .await?
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(KATA_RUNTIME_LABEL))
+            .cloned();
+
+        match observed.as_deref() {
+            Some(value) if value == expected => Ok(()),
+            other => anyhow::bail!(
+                "node {node} does not carry {KATA_RUNTIME_LABEL}={expected} after patching it \
+                 (observed: {}); workloads would not be scheduled there",
+                other.unwrap_or("<absent>")
+            ),
+        }
+    }
+
+    /// Best-effort on purpose: the runtime is installed and the node is labelled
+    /// by now, and a taint left in place only keeps workloads away - the safe
+    /// direction - so a failure here warns and leaves a later run to retry rather
+    /// than failing an otherwise complete install.
+    async fn lift_taints(&self, node: &str) {
+        if self.remove_taints.is_empty() {
+            return;
+        }
+
+        match self.try_lift_taints(node).await {
+            Ok(removed) if removed.is_empty() => {
+                info!(
+                    "node {node}: no matching start-up taint to remove ({})",
+                    self.remove_taints.join(", ")
+                );
+            }
+            Ok(removed) => info!(
+                "node {node}: removed start-up taint(s) {}",
+                removed.join(", ")
+            ),
+            Err(err) => warn!(
+                "node {node}: could not remove start-up taint(s) {} ({err:#}). Kata is installed \
+                 and the node is labelled, but workloads will stay off it until the taint goes; \
+                 a later run retries",
+                self.remove_taints.join(", ")
+            ),
+        }
+    }
+
+    async fn try_lift_taints(&self, node: &str) -> Result<Vec<String>> {
+        let current = self
+            .get(node)
+            .await?
+            .spec
+            .and_then(|spec| spec.taints)
+            .unwrap_or_default();
+        if current.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let (retained, removed) = partition_taints(current, &self.remove_taints);
+        if removed.is_empty() {
+            return Ok(removed);
+        }
+
+        // `.spec.taints` is an atomic list server-side, so the retained set
+        // replaces it wholesale.
+        let patch = json!({"spec": {"taints": retained}});
+        self.api
+            .patch(node, &PatchParams::default(), &Patch::Merge(&patch))
+            .await
+            .with_context(|| format!("failed to patch taints on node {node}"))?;
+
+        Ok(removed)
+    }
+
+    /// Wait for the node's Ready condition, which is how we know the CRI runtime
+    /// the install just restarted is serving again.
+    async fn wait_till_ready(&self, node: &str, timeout: Duration) -> Result<()> {
+        let start = Instant::now();
+        let mut announced = false;
+
+        loop {
+            let ready = match self.get(node).await {
+                Ok(n) => node_ready_condition(&n).unwrap_or_else(|| "Unknown".to_string()),
+                Err(err) => {
+                    warn!("node {node}: could not read readiness ({err:#})");
+                    "Unknown".to_string()
+                }
+            };
+
+            if ready == "True" {
+                return Ok(());
+            }
+
+            if start.elapsed() >= timeout {
+                anyhow::bail!(
+                    "node {node} did not become Ready within {}s of its install finishing (last \
+                     seen: {ready}); not labelling it, so workloads are not sent to a node whose \
+                     CRI runtime may still be restarting",
+                    timeout.as_secs()
+                );
+            }
+
+            if !announced {
+                info!(
+                    "node {node}: waiting up to {}s for it to report Ready after the CRI runtime \
+                     restart",
+                    timeout.as_secs()
+                );
+                announced = true;
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+
+    /// Advisory pre-flight: a kubelet `runtimeRequestTimeout` well below the time
+    /// a large image needs can abort `CreateContainer` mid-pull.
+    ///
+    /// Warning-only, and deliberately never fatal - it used to run inside the
+    /// per-node Job, and the only reason it moved here is that it needs the
+    /// apiserver (`nodes/proxy`), which those Jobs no longer have.
+    async fn warn_on_low_kubelet_timeout(&self, node: &str, threshold: Duration) {
+        let timeout = match self.kubelet_runtime_request_timeout(node).await {
+            Ok(Some(value)) => value,
+            Ok(None) => {
+                warn!("node {node}: kubelet /configz did not report runtimeRequestTimeout");
+                return;
+            }
+            Err(err) => {
+                warn!("node {node}: could not read kubelet runtimeRequestTimeout ({err:#})");
+                return;
+            }
+        };
+
+        let parsed = match humantime::parse_duration(&timeout) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warn!(
+                    "node {node}: could not parse kubelet runtimeRequestTimeout {timeout} ({err})"
+                );
+                return;
+            }
+        };
+
+        if parsed < threshold {
+            warn!(
+                "node {node}: kubelet runtimeRequestTimeout is {timeout} ({}s). Pulling a large \
+                 image, or converting one, happens during CreateContainer and can exceed it; \
+                 consider raising it to at least {}s on nodes running Kata",
+                parsed.as_secs(),
+                threshold.as_secs()
+            );
+        } else {
+            info!(
+                "node {node}: kubelet runtimeRequestTimeout is {timeout} ({}s)",
+                parsed.as_secs()
+            );
+        }
+    }
+
+    async fn kubelet_runtime_request_timeout(&self, node: &str) -> Result<Option<String>> {
+        let request = Request::new(format!("/api/v1/nodes/{node}/proxy"))
+            .get("configz", &GetParams::default())?;
+        let configz: serde_json::Value = self
+            .client
+            .request(request)
+            .await
+            .with_context(|| format!("failed to query kubelet /configz for node {node}"))?;
+
+        Ok(configz
+            .get("kubeletconfig")
+            .or_else(|| configz.get("kubeletConfig"))
+            .and_then(|config| config.get("runtimeRequestTimeout"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string))
+    }
+}
+
+/// The node's `Ready` condition status, if it reports one.
+fn node_ready_condition(node: &Node) -> Option<String> {
+    node.status
+        .as_ref()?
+        .conditions
+        .as_ref()?
+        .iter()
+        .find(|condition| condition.type_ == "Ready")
+        .map(|condition| condition.status.clone())
+}
+
+/// Each matcher is `key` (any effect) or `key:effect` (that effect only). A
+/// matcher that matches nothing is not an error: on a re-run the taint is simply
+/// already gone, which is the expected steady state.
+fn partition_taints(taints: Vec<Taint>, matchers: &[String]) -> (Vec<Taint>, Vec<String>) {
+    let parsed: Vec<(&str, Option<&str>)> = matchers
+        .iter()
+        .map(|matcher| match matcher.split_once(':') {
+            Some((key, effect)) => (key.trim(), Some(effect.trim())),
+            None => (matcher.trim(), None),
+        })
+        .filter(|(key, _)| !key.is_empty())
+        .collect();
+
+    let mut retained = Vec::new();
+    let mut removed = Vec::new();
+
+    for taint in taints {
+        let matched = parsed.iter().any(|(key, effect)| {
+            taint.key == *key && effect.map(|e| e == taint.effect).unwrap_or(true)
+        });
+        if matched {
+            removed.push(format!("{}:{}", taint.key, taint.effect));
+        } else {
+            retained.push(taint);
+        }
+    }
+
+    (retained, removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{NodeCondition, NodeStatus, NodeSystemInfo};
+    fn taint(key: &str, effect: &str) -> Taint {
+        Taint {
+            key: key.to_string(),
+            effect: effect.to_string(),
+            value: None,
+            time_added: None,
+        }
+    }
+
+    fn keys(taints: &[Taint]) -> Vec<(String, String)> {
+        taints
+            .iter()
+            .map(|t| (t.key.clone(), t.effect.clone()))
+            .collect()
+    }
+
+    /// A bare key removes the taint whatever its effect; `key:effect` is exact.
+    #[test]
+    fn taint_matchers_respect_the_effect() {
+        let taints = vec![
+            taint("kata/startup", "NoSchedule"),
+            taint("kata/startup", "NoExecute"),
+            taint("other", "NoSchedule"),
+        ];
+
+        let (retained, removed) = partition_taints(taints.clone(), &["kata/startup".to_string()]);
+        assert_eq!(keys(&retained), vec![("other".into(), "NoSchedule".into())]);
+        assert_eq!(removed.len(), 2);
+
+        let (retained, removed) = partition_taints(taints, &["kata/startup:NoExecute".to_string()]);
+        assert_eq!(removed, vec!["kata/startup:NoExecute".to_string()]);
+        assert_eq!(keys(&retained).len(), 2);
+    }
+
+    /// A matcher that matches nothing leaves the taints alone and reports nothing
+    /// removed, so a re-run is a no-op rather than a failure.
+    #[test]
+    fn unmatched_matchers_change_nothing() {
+        let taints = vec![taint("other", "NoSchedule")];
+        let (retained, removed) = partition_taints(taints, &["kata/startup".to_string()]);
+        assert_eq!(keys(&retained), vec![("other".into(), "NoSchedule".into())]);
+        assert!(removed.is_empty());
+    }
+
+    /// The facts handed to a per-node Job come straight off the Node object the
+    /// dispatcher already listed, so no extra API call is needed to collect them.
+    #[test]
+    fn facts_are_read_off_the_node() {
+        let node = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("node-1".to_string()),
+                ..Default::default()
+            },
+            status: Some(NodeStatus {
+                node_info: Some(NodeSystemInfo {
+                    container_runtime_version: "containerd://2.1.5".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let facts = NodeFacts::from_node(&node);
+        assert_eq!(facts.name, "node-1");
+        assert_eq!(
+            facts.container_runtime_version.as_deref(),
+            Some("containerd://2.1.5")
+        );
+    }
+
+    /// A node with no runtime version reported yields no override, so the install
+    /// falls back to looking it up rather than acting on an empty string.
+    #[test]
+    fn missing_facts_are_absent_not_empty() {
+        let node = Node {
+            metadata: kube::core::ObjectMeta {
+                name: Some("node-2".to_string()),
+                ..Default::default()
+            },
+            status: Some(NodeStatus {
+                node_info: Some(NodeSystemInfo {
+                    container_runtime_version: String::new(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let facts = NodeFacts::from_node(&node);
+        assert!(facts.container_runtime_version.is_none());
+    }
+
+    /// Readiness is read from the Ready condition, not from the first condition.
+    #[test]
+    fn ready_condition_is_picked_by_type() {
+        let node = Node {
+            status: Some(NodeStatus {
+                conditions: Some(vec![
+                    NodeCondition {
+                        type_: "MemoryPressure".to_string(),
+                        status: "False".to_string(),
+                        ..Default::default()
+                    },
+                    NodeCondition {
+                        type_: "Ready".to_string(),
+                        status: "True".to_string(),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(node_ready_condition(&node).as_deref(), Some("True"));
+        assert_eq!(node_ready_condition(&Node::default()), None);
+    }
+}


### PR DESCRIPTION
In job mode the per-node Jobs are the privileged half of the install: root on the host, on every node Kata is installed on — including the nodes running the very untrusted workloads Kata exists to isolate.

They were also talking to the apiserver, using the `kata-deploy` ServiceAccount, which can patch any node in the cluster and read any node's kubelet configuration.

Root on a node can read any token mounted into a pod there, so that token was in practice available wherever Kata was installed.

After this PR nothing inside a per-node Job needs the apiserver, and none of them mount a token. The `kata-deploy` ServiceAccount is not created at all in job mode.

The node-level API work moves into the dispatcher: one unprivileged pod that never touches a host and that can be confined to trusted nodes with `job.dispatcherNodeSelector`.

| Pod | Runs on | Host access | API rights |
| --- | --- | --- | --- |
| `kata-deploy` DaemonSet (daemonset mode) | every Kata node, for the life of the release | privileged | patch any node, read any node's kubelet config |
| per-node Job (job mode) | every Kata node, briefly | privileged | **none** — no ServiceAccount, no token |
| dispatcher (job mode) | anywhere, pinnable | none | list/get/patch nodes, own Jobs in the release namespace, `nodes/proxy` only when relevant |

So job mode is no longer "a DaemonSet that exits": it is a strictly smaller blast radius than daemonset mode can offer, which is the point of having it. Job mode is still opt-in (`deploymentMode=job`); daemonset mode is unchanged.

## Behaviour worth knowing about

- New `job.waitNodeReadySeconds` (default 300). A node that does not report Ready again within it fails its own install and stays unlabelled, so workloads are not sent to a node whose CRI runtime may still be restarting; a later run retries it.
- Lifting start-up taints is best-effort on purpose: by then the runtime is installed and the node labelled, and a taint left in place only keeps workloads away, which is the safe direction.
- `nodes/proxy` is granted only when guest pull or image conversion is configured, the only case in which the kubelet timeout warning has anything to say.
- A `k8sDistribution` that disagrees with the node now fails the install where it previously produced a silently misconfigured node.
