### PR TITLE
kata-deploy: make Nydus cleanup safe to retry

### DIFF
--- a/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
@@ -391,9 +391,12 @@ pub async fn uninstall_nydus_snapshotter(config: &Config) -> Result<()> {
         _ => NYDUS_FOR_KATA_TEE.to_string(),
     };
 
-    utils::host_systemctl(&["disable", "--now", &format!("{nydus_snapshotter}.service")]).await?;
-
-    fs::remove_file(format!("/etc/systemd/system/{nydus_snapshotter}.service")).ok();
+    let service = format!("/etc/systemd/system/{nydus_snapshotter}.service");
+    if Path::new(&service).exists() {
+        utils::host_systemctl(&["disable", "--now", &format!("{nydus_snapshotter}.service")])
+            .await?;
+        fs::remove_file(service).ok();
+    }
     fs::remove_dir_all(format!("{}/{NYDUS_FOR_KATA_TEE}", config.host_install_dir)).ok();
 
     // The nydus data directory (/var/lib/nydus-for-kata-tee) is intentionally preserved.


### PR DESCRIPTION
A partial or retried installation may leave Nydus artifacts without leaving its systemd service behind. Cleanup currently calls `systemctl disable` unconditionally, so that already-clean state becomes an error and prevents the remaining artifacts from being removed.

Treat a missing service file as evidence that the service is already gone. When the file exists, disable the service as before; either way, continue cleaning the installation directory. This makes Nydus cleanup idempotent without changing a normal uninstall.