### PR TITLE
kata-deploy: remove Kubernetes credentials from per-node Jobs

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -161,27 +161,125 @@ top-level `deploymentMode` value:
   pipeline as ordered `initContainers` and then exits:
 
   ```
-  host-check -> artifacts -> cri   (initContainers)  ->  label (main)
+  host-check -> artifacts   (initContainers)  ->  cri (main)
   ```
 
   On `helm uninstall`, a `pre-delete` dispatcher fans out per-node Jobs that run
-  the pipeline in reverse (`unlabel -> revert-cri -> remove-artifacts`). Unlike
+  the pipeline in reverse (`revert-cri -> remove-artifacts`). Unlike
   the DaemonSet, **nothing keeps running on the node after installation
   completes**, and the dispatcher itself only ever talks to the API server — it
   never touches the host (so it ships as a separate, minimal image,
   `job.dispatcherImage`).
 
-  The privilege split is explicit: the dispatcher pod runs **fully unprivileged**
-  (`runAsNonRoot`, all capabilities dropped, no privilege escalation, read-only
-  root filesystem, `RuntimeDefault` seccomp) under a **dedicated minimal
-  ServiceAccount** whose only rights are `nodes: list` (cluster-scoped) and
-  managing Jobs in the release namespace. All privileged, host-mutating work
-  stays in the per-node Jobs, which continue to use the `kata-deploy`
-  ServiceAccount.
+  The privilege split is explicit, and it is what `job` mode buys you over the
+  DaemonSet: **the privileged pods hold no API credentials at all**. Everything
+  that needs the API server is done by the dispatcher, which runs **fully
+  unprivileged** (`runAsNonRoot`, all capabilities dropped, no privilege
+  escalation, read-only root filesystem, `RuntimeDefault` seccomp), never touches
+  the host, and can be confined to nodes you trust.
 
 ```yaml title="values.yaml"
 deploymentMode: job
 ```
+
+#### Where the credentials live
+
+The pods that run on your nodes hold no API credentials at all: the per-node Jobs
+are rendered with `automountServiceAccountToken: false` and no ServiceAccount of
+their own. This matters because root on a node can read the ServiceAccount token
+of any pod running there.
+
+| | runs where | privileged on the host | API rights |
+|---|---|---|---|
+| dispatcher (install, uninstall) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; Jobs in the release namespace; `nodes/proxy: get` only when guest pull or image conversion is configured |
+| per-node Jobs | every node Kata is installed on | yes | **none — no token is mounted** |
+| `post-delete` hook (uninstall only) | one pod, wherever it schedules | no | `delete` on ClusterRoles, ClusterRoleBindings, Roles, RoleBindings and ServiceAccounts |
+| verification Job (only if `verification.pod` is set) | one pod, wherever it schedules | no | pods and pod logs (`create`, `delete`, `get`, `list`, `watch`), `nodes`/`events`/`daemonsets`/`jobs`: `get`, `list` |
+
+The last two rows are the exceptions worth knowing about, and both exist in either
+mode. The `post-delete` hook deletes the RBAC the release keeps, so its own rights
+have to outlive everything else; the verification Job runs the pod you gave it and
+reports what happened. Both are short-lived — one runs during `helm uninstall`, the
+other after `helm install`/`helm upgrade` — but neither is pinned, so for those few
+seconds their tokens can be on any schedulable node. The verification Job is opt-in:
+leave `verification.pod` unset and it does not exist.
+
+Three things need the Kubernetes API, so none of them happen inside a per-node Job:
+
+- **Labelling the node, and everything that gates it.** The dispatcher claims a node
+  with `katacontainers.io/kata-runtime=false` before its Job starts. It promotes the
+  label to `true` only once three things hold: that Job succeeded, the node reports
+  `Ready` again (`job.waitNodeReadySeconds`), and the node's own
+  `.status.runtimeHandlers` confirms its CRI runtime is serving the handlers this
+  release installed. Only then does it lift the configured `startupTaints`. A pod on
+  the node could not offer any of that. The label cannot appear on a node whose
+  pipeline failed half way, nor on one whose runtime quietly ignored the
+  configuration that was written. It survives a kubelet that re-registers after the
+  runtime restart and drops it, because the dispatcher re-applies it until it holds.
+  On uninstall the value drops to `false`, which stops workloads being scheduled,
+  *before* that node's Job starts taking the node apart — and the label itself goes
+  only once that Job has succeeded.
+
+    The claim is best-effort by design: a node that cannot be claimed is still
+    worth installing on, so a failure there is logged and the install proceeds.
+    Uninstall then relies on what the node does carry — see
+    [Choosing which nodes are cleaned up on uninstall](#choosing-which-nodes-are-cleaned-up-on-uninstall).
+
+    The handler check has one limit worth knowing: `.status.runtimeHandlers` is
+    populated by kubelet from Kubernetes 1.30 on. A node that does not report the
+    field at all cannot answer, and is labelled on the strength of its Job
+    succeeding. A node that reports the field without any of this release's handlers
+    in it fails, and an empty list counts the same way: that node has answered, it
+    just has nothing this release installed. One handler is enough to pass, because
+    the release names the handlers for every architecture it can install and a node
+    only serves its own; the ones it does not serve are logged. A release that
+    registers no handler names — every shim disabled and no custom runtime — has
+    nothing to ask about, and skips the check.
+- **The node's container runtime version.** It is the one fact the install cannot
+  work out on the host itself, so the dispatcher reads it from the `Node` objects it
+  has already listed and passes it down as an environment variable. Everything else
+  the install needs to know about its node, the Kubernetes flavour included, it gets
+  by asking the host.
+- **The cluster-scoped objects**: the `RuntimeClass`es and the `NodeFeatureRule`
+  advertising TEE key counts are rendered by the chart (see
+  [TEE key advertisement](#tee-key-advertisement)), so nothing on a node needs
+  write access to them. `helm uninstall` removes them for free.
+
+!!! note "How this compares to `daemonset` mode"
+
+    Installing Kata means writing to the host and restarting the CRI runtime, so
+    something privileged has to run on each node in either mode. Two things differ.
+    The DaemonSet pod carries the `kata-deploy` ServiceAccount, which can patch any
+    node in the cluster and read any node's kubelet configuration, and it stays on
+    the node — token and all — for the life of the release. A per-node Job carries
+    no token and exits when it is done.
+
+    So in `job` mode a compromised worker node yields no cluster credentials, unless
+    the `post-delete` hook or the verification Job happens to be running there at that
+    moment. The component that does hold the node-patching token can be kept on the
+    control plane. In `daemonset` mode that token is, by construction, on every node
+    Kata runs on, for the life of the release.
+
+!!! warning "Switching an existing `daemonset` release to `job` mode"
+
+    The privileged `kata-deploy` ServiceAccount, ClusterRole and ClusterRoleBinding
+    are annotated `helm.sh/resource-policy: keep`, so that a DaemonSet pod being
+    terminated still has the API access its own cleanup needs. `keep` also means
+    Helm leaves them behind on an upgrade that no longer renders them — which is
+    exactly what switching to `job` mode does. The release stops using them, but the
+    credential that can patch any node in the cluster is still there.
+
+    They are cluster-scoped and un-suffixed, so a release in another namespace may
+    share them; the chart cannot safely delete them for you. Once no `daemonset`
+    release is left, remove them by hand:
+
+    ```sh
+    kubectl delete clusterrolebinding kata-deploy-rb
+    kubectl delete clusterrole kata-deploy-role
+    kubectl delete serviceaccount kata-deploy-sa -n <release namespace>
+    ```
+
+    With `env.multiInstallSuffix` set, the names carry that suffix.
 
 #### Why a dispatcher instead of Helm-rendered per-node Jobs
 
@@ -225,17 +323,19 @@ the dispatcher's placement. When `job.dispatcherTolerations` is empty it falls
 back to the top-level `tolerations`, so the dispatcher stays schedulable on a
 cluster whose every node is tainted.
 
-!!! warning "What this does, and what it leaves alone"
+!!! tip "What pinning does and does not cover"
 
-    Pinning moves one credential, not all of them. The per-node Jobs still run
-    under the `kata-deploy` ServiceAccount on every node Kata is installed on,
-    so a worker still hosts a token that can patch nodes and RuntimeClasses.
-    What it takes off those workers is the credential that reaches the *whole*
-    cluster: node enumeration, and the ability to create privileged Jobs
-    anywhere.
+    Pinning the dispatcher keeps the release's one cluster-wide, long-lived
+    identity — the one that can enumerate and patch every node — off your workers.
+    The privileged pods that do run on every node mount no token at all.
 
-    That much is a boundary `daemonset` mode cannot draw at all, since the pod
-    holding its token has to run on every node by definition.
+    It does not pin the two short-lived hooks: the `post-delete` RBAC cleanup and,
+    if you set `verification.pod`, the verification Job (see
+    [Where the credentials live](#where-the-credentials-live)). Both can land on
+    any schedulable node for as long as they run.
+
+    That is still a boundary `daemonset` mode cannot draw, since the pod holding
+    its node-patching token has to run on every node by definition.
 
 ### Adding nodes in `job` mode
 
@@ -263,10 +363,15 @@ What survives the dispatcher dying:
 
 - **Per-node Jobs already created keep running.** They are independent,
   `nodeName`-pinned Jobs, not children of the dispatcher pod, so installs that
-  were already dispatched run to completion and those nodes get labeled. Only
-  nodes still queued (never dispatched) are skipped, so at worst you get
-  *partial coverage* — never a half-mutated host, because each stage is
-  idempotent.
+  were already dispatched run to completion. Only nodes still queued (never
+  dispatched) are skipped, so at worst you get *partial coverage* — never a
+  half-mutated host, because each stage is idempotent.
+- **Those nodes are not labelled**, though. Labelling is the dispatcher's job (it
+  is what lets the per-node Jobs run without a token), so a node whose install
+  finished after the dispatcher died is left installed but not advertised, and no
+  Kata workload is scheduled there. It still carries
+  `katacontainers.io/kata-runtime=false` from being claimed, so `helm uninstall`
+  reaches it, and the re-run below labels it.
 - Those per-node Jobs carry a (non-controller) `ownerReference` to the dispatcher
   Job, so they survive *pod* deletion but are garbage-collected once the
   dispatcher **Job** itself is removed or its `job.ttlSecondsAfterFinished`
@@ -372,6 +477,12 @@ with no eligible node. Failing is deliberate: in `job` mode an empty selection
 is permanent — nothing installs the node later — so a silent success would leave
 the fleet without Kata and nothing to point at.
 
+Finding one eligible node is not the end of the wait either. Eligibility arrives
+per node, so the dispatcher keeps looking until a whole pass adds nothing new
+(or the wait expires) — otherwise it would install on whichever node was labelled
+first and quietly leave the rest of the fleet out. This costs one extra poll on a
+cluster where every node is eligible from the start.
+
 ```yaml title="values.yaml"
 job:
   # Give a slow-labelling cluster longer (see the timeout warning below)...
@@ -392,6 +503,25 @@ job:
 
 The uninstall dispatcher never waits: it has to run to completion on a release
 that may never have labeled a node.
+
+#### Bounding a node that never finishes
+
+The dispatcher waits for every node it dispatched to, so one host wedged on
+something it cannot finish — a CRI restart that never returns, a hung mount —
+would otherwise hold up the whole rollout until Helm's own timeout fired. Two
+knobs bound that:
+
+```yaml title="values.yaml"
+job:
+  # Kubernetes fails a per-node Job that runs longer than this, and the
+  # dispatcher reports that node as failed and carries on with the others.
+  activeDeadlineSeconds: 3600
+  # How long a finished per-node Job is kept. The dispatcher reads each Job's
+  # result by polling it, so a Job collected before its next poll leaves its node
+  # with no result at all - which reads as a failure. The chart refuses anything
+  # below 60.
+  ttlSecondsAfterFinished: 600
+```
 
 #### Installing on control-plane nodes
 
@@ -448,12 +578,30 @@ cleanup selector can simply be "nodes carrying the
 touched, regardless of how the install selector has drifted since.
 
 The selector matches the label's *key*, not the value `"true"`, and that is
-deliberate. An install claims its node with `katacontainers.io/kata-runtime=false`
-before it writes anything to it, and only promotes it to `"true"` once the node
-is kata-capable. Uninstall therefore also reaches nodes where the install failed
-part way through — the ones most likely to have artifacts or CRI configuration
-left on them. Nothing schedules onto a claimed node in the meantime, since the
-RuntimeClasses select the exact value `"true"`.
+deliberate. A node is claimed with `katacontainers.io/kata-runtime=false` before
+anything is written to it — by the dispatcher in `job` mode, before it even creates
+that node's Job — and only promoted to `"true"` once the node is kata-capable.
+Uninstall therefore also reaches nodes where the install failed part way through —
+the ones most likely to have artifacts or CRI configuration left on them. Nothing
+schedules onto a claimed node in the meantime, since the RuntimeClasses select the
+exact value `"true"`. For the same reason an uninstall demotes the label to
+`"false"` rather than removing it, and removes it only once that node's cleanup Job
+has succeeded: a cleanup that fails is still a node the next `helm uninstall` can
+find.
+
+!!! warning "Claiming is best-effort, so this is not a guarantee"
+
+    A node whose claim could not be written (a rejected patch, an API server that
+    was unreachable at that moment) carries no label, and the default selector
+    cannot see it. If an install failed and you are unsure whether every node was
+    reached, name the nodes explicitly under `job.cleanup.nodes`, or widen the
+    selector to the nodes the install targeted.
+
+Cleanup pods also tolerate **every** taint, unlike the install's, which carry the
+`tolerations` you configured. Where an install may run is your decision; where an
+uninstall must run is decided by what is already on the node. A `NoExecute` taint
+added since the install would otherwise evict the cleanup pod from a node that has
+Kata on it, and nothing would come back for it.
 
 Override it under `job.cleanup` (`cleanup.nodes`, then `cleanup.nodeSelector`
 ANDed with `cleanup.nodeAffinity`, else all nodes):

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -782,3 +782,39 @@ no manual `runtimeClass.nodeSelector` is set for that shim.
 **Note**: NFD detection requires cluster access. During `helm template` (dry-run without a
 cluster), external NFD is not seen, so auto-injected labels are not added. Manual
 `runtimeClass.nodeSelector` values are still applied in all cases.
+
+## TEE key advertisement
+
+A confidential VM consumes a *hardware key slot* — an encrypted-state ID on AMD
+SEV-SNP, a key ID on Intel TDX — and a node has a small, fixed number of them. The chart models that
+as an extended resource so the scheduler stops placing confidential pods on a node
+whose slots are all taken, instead of letting the VM fail to start:
+
+- a `NodeFeatureRule` tells node-feature-discovery to advertise the per-node counts
+  as `sev-snp.amd.com/esids` and `tdx.intel.com/keys`
+- the matching `RuntimeClass`es request one of them in `overhead.podFixed`, so every
+  pod that uses the class consumes a slot
+
+Both halves are one switch, because requesting a resource nothing advertises would
+leave confidential pods `Pending` forever:
+
+```yaml title="values.yaml"
+nodeFeatureRules:
+  create: auto   # auto | true | false
+```
+
+`auto` renders them when NFD is in the picture: installed by this chart
+(`node-feature-discovery.enabled=true`), already present in the cluster, or its CRD
+is registered. `true` and `false` decide outright.
+
+`false` turns off **both** halves: no rule, and no confidential `RuntimeClass` asks
+for a TEE key. It is the escape hatch for a cluster that wants no part of this — not
+the way to keep the requests while managing the rule elsewhere. If you create an
+equivalent rule yourself, leave this at `auto` (or set it to `true`) so the requests
+are still rendered, and delete the chart's rule if it duplicates yours.
+
+!!! note "Naming, and a rule you may have to delete by hand"
+    The chart's rule is named `kata-tee-keys`, suffixed with
+    `env.multiInstallSuffix` when that is set. A rule called `amd64-tee-keys`
+    belongs to a release that has not been upgraded yet, and can be deleted once
+    every release has been.

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -138,13 +138,13 @@ containerd matches none of the presets.
 
 !!! warning "A wrong value stops the install before changing the node"
 
-    Which *file* to write is worked out on the node itself, from the CRI runtime
-    actually running there — so declaring `k8s` on a `k3s` cluster used to produce a
-    perfectly good `k3s` configuration inside a directory `k3s` does not read, with
-    nothing to show for it afterwards but a node that never runs a Kata workload.
-    The install now compares the two and stops before writing anything, naming the
-    value to set. An explicit `containerd.configDir` overrides the derivation this
-    check is about, so it does not apply in that case.
+    This value picks the *directory*, while which *file* to write is worked out on
+    the node itself, from the CRI runtime actually running there. Declaring `k8s` on
+    a `k3s` cluster therefore describes a perfectly good `k3s` configuration inside a
+    directory `k3s` does not read — a node that never runs a Kata workload, with
+    nothing to show for it. The install compares the two and stops before writing
+    anything, naming the value to set. An explicit `containerd.configDir` overrides
+    the derivation this check is about, so it does not apply in that case.
 
 ## Deployment Modes (DaemonSet vs Job)
 

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -1,0 +1,323 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for who holds which credentials. No cluster required.
+#
+# Job mode's claim is that the privileged pods, the ones running as root on every
+# node Kata is installed on, hold no API credentials at all. The claim is only
+# worth as much as the rendered manifests, and it is easy to undo by accident:
+# adding a ServiceAccount to a per-node Job, or bringing back a stage that talks
+# to the apiserver, would both look harmless in review.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+# Render one template of the chart in job mode.
+render_job_mode() {
+	local template="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		--set deploymentMode=job \
+		--show-only "templates/${template}" \
+		"$@"
+}
+
+# The per-node Job templates the dispatcher reads, as one YAML stream.
+per_node_jobs() {
+	render_job_mode kata-deploy-job-templates.yaml "$@"
+}
+
+# Assert that rendered output does NOT contain a pattern. Not `! grep`: set -e
+# ignores its status, so anywhere but the last line of a test it could never fail
+# one.
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
+# The pod spec of one stage's per-node Job template, as it sits inside the
+# job-templates ConfigMap.
+#
+# Grepping the whole ConfigMap cannot tell a pod-level key from a container-level
+# one, and that is precisely the difference between a pod with a token and a pod
+# without one.
+per_node_pod_spec() {
+	local stage="${1}"
+	shift
+	per_node_jobs "$@" | awk -v stage="${stage}" '
+		$0 == "  " stage "-job.yaml: |" { inside = 1; next }
+		inside && /^  [^ ]/ { inside = 0 }
+		inside && $0 == "        spec:" { pod = 1; next }
+		pod && /^        [^ ]/ { pod = 0 }
+		pod { print }
+	'
+}
+
+# One YAML document out of a rendered multi-document template, picked by name, so
+# that a test can assert what a single ClusterRole grants rather than counting
+# substrings across every document at once.
+rbac_doc() {
+	local rendered="${1}" name="${2}"
+	echo "${rendered}" | awk -v want="  name: ${name}" '
+		/^---$/ { if (found) { printf "%s", doc; exit } doc = ""; found = 0; next }
+		{ doc = doc $0 "\n"; if ($0 == want) found = 1 }
+		END { if (found) printf "%s", doc }
+	'
+}
+
+@test "Helm template (job mode): the pods that run on every node carry no token" {
+	local jobs
+	jobs=$(per_node_jobs)
+
+	# Root on the node can read whatever these pods mount, and they are privileged
+	# on purpose, so there is deliberately nothing to read.
+	refute_match "${jobs}" 'serviceAccountName'
+
+	# Kubernetes mounts the namespace's default token unless told not to, so
+	# omitting serviceAccountName is not enough on its own. The key only counts
+	# where kubelet reads it, in each stage's pod spec.
+	local stage pod_spec
+	for stage in install cleanup; do
+		pod_spec=$(per_node_pod_spec "${stage}")
+		[[ -n "${pod_spec}" ]]
+		echo "${pod_spec}" | grep -qE '^          automountServiceAccountToken: false$'
+	done
+}
+
+@test "Helm template (job mode): nothing can keep a cleanup pod off a node" {
+	# Pinning by name gets these pods past the scheduler, but a NoExecute taint
+	# added since the install would evict a bound pod all the same, leaving the
+	# node modified and out of reach. Hence one entry and nothing narrowing it: a
+	# key or an effect would leave some taint untolerated.
+	local cleanup_spec install_spec
+	cleanup_spec=$(per_node_pod_spec cleanup)
+	[[ "$(echo "${cleanup_spec}" | tolerations_of)" == "operator: Exists" ]]
+
+	# The install is the opposite case: where it may land is the operator's call,
+	# so its tolerations are theirs and none of them is a catch-all.
+	install_spec=$(per_node_pod_spec install --set 'tolerations[0].key=kata' \
+		--set 'tolerations[0].operator=Exists')
+	echo "${install_spec}" | tolerations_of | grep 'key: kata' | grep -q 'operator: Exists'
+	refute_match "$(echo "${install_spec}" | tolerations_of)" '^operator: Exists$'
+}
+
+@test "Helm template (job mode): no stage inside a per-node Job talks to the apiserver" {
+	local jobs
+	jobs=$(per_node_jobs)
+
+	# The label and unlabel stages were the ones using the apiserver. Bringing
+	# either back here would mean mounting a token again.
+	refute_match "${jobs}" 'install-stage-label'
+	refute_match "${jobs}" 'cleanup-stage-unlabel'
+
+	# The stages that are left, in order. Install ends with the CRI restart, which
+	# is why it is the main container rather than an init container.
+	echo "${jobs}" | grep -q 'install-stage-host-check'
+	echo "${jobs}" | grep -q 'install-stage-artifacts'
+	echo "${jobs}" | grep -q 'install-stage-cri'
+	echo "${jobs}" | grep -q 'cleanup-stage-revert-cri'
+	echo "${jobs}" | grep -q 'cleanup-stage-remove-artifacts'
+}
+
+@test "Helm template (job mode): the privileged ServiceAccount is not created at all" {
+	local rbac
+	rbac=$(render_job_mode kata-rbac.yaml)
+
+	# kata-deploy-sa can patch any node in the cluster and read any node's kubelet
+	# configuration. In job mode nothing needs it, so it does not exist.
+	refute_match "${rbac}" 'name: kata-deploy-sa$'
+	refute_match "${rbac}" 'name: kata-deploy-role$'
+	refute_match "${rbac}" 'name: kata-deploy-rb$'
+
+	# Daemonset mode still needs it: that pod does the node-level work itself.
+	local ds_rbac
+	ds_rbac=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--show-only templates/kata-rbac.yaml)
+	echo "${ds_rbac}" | grep -qE 'name: kata-deploy-sa$'
+}
+
+@test "Helm template (job mode): the dispatcher does the node-level work" {
+	local install cleanup
+	install=$(render_job_mode kata-deploy-install-job.yaml \
+		--set 'startupTaints[0]=kata/installing:NoSchedule')
+	cleanup=$(render_job_mode kata-deploy-cleanup-job.yaml)
+
+	# Labelling last, and only once the node is Ready again: the install restarts
+	# the node's CRI runtime, and the label is what admits workloads.
+	echo "${install}" | grep -q -- '--node-label=true'
+	echo "${install}" | grep -q -- '--wait-node-ready-secs=300'
+	echo "${install}" | grep -q -- '--remove-node-taints=kata/installing:NoSchedule'
+
+	# Claimed before its Job starts, so an install that dies half way still leaves
+	# a node an uninstall can find.
+	echo "${install}" | grep -q -- '--claim-node-pending'
+
+	# Cleanup goes the other way: unlabel before the node is taken apart.
+	echo "${cleanup}" | grep -q -- '--remove-node-label'
+	refute_match "${cleanup}" '--node-label='
+	refute_match "${cleanup}" '--claim-node-pending'
+	refute_match "${cleanup}" '--require-node-handlers'
+}
+
+@test "Helm template (job mode): the dispatcher requires the handlers this release installs" {
+	# The names must be the ones the chart registers RuntimeClasses for: waiting on
+	# a handler no node will ever report fails every node.
+	local suffix_args install flag_handlers rc_handlers
+	for suffix_args in "" "--set env.multiInstallSuffix=dev"; do
+		# shellcheck disable=SC2086
+		install=$(render_job_mode kata-deploy-install-job.yaml ${suffix_args})
+		flag_handlers=$(echo "${install}" |
+			grep -o -- '--require-node-handlers=[^"]*' |
+			sed 's/--require-node-handlers=//' | tr ',' '\n' | sort -u)
+		[[ -n "${flag_handlers}" ]]
+
+		# shellcheck disable=SC2086
+		rc_handlers=$(helm template kata-deploy "${CHART_PATH}" \
+			--set deploymentMode=job ${suffix_args} \
+			--show-only templates/runtimeclasses.yaml |
+			awk '/^handler: /{print $2}' | sort -u)
+
+		[[ "${flag_handlers}" == "${rc_handlers}" ]]
+	done
+
+	# Custom runtimes are checked too, from the RuntimeClasses the user supplied.
+	# Otherwise these nodes would be labelled on a stage's exit code alone.
+	local values_file custom custom_flag custom_rc
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+shims:
+  disableAll: true
+snapshotter:
+  setup: null
+customRuntimes:
+  enabled: true
+  runtimes:
+    my-gpu-runtime:
+      baseConfig: "qemu"
+      runtimeClass: |
+        kind: RuntimeClass
+        apiVersion: node.k8s.io/v1
+        metadata:
+          name: kata-my-gpu-runtime
+        handler: kata-my-gpu-runtime
+EOF
+
+	custom=$(render_job_mode kata-deploy-install-job.yaml -f "${values_file}")
+	custom_flag=$(echo "${custom}" |
+		grep -o -- '--require-node-handlers=[^"]*' |
+		sed 's/--require-node-handlers=//' | tr ',' '\n' | sort -u)
+	custom_rc=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job -f "${values_file}" \
+		--show-only templates/custom-runtimes.yaml |
+		awk '/^handler: /{print $2}' | sort -u)
+
+	[[ "${custom_flag}" == "kata-my-gpu-runtime" ]]
+	[[ "${custom_flag}" == "${custom_rc}" ]]
+	rm -f "${values_file}"
+}
+
+@test "Helm template (job mode): the dispatcher may patch nodes, and nothing else may" {
+	local rbac noderole
+	rbac=$(render_job_mode kata-rbac.yaml)
+
+	# Read that one document rather than the whole file, or a rule that drifted
+	# into another role would still match.
+	noderole=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-noderole')
+	[[ -n "${noderole}" ]]
+	echo "${noderole}" | grep -q 'resources: \["nodes"\]'
+	echo "${noderole}" | grep -q 'verbs: \["list", "get", "patch"\]'
+
+	# Nothing beyond nodes and their kubelet proxy, and no verb that could delete
+	# or create one.
+	refute_match "${noderole}" 'pods'
+	refute_match "${noderole}" '"delete"'
+	refute_match "${noderole}" '"create"'
+	[[ "$(echo "${rbac}" | grep -c 'resources: \["nodes"\]')" -eq 1 ]]
+
+	# Per-node Jobs are created and deleted, since a Job left by an earlier run has
+	# to be replaced rather than adopted, but only in one namespace.
+	local role
+	role=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-role')
+	[[ -n "${role}" ]]
+	echo "${role}" | grep -q 'resources: \["jobs"\]'
+	echo "${role}" | grep -q 'verbs: \["create", "get", "delete"\]'
+	echo "${role}" | grep -q '^kind: Role$'
+}
+
+@test "Helm template (job mode): kubelet config is only read when it matters" {
+	local rbac install
+	rbac=$(render_job_mode kata-rbac.yaml)
+	install=$(render_job_mode kata-deploy-install-job.yaml)
+
+	# The default enables the confidential shims, which pull images inside
+	# CreateContainer - the one thing slow enough to hit runtimeRequestTimeout.
+	echo "${rbac}" | grep -q 'resources: \["nodes/proxy"\]'
+	echo "${install}" | grep -q -- '--kubelet-timeout-warn-secs=600'
+
+	# Without guest pull or image conversion there is nothing to warn about, so the
+	# right to read any node's kubelet configuration is not asked for.
+	local plain_rbac plain_install
+	plain_rbac=$(render_job_mode kata-rbac.yaml \
+		--set shims.disableAll=true \
+		--set shims.qemu.enabled=true \
+		--set snapshotter.setup=null)
+	plain_install=$(render_job_mode kata-deploy-install-job.yaml \
+		--set shims.disableAll=true \
+		--set shims.qemu.enabled=true \
+		--set snapshotter.setup=null)
+
+	refute_match "${plain_rbac}" 'nodes/proxy'
+	refute_match "${plain_install}" '--kubelet-timeout-warn-secs'
+
+	# A custom runtime asking for guest pull brings it back. Worth its own case:
+	# customRuntimes.runtimes is a map, not a list, so the check that walks it is
+	# easy to write in a way that silently matches nothing.
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+shims:
+  disableAll: true
+  qemu:
+    enabled: true
+snapshotter:
+  setup: null
+customRuntimes:
+  enabled: true
+  runtimes:
+    guest-pulling-workload:
+      baseConfig: "qemu"
+      crio:
+        pullType: "guest-pull"
+EOF
+
+	render_job_mode kata-deploy-install-job.yaml -f "${values_file}" |
+		grep -q -- '--kubelet-timeout-warn-secs=600'
+	render_job_mode kata-rbac.yaml -f "${values_file}" | grep -q 'nodes/proxy'
+	rm -f "${values_file}"
+}
+
+@test "Helm template: neither mode grants the cluster-scoped rights the install shed" {
+	# Advertising TEE keys and adjusting RuntimeClass overhead is the chart's job,
+	# so no pod needs to write these any more, in either mode.
+	local mode rbac
+	for mode in job daemonset; do
+		rbac=$(helm template kata-deploy "${CHART_PATH}" \
+			--set "deploymentMode=${mode}" \
+			--show-only templates/kata-rbac.yaml)
+
+		refute_match "${rbac}" 'nodefeaturerules'
+		refute_match "${rbac}" 'runtimeclasses'
+		refute_match "${rbac}" 'customresourcedefinitions'
+	done
+}

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -830,3 +830,23 @@ EOF
 	echo "${rendered}" | grep -q 'tolerations:'
 	echo "${rendered}" | grep -q 'operator: Exists'
 }
+
+@test "Helm template (job mode): a per-node Job cannot run forever" {
+	# The dispatcher waits for every node it dispatched to, so one host wedged on a
+	# restart that never returns would hold up the whole rollout.
+	render_job_templates
+
+	local install
+	install=$(extract_pernode_job install)
+	echo "${install}" | grep -q "activeDeadlineSeconds: 3600"
+}
+
+@test "Helm template (job mode): a Job TTL the dispatcher could not observe is refused" {
+	# A Job deleted before the next poll leaves its node with no result, and that
+	# counts as a failure: an install that worked, reported as broken.
+	run helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set job.ttlSecondsAfterFinished=30
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q "too short for the dispatcher to observe"
+}

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -628,10 +628,30 @@ EOF
 
 	# Load-bearing: the dispatcher decides which tainted nodes are eligible by
 	# reading the tolerations out of this very template, so dropping them here
-	# would silently skip every tainted node.
-	echo "${install}" | grep -q "key: node-role.kubernetes.io/control-plane"
-	echo "${install}" | grep -q "operator: Exists"
-	echo "${cleanup}" | grep -q "key: node-role.kubernetes.io/control-plane"
+	# would silently skip every tainted node. Asserted as whole entries, since a
+	# key on one line says nothing about the operator on another.
+	echo "${install}" | tolerations_of |
+		grep "key: node-role.kubernetes.io/control-plane" | grep -q "operator: Exists"
+
+	# Cleanup tolerates everything instead: a taint added after the install must
+	# not leave a node with Kata on it that no uninstall can reach. A key or an
+	# effect on that entry would narrow it back down.
+	[[ "$(echo "${cleanup}" | tolerations_of)" == "operator: Exists" ]]
+}
+
+@test "Helm template (job mode): install Jobs tolerate what a DaemonSet pod tolerates" {
+	# The DaemonSet controller adds these to its own pods, and job mode installs on
+	# the same nodes. not-ready matters most: the install restarts the CRI runtime,
+	# which takes the node NotReady long enough for the taint manager to evict a pod
+	# that does not tolerate it.
+	render_job_templates
+
+	local install taint
+	install=$(extract_pernode_job install)
+
+	for taint in not-ready unreachable disk-pressure memory-pressure pid-pressure unschedulable; do
+		echo "${install}" | grep -q "key: node.kubernetes.io/${taint}"
+	done
 }
 
 @test "Helm template (job mode): uninstall targets labeled nodes and ignores taints" {

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -15,6 +15,40 @@
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-kata-deploy}"
 HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
 
+# The tolerations of a rendered pod spec, one entry per line, its fields joined
+# by "; " in the order they were rendered.
+#
+# Grepping for a single field cannot say which entry that field belongs to, and
+# the difference matters here: a bare `operator: Exists` tolerates every taint,
+# while the same operator next to a key tolerates exactly one.
+tolerations_of() {
+	awk '
+		!inside && /^[[:space:]]*tolerations:[[:space:]]*$/ {
+			match($0, /^[[:space:]]*/)
+			indent = RLENGTH
+			inside = 1
+			next
+		}
+		inside && /^[[:space:]]*$/ { next }
+		inside {
+			match($0, /^[[:space:]]*/)
+			if (RLENGTH <= indent) {
+				if (entry != "") { print entry; entry = "" }
+				inside = 0
+				next
+			}
+			field = substr($0, RLENGTH + 1)
+			if (sub(/^- /, "", field)) {
+				if (entry != "") print entry
+				entry = field
+			} else {
+				entry = entry "; " field
+			}
+		}
+		END { if (entry != "") print entry }
+	'
+}
+
 # Get the path to the helm chart
 get_chart_path() {
 	local script_dir

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -25,6 +25,7 @@ else
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \
 		"kata-deploy-distribution.bats" \
+		"kata-deploy-privileges.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -72,15 +72,6 @@ enum Action {
     /// runtime, and wait for node readiness.
     #[clap(name = "install-stage-cri")]
     InstallStageCri,
-    /// Stage 3 of a staged (JobSet) install: apply the kata-runtime node label.
-    /// Unprivileged, Kubernetes API only.
-    #[clap(name = "install-stage-label")]
-    InstallStageLabel,
-    /// Cleanup stage 1 of a staged (JobSet) uninstall: remove the kata-runtime
-    /// node label first so the scheduler stops placing kata workloads here.
-    /// Unprivileged, Kubernetes API only.
-    #[clap(name = "cleanup-stage-unlabel")]
-    CleanupStageUnlabel,
     /// Cleanup stage 2 of a staged (JobSet) uninstall: remove CRI drop-ins,
     /// restart the runtime, and wait for readiness.
     #[clap(name = "cleanup-stage-revert-cri")]
@@ -158,8 +149,6 @@ async fn main() -> Result<()> {
         Action::InstallStageHostCheck => "install-stage-host-check",
         Action::InstallStageArtifacts => "install-stage-artifacts",
         Action::InstallStageCri => "install-stage-cri",
-        Action::InstallStageLabel => "install-stage-label",
-        Action::CleanupStageUnlabel => "cleanup-stage-unlabel",
         Action::CleanupStageRevertCri => "cleanup-stage-revert-cri",
         Action::CleanupStageRemoveArtifacts => "cleanup-stage-remove-artifacts",
         Action::InternalPostInstallWait => "internal-post-install-wait",
@@ -309,25 +298,15 @@ async fn main() -> Result<()> {
             info!("Install host-check stage completed, exiting");
         }
         Action::InstallStageArtifacts => {
-            install_stage_artifacts(&config, &runtime).await?;
+            install_stage_artifacts(&config, &runtime, true).await?;
             info!("Install artifacts stage completed, exiting");
         }
         Action::InstallStageCri => {
             install_stage_cri(&config, &runtime, true).await?;
             info!("Install CRI stage completed, exiting");
         }
-        Action::InstallStageLabel => {
-            install_stage_label(&config).await?;
-            info!("Install label stage completed, exiting");
-        }
-        // Staged (JobSet) cleanup actions. These run in reverse order
-        // (unlabel -> revert-cri -> remove-artifacts) and, unlike the DaemonSet
-        // `cleanup` above, do not perform DaemonSet-presence gating: the JobSet
-        // workflow only schedules these when an uninstall is actually intended.
-        Action::CleanupStageUnlabel => {
-            cleanup_stage_unlabel(&config).await?;
-            info!("Cleanup unlabel stage completed, exiting");
-        }
+        // No DaemonSet check here, unlike `cleanup` above: these stages only run
+        // when an uninstall is what the dispatcher was asked for.
         Action::CleanupStageRevertCri => {
             cleanup_stage_revert_cri(&config, &runtime, true).await?;
             info!("Cleanup revert-cri stage completed, exiting");
@@ -371,7 +350,7 @@ async fn install(config: &config::Config, runtime: &str) -> Result<()> {
     info!("Installing Kata Containers");
 
     install_stage_host_check(config, runtime, false).await?;
-    install_stage_artifacts(config, runtime).await?;
+    install_stage_artifacts(config, runtime, false).await?;
     install_stage_cri(config, runtime, false).await?;
     install_stage_label(config).await?;
 
@@ -772,19 +751,14 @@ fn mapping_contains_value(mapping: Option<&str>, expected_value: &str) -> bool {
     })
 }
 
-/// Mark the node as one kata-deploy has started installing on, before anything
-/// is written to it.
+/// Mark the node before anything is written to it, so `helm uninstall` can find a
+/// node whose install died half-way: it cleans every node that carries the
+/// kata-runtime label, whatever the value. The value is not `true`, because
+/// RuntimeClasses select that exact value.
 ///
-/// `helm uninstall` cleans the nodes carrying the kata-runtime label, whatever
-/// its value, so a node labelled only once the install *finishes* is out of
-/// uninstall's reach for the whole time it is half-installed. Not `true`,
-/// because RuntimeClasses select that exact value; an existing label is left
-/// alone, so reinstalling over a working node cannot withdraw it from
-/// scheduling.
-///
-/// Best-effort: this guards a failure that may never happen, and refusing to
-/// install over one failed label write would trade a rare orphan for a common
-/// outage.
+/// Best-effort: failing an install over one label write would trade a rare orphan
+/// for a common outage. Staged runs skip this, because their dispatcher marks the
+/// node before creating the Job.
 async fn claim_node(config: &config::Config) {
     if let Err(e) = k8s::label_node(
         config,
@@ -804,10 +778,16 @@ async fn claim_node(config: &config::Config) {
 
 /// Install stage 1 (artifacts): place kata artifacts/config on the host and set
 /// up any configured snapshotters. This does not touch CRI configuration.
-async fn install_stage_artifacts(config: &config::Config, runtime: &str) -> Result<()> {
+async fn install_stage_artifacts(
+    config: &config::Config,
+    runtime: &str,
+    staged: bool,
+) -> Result<()> {
     info!("install (artifacts): installing kata artifacts on host");
 
-    claim_node(config).await;
+    if !staged {
+        claim_node(config).await;
+    }
 
     artifacts::install_artifacts(config, runtime).await?;
 
@@ -885,29 +865,14 @@ async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool)
             if unchanged
                 && runtime::lifecycle::cri_serving_config_from(runtime, before.written_at()).await
             {
-                // Everything up to here is inference about a pod no longer around
-                // to ask. The node seeing our handlers is the one direct answer.
-                let report =
-                    runtime::lifecycle::kata_handlers_loaded(config, &handlers, HANDLER_WAIT_SECS)
-                        .await;
-
-                if let runtime::lifecycle::HandlerReport::Missing(missing) = report {
-                    info!(
-                        "install (cri): {runtime} has been up since this config was written, but \
-                         node {} still does not report {missing:?}, so it is not serving it after \
-                         all. Restarting.",
-                        config.node_name
-                    );
-                } else {
-                    info!(
-                        "install (cri): CRI config for {runtime} is unchanged from a previous \
-                         attempt, and {runtime} is already serving it. Skipping the \
-                         (self-terminating) restart and checking the runtime is up instead."
-                    );
-                    runtime::lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
-                    info!("install (cri): runtime is up; CRI stage complete without restart");
-                    return Ok(());
-                }
+                info!(
+                    "install (cri): CRI config for {runtime} is unchanged from a previous \
+                     attempt, and {runtime} has been up since it was written. Skipping the \
+                     (self-terminating) restart and checking the runtime is up instead."
+                );
+                runtime::lifecycle::wait_till_cri_unit_active(runtime, 300).await?;
+                info!("install (cri): runtime is up; CRI stage complete without restart");
+                return Ok(());
             }
         }
     }
@@ -915,6 +880,18 @@ async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool)
     info!("About to restart runtime: {}", runtime);
     runtime::lifecycle::restart_runtime(config, runtime, staged).await?;
     info!("Runtime restart completed successfully");
+
+    if staged {
+        // Only the node can say whether the runtime is serving what was written,
+        // and asking needs the apiserver. The dispatcher asks before it labels.
+        if !handlers.is_empty() {
+            info!(
+                "install (cri): leaving the check that {runtime} is serving {handlers:?} to the \
+                 dispatcher, which can ask the node"
+            );
+        }
+        return Ok(());
+    }
 
     confirm_handlers_are_served(config, runtime, &handlers).await
 }
@@ -963,15 +940,14 @@ async fn confirm_handlers_are_served(
     }
 }
 
-/// Install stage 3 (label): apply the kata-runtime node label. Unprivileged,
-/// Kubernetes API only. Skips re-applying when the label is already correct.
+/// The last step of the DaemonSet install. Job mode has no such stage: there the
+/// dispatcher labels the node, which is what lets the per-node Jobs run without a
+/// token.
 ///
-/// As the very last action, once the label is confirmed present, remove any
-/// configured startup taints (`STARTUP_TAINTS`). This is what makes the
-/// scheduling handshake safe: a node can be provisioned with a startup taint
-/// that keeps kata workloads off it until the runtime exists, and that taint is
-/// only lifted here, strictly after artifacts are installed, the CRI runtime is
-/// configured and restarted, and the node is labeled kata-capable.
+/// Startup taints are lifted here and nowhere else. A node can be provisioned with
+/// one to keep Kata workloads away until the runtime exists, so it may only be
+/// lifted after the artifacts are installed, the runtime is configured and
+/// restarted, and the node is labelled.
 async fn install_stage_label(config: &config::Config) -> Result<()> {
     info!("install (label): applying node label");
 
@@ -1219,28 +1195,6 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     Ok(())
 }
 
-/// Cleanup stage 1 (unlabel): remove the kata-runtime node label first so the
-/// scheduler stops placing kata workloads on this node before any host
-/// mutation. Unprivileged, Kubernetes API only. Skips when already absent.
-async fn cleanup_stage_unlabel(config: &config::Config) -> Result<()> {
-    info!("cleanup (unlabel): removing node label");
-
-    // If the label is already absent, there is nothing to do. Any other state
-    // (present, or unknown due to a transient read error) falls through to the
-    // removal below.
-    if let Ok(None) = k8s::get_node_label(config, KATA_RUNTIME_LABEL).await {
-        info!(
-            "cleanup (unlabel): label {} already absent, skipping",
-            KATA_RUNTIME_LABEL
-        );
-        return Ok(());
-    }
-
-    k8s::label_node(config, KATA_RUNTIME_LABEL, None, false).await?;
-    info!("cleanup (unlabel): label removed");
-    Ok(())
-}
-
 /// Cleanup stage 2 (revert-cri): remove CRI drop-ins (and any snapshotter
 /// config), then restart the runtime and wait for readiness. This is the
 /// privileged, node-disrupting cleanup stage and is kept short-lived. Skips
@@ -1362,8 +1316,6 @@ mod tests {
     #[case("install-stage-host-check", Action::InstallStageHostCheck)]
     #[case("install-stage-artifacts", Action::InstallStageArtifacts)]
     #[case("install-stage-cri", Action::InstallStageCri)]
-    #[case("install-stage-label", Action::InstallStageLabel)]
-    #[case("cleanup-stage-unlabel", Action::CleanupStageUnlabel)]
     #[case("cleanup-stage-revert-cri", Action::CleanupStageRevertCri)]
     #[case("cleanup-stage-remove-artifacts", Action::CleanupStageRemoveArtifacts)]
     #[case("internal-post-install-wait", Action::InternalPostInstallWait)]
@@ -1377,11 +1329,13 @@ mod tests {
         );
     }
 
-    /// Unknown actions must be rejected rather than silently accepted.
     #[rstest]
     #[case("install-stage")]
     #[case("cleanup-stage")]
     #[case("install-stage-foo")]
+    // These two were real actions once, so an older chart can still ask for them.
+    #[case("install-stage-label")]
+    #[case("cleanup-stage-unlabel")]
     #[case("bogus")]
     fn test_unknown_action_is_rejected(#[case] arg: &str) {
         assert!(
@@ -1428,8 +1382,6 @@ mod tests {
     #[case(Action::InstallStageHostCheck)]
     #[case(Action::InstallStageArtifacts)]
     #[case(Action::InstallStageCri)]
-    #[case(Action::InstallStageLabel)]
-    #[case(Action::CleanupStageUnlabel)]
     #[case(Action::CleanupStageRevertCri)]
     #[case(Action::CleanupStageRemoveArtifacts)]
     fn test_staged_actions_are_visible(#[case] action: Action) {

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1115,9 +1115,39 @@ spec:
              pods need no API access: the dispatcher does all of it. */}}
       automountServiceAccountToken: false
       restartPolicy: Never
-{{- with $root.Values.tolerations }}
+{{- if eq $stage "cleanup" }}
+      {{- /* nodeName gets the pod past the scheduler, but not past the taint
+             manager, which evicts even a bound pod. A node tainted after the
+             install would keep its Kata configuration for good. */}}
       tolerations:
+        - operator: Exists
+{{- else }}
+      {{- /* The DaemonSet controller adds these to its own pods, and job mode
+             installs on the same nodes. not-ready matters most: this Job
+             restarts the CRI runtime, which takes the node NotReady long enough
+             for the taint manager to evict it mid-install. */}}
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/memory-pressure
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/pid-pressure
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/unschedulable
+          operator: Exists
+          effect: NoSchedule
+{{- with $root.Values.tolerations }}
 {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- end }}
 {{- with $root.Values.priorityClassName }}
       priorityClassName: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -756,6 +756,107 @@ Returns the comma-joined selector string (possibly empty, meaning "all nodes").
 {{- end -}}
 
 {{/*
+Flags handing the node-level API work to the dispatcher, for the stage named in
+`stage` ("install" or "cleanup").
+
+The per-node Jobs can run without a token because this work happens here instead.
+Install labels the node only after its runtime serves what was installed. Cleanup
+removes the label first, so no new Kata workload lands on a node that is about to
+lose its runtime.
+
+Arguments (dict): root, stage. Emitted at column 0; `nindent` at the call site.
+*/}}
+{{- define "kata-deploy.dispatcherNodeWorkFlags" -}}
+{{- $root := .root -}}
+{{- if eq .stage "cleanup" }}
+- "--remove-node-label"
+{{- else }}
+- "--node-label=true"
+- "--claim-node-pending"
+- "--wait-node-ready-secs={{ $root.Values.job.waitNodeReadySeconds | default 300 }}"
+{{- with include "kata-deploy.criHandlers" $root | trim }}
+- "--require-node-handlers={{ . }}"
+{{- end }}
+{{- with $root.Values.startupTaints }}
+- "--remove-node-taints={{ join "," . }}"
+{{- end }}
+{{- with include "kata-deploy.kubeletTimeoutWarnSecs" $root | trim }}
+- "--kubelet-timeout-warn-secs={{ . }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The CRI runtime handlers this release installs, across every architecture.
+
+A node only serves the handlers built for its architecture, so look for any one of
+these rather than all of them. A node that serves none of them has a runtime that
+never read what the install wrote. Custom runtimes are included: on a release that
+configures nothing else, they are the only handlers there are.
+*/}}
+{{- define "kata-deploy.criHandlers" -}}
+{{- $root := . -}}
+{{- $suffix := $root.Values.env.multiInstallSuffix | default "" -}}
+{{- $handlers := list -}}
+{{- range $arch := list "amd64" "arm64" "s390x" "ppc64le" -}}
+{{- range $shim := include "kata-deploy.getEnabledShimsForArch" (dict "root" $root "arch" $arch) | trim | splitList " " -}}
+{{- if $shim -}}
+{{- $handler := printf "kata-%s" $shim -}}
+{{- if $suffix -}}
+{{- $handler = printf "kata-%s-%s" $shim $suffix -}}
+{{- end -}}
+{{- if not (has $handler $handlers) -}}
+{{- $handlers = append $handlers $handler -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and $root.Values.customRuntimes.enabled $root.Values.customRuntimes.runtimes -}}
+{{- range $name := keys $root.Values.customRuntimes.runtimes | sortAlpha -}}
+{{- $runtime := index $root.Values.customRuntimes.runtimes $name -}}
+{{- with $runtime.runtimeClass -}}
+{{- $handler := (fromYaml . | default dict).handler | default "" -}}
+{{- if and $handler (not (has $handler $handlers)) -}}
+{{- $handlers = append $handlers $handler -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $handlers -}}
+{{- end -}}
+
+{{/*
+Seconds below which a node's kubelet `runtimeRequestTimeout` is worth warning
+about, or EMPTY when this configuration has no reason to care.
+
+Only pulling or converting an image inside `CreateContainer` takes long enough to
+hit that timeout. The kubelet default is 2 minutes, so warning in any other case
+would warn about every cluster.
+*/}}
+{{- define "kata-deploy.kubeletTimeoutWarnSecs" -}}
+{{- $needed := false -}}
+{{- range $arch := list "amd64" "arm64" "s390x" "ppc64le" -}}
+{{- if include "kata-deploy.getForceGuestPullForArch" (dict "root" $ "arch" $arch) | trim -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- if contains "guest-pull" (include "kata-deploy.getPullTypeMappingForArch" (dict "root" $ "arch" $arch) | trim) -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- end -}}
+{{- if contains "erofs" (include "kata-deploy.getSnapshotterSetup" . | trim) -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- if .Values.customRuntimes.enabled -}}
+{{- range $runtime := (.Values.customRuntimes.runtimes | default list) -}}
+{{- if contains "guest-pull" (dig "crio" "pullType" "" $runtime | toString) -}}
+{{- $needed = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $needed -}}600{{- end -}}
+{{- end -}}
+
+{{/*
 Whether to render the NFD-derived resources: the `NodeFeatureRule` that advertises
 TEE key counts, and the matching `overhead.podFixed` entries that make Kata's
 confidential RuntimeClasses consume one of those keys per pod.
@@ -797,42 +898,14 @@ true
 {{- end -}}
 
 {{/*
-Only guest pull and EROFS conversion can make CreateContainer exceed kubelet's
-default two-minute runtime timeout. The dispatcher owns this API check once the
-staged per-node process takes its runtime facts from the environment.
-*/}}
-{{- define "kata-deploy.kubeletTimeoutWarnSecs" -}}
-{{- $needed := false -}}
-{{- range $arch := list "amd64" "arm64" "s390x" "ppc64le" -}}
-{{- if include "kata-deploy.getForceGuestPullForArch" (dict "root" $ "arch" $arch) | trim -}}
-{{- $needed = true -}}
-{{- end -}}
-{{- if contains "guest-pull" (include "kata-deploy.getPullTypeMappingForArch" (dict "root" $ "arch" $arch) | trim) -}}
-{{- $needed = true -}}
-{{- end -}}
-{{- end -}}
-{{- if contains "erofs" (include "kata-deploy.getSnapshotterSetup" . | trim) -}}
-{{- $needed = true -}}
-{{- end -}}
-{{- if .Values.customRuntimes.enabled -}}
-{{- range $runtime := (.Values.customRuntimes.runtimes | default list) -}}
-{{- if contains "guest-pull" (dig "crio" "pullType" "" $runtime | toString) -}}
-{{- $needed = true -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- if $needed -}}600{{- end -}}
-{{- end -}}
-
-{{/*
 Where a dispatcher pod may run: `nodeSelector` and `tolerations` blocks for the
 install and cleanup dispatchers.
 
-This is about the dispatcher pod, not about which nodes get Kata. The dispatcher
-holds the one token that reaches the whole cluster - it enumerates every node and
-creates the privileged per-node Jobs - and root on the node it lands on can read
-it; confining it to trusted nodes is a hardening step a DaemonSet cannot offer,
-having to run everywhere by definition.
+This is about the dispatcher pod, not about which nodes get Kata. The distinction
+matters because the dispatcher is the only part of job mode that holds
+credentials, and root on the node it lands on can read them; confining it to
+trusted nodes is a hardening step a DaemonSet cannot offer. The per-node Jobs,
+which do run on every target node, hold no token at all.
 
 Tolerations fall back to the top-level `tolerations` so the dispatcher stays
 schedulable wherever the per-node Jobs are allowed to run - without that, a
@@ -988,8 +1061,12 @@ Arguments (dict):
   root  - top-level context (.)
   stage - "install" | "cleanup"
 
-install pipeline:  host-check -> artifacts -> cri (initContainers) ; label (main)
-cleanup pipeline:  unlabel -> revert-cri    (initContainers) ; remove-artifacts (main)
+install pipeline:  host-check -> artifacts (initContainers) ; cri (main)
+cleanup pipeline:  revert-cri              (initContainer)  ; remove-artifacts (main)
+
+The node label is not a stage here: the dispatcher sets it once the Job as a whole
+has succeeded (and removes it before a cleanup Job runs), which is what lets these
+pods run without a ServiceAccount token.
 
 Emitted at column 0 (a standalone Job document); embed with `indent` at the call
 site under a ConfigMap data key.
@@ -997,6 +1074,11 @@ site under a ConfigMap data key.
 {{- define "kata-deploy.perNodeJob" -}}
 {{- $root := .root -}}
 {{- $stage := .stage -}}
+{{- /* The dispatcher polls each Job for its result. A Job deleted before the next
+       poll leaves its node with no result, and that counts as a failure. */}}
+{{- if lt (int $root.Values.job.ttlSecondsAfterFinished) 60 -}}
+{{- fail (printf "job.ttlSecondsAfterFinished is %v, which is too short for the dispatcher to observe a per-node Job finishing: the Job is deleted before it is next polled and its node is reported as failed even though its install succeeded. Use 60 or more." $root.Values.job.ttlSecondsAfterFinished) -}}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -1007,6 +1089,9 @@ metadata:
 spec:
   backoffLimit: {{ $root.Values.job.backoffLimit }}
   ttlSecondsAfterFinished: {{ $root.Values.job.ttlSecondsAfterFinished }}
+  {{- /* The dispatcher waits for every node it dispatched to. Without a deadline,
+         one stuck pod would hold up the whole rollout. */}}
+  activeDeadlineSeconds: {{ $root.Values.job.activeDeadlineSeconds | default 3600 }}
   template:
     metadata:
       labels:
@@ -1026,7 +1111,9 @@ spec:
       imagePullSecrets:
 {{- toYaml . | nindent 8 }}
 {{- end }}
-      serviceAccountName: {{ include "kata-deploy.serviceAccountName" $root }}
+      {{- /* Without this, Kubernetes mounts the namespace's default token. These
+             pods need no API access: the dispatcher does all of it. */}}
+      automountServiceAccountToken: false
       restartPolicy: Never
 {{- with $root.Values.tolerations }}
       tolerations:
@@ -1039,12 +1126,10 @@ spec:
       initContainers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "host-check" "action" "install-stage-host-check" "privileged" false "mountHost" true) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "artifacts" "action" "install-stage-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "cri" "action" "install-stage-cri" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "label" "action" "install-stage-label" "privileged" false "mountHost" false) | nindent 8 }}
+{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "cri" "action" "install-stage-cri" "privileged" false "mountHost" true) | nindent 8 }}
 {{- else }}
       initContainers:
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "unlabel" "action" "cleanup-stage-unlabel" "privileged" false "mountHost" false) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "revert-cri" "action" "cleanup-stage-revert-cri" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "remove-artifacts" "action" "cleanup-stage-remove-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
@@ -1054,8 +1139,10 @@ spec:
 {{- end -}}
 
 {{/*
-Service account name (honoring multiInstallSuffix), shared by all kata-deploy
-workloads (DaemonSet and staged Jobs).
+Service account name (honoring multiInstallSuffix) for the DaemonSet, the only
+workload that carries the privileged host-mutation rights. Job mode's per-node
+Jobs deliberately have no ServiceAccount; its dispatcher uses
+kata-deploy.dispatcherServiceAccountName.
 */}}
 {{- define "kata-deploy.serviceAccountName" -}}
 {{- if .Values.env.multiInstallSuffix -}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -92,6 +92,7 @@ spec:
             - "--name-prefix={{ $base }}-cleanup"
             - "--owner-job-name={{ $dispatcherName }}"
             - "--parallelism={{ $root.Values.job.parallelism }}"
+{{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "cleanup") | nindent 12 }}
 {{- if $cNodes }}
             - "--nodes={{ join "," $cNodes }}"
 {{- else }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -8,10 +8,13 @@ keeping at most job.parallelism in flight and refilling as they finish. This
 guarantees one install per node (coverage) with a paced rollout, while the Helm
 release stays O(1) regardless of fleet size.
 
-Each per-node Job runs the staged pipeline as ordered initContainers and exits:
+Each per-node Job runs the staged pipeline and exits:
 
-  host-check -> artifacts -> cri   (initContainers, run sequentially)
-  label                            (main container)
+  host-check -> artifacts   (initContainers, run sequentially)
+  cri                       (main container)
+
+Labelling the node is not one of the stages: the dispatcher does it once the Job
+as a whole has succeeded, which is what lets these pods run with no token.
 
 Helm waits only on THIS dispatcher Job (the verification hook runs at a higher
 weight, after it). before-hook-creation lets `helm upgrade` re-run the dispatcher,
@@ -110,9 +113,7 @@ job.nodes list, which names nodes outright and needs no discovery.
 */}}
             - "--wait-for-nodes-secs={{ $root.Values.job.waitForNodesSeconds | default 0 }}"
 {{- end }}
-{{- with include "kata-deploy.kubeletTimeoutWarnSecs" $root | trim }}
-            - "--kubelet-timeout-warn-secs={{ . }}"
-{{- end }}
+{{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "install") | nindent 12 }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -60,11 +60,7 @@ spec:
       imagePullSecrets:
 {{- toYaml . | nindent 6 }}
 {{- end }}
-{{- if .Values.env.multiInstallSuffix }}
-      serviceAccountName: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
-{{- else }}
-      serviceAccountName: {{ .Chart.Name }}-sa
-{{- end }}
+      serviceAccountName: {{ include "kata-deploy.serviceAccountName" . }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{- toYaml . | nindent 8 }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -1,3 +1,9 @@
+{{- if eq (.Values.deploymentMode | default "daemonset") "daemonset" }}
+{{- /*
+  Only daemonset mode needs this: its pod labels its own node and reads its own
+  kubelet config. Job mode creates no such identity, because its per-node Jobs
+  mount no token.
+*/}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -61,14 +67,12 @@ subjects:
   name: {{ .Chart.Name }}-sa
 {{- end }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if eq (.Values.deploymentMode | default "daemonset") "job" }}
 ---
-# Dedicated, least-privilege identity for the job-mode dispatcher
-# (kata-deploy-job-dispatcher). It is a pure control-plane client: it lists nodes
-# (cluster-scoped) and manages per-node Jobs in the release namespace
-# (namespace-scoped). It deliberately does NOT get the privileged kata-deploy
-# host-mutation rights (node patch, runtimeclasses, NFD, etc.); those stay on
-# kata-deploy-sa, which only the per-node Jobs use.
+# The only long-lived identity job mode has. All the node-level API work is
+# gathered here so that it runs in one unprivileged pod, which can be kept on a
+# trusted node, instead of in a privileged pod on every node.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -87,6 +91,14 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list", "get", "patch"]
+{{- if include "kata-deploy.kubeletTimeoutWarnSecs" . | trim }}
+# Granted only when this configuration pulls or converts images inside
+# CreateContainer, which is the one case where the kubelet's
+# runtimeRequestTimeout is worth reading and warning about.
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -121,7 +121,9 @@ job:
   # the nodes with something left on them.
   #
   # Precedence: cleanup.nodes, else cleanup.nodeSelector (equality) ANDed with
-  # cleanup.nodeAffinity, else all nodes. Override to clean a different set, e.g.:
+  # cleanup.nodeAffinity - which is what the default below expresses. Setting all
+  # three to empty is what means "every node". Override to clean a different set,
+  # e.g.:
   #   job:
   #     cleanup:
   #       nodes: ["worker-1"]

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -37,11 +37,9 @@ job:
   # to do with which nodes get Kata - that is the top-level `nodeSelector` /
   # `affinity` / `tolerations`.
   #
-  # Worth setting: the dispatcher is the component that holds Kubernetes
-  # credentials, and root on whatever node it lands on can read them.
-  # Confining it to nodes you trust - typically the control plane - means a
-  # compromised worker cannot reach them, something a DaemonSet can never offer
-  # because it must run everywhere.
+  # Worth setting: the dispatcher is the only component that holds credentials,
+  # and root on the node it runs on can read them. The per-node Jobs hold no
+  # token, so they do not need this.
   #
   # Example (control plane only; the toleration is required because those nodes are
   # normally tainted):
@@ -98,6 +96,13 @@ job:
   # this alone just trades a dispatcher error that names the selectors it tried
   # for Helm's opaque "timed out waiting for the condition".
   waitForNodesSeconds: 120
+  # How long to wait for a node to report Ready again after its install Job
+  # finished, before advertising it as Kata-capable.
+  #
+  # Install ends by restarting the node's CRI runtime, which makes the node
+  # NotReady for a moment. Waiting keeps the first Kata workload away until the
+  # runtime is back. A node that never becomes Ready stays unlabeled.
+  waitNodeReadySeconds: 300
   # Node selection for the UNINSTALL (pre-delete hook) dispatcher.
   #
   # Deliberately independent of the install selection: uninstall has to reach
@@ -131,7 +136,17 @@ job:
                 operator: Exists
   # How long finished per-node Jobs are retained before automatic garbage
   # collection (seconds). Applies to both install and cleanup per-node Jobs.
+  #
+  # The dispatcher polls each Job for its result. A Job deleted before the next
+  # poll leaves its node with no result, and that counts as a failed install.
+  # Values below 60 are refused.
   ttlSecondsAfterFinished: 600
+  # How long a single node's Job may run before Kubernetes fails it (seconds).
+  #
+  # The dispatcher waits for every node it dispatched to, so this limits how long
+  # one stuck node can hold up the whole rollout. The default is generous: a slow
+  # node pulling a large image is normal, an hour of it is not.
+  activeDeadlineSeconds: 3600
   # Per-node retry budget: retries for a single node's Job before it is marked
   # failed. One node failing never aborts the others.
   backoffLimit: 3


### PR DESCRIPTION
A job-mode install runs privileged pods with host mounts on every selected node. Mounting a ServiceAccount token into those pods expands a compromised worker into cluster-wide Node access, even though the host-changing stages do not need to contact the API server.

Run per-node Jobs without a ServiceAccount and explicitly disable token mounting. The dispatcher introduced by the preceding changes performs all Kubernetes API work before and after each host operation, including node claims, readiness checks, labels, runtime-handler verification, and startup-taint removal.

Cleanup Jobs also tolerate every taint so uninstall can still reach an owned node after its scheduling state changes. DaemonSet mode keeps its existing credential model because the long-running pod still performs its own node lifecycle operations.