### PR TITLE
kata-deploy: validate the Kubernetes distribution before configuring CRI

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -123,6 +123,30 @@ found [here](runtime-configuration.md#drop-in-files).
 You can also use the `customRuntimes.runtimes.[name].dropIn` configuration in the helm
 chart to achieve the same results.
 
+### k8sDistribution
+
+Different Kubernetes distributions keep containerd's configuration in different
+places, so the chart needs to be told which one this cluster is. The value picks the
+host directory that gets mounted into the install:
+
+```yaml title="values.yaml"
+k8sDistribution: k8s   # k8s | k3s | rke2 | k0s | microk8s
+```
+
+Any other value means the default location, `/etc/containerd/` — so `kubeadm` and
+`vanilla` are as good as `k8s`. Set `containerd.configDir` instead if your
+containerd matches none of the presets.
+
+!!! warning "A wrong value fails the install rather than misconfiguring the node"
+
+    Which *file* to write is worked out on the node itself, from the CRI runtime
+    actually running there — so declaring `k8s` on a `k3s` cluster used to produce a
+    perfectly good `k3s` configuration inside a directory `k3s` does not read, with
+    nothing to show for it afterwards but a node that never runs a Kata workload.
+    The install now compares the two and stops before writing anything, naming the
+    value to set. An explicit `containerd.configDir` overrides the derivation this
+    check is about, so it does not apply in that case.
+
 ## Deployment Modes (DaemonSet vs Job)
 
 The chart can install Kata on nodes in one of two ways, selected with the

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -137,7 +137,7 @@ Any other value means the default location, `/etc/containerd/` — so `kubeadm` 
 `vanilla` are as good as `k8s`. Set `containerd.configDir` instead if your
 containerd matches none of the presets.
 
-!!! warning "A wrong value fails the install rather than misconfiguring the node"
+!!! warning "A wrong value stops the install before changing the node"
 
     Which *file* to write is worked out on the node itself, from the CRI runtime
     actually running there — so declaring `k8s` on a `k3s` cluster used to produce a

--- a/tests/functional/kata-deploy/kata-deploy-distribution.bats
+++ b/tests/functional/kata-deploy/kata-deploy-distribution.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for k8sDistribution reaching the install. No cluster
+# required.
+#
+# The value picks which host directory is mounted at /etc/containerd, while the
+# install detects the node's CRI runtime itself and picks the file to write inside
+# that mount. The install can only refuse a disagreement between the two if it is
+# told what was declared, so these tests cover that it is.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+render() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@"
+}
+
+@test "Helm template: the declared distribution reaches the install, in both modes" {
+	local mode rendered
+	for mode in job daemonset; do
+		rendered=$(render --set "deploymentMode=${mode}" --set k8sDistribution=k3s)
+
+		echo "${rendered}" | grep -q 'name: K8S_DISTRIBUTION'
+		echo "${rendered}" | grep -A1 'name: K8S_DISTRIBUTION' | grep -q 'value: "k3s"'
+	done
+}
+
+@test "Helm template: pinning the containerd directory takes the check out of the way" {
+	# containerd.configDir overrides the very derivation the install would be
+	# checking, so an operator who set it is taken at their word.
+	local rendered
+	rendered=$(render --set deploymentMode=job \
+		--set 'containerd.configDir=/etc/my-containerd/')
+
+	if echo "${rendered}" | grep -q 'name: K8S_DISTRIBUTION'; then
+		echo "K8S_DISTRIBUTION was passed despite an explicit containerd.configDir" >&2
+		return 1
+	fi
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -24,6 +24,7 @@ else
 		"kata-deploy-lifecycle.bats" \
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \
+		"kata-deploy-distribution.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -2471,6 +2471,7 @@ mod tests {
             erofs_dmverity: false,
             startup_taints: vec![],
             container_runtime_version: None,
+            k8s_distribution: None,
         };
 
         let without_debug = generate_kernel_params_drop_in(&config, "qemu", false).unwrap();

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -236,6 +236,12 @@ pub struct Config {
     /// of the install, and the less they can reach the better. Absent (the
     /// DaemonSet), the value is read from the Node.
     pub container_runtime_version: Option<String>,
+    /// The Kubernetes flavour the chart was configured for (`K8S_DISTRIBUTION`),
+    /// which is what chose the host directory mounted at /etc/containerd.
+    ///
+    /// Absent when the operator pinned that directory themselves, or when this
+    /// process was not started by the chart.
+    pub k8s_distribution: Option<String>,
 }
 
 impl Config {
@@ -436,6 +442,11 @@ impl Config {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        let k8s_distribution = env::var("K8S_DISTRIBUTION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let config = Config {
             node_name,
             debug,
@@ -469,6 +480,7 @@ impl Config {
             erofs_dmverity,
             startup_taints,
             container_runtime_version,
+            k8s_distribution,
         };
 
         // Validate the configuration

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -413,6 +413,8 @@ async fn install_stage_host_check(
         ));
     }
 
+    runtime::validate_declared_distribution(config, runtime)?;
+
     if runtime != "crio" {
         runtime::containerd::containerd_snapshotter_version_check(config).await?;
         runtime::containerd::snapshotter_handler_mapping_validation_check(config)?;

--- a/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/manager.rs
@@ -6,6 +6,7 @@
 use crate::config::Config;
 use crate::utils;
 use anyhow::{Context, Result};
+use log::info;
 use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -48,6 +49,13 @@ pub async fn get_container_runtime(config: &Config) -> Result<String> {
         .resolve_container_runtime_version()
         .await
         .context("Failed to get container runtime version")?;
+
+    // Cleanup is precisely when the service may be failed or inactive. The
+    // generic `containerd://...` version cannot distinguish MicroK8s, but the
+    // chart declaration can, and points at its snap-owned configuration and unit.
+    if declared_runtime_override(config.k8s_distribution.as_deref()) == Some("microk8s") {
+        return Ok("microk8s".to_string());
+    }
 
     // Asked of the host rather than of the `microk8s.io/cluster` node label, so
     // that a pod holding no Kubernetes credentials can still tell: microk8s runs
@@ -92,6 +100,95 @@ pub async fn get_container_runtime(config: &Config) -> Result<String> {
         .to_string();
 
     Ok(runtime)
+}
+
+fn declared_runtime_override(distribution: Option<&str>) -> Option<&'static str> {
+    match distribution {
+        Some("microk8s") => Some("microk8s"),
+        _ => None,
+    }
+}
+
+/// Distributions keeping containerd's configuration somewhere of their own, and
+/// the runtimes each can turn out to be. More than one apiece because a single
+/// Helm value covers a whole cluster while the runtime differs per node role.
+const DISTRIBUTION_RUNTIMES: &[(&str, &[&str])] = &[
+    ("k3s", &["k3s", "k3s-agent"]),
+    ("rke2", &["rke2-server", "rke2-agent"]),
+    ("k0s", &["k0s-controller", "k0s-worker"]),
+    ("microk8s", &["microk8s"]),
+];
+
+/// Runtimes reading their configuration from the default location.
+const VANILLA_RUNTIMES: &[&str] = &["containerd", "crio"];
+
+/// Unrecognised values answer with the vanilla runtimes rather than with nothing,
+/// because that is what the chart does with them: `containerdConfPath` falls
+/// through to /etc/containerd for everything it does not know, so "kubeadm" and
+/// "vanilla" describe the same mount as "k8s" and can be checked just as well.
+fn runtimes_for_distribution(distribution: &str) -> &'static [&'static str] {
+    DISTRIBUTION_RUNTIMES
+        .iter()
+        .find(|(name, _)| *name == distribution)
+        .map(|(_, runtimes)| *runtimes)
+        .unwrap_or(VANILLA_RUNTIMES)
+}
+
+/// The `k8sDistribution` a node running `runtime` should have been declared as,
+/// or `None` when any of the values meaning "vanilla" would have done.
+fn distribution_for_runtime(runtime: &str) -> Option<&'static str> {
+    DISTRIBUTION_RUNTIMES
+        .iter()
+        .find(|(_, runtimes)| runtimes.contains(&runtime))
+        .map(|(name, _)| *name)
+}
+
+/// Refuse to continue when the Kubernetes flavour the chart was configured for is
+/// not the one this node turns out to run.
+///
+/// Neither value corrects the other: the declared one chose which host directory
+/// is mounted at /etc/containerd, while the detected runtime chooses the file
+/// written inside that mount. Disagreeing writes a valid configuration into a
+/// directory this node's CRI runtime never reads, and the install can then go on
+/// to restart the runtime and advertise the node as Kata-capable regardless.
+pub fn validate_declared_distribution(config: &Config, runtime: &str) -> Result<()> {
+    check_declared_distribution(config.k8s_distribution.as_deref(), runtime)
+}
+
+fn check_declared_distribution(declared: Option<&str>, runtime: &str) -> Result<()> {
+    let Some(declared) = declared else {
+        return Ok(());
+    };
+
+    // CRI-O reads /etc/crio, which the chart mounts from the same place whatever
+    // the declared flavour is. There is no directory here for the two values to
+    // disagree about, so a CRI-O node running a distribution that also ships
+    // containerd is not misconfigured, just unusual.
+    if runtime == "crio" {
+        info!(
+            "this node runs CRI-O, whose configuration directory does not depend on \
+             k8sDistribution ({declared:?}); nothing to cross-check"
+        );
+        return Ok(());
+    }
+
+    if runtimes_for_distribution(declared).contains(&runtime) {
+        return Ok(());
+    }
+
+    let advice = match distribution_for_runtime(runtime) {
+        Some(distribution) => format!("set k8sDistribution to {distribution:?}"),
+        // Nothing to name: this runtime keeps its configuration where the chart
+        // already mounts by default, so the declared value is the odd one out.
+        None => "set k8sDistribution to \"k8s\"".to_string(),
+    };
+
+    anyhow::bail!(
+        "this node runs {runtime}, but the chart was configured for k8sDistribution \
+         {declared:?}, so the directory mounted at /etc/containerd is not the one \
+         {runtime} reads its configuration from. Kata would be configured where nothing \
+         looks for it: {advice}, or override containerd.configDir directly."
+    )
 }
 
 /// Returns the systemd unit that runs the node's CRI runtime.
@@ -335,6 +432,15 @@ mod tests {
     use rstest::rstest;
     use tempfile::tempdir;
 
+    #[test]
+    fn declared_microk8s_survives_an_inactive_runtime() {
+        assert_eq!(
+            declared_runtime_override(Some("microk8s")),
+            Some("microk8s")
+        );
+        assert_eq!(declared_runtime_override(Some("k8s")), None);
+    }
+
     // --- snapshot_files ---
     //
     // What install_stage_cri decides on: equal fingerprints across per-node Job
@@ -459,6 +565,60 @@ mod tests {
     #[case::unknown_runtime_falls_back_to_its_own_name("something-else", "something-else.service")]
     fn test_cri_systemd_unit(#[case] runtime: &str, #[case] expected: &str) {
         assert_eq!(cri_systemd_unit(runtime), expected, "runtime: {}", runtime);
+    }
+
+    // --- check_declared_distribution ---
+
+    /// Every runtime a flavour can present as is accepted, since one Helm value
+    /// covers a whole cluster while the runtime differs per node role: declaring
+    /// k3s and finding an agent is right, finding cri-o is not.
+    #[rstest]
+    #[case::vanilla_containerd(Some("k8s"), "containerd", true)]
+    #[case::crio_is_also_vanilla_k8s(Some("k8s"), "crio", true)]
+    #[case::k3s_server(Some("k3s"), "k3s", true)]
+    #[case::k3s_agent(Some("k3s"), "k3s-agent", true)]
+    #[case::rke2_agent(Some("rke2"), "rke2-agent", true)]
+    #[case::k0s_worker(Some("k0s"), "k0s-worker", true)]
+    #[case::microk8s(Some("microk8s"), "microk8s", true)]
+    #[case::k3s_node_left_at_the_default(Some("k8s"), "k3s", false)]
+    #[case::k8s_node_declared_as_k3s(Some("k3s"), "containerd", false)]
+    #[case::k3s_and_rke2_are_not_interchangeable(Some("k3s"), "rke2-agent", false)]
+    // The chart mounts /etc/containerd for any value it does not recognise, so
+    // these mean the same as "k8s" and are held to the same answer.
+    #[case::kubeadm_is_vanilla(Some("kubeadm"), "containerd", true)]
+    #[case::vanilla_on_a_k3s_node(Some("vanilla"), "k3s", false)]
+    // Not started by the chart, so there is nothing to check against.
+    #[case::unset(None, "k3s", true)]
+    fn test_check_declared_distribution(
+        #[case] declared: Option<&str>,
+        #[case] runtime: &str,
+        #[case] accepted: bool,
+    ) {
+        assert_eq!(
+            check_declared_distribution(declared, runtime).is_ok(),
+            accepted,
+            "declared: {declared:?}, runtime: {runtime}"
+        );
+    }
+
+    /// The error has to say which value to change, since the two names differ
+    /// (`k0s-worker` is not a k8sDistribution) and only one of them is a knob.
+    /// CRI-O keeps its configuration in one place, so the flavour cannot put it
+    /// anywhere CRI-O would not look - k0s with CRI-O is a real deployment.
+    #[test]
+    fn crio_is_not_cross_checked_against_the_flavour() {
+        for declared in ["k8s", "k3s", "rke2", "k0s", "microk8s"] {
+            assert!(check_declared_distribution(Some(declared), "crio").is_ok());
+        }
+    }
+
+    #[test]
+    fn a_mismatch_names_the_value_to_set() {
+        let err = check_declared_distribution(Some("k8s"), "k0s-worker")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("k0s-worker"), "{err}");
+        assert!(err.contains(r#"set k8sDistribution to "k0s""#), "{err}");
     }
 
     // --- is_containerd_capable_of_drop_in (pure version) ---

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -684,6 +684,14 @@ e.g. `{{- include "kata-deploy.commonEnv" . | nindent 8 }}`.
 - name: CONTAINERD_CONFIG_FILE_NAME
   value: {{ .Values.containerd.configFileName | trim | quote }}
 {{- end }}
+{{- if not (.Values.containerd.configDir | trim) }}
+{{- /* This value picks the host directory mounted at /etc/containerd, while the
+       install detects the runtime itself and picks the file written within it, so
+       the install needs it to refuse a directory its runtime does not read.
+       Omitted when configDir overrides the derivation being checked. */}}
+- name: K8S_DISTRIBUTION
+  value: {{ .Values.k8sDistribution | quote }}
+{{- end }}
 {{- if .Values.containerd.userDropIn | trim }}
 - name: CONTAINERD_USER_DROP_IN_SOURCE_FILE
   value: "/custom-containerd-config/containerd-user-dropin.toml"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -173,6 +173,15 @@ monitor:
       cpu: 200m
       memory: 300Mi
 
+# Which Kubernetes flavour this cluster runs. It picks the host directory that
+# holds containerd's configuration, which is mounted into the install.
+#
+# Getting it wrong used to pass unnoticed: the install detects the runtime on the
+# node itself, so it would write a correct configuration into whichever directory
+# was mounted - and if that is not the one this node's containerd reads, Kata is
+# configured where nothing looks for it. The install now refuses to continue when
+# the two disagree, naming the value to set. Setting containerd.configDir takes
+# that check out of the way, being an explicit override of this derivation.
 k8sDistribution: "k8s"  # k8s, k3s, rke2, k0s, microk8s
 
 # Containerd configuration overrides


### PR DESCRIPTION
`k8sDistribution` determines which host directory the chart mounts as `/etc/containerd`, while kata-deploy independently detects the runtime and chooses the configuration file to write. If those choices disagree, Kata can write a valid configuration into a directory the runtime never reads.

Pass the chart's distribution choice to kata-deploy and compare it with the detected runtime during the host-check stage, before changing the node. The error identifies the conflicting value instead of allowing an apparently successful installation that never registers Kata with the runtime.

An explicit `containerd.configDir` remains an escape hatch because it replaces the chart's directory derivation. Unknown distribution names are validated as vanilla Kubernetes, matching the chart's existing path fallback.