### PR TITLE
runtime-rs: Use host CPU model for SNP guests instead of EPYC-v4

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -3290,7 +3290,7 @@ impl<'a> QemuCmdLine<'a> {
             .set_confidential_guest_support("snp")
             .set_nvdimm(false);
 
-        self.cpu.set_type("EPYC-v4");
+        self.cpu.set_type("host");
     }
 
     pub fn add_tdx_protection_device(

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -184,10 +184,16 @@ setup() {
 	# Remove escape backslashes for quotes from output for dm-mod.create parameters
 	append="${append//\\\"/\"}"
 
+	vcpu_family=$(cpuid -1 | grep -oP -- '\(family synth\).*\(\K[^)]+' | head -n 1)
+	vcpu_model=$(cpuid -1 | grep -oP -- '\(model synth\).*\(\K[^)]+' | head -n 1)
+	vcpu_stepping=$(cpuid -1 | grep -oP -- 'stepping id.*\(\K[^)]+' | head -n 1)
+
 	measure_args=(
 		--mode=snp
 		--vcpus="${vcpu_count}"
-		--vcpu-type=EPYC-v4
+		--vcpu-family="${vcpu_family}"
+		--vcpu-model="${vcpu_model}"
+		--vcpu-stepping="${vcpu_stepping}"
 		--output-format=hex
 		--ovmf="${firmware_path}"
 		--kernel="${kernel_path}"


### PR DESCRIPTION
This change removes the hardcoded EPYC-v4 CPU model for AMD SEV-SNP VMs and uses the host CPU model instead.

### Changes

* **runtime-rs:** Change the SNP CPU type from `EPYC-v4` to `host`.
* **Confidential CI:** Update the SNP launch measurement calculation to use the host CPU family, model, and stepping.

Note - There is a separate PR for go runtime changes [PR#13601](https://github.com/kata-containers/kata-containers/pull/13601)

A similar change was previously proposed in [PR #12329](https://github.com/kata-containers/kata-containers/pull/12329). At the time, there were some questions around whether changing the SNP CPU model was necessary, and the change was not merged.

We now have a clearer functional need for this update. On newer AMD processors such as Genoa and Turin, using the hardcoded EPYC-v4 model prevents SNP guests from seeing newer CPU instruction sets, including AVX-512, AVX-VNNI, AVX512-FP16, and related features.

This has a direct impact on workloads that depend on newer processor capabilities. For example, AMD ZenDNN can require newer instruction set support, and restricting the guest CPU model can prevent the library from initializing or using optimized execution paths. Similar limitations can affect other CPU-optimized AI/ML and compute libraries.

### Business Impact

The current hardcoded CPU model limits the capabilities that customers can use from newer AMD EPYC processors inside Kata confidential containers.

As AMD introduces newer processor generations with additional AI/ML and compute-focused instruction sets, SNP guests should be able to take advantage of those capabilities. Keeping the older CPU model can result in reduced performance, unavailable optimized code paths, or functional limitations for workloads designed for newer AMD platforms.

Using the host CPU model removes this restriction and enables Kata confidential workloads to make better use of the capabilities available on current and future AMD processors.

@pmores @ruzickajakub