### PR TITLE
runtime: Use host CPU model for SNP guests instead of EPYC-v4

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -235,18 +235,8 @@ func nestedPCIeBridges(number uint32) []types.Bridge {
 }
 
 func (q *qemuAmd64) cpuModel() string {
-	var err error
-	cpuModel := defaultCPUModel
-
-	// Temporary until QEMU cpu model 'host' supports AMD SEV-SNP
-	protection, err := availableGuestProtection()
-	if err == nil {
-		if protection == snpProtection && q.snpGuest {
-			cpuModel = "EPYC-v4"
-		}
-	}
-
-	return cpuModel
+	// returning the default CPU model for AMD64 architecture, which is "host"
+	return defaultCPUModel
 }
 
 func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {


### PR DESCRIPTION
This change removes the hardcoded EPYC-v4 CPU model for AMD SEV-SNP VMs and uses the host CPU model instead.

### Changes
runtime: Simplified cpuModel() to return defaultCPUModel (host

Note - There is a separate PR for runtime-rs changes [PR#13600](https://github.com/kata-containers/kata-containers/pull/13600). This PR also includes the CI test fix as well. 

A similar change was previously proposed in [PR#12329](https://github.com/kata-containers/kata-containers/pull/12329). At the time, there were some questions around whether changing the SNP CPU model was necessary, and the change was not merged.

We now have a clearer functional need for this update. On newer AMD processors such as Genoa and Turin, using the hardcoded EPYC-v4 model prevents SNP guests from seeing newer CPU instruction sets, including AVX-512, AVX-VNNI, AVX512-FP16, and related features.

This has a direct impact on workloads that depend on newer processor capabilities. For example, AMD ZenDNN can require newer instruction set support, and restricting the guest CPU model can prevent the library from initializing or using optimized execution paths. Similar limitations can affect other CPU-optimized AI/ML and compute libraries.

### Business Impact
The current hardcoded CPU model limits the capabilities that customers can use from newer AMD EPYC processors inside Kata confidential containers.

As AMD introduces newer processor generations with additional AI/ML and compute-focused instruction sets, SNP guests should be able to take advantage of those capabilities. Keeping the older CPU model can result in reduced performance, unavailable optimized code paths, or functional limitations for workloads designed for newer AMD platforms.

Using the host CPU model removes this restriction and enables Kata confidential workloads to make better use of the capabilities available on current and future AMD processors.

@pmores @ruzickajakub