### PR TITLE
kata-deploy: track node ownership per installation

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -587,7 +587,9 @@ schedules onto a claimed node in the meantime, since the RuntimeClasses select t
 exact value `"true"`. For the same reason an uninstall demotes the label to
 `"false"` rather than removing it, and removes it only once that node's cleanup Job
 has succeeded: a cleanup that fails is still a node the next `helm uninstall` can
-find.
+find. Where several installations share a node, neither the demotion nor the removal
+happens while another one is still holding it — see
+[How installations keep out of each other's way on a node](#how-installations-keep-out-of-each-others-way-on-a-node).
 
 !!! warning "Claiming is best-effort, so this is not a guarantee"
 
@@ -908,6 +910,77 @@ kata-qemu-snp-cicd              kata-qemu-snp-cicd              77s
 kata-qemu-tdx-cicd              kata-qemu-tdx-cicd              77s
 kata-stratovirt-cicd            kata-stratovirt-cicd            77s
 ```
+
+#### How installations keep out of each other's way on a node
+
+One thing is deliberately *not* suffixed: the node label
+`katacontainers.io/kata-runtime`, which every installation's RuntimeClasses select.
+It says "this node can run Kata", not "this installation is here", so it cannot be
+used to work out whether removing it is safe.
+
+Each installation therefore also marks the nodes it holds with a label of its own,
+named after its suffix — `kata-deploy.katacontainers.io/cicd` for the example above,
+and `kata-deploy.katacontainers.io/default` for an installation that sets no suffix.
+The value follows the shared label's: `false` while the installation is being put in
+place, `true` once the node can run its workloads.
+
+```sh
+$ kubectl get node worker-1 -o jsonpath='{.metadata.labels}' | tr ',' '\n' | grep kata
+"katacontainers.io/kata-runtime":"true"
+"kata-deploy.katacontainers.io/default":"true"
+"kata-deploy.katacontainers.io/cicd":"true"
+```
+
+With a suffix set, an installation's RuntimeClasses select **both** labels — the
+shared one and its own mark. That is what makes the mark do something for
+scheduling: removing `kata-deploy-cicd` from a node stops `kata-qemu-cicd` pods
+being sent there immediately, even though the shared label stays behind for the
+other installation. An installation with no suffix selects the shared label alone,
+since there is nobody else to be outvoted by.
+
+An uninstall removes its own mark from every node it reaches, and the shared label
+only from the nodes where no other mark is left. So uninstalling `kata-deploy-cicd`
+above leaves `worker-1` running Kata for the other installation, while a node that
+only ever had `cicd` on it loses the label and stops being a Kata node. The same
+rule decides whether the CRI runtime is restarted, since that restart is shared too.
+
+A mark reading `false` does not count as another installation serving Kata: if the
+last `true` mark goes and only a half-finished installation is left, the shared
+label is set back to `false` rather than removed. Nothing is scheduled on the
+strength of it, and the installation that is still working on the node keeps a
+label its own uninstall can find.
+
+!!! warning "Upgrade every installation before uninstalling any"
+
+    Nodes installed by a version that did not write marks carry none, and an
+    uninstall reading a node with no marks at all falls back to asking whether any
+    kata-deploy is left in the cluster. Run `helm upgrade` on every installation
+    before uninstalling one of them, so each has marked its own nodes.
+
+In `job` mode this means an uninstall may visit a node that only ever belonged to
+another installation — the default cleanup selection is the shared label, which is
+by definition not yours alone — and find nothing of its own to remove. That is
+deliberately the safe direction: it reaches every node it might have touched. If you
+would rather it visited only its own nodes, select on its mark:
+
+```yaml title="values.yaml"
+job:
+  cleanup:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kata-deploy.katacontainers.io/cicd
+                operator: Exists
+```
+
+!!! note "Both deployment modes keep the same books"
+
+    The marks are the same labels in either mode — written by the dispatcher in
+    `job` mode and by the pod on the node in `daemonset` mode — so an uninstall in
+    one mode does see an installation running in the other. Mixing modes across
+    installations is not a combination we test, though: give every installation the
+    same `deploymentMode`.
 
 ## RuntimeClass Node Selectors for TEE Shims
 

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -931,18 +931,20 @@ $ kubectl get node worker-1 -o jsonpath='{.metadata.labels}' | tr ',' '\n' | gre
 "kata-deploy.katacontainers.io/cicd":"true"
 ```
 
-With a suffix set, an installation's RuntimeClasses select **both** labels — the
-shared one and its own mark. That is what makes the mark do something for
-scheduling: removing `kata-deploy-cicd` from a node stops `kata-qemu-cicd` pods
-being sent there immediately, even though the shared label stays behind for the
-other installation. An installation with no suffix selects the shared label alone,
-since there is nobody else to be outvoted by.
+Every installation's RuntimeClasses select **both** labels — the shared one and
+its own mark, including `kata-deploy.katacontainers.io/default` when no suffix was
+set. The default installation can still share a node with a suffixed release, so
+it needs the same gate. Removing one mark stops that installation's workloads
+being sent there immediately, even when the shared label stays for another one.
 
 An uninstall removes its own mark from every node it reaches, and the shared label
 only from the nodes where no other mark is left. So uninstalling `kata-deploy-cicd`
 above leaves `worker-1` running Kata for the other installation, while a node that
-only ever had `cicd` on it loses the label and stops being a Kata node. The same
-rule decides whether the CRI runtime is restarted, since that restart is shared too.
+only ever had `cicd` on it loses the label and stops being a Kata node. Cleanup
+still restarts the shared CRI runtime after removing this installation's
+configuration: otherwise the live runtime could keep advertising a handler whose
+binary has just been deleted. The other installation's configuration remains and
+is reloaded by that restart.
 
 A mark reading `false` does not count as another installation serving Kata: if the
 last `true` mark goes and only a half-finished installation is left, the shared
@@ -953,9 +955,33 @@ label its own uninstall can find.
 !!! warning "Upgrade every installation before uninstalling any"
 
     Nodes installed by a version that did not write marks carry none, and an
-    uninstall reading a node with no marks at all falls back to asking whether any
-    kata-deploy is left in the cluster. Run `helm upgrade` on every installation
-    before uninstalling one of them, so each has marked its own nodes.
+    uninstall cannot attribute such a node to one release. Run `helm upgrade` on
+    every installation before uninstalling one of them, so each release has first
+    marked the nodes it owns.
+
+`env.multiInstallSuffix` is immutable for the life of a Helm release. The chart
+stores the first value under a suffix-independent ConfigMap name and rejects an
+upgrade that changes it: the install directory, handlers, resource names, and
+node marker all derive from the suffix, so changing it in place would create a
+second installation while forgetting how to remove the first.
+
+For containerd, a suffixed installation also requires drop-in configuration
+support. Older whole-file configuration has one shared backup; uninstalling one
+release would restore a file that predates every release and erase the surviving
+handlers. Installation therefore fails before modifying CRI configuration when
+that unsafe combination is detected.
+
+On the first upgrade from a chart version that predates that state ConfigMap, the
+chart verifies the previous identity from the existing mode-specific resource
+whose name derives from the suffix. If it cannot find one, the upgrade stops and
+the error names the ConfigMap data that can be seeded explicitly; guessing would
+be the unsafe choice.
+
+The same state makes `deploymentMode` immutable and rejects values other than
+`daemonset` and `job`. An in-place mode switch can strand nodes owned by the old
+controller, and recording a new mode before its hook succeeds can also make a
+rollback reject the previous mode. Uninstall the existing mode cleanly before
+installing the other one.
 
 In `job` mode this means an uninstall may visit a node that only ever belonged to
 another installation — the default cleanup selection is the shared label, which is

--- a/tests/functional/kata-deploy/kata-deploy-multi-install.bats
+++ b/tests/functional/kata-deploy/kata-deploy-multi-install.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for running several kata-deploy installations side by side
+# (env.multiInstallSuffix). No cluster required.
+#
+# Everything belonging to one installation is named after its suffix, except
+# katacontainers.io/kata-runtime: every installation's RuntimeClasses select it, so
+# it says "this node can run Kata", not "this installation is here". Each
+# installation therefore marks its own nodes as well, and an uninstall gives the
+# shared label up only once no other mark is left.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+render_dispatcher() {
+	local stage="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only "templates/kata-deploy-${stage}-job.yaml" \
+		"$@"
+}
+
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
+@test "Helm template (job mode): both dispatchers know which install they are" {
+	local stage rendered
+	for stage in install cleanup; do
+		rendered=$(render_dispatcher "${stage}" --set env.multiInstallSuffix=dev)
+		echo "${rendered}" | grep -q -- '--multi-install-suffix=dev'
+	done
+}
+
+@test "Helm template (job mode): a single install needs no suffix to say so" {
+	# The dispatcher falls back to the "default" instance, so the flag is only
+	# rendered when there is something to say.
+	local stage rendered
+	for stage in install cleanup; do
+		rendered=$(render_dispatcher "${stage}")
+		refute_match "${rendered}" '--multi-install-suffix'
+	done
+}
+
+@test "Helm template: the node label the RuntimeClasses select is never suffixed" {
+	# Which is why the per-install mark exists: this label cannot tell two
+	# installations apart, so removing it cannot be decided from it.
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set env.multiInstallSuffix=dev \
+		--show-only templates/runtimeclasses.yaml)
+
+	echo "${rendered}" | grep -q 'katacontainers.io/kata-runtime: "true"'
+	refute_match "${rendered}" 'katacontainers.io/kata-runtime-dev'
+}
+
+@test "Helm template: an install's RuntimeClasses select its own mark as well" {
+	# Without this, removing an install from a node would not stop its own workloads
+	# landing there, since the shared label stays while another install holds it.
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set env.multiInstallSuffix=dev \
+		--show-only templates/runtimeclasses.yaml)
+
+	echo "${rendered}" | grep -q 'kata-deploy.katacontainers.io/dev: "true"'
+}
+
+@test "Helm template: a shim's own nodeSelector cannot weaken the ownership gate" {
+	# The gate and the shim's selector end up in one YAML mapping, where a repeated
+	# key is resolved in the user's favour, pointing the RuntimeClass at nodes this
+	# install does not hold.
+	local rendered qemu
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set env.multiInstallSuffix=dev \
+		--set 'shims.qemu.runtimeClass.nodeSelector.katacontainers\.io/kata-runtime=false' \
+		--set 'shims.qemu.runtimeClass.nodeSelector.kata-deploy\.katacontainers\.io/dev=false' \
+		--set 'shims.qemu.runtimeClass.nodeSelector.disktype=ssd' \
+		--show-only templates/runtimeclasses.yaml)
+
+	refute_match "${rendered}" 'katacontainers.io/kata-runtime: "false"'
+	refute_match "${rendered}" 'kata-deploy.katacontainers.io/dev: "false"'
+
+	qemu=$(echo "${rendered}" | awk '/^handler: kata-qemu-dev$/,/^---$/')
+	[ "$(echo "${qemu}" | grep -c 'katacontainers.io/kata-runtime:')" -eq 1 ]
+	[ "$(echo "${qemu}" | grep -c 'kata-deploy.katacontainers.io/dev:')" -eq 1 ]
+	# Everything else the shim asked for is still there.
+	echo "${qemu}" | grep -q 'disktype: "ssd"'
+}
+
+@test "Helm template: a single install's RuntimeClasses select the shared label only" {
+	# With one install there is nothing to disambiguate, and requiring a mark would
+	# strand its workloads until an upgrade had marked every node.
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only templates/runtimeclasses.yaml)
+
+	echo "${rendered}" | grep -q 'katacontainers.io/kata-runtime: "true"'
+	refute_match "${rendered}" 'kata-deploy.katacontainers.io/'
+}
+
+@test "Helm template: custom RuntimeClasses are gated on the mark too" {
+	local rendered
+	rendered=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set env.multiInstallSuffix=dev \
+		--set customRuntimes.enabled=true \
+		--set customRuntimes.runtimes.mine.baseConfig=qemu \
+		--set-string customRuntimes.runtimes.mine.runtimeClass='kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+  name: mine
+handler: mine
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+' \
+		--show-only templates/custom-runtimes.yaml)
+
+	echo "${rendered}" | grep -q 'kata-deploy.katacontainers.io/dev: "true"'
+	echo "${rendered}" | grep -q 'katacontainers.io/kata-runtime: "true"'
+}

--- a/tests/functional/kata-deploy/kata-deploy-multi-install.bats
+++ b/tests/functional/kata-deploy/kata-deploy-multi-install.bats
@@ -53,6 +53,41 @@ refute_match() {
 	done
 }
 
+@test "Helm template: the suffix is persisted under a stable release name" {
+	# Every host path, handler, and marker derives from the suffix. Keeping the
+	# record under a name that does not derive from it lets a live upgrade reject
+	# an in-place suffix change instead of orphaning the old installation.
+	local rendered
+	rendered=$(helm template my-release "${CHART_PATH}" \
+		--set env.multiInstallSuffix=dev \
+		--show-only templates/kata-deploy-state.yaml)
+
+	echo "${rendered}" | grep -q 'name: my-release-kata-deploy-state'
+	echo "${rendered}" | grep -q 'multiInstallSuffix: "dev"'
+	echo "${rendered}" | grep -q 'deploymentMode: "daemonset"'
+}
+
+@test "Helm template: an unverifiable pre-state upgrade is refused" {
+	# A suffix change makes every old mode-specific resource disappear under the
+	# newly derived name. Proceeding would create a second installation and forget
+	# the first, so the safe answer is to require the previous identity to be
+	# restored or seeded.
+	run helm template my-release "${CHART_PATH}" \
+		--is-upgrade \
+		--set env.multiInstallSuffix=dev \
+		--show-only templates/kata-deploy-state.yaml
+
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'cannot verify the previous kata-deploy identity'
+}
+
+@test "Helm template: deployment mode is validated before state is persisted" {
+	run helm template my-release "${CHART_PATH}" --set deploymentMode=bogus
+
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'deploymentMode must be one of daemonset or job'
+}
+
 @test "Helm template: the node label the RuntimeClasses select is never suffixed" {
 	# Which is why the per-install mark exists: this label cannot tell two
 	# installations apart, so removing it cannot be decided from it.
@@ -101,16 +136,17 @@ refute_match() {
 	echo "${qemu}" | grep -q 'disktype: "ssd"'
 }
 
-@test "Helm template: a single install's RuntimeClasses select the shared label only" {
-	# With one install there is nothing to disambiguate, and requiring a mark would
-	# strand its workloads until an upgrade had marked every node.
+@test "Helm template: the default install's RuntimeClasses select its mark too" {
+	# "Default" is one installation like any other. Without its mark in the selector,
+	# removing it while another release holds the shared label would keep default
+	# workloads landing on a node whose default runtime is going away.
 	local rendered
 	rendered=$(helm template kata-deploy "${CHART_PATH}" \
 		--set deploymentMode=job \
 		--show-only templates/runtimeclasses.yaml)
 
 	echo "${rendered}" | grep -q 'katacontainers.io/kata-runtime: "true"'
-	refute_match "${rendered}" 'kata-deploy.katacontainers.io/'
+	echo "${rendered}" | grep -q 'kata-deploy.katacontainers.io/default: "true"'
 }
 
 @test "Helm template: custom RuntimeClasses are gated on the mark too" {
@@ -128,9 +164,11 @@ handler: mine
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
+    kata-deploy.katacontainers.io/dev: "false"
 ' \
 		--show-only templates/custom-runtimes.yaml)
 
 	echo "${rendered}" | grep -q 'kata-deploy.katacontainers.io/dev: "true"'
+	refute_match "${rendered}" 'kata-deploy.katacontainers.io/dev: "false"'
 	echo "${rendered}" | grep -q 'katacontainers.io/kata-runtime: "true"'
 }

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -26,6 +26,7 @@ else
 		"kata-deploy-tee-keys.bats" \
 		"kata-deploy-distribution.bats" \
 		"kata-deploy-privileges.bats" \
+		"kata-deploy-multi-install.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/binary/src/k8s/client.rs
+++ b/tools/packaging/kata-deploy/binary/src/k8s/client.rs
@@ -17,9 +17,18 @@ use serde_json::json;
 /// A concurrent taint update is a lost race, not a broken node.
 const TAINT_PATCH_ATTEMPTS: u32 = 3;
 
+/// Same for labels another install rewrote while we were deciding what to write.
+const LABEL_PATCH_ATTEMPTS: u32 = 5;
+
 /// A rejected precondition, as opposed to a request that failed on its merits.
 /// The apiserver answers a failing JSON Patch `test` with 422, and a genuine write
 /// conflict with 409.
+/// A label key as a JSON Pointer token: `~` and `/` are the two characters with a
+/// meaning of their own there (RFC 6901).
+fn escape_pointer(token: &str) -> String {
+    token.replace('~', "~0").replace('/', "~1")
+}
+
 fn is_precondition_failure(err: &kube::Error) -> bool {
     matches!(err, kube::Error::Api(status) if status.code == 409 || status.code == 422)
 }
@@ -70,15 +79,8 @@ impl K8sClient {
             })
     }
 
-    /// Return the value of a single label from `.metadata.labels` on the
-    /// bound node, or `None` if the label is absent.
-    pub async fn get_node_label(&self, key: &str) -> Result<Option<String>> {
-        let node = self.get_node().await?;
-        Ok(node
-            .metadata
-            .labels
-            .as_ref()
-            .and_then(|labels| labels.get(key).cloned()))
+    pub async fn get_node_labels(&self) -> Result<std::collections::BTreeMap<String, String>> {
+        Ok(self.get_node().await?.metadata.labels.unwrap_or_default())
     }
 
     pub async fn get_kubelet_runtime_request_timeout(&self) -> Result<Option<String>> {
@@ -143,6 +145,91 @@ impl K8sClient {
             .with_context(|| format!("Failed to patch node: {}", self.node_name))?;
 
         Ok(())
+    }
+
+    /// Read the bound node's labels, decide what to write from them, and write it
+    /// only if nothing else changed the node in between.
+    ///
+    /// The decision is read from marks other installs write at the same time, so an
+    /// unconditional write could act on a node that has already moved on: two
+    /// uninstalls each seeing the other's mark, each removing their own, leaving a
+    /// node advertising Kata with nothing installed.
+    ///
+    /// `decide` returns the label writes (`None` removes) and whatever the caller
+    /// concluded from the labels it saw.
+    pub async fn rewrite_node_labels<F, T>(&self, decide: F) -> Result<T>
+    where
+        F: Fn(&std::collections::BTreeMap<String, String>) -> (Vec<(String, Option<String>)>, T),
+    {
+        for attempt in 1..=LABEL_PATCH_ATTEMPTS {
+            let node = self.get_node().await?;
+            let version = node.metadata.resource_version.clone().unwrap_or_default();
+            let labels = node.metadata.labels.unwrap_or_default();
+
+            let (updates, outcome) = decide(&labels);
+            if updates.is_empty() {
+                return Ok(outcome);
+            }
+
+            let mut ops =
+                vec![json!({"op": "test", "path": "/metadata/resourceVersion", "value": version})];
+            for (key, value) in &updates {
+                let path = format!("/metadata/labels/{}", escape_pointer(key));
+                match value {
+                    Some(value) => ops.push(json!({"op": "add", "path": path, "value": value})),
+                    // `remove` is what makes this rejectable: it fails when the key
+                    // is already gone, which is another way of saying we read a
+                    // stale node.
+                    None => ops.push(json!({"op": "remove", "path": path})),
+                }
+            }
+
+            let patch: json_patch::Patch =
+                serde_json::from_value(json!(ops)).context("Failed to build the label patch")?;
+
+            match self
+                .node_api
+                .patch(
+                    &self.node_name,
+                    &PatchParams::default(),
+                    &Patch::Json::<Node>(patch),
+                )
+                .await
+            {
+                Ok(_) => {
+                    for (key, value) in &updates {
+                        match value {
+                            Some(value) => {
+                                info!("Set label {}={} on node {}", key, value, self.node_name)
+                            }
+                            None => {
+                                info!("Removed label {} from node {}", key, self.node_name)
+                            }
+                        }
+                    }
+                    return Ok(outcome);
+                }
+                Err(e) if is_precondition_failure(&e) => {
+                    info!(
+                        "Labels on node {} changed while they were being rewritten (attempt \
+                         {}/{}); reading them again",
+                        self.node_name, attempt, LABEL_PATCH_ATTEMPTS
+                    );
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("Failed to patch the labels on node {}", self.node_name)
+                    })
+                }
+            }
+        }
+
+        anyhow::bail!(
+            "Gave up rewriting the labels on node {} after {} attempts: something keeps changing \
+             them concurrently",
+            self.node_name,
+            LABEL_PATCH_ATTEMPTS
+        )
     }
 
     /// Remove taints from the bound node.
@@ -318,9 +405,11 @@ pub async fn get_container_runtime_version(config: &Config) -> Result<String> {
     client.get_container_runtime_version().await
 }
 
-pub async fn get_node_label(config: &Config, key: &str) -> Result<Option<String>> {
+pub async fn get_node_labels(
+    config: &Config,
+) -> Result<std::collections::BTreeMap<String, String>> {
     let client = K8sClient::new(&config.node_name).await?;
-    client.get_node_label(key).await
+    client.get_node_labels().await
 }
 
 pub async fn get_kubelet_runtime_request_timeout(config: &Config) -> Result<Option<String>> {
@@ -370,6 +459,14 @@ pub async fn label_node(
 ) -> Result<()> {
     let client = K8sClient::new(&config.node_name).await?;
     client.label_node(label_key, label_value, overwrite).await
+}
+
+pub async fn rewrite_node_labels<F, T>(config: &Config, decide: F) -> Result<T>
+where
+    F: Fn(&std::collections::BTreeMap<String, String>) -> (Vec<(String, Option<String>)>, T),
+{
+    let client = K8sClient::new(&config.node_name).await?;
+    client.rewrite_node_labels(decide).await
 }
 
 pub async fn remove_node_taints(config: &Config, matchers: &[String]) -> Result<Vec<String>> {

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -906,6 +906,23 @@ async fn install_stage_artifacts(
         claim_node(config).await;
     }
 
+    // Refuse before touching the host: whole-file containerd configuration keeps a
+    // single backup, which the first uninstall would restore over every other
+    // installation's handlers.
+    if runtime != "crio"
+        && config
+            .multi_install_suffix
+            .as_deref()
+            .is_some_and(|suffix| !suffix.is_empty())
+    {
+        let paths = config.get_containerd_paths(runtime).await?;
+        anyhow::ensure!(
+            paths.use_drop_in,
+            "multi-install requires containerd drop-in support: whole-file configuration and its \
+             single backup cannot preserve another installation during uninstall"
+        );
+    }
+
     artifacts::install_artifacts(config, runtime).await?;
 
     if runtime != "crio" {

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use flate2::read::GzDecoder;
 use log::{error, info};
+use std::collections::BTreeMap;
 use std::io::BufRead;
 
 /// Env var name used to thread the detected container runtime through the
@@ -93,6 +94,13 @@ const KATA_RUNTIME_LABEL: &str = "katacontainers.io/kata-runtime";
 /// The value [`KATA_RUNTIME_LABEL`] carries while an install is under way: this
 /// node has to be cleaned up, but cannot run kata workloads yet.
 const KATA_RUNTIME_PENDING: &str = "false";
+/// Every install marks its own nodes with a label named after its
+/// `MULTI_INSTALL_SUFFIX`. Without it, an uninstall removing the shared
+/// [`KATA_RUNTIME_LABEL`] could not tell whether it leaves another install's
+/// workloads with nowhere to run.
+const INSTANCE_LABEL_PREFIX: &str = "kata-deploy.katacontainers.io/";
+/// The instance name of an install that set no `MULTI_INSTALL_SUFFIX`.
+const DEFAULT_INSTANCE: &str = "default";
 const SUGGESTED_KUBELET_RUNTIME_REQUEST_TIMEOUT_SECS: u64 = 10 * 60;
 const MKFS_EROFS: &str = "mkfs.erofs";
 const MIN_EROFS_UTILS_VERSION: &str = "1.8.2";
@@ -751,28 +759,137 @@ fn mapping_contains_value(mapping: Option<&str>, expected_value: &str) -> bool {
     })
 }
 
-/// Mark the node before anything is written to it, so `helm uninstall` can find a
-/// node whose install died half-way: it cleans every node that carries the
-/// kata-runtime label, whatever the value. The value is not `true`, because
-/// RuntimeClasses select that exact value.
+/// The marker label of one install.
+fn instance_label(suffix: Option<&str>) -> String {
+    format!(
+        "{INSTANCE_LABEL_PREFIX}{}",
+        suffix.unwrap_or(DEFAULT_INSTANCE)
+    )
+}
+
+/// What the marks of the other installs on a node say about the label they share.
+#[derive(Debug, PartialEq, Eq)]
+enum SharedLabel {
+    /// At least one other install is serving Kata here: the shared label stays `true`.
+    Keep,
+    /// The other installs here are all mid-flight or failed. Nothing may be scheduled
+    /// on the strength of the shared label, but the key has to stay so those installs'
+    /// own uninstalls can still find the node.
+    Demote,
+    /// Ours was the last mark: the key goes.
+    Remove,
+}
+
+/// Read the marks other installs left on a node.
+///
+/// The value matters, not just the key: a `false` mark is a claim on a node whose
+/// install has not finished, and reading it as "Kata is served here" would leave the
+/// node advertised with nothing behind it.
+fn shared_label_after(labels: &BTreeMap<String, String>, ours: &str) -> SharedLabel {
+    let mut any = false;
+    for (key, value) in labels {
+        if key == ours || !key.starts_with(INSTANCE_LABEL_PREFIX) {
+            continue;
+        }
+        any = true;
+        if value != KATA_RUNTIME_PENDING {
+            return SharedLabel::Keep;
+        }
+    }
+
+    if any {
+        SharedLabel::Demote
+    } else {
+        SharedLabel::Remove
+    }
+}
+
+/// Take this install's mark off the node, and the label it shares with every other
+/// install with it, unless another install is still holding the node. Returns
+/// whether one is.
+async fn release_node(config: &config::Config) -> Result<bool> {
+    let ours = instance_label(config.multi_install_suffix.as_deref());
+
+    // A node nothing has marked was installed on by a version that did not mark it,
+    // so ask the question that version asked: is any other kata-deploy left in the
+    // cluster at all?
+    let labels = k8s::get_node_labels(config).await?;
+    let unmarked =
+        !labels.contains_key(&ours) && shared_label_after(&labels, &ours) == SharedLabel::Remove;
+    let legacy_others = unmarked && k8s::count_any_kata_deploy_daemonsets(config).await? > 0;
+
+    let others = k8s::rewrite_node_labels(config, |labels| {
+        let mut updates: Vec<(String, Option<String>)> = Vec::new();
+        if labels.contains_key(&ours) {
+            updates.push((ours.clone(), None));
+        }
+
+        let verdict = if legacy_others {
+            SharedLabel::Keep
+        } else {
+            shared_label_after(labels, &ours)
+        };
+
+        match verdict {
+            SharedLabel::Keep => (),
+            SharedLabel::Demote => {
+                if labels.get(KATA_RUNTIME_LABEL).map(String::as_str) != Some(KATA_RUNTIME_PENDING)
+                {
+                    updates.push((
+                        KATA_RUNTIME_LABEL.to_string(),
+                        Some(KATA_RUNTIME_PENDING.to_string()),
+                    ));
+                }
+            }
+            SharedLabel::Remove => {
+                if labels.contains_key(KATA_RUNTIME_LABEL) {
+                    updates.push((KATA_RUNTIME_LABEL.to_string(), None));
+                }
+            }
+        }
+
+        (updates, verdict)
+    })
+    .await?;
+
+    match others {
+        SharedLabel::Keep => info!(
+            "another kata-deploy install is still serving Kata from this node, leaving {} in place",
+            KATA_RUNTIME_LABEL
+        ),
+        SharedLabel::Demote => info!(
+            "one or more kata-deploy installs have claimed this node but none has finished \
+             installing on it, so {} stays as {}",
+            KATA_RUNTIME_LABEL, KATA_RUNTIME_PENDING
+        ),
+        SharedLabel::Remove => info!("removed {} from this node", KATA_RUNTIME_LABEL),
+    }
+
+    Ok(others != SharedLabel::Remove)
+}
+
+/// Mark the node as one kata-deploy has started installing on, before anything is
+/// written to it.
+///
+/// `helm uninstall` cleans every node carrying the kata-runtime label, whatever its
+/// value, so a node labelled only once the install *finishes* is out of its reach
+/// for as long as it is half-installed. Not `true`, because RuntimeClasses select
+/// that exact value; an existing label is left alone, so reinstalling over a working
+/// node cannot withdraw it from scheduling.
 ///
 /// Best-effort: failing an install over one label write would trade a rare orphan
 /// for a common outage. Staged runs skip this, because their dispatcher marks the
 /// node before creating the Job.
 async fn claim_node(config: &config::Config) {
-    if let Err(e) = k8s::label_node(
-        config,
-        KATA_RUNTIME_LABEL,
-        Some(KATA_RUNTIME_PENDING),
-        false,
-    )
-    .await
-    {
-        log::warn!(
-            "install: could not mark node {} as being installed on ({e}). Should this install \
-             fail before it labels the node, `helm uninstall` will not clean this node up.",
-            config.node_name
-        );
+    let ours = instance_label(config.multi_install_suffix.as_deref());
+    for key in [KATA_RUNTIME_LABEL, ours.as_str()] {
+        if let Err(e) = k8s::label_node(config, key, Some(KATA_RUNTIME_PENDING), false).await {
+            log::warn!(
+                "install: could not mark node {} as being installed on ({e}). Should this install \
+                 fail before it labels the node, `helm uninstall` will not clean this node up.",
+                config.node_name
+            );
+        }
     }
 }
 
@@ -951,18 +1068,24 @@ async fn confirm_handlers_are_served(
 async fn install_stage_label(config: &config::Config) -> Result<()> {
     info!("install (label): applying node label");
 
-    match k8s::get_node_label(config, KATA_RUNTIME_LABEL).await {
-        Ok(Some(ref val)) if val == "true" => {
-            info!(
-                "install (label): node already labeled {}=true, skipping",
-                KATA_RUNTIME_LABEL
-            );
+    // The shared label admits Kata workloads; our own mark is what this install's
+    // RuntimeClasses select on top of it, and what tells another install's uninstall
+    // that the shared label is not its to remove. A kubelet that clobbers either
+    // leaves the node unusable, so both have to be seen to hold.
+    let ours = instance_label(config.multi_install_suffix.as_deref());
+    let wanted = [(KATA_RUNTIME_LABEL, "true"), (ours.as_str(), "true")];
+
+    match k8s::get_node_labels(config).await {
+        Ok(labels)
+            if wanted
+                .iter()
+                .all(|(key, value)| labels.get(*key).map(String::as_str) == Some(*value)) =>
+        {
+            info!("install (label): node is already labelled, skipping");
         }
-        // Any other state (absent, different value, or a transient read error)
+        // Any other state (absent, a different value, or a transient read error)
         // falls through to label_node_with_retry, which applies and verifies.
-        _ => {
-            label_node_with_retry(config, KATA_RUNTIME_LABEL, "true").await?;
-        }
+        _ => label_node_with_retry(config, &wanted).await?,
     }
 
     remove_startup_taints(config).await;
@@ -1023,27 +1146,30 @@ async fn remove_startup_taints(config: &config::Config) {
 /// confirm the label is set, declare install done, and only then would the kubelet
 /// come back up and clobber the label with its cached set.
 ///
-/// To outlive that race we require the label to remain at `label_value` for
+/// To outlive that race we require every label to remain at its value for
 /// `STABILITY_CHECKS` consecutive observations spaced `CHECK_INTERVAL` apart
 /// (≈ 15 s by default — comfortably more than the kubelet's status-update period).
-/// If it ever drifts inside that window we re-apply and restart the stability
+/// If any of them drifts inside that window we re-apply and restart the stability
 /// counter. The whole thing is bounded by `MAX_APPLY_ATTEMPTS`.
-async fn label_node_with_retry(
-    config: &config::Config,
-    label_key: &str,
-    label_value: &str,
-) -> Result<()> {
+async fn label_node_with_retry(config: &config::Config, labels: &[(&str, &str)]) -> Result<()> {
     const MAX_APPLY_ATTEMPTS: u32 = 12;
     const STABILITY_CHECKS: u32 = 6;
     const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
     const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
+    let described = labels
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
     for attempt in 1..=MAX_APPLY_ATTEMPTS {
-        k8s::label_node(config, label_key, Some(label_value), true).await?;
+        for (key, value) in labels {
+            k8s::label_node(config, key, Some(value), true).await?;
+        }
         info!(
-            "Applied label {}={} (attempt {}/{}); verifying stability ({} checks @ {}s)",
-            label_key,
-            label_value,
+            "Applied label(s) {} (attempt {}/{}); verifying stability ({} checks @ {}s)",
+            described,
             attempt,
             MAX_APPLY_ATTEMPTS,
             STABILITY_CHECKS,
@@ -1055,21 +1181,29 @@ async fn label_node_with_retry(
         while stable_count < STABILITY_CHECKS {
             tokio::time::sleep(CHECK_INTERVAL).await;
 
-            match k8s::get_node_label(config, label_key).await {
-                Ok(Some(val)) if val == label_value => {
-                    stable_count += 1;
-                    info!(
-                        "Label {}={} stable {}/{}",
-                        label_key, label_value, stable_count, STABILITY_CHECKS
-                    );
-                }
-                Ok(actual) => {
+            match k8s::get_node_labels(config).await {
+                Ok(observed) => {
+                    let drifted = labels
+                        .iter()
+                        .filter(|(key, value)| {
+                            observed.get(*key).map(String::as_str) != Some(value)
+                        })
+                        .map(|(key, _)| format!("{key}={:?}", observed.get(*key)))
+                        .collect::<Vec<_>>();
+
+                    if drifted.is_empty() {
+                        stable_count += 1;
+                        info!(
+                            "Label(s) {} stable {}/{}",
+                            described, stable_count, STABILITY_CHECKS
+                        );
+                        continue;
+                    }
+
                     log::warn!(
-                        "Label {}={} drifted to {:?} after {}/{} stable observation(s); \
-                         re-applying (attempt {}/{})",
-                        label_key,
-                        label_value,
-                        actual,
+                        "Label(s) {} drifted after {}/{} stable observation(s); re-applying \
+                         (attempt {}/{})",
+                        drifted.join(", "),
                         stable_count,
                         STABILITY_CHECKS,
                         attempt,
@@ -1080,9 +1214,9 @@ async fn label_node_with_retry(
                 }
                 Err(e) => {
                     log::warn!(
-                        "Failed to verify label {} during stability check \
+                        "Failed to verify label(s) {} during stability check \
                          (attempt {}/{}): {}; will re-apply",
-                        label_key,
+                        described,
                         attempt,
                         MAX_APPLY_ATTEMPTS,
                         e,
@@ -1095,8 +1229,8 @@ async fn label_node_with_retry(
 
         if !needs_reapply {
             info!(
-                "Label {}={} confirmed stable on node after {} apply attempt(s)",
-                label_key, label_value, attempt
+                "Label(s) {} confirmed stable on node after {} apply attempt(s)",
+                described, attempt
             );
             return Ok(());
         }
@@ -1107,9 +1241,8 @@ async fn label_node_with_retry(
     }
 
     anyhow::bail!(
-        "Label {}={} did not remain stable after {} apply attempts",
-        label_key,
-        label_value,
+        "Label(s) {} did not remain stable after {} apply attempts",
+        described,
         MAX_APPLY_ATTEMPTS
     );
 }
@@ -1140,6 +1273,12 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
         config.daemonset_name
     );
 
+    // Unmark before mutating the host, so nothing lands on files about to go.
+    // Only the shared label waits for the last install; the restart below does
+    // not - this install's configuration is leaving the disk the runtime reads.
+    info!("Removing this install's node labels");
+    release_node(config).await?;
+
     if runtime != "crio" {
         match config.experimental_setup_snapshotter.as_ref() {
             Some(snapshotters) => {
@@ -1164,25 +1303,6 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     info!("Removing kata artifacts from host");
     artifacts::remove_artifacts(config).await?;
     info!("Successfully removed kata artifacts");
-
-    // Step 3: Check if ANY other kata-deploy DaemonSets still exist.
-    // Shared resources (node label, CRI restart) are only safe to touch
-    // when no other kata-deploy instance remains.
-    let other_ds_count = k8s::count_any_kata_deploy_daemonsets(config).await?;
-    if other_ds_count > 0 {
-        info!(
-            "{} other kata-deploy DaemonSet(s) still exist, \
-             skipping node label removal and CRI restart",
-            other_ds_count
-        );
-        return Ok(());
-    }
-
-    info!("No other kata-deploy DaemonSets found, performing full shared cleanup");
-
-    info!("Removing kata-runtime label from node");
-    k8s::label_node(config, KATA_RUNTIME_LABEL, None, false).await?;
-    info!("Successfully removed kata-runtime label");
 
     // Restart the CRI runtime last. On k3s/rke2 this restarts the entire
     // server process, which kills this (terminating) pod. By doing it after
@@ -1285,7 +1405,14 @@ async fn cri_drop_in_present(config: &config::Config, runtime: &str) -> bool {
 async fn reset(config: &config::Config, runtime: &str) -> Result<()> {
     info!("Resetting Kata Containers");
 
-    k8s::label_node(config, KATA_RUNTIME_LABEL, None, false).await?;
+    // Nothing has been removed from the host here, so there is nothing the live
+    // runtime must converge to: the shared runtime, and the kubelet with it, are
+    // only bounced when this is the last install left on the node.
+    if release_node(config).await? {
+        info!("Skipping the CRI restart, another install is still using it");
+        return Ok(());
+    }
+
     runtime::lifecycle::restart_cri_runtime(config, runtime).await?;
     if matches!(runtime, "crio" | "containerd") {
         utils::host_systemctl(&["restart", "kubelet"]).await?;
@@ -1346,6 +1473,88 @@ mod tests {
 
     /// The hidden internal waiter must stay hidden from `--help` so users never
     /// invoke it directly, while still being parseable (asserted above).
+    #[test]
+    fn an_install_is_named_after_its_suffix() {
+        assert_eq!(
+            instance_label(None),
+            "kata-deploy.katacontainers.io/default"
+        );
+        assert_eq!(
+            instance_label(Some("dev")),
+            "kata-deploy.katacontainers.io/dev"
+        );
+    }
+
+    /// The shared label may only be taken away when it is nobody else's.
+    #[test]
+    fn only_another_installs_mark_counts() {
+        let ours = instance_label(Some("dev"));
+        let mark = |keys: &[&str]| -> BTreeMap<String, String> {
+            keys.iter()
+                .map(|key| (key.to_string(), "true".to_string()))
+                .collect()
+        };
+
+        assert_eq!(
+            shared_label_after(&mark(&[&ours]), &ours),
+            SharedLabel::Remove
+        );
+        assert_eq!(
+            shared_label_after(
+                &mark(&[&ours, KATA_RUNTIME_LABEL, "kubernetes.io/hostname"]),
+                &ours
+            ),
+            SharedLabel::Remove,
+            "neither the shared label nor an unrelated one is another install's mark"
+        );
+        assert_eq!(
+            shared_label_after(&mark(&[&ours, &instance_label(None)]), &ours),
+            SharedLabel::Keep
+        );
+        assert_eq!(
+            shared_label_after(&mark(&[&instance_label(Some("prod"))]), &ours),
+            SharedLabel::Keep
+        );
+    }
+
+    /// Installs that have claimed the node but not finished on it must not keep it
+    /// advertised as able to run Kata - and must still be able to find it.
+    #[test]
+    fn unfinished_installs_hold_the_key_without_the_promise() {
+        let ours = instance_label(Some("dev"));
+        let labels = BTreeMap::from([
+            (ours.clone(), "true".to_string()),
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Demote);
+
+        // However many of them there are.
+        let labels = BTreeMap::from([
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+            (
+                instance_label(Some("prod")),
+                KATA_RUNTIME_PENDING.to_string(),
+            ),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Demote);
+    }
+
+    /// One install serving Kata is enough to keep the shared label, however many
+    /// unfinished ones are read before it - and labels are read in key order, so
+    /// "default" here is read before "prod".
+    #[test]
+    fn a_serving_install_outweighs_unfinished_ones() {
+        let ours = instance_label(Some("dev"));
+        let labels = BTreeMap::from([
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+            (instance_label(Some("prod")), "true".to_string()),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Keep);
+    }
+
     #[test]
     fn test_internal_action_is_hidden() {
         let internal = Action::InternalPostInstallWait

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -766,8 +766,30 @@ lose its runtime.
 
 Arguments (dict): root, stage. Emitted at column 0; `nindent` at the call site.
 */}}
+{{/*
+The label key this install marks its nodes with: the per-install half of the
+scheduling gate.
+
+katacontainers.io/kata-runtime is shared by every install on the node, so it
+cannot say *which* install is serving Kata there. With multiInstallSuffix set, the
+RuntimeClasses of an install therefore select this mark as well: taking it away is
+then what stops that install's workloads reaching the node, while the other
+installs keep theirs.
+*/}}
+{{- define "kata-deploy.instanceMarkerLabel" -}}
+{{- if .Values.env.multiInstallSuffix -}}
+kata-deploy.katacontainers.io/{{ .Values.env.multiInstallSuffix }}
+{{- end -}}
+{{- end -}}
+
 {{- define "kata-deploy.dispatcherNodeWorkFlags" -}}
 {{- $root := .root -}}
+{{- /* Installs share katacontainers.io/kata-runtime, so each one also marks its
+       own nodes and gives the shared label up only once no other mark is left.
+       Both stages need to know which mark is ours. */}}
+{{- with $root.Values.env.multiInstallSuffix }}
+- "--multi-install-suffix={{ . }}"
+{{- end }}
 {{- if eq .stage "cleanup" }}
 - "--remove-node-label"
 {{- else }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -779,6 +779,8 @@ installs keep theirs.
 {{- define "kata-deploy.instanceMarkerLabel" -}}
 {{- if .Values.env.multiInstallSuffix -}}
 kata-deploy.katacontainers.io/{{ .Values.env.multiInstallSuffix }}
+{{- else -}}
+kata-deploy.katacontainers.io/default
 {{- end -}}
 {{- end -}}
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
@@ -25,7 +25,8 @@
        strength of a label another install holds. */}}
 {{- with include "kata-deploy.instanceMarkerLabel" $ }}
 {{- $scheduling := dig "scheduling" (dict) $runtimeClassObj }}
-{{- $selector := merge (dig "nodeSelector" (dict) $scheduling) (dict . "true") }}
+{{- $selector := dig "nodeSelector" (dict) $scheduling }}
+{{- $_ := set $selector . "true" }}
 {{- $_ := set $runtimeClassObj "scheduling" (merge (dict "nodeSelector" $selector) $scheduling) }}
 {{- end }}
 {{ toYaml $runtimeClassObj }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
@@ -20,6 +20,14 @@
 {{- $runtimeOverhead := dig "overhead" "podFixed" (dict) $runtimeClassObj }}
 {{- $_ := set $runtimeClassObj "overhead" (dict "podFixed" (mergeOverwrite $defaultOverhead $runtimeOverhead)) }}
 {{- end }}
+{{- /* Custom RuntimeClasses need the same gate as the built-in ones, or they would
+       keep scheduling onto a node this install is being removed from, on the
+       strength of a label another install holds. */}}
+{{- with include "kata-deploy.instanceMarkerLabel" $ }}
+{{- $scheduling := dig "scheduling" (dict) $runtimeClassObj }}
+{{- $selector := merge (dig "nodeSelector" (dict) $scheduling) (dict . "true") }}
+{{- $_ := set $runtimeClassObj "scheduling" (merge (dict "nodeSelector" $selector) $scheduling) }}
+{{- end }}
 {{ toYaml $runtimeClassObj }}
 ---
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-state.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-state.yaml
@@ -1,0 +1,58 @@
+{{- /*
+The install directory, runtime handlers, resource names, and per-node ownership
+marker all derive from multiInstallSuffix. Changing it in place creates a second
+installation while the release forgets how to remove the first one, so persist
+the first value under a suffix-independent name and reject changes.
+*/ -}}
+{{- $name := printf "%s-kata-deploy-state" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $wantedSuffix := .Values.env.multiInstallSuffix | default "" | toString -}}
+{{- $wantedMode := .Values.deploymentMode | default "daemonset" | toString -}}
+{{- if not (has $wantedMode (list "daemonset" "job")) -}}
+{{- fail (printf "deploymentMode must be one of daemonset or job, got %q" $wantedMode) -}}
+{{- end -}}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace $name -}}
+{{- $previousSuffix := "" -}}
+{{- $previousMode := "" -}}
+{{- $known := false -}}
+{{- if $existing -}}
+{{- $previousSuffix = index ($existing.data | default dict) "multiInstallSuffix" | default "" -}}
+{{- $previousMode = index ($existing.data | default dict) "deploymentMode" | default "" -}}
+{{- $known = true -}}
+{{- else if .Release.IsUpgrade -}}
+{{- /* Releases installed before this state object existed can still prove that
+       the suffix is unchanged: the old mode-specific resource has the exact name
+       derived from it. A changed suffix finds neither and is rejected below. */ -}}
+{{- $base := .Chart.Name -}}
+{{- if $wantedSuffix -}}{{- $base = printf "%s-%s" .Chart.Name $wantedSuffix -}}{{- end -}}
+{{- $oldJobs := lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-job-templates" $base | trunc 63 | trimSuffix "-") -}}
+{{- $oldDaemonSet := lookup "apps/v1" "DaemonSet" .Release.Namespace $base -}}
+{{- if $oldJobs -}}
+{{- $previousSuffix = $wantedSuffix -}}
+{{- $previousMode = "job" -}}
+{{- $known = true -}}
+{{- else if $oldDaemonSet -}}
+{{- $previousSuffix = $wantedSuffix -}}
+{{- $previousMode = "daemonset" -}}
+{{- $known = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Release.IsUpgrade (not $known) -}}
+{{- fail (printf "cannot verify the previous kata-deploy identity for release %q. Refusing the upgrade because changing env.multiInstallSuffix or deploymentMode would orphan nodes. Restore the release's previous values, or seed ConfigMap %q with data.multiInstallSuffix and data.deploymentMode before retrying." .Release.Name $name) -}}
+{{- end -}}
+{{- if and $known (ne $previousSuffix $wantedSuffix) -}}
+{{- fail (printf "env.multiInstallSuffix is immutable for an existing release: release %q was installed with %q and this upgrade asks for %q. Restore the previous value, uninstall that installation cleanly, then install the new suffix as a separate release." .Release.Name $previousSuffix $wantedSuffix) -}}
+{{- end -}}
+{{- if and $known (ne $previousMode $wantedMode) -}}
+{{- fail (printf "deploymentMode is immutable for an existing release: release %q was installed in %s mode and this upgrade asks for %s. Uninstall the existing mode cleanly before installing the other mode." .Release.Name $previousMode $wantedMode) -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "kata-deploy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  multiInstallSuffix: {{ $wantedSuffix | quote }}
+  deploymentMode: {{ $wantedMode | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -132,13 +132,23 @@ overhead:
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
+{{- $instanceMarker := include "kata-deploy.instanceMarkerLabel" .root }}
+{{- with $instanceMarker }}
+    {{ . }}: "true"
+{{- end }}
+{{- /* Both keys above are the ownership gate, so a shim's own nodeSelector may not
+       restate them: a duplicate key is resolved in the user's favour, which would
+       point the RuntimeClass at nodes this install does not hold. */}}
+{{- $ownershipKeys := list "katacontainers.io/kata-runtime" $instanceMarker }}
 {{- /* TEE shims: snp, tdx, -se, -se-runtime-rs (SE = IBM Secure Execution / SEL) */ -}}
 {{- $isTeeShim := or (contains "snp" .shim) (contains "tdx" .shim) (hasSuffix "-se" .shim) (hasSuffix "-se-runtime-rs" .shim) -}}
 {{- $isPureTeeShim := and $isTeeShim (not (contains "nvidia-gpu" .shim)) -}}
 {{- if or (and .shimConfig.runtimeClass .shimConfig.runtimeClass.nodeSelector) (and .useShimNodeSelectors $isPureTeeShim) }}
 {{- if and .shimConfig.runtimeClass .shimConfig.runtimeClass.nodeSelector }}
 {{- range $key, $value := .shimConfig.runtimeClass.nodeSelector }}
+{{- if not (has $key $ownershipKeys) }}
     {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- else }}
 {{- if contains "snp" .shim }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -120,6 +120,11 @@ job:
   # also reaches nodes where the install failed half way, which are precisely
   # the nodes with something left on them.
   #
+  # With env.multiInstallSuffix this label is shared with the other installs, so
+  # the default reaches their nodes too and finds nothing of its own to remove
+  # there - the safe direction. Narrow it to this install's own mark
+  # (kata-deploy.katacontainers.io/<suffix>, Exists) to visit only its nodes.
+  #
   # Precedence: cleanup.nodes, else cleanup.nodeSelector (equality) ANDed with
   # cleanup.nodeAffinity - which is what the default below expresses. Setting all
   # three to empty is what means "every node". Override to clean a different set,

--- a/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
@@ -33,7 +33,7 @@ use kube::api::{Api, DeleteParams, ListParams, PostParams};
 use kube::Client;
 use log::{error, info};
 use node_filter::{describe_taint, partition_by_tolerations, suggested_toleration, SkippedNode};
-use nodes::{NodeFacts, NodeOps};
+use nodes::{instance_label, NodeFacts, NodeOps};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -161,6 +161,15 @@ struct Args {
     #[arg(long)]
     require_node_handlers: Option<String>,
 
+    /// This release's `env.multiInstallSuffix`, if it set one.
+    ///
+    /// Installs share katacontainers.io/kata-runtime - every install's
+    /// RuntimeClasses select it - so each one also marks the nodes it holds with a
+    /// label named after its suffix. An uninstall takes the shared label away only
+    /// once no other install's mark is left on the node.
+    #[arg(long)]
+    multi_install_suffix: Option<String>,
+
     /// Comma-separated taints to lift after labelling a node, as `key` (any
     /// effect) or `key:effect`. These are the start-up taints that keep workloads
     /// off a node until Kata is actually installed on it.
@@ -274,6 +283,7 @@ fn node_ops_from_args(client: &Client, args: &Args) -> Result<NodeOps> {
     ops.claim_pending = args.claim_node_pending;
     ops.remove_taints = comma_separated(args.remove_node_taints.as_deref());
     ops.require_handlers = comma_separated(args.require_node_handlers.as_deref());
+    ops.instance_label = instance_label(args.multi_install_suffix.as_deref());
     if args.wait_node_ready_secs > 0 {
         ops.wait_ready = Some(Duration::from_secs(args.wait_node_ready_secs));
     }

--- a/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
@@ -18,6 +18,7 @@ use kube::api::{Api, GetParams, Patch, PatchParams, Request};
 use kube::Client;
 use log::{info, warn};
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 /// The RuntimeClasses select on this label, so it is the switch that admits Kata
@@ -44,6 +45,63 @@ const TAINT_PATCH_ATTEMPTS: u32 = 3;
 
 /// Same for a node that gained the label while it was being claimed.
 const CLAIM_PATCH_ATTEMPTS: u32 = 3;
+
+/// Same for a node whose labels another install rewrote mid-decision.
+const LABEL_PATCH_ATTEMPTS: u32 = 5;
+
+/// Every install marks its own nodes with a label named after its
+/// multiInstallSuffix. Without it, an uninstall removing the shared
+/// [`KATA_RUNTIME_LABEL`] could not tell whether it leaves another install's
+/// workloads with nowhere to run.
+const INSTANCE_LABEL_PREFIX: &str = "kata-deploy.katacontainers.io/";
+
+/// The instance name of an install that set no multiInstallSuffix.
+const DEFAULT_INSTANCE: &str = "default";
+
+/// The marker label of one install.
+pub fn instance_label(suffix: Option<&str>) -> String {
+    format!(
+        "{INSTANCE_LABEL_PREFIX}{}",
+        suffix.unwrap_or(DEFAULT_INSTANCE)
+    )
+}
+
+/// What the marks of the other installs on a node say about the label they share.
+#[derive(Debug, PartialEq, Eq)]
+enum SharedLabel {
+    /// At least one other install is serving Kata here: the shared label stays `true`.
+    Keep,
+    /// The other installs here are all mid-flight or failed. Nothing may be scheduled
+    /// on the strength of it, but the key has to stay so those installs' own uninstalls
+    /// can still find the node.
+    Demote,
+    /// Ours was the last mark: the key goes.
+    Remove,
+}
+
+/// Read the marks other installs left on a node.
+///
+/// The value matters, not just the key: a `false` mark is a claim on a node whose
+/// install has not finished, and reading it as "Kata is served here" would leave the
+/// node advertised with nothing behind it.
+fn shared_label_after(labels: &BTreeMap<String, String>, ours: &str) -> SharedLabel {
+    let mut any = false;
+    for (key, value) in labels {
+        if key == ours || !key.starts_with(INSTANCE_LABEL_PREFIX) {
+            continue;
+        }
+        any = true;
+        if value != KATA_RUNTIME_PENDING {
+            return SharedLabel::Keep;
+        }
+    }
+
+    if any {
+        SharedLabel::Demote
+    } else {
+        SharedLabel::Remove
+    }
+}
 
 /// The kubelet may be unreachable through the apiserver proxy, and this check is
 /// only advisory: it must not hold up the node it is about, let alone the queue
@@ -92,6 +150,8 @@ pub struct NodeOps {
     /// labelled. Empty skips the check.
     pub require_handlers: Vec<String>,
     pub kubelet_timeout_warn: Option<Duration>,
+    /// This install's own marker label; see [`INSTANCE_LABEL_PREFIX`].
+    pub instance_label: String,
 }
 
 impl NodeOps {
@@ -106,6 +166,7 @@ impl NodeOps {
             wait_ready: None,
             require_handlers: Vec::new(),
             kubelet_timeout_warn: None,
+            instance_label: instance_label(None),
         }
     }
 
@@ -148,7 +209,7 @@ impl NodeOps {
         // spent now, and leaving the key behind would have a later uninstall clean
         // a node that has nothing left on it.
         if self.remove_label {
-            return self.set_label(node, None).await;
+            return self.release(node).await;
         }
 
         let Some(value) = self.label_value.clone() else {
@@ -171,10 +232,162 @@ impl NodeOps {
     /// was never installed on, and adding a key here would only invite the next
     /// uninstall to come back for it.
     async fn demote(&self, node: &str) -> Result<()> {
-        match self.read_label(node).await? {
-            Some(value) if value == KATA_RUNTIME_PENDING => Ok(()),
-            Some(_) => self.set_label(node, Some(KATA_RUNTIME_PENDING)).await,
-            None => Ok(()),
+        self.rewrite_labels(node, |labels, ours| {
+            let mut updates: Vec<(String, Option<String>)> = Vec::new();
+
+            if labels.contains_key(ours) {
+                updates.push((ours.to_string(), Some(KATA_RUNTIME_PENDING.to_string())));
+            }
+
+            // Our RuntimeClasses select our own mark, so demoting that is what keeps
+            // this install's workloads off the node. The shared label is another
+            // question: an install still serving Kata here needs it.
+            let shared = labels.get(KATA_RUNTIME_LABEL).map(String::as_str);
+            match (shared, shared_label_after(labels, ours)) {
+                (None, _) | (Some(KATA_RUNTIME_PENDING), _) => (),
+                (Some(_), SharedLabel::Keep) => info!(
+                    "node {node}: leaving {KATA_RUNTIME_LABEL} in place, another kata-deploy \
+                     install is still serving Kata from this node"
+                ),
+                (Some(_), _) => updates.push((
+                    KATA_RUNTIME_LABEL.to_string(),
+                    Some(KATA_RUNTIME_PENDING.to_string()),
+                )),
+            }
+
+            updates
+        })
+        .await
+    }
+
+    /// Give the node back: this install's marker goes, and the label it shares with
+    /// every other install goes with it only if no other install is left holding
+    /// this node.
+    async fn release(&self, node: &str) -> Result<()> {
+        self.rewrite_labels(node, |labels, ours| {
+            let mut updates: Vec<(String, Option<String>)> = Vec::new();
+            if labels.contains_key(ours) {
+                updates.push((ours.to_string(), None));
+            }
+
+            match shared_label_after(labels, ours) {
+                SharedLabel::Keep => info!(
+                    "node {node}: keeping {KATA_RUNTIME_LABEL}, another kata-deploy install is \
+                     still serving Kata from this node"
+                ),
+                // Unfinished installs elsewhere: they need the key to find this node
+                // again, but nothing may be scheduled here meanwhile.
+                SharedLabel::Demote => {
+                    if labels.get(KATA_RUNTIME_LABEL).map(String::as_str)
+                        != Some(KATA_RUNTIME_PENDING)
+                    {
+                        info!(
+                            "node {node}: leaving {KATA_RUNTIME_LABEL}={KATA_RUNTIME_PENDING}, \
+                             one or more kata-deploy installs have claimed this node but none \
+                             has finished installing on it"
+                        );
+                        updates.push((
+                            KATA_RUNTIME_LABEL.to_string(),
+                            Some(KATA_RUNTIME_PENDING.to_string()),
+                        ));
+                    }
+                }
+                SharedLabel::Remove => {
+                    if labels.contains_key(KATA_RUNTIME_LABEL) {
+                        updates.push((KATA_RUNTIME_LABEL.to_string(), None));
+                    }
+                }
+            }
+
+            updates
+        })
+        .await
+    }
+
+    /// Read a node's labels, decide what to write from them, and write it only if
+    /// nothing else changed the node in between.
+    ///
+    /// The decision is read from labels other installs write at the same time, so an
+    /// unconditional write could act on a node that has already moved on: two
+    /// uninstalls each seeing the other's mark, each removing their own, leaving a
+    /// node advertising Kata with nothing installed.
+    async fn rewrite_labels<F>(&self, node: &str, decide: F) -> Result<()>
+    where
+        F: Fn(&BTreeMap<String, String>, &str) -> Vec<(String, Option<String>)>,
+    {
+        for attempt in 1..=LABEL_PATCH_ATTEMPTS {
+            let fetched = self.get(node).await?;
+            let version = fetched
+                .metadata
+                .resource_version
+                .clone()
+                .unwrap_or_default();
+            let labels = fetched.metadata.labels.unwrap_or_default();
+
+            let updates = decide(&labels, &self.instance_label);
+            if updates.is_empty() {
+                return Ok(());
+            }
+
+            match self.patch_labels_guarded(node, &version, &updates).await {
+                Ok(()) => return Ok(()),
+                Err(err) if err.is_conflict => {
+                    info!(
+                        "node {node}: its labels changed while they were being rewritten \
+                         (attempt {attempt}/{LABEL_PATCH_ATTEMPTS}); reading them again"
+                    );
+                }
+                Err(err) => return Err(err.error),
+            }
+        }
+
+        anyhow::bail!(
+            "gave up rewriting the labels on node {node} after {LABEL_PATCH_ATTEMPTS} attempts: \
+             something keeps changing them concurrently"
+        )
+    }
+
+    /// One label write, rejected if the node changed since `version` was read.
+    async fn patch_labels_guarded(
+        &self,
+        node: &str,
+        version: &str,
+        updates: &[(String, Option<String>)],
+    ) -> std::result::Result<(), GuardedPatchError> {
+        let mut ops =
+            vec![json!({"op": "test", "path": "/metadata/resourceVersion", "value": version})];
+        for (key, value) in updates {
+            let path = format!("/metadata/labels/{}", escape_pointer(key));
+            match value {
+                Some(value) => ops.push(json!({"op": "add", "path": path, "value": value})),
+                // `remove` is what makes this rejectable: it fails when the key is
+                // already gone, which is another way of saying we read a stale node.
+                None => ops.push(json!({"op": "remove", "path": path})),
+            }
+        }
+
+        let patch: json_patch::Patch =
+            serde_json::from_value(json!(ops)).map_err(|err| GuardedPatchError {
+                is_conflict: false,
+                error: anyhow::Error::new(err).context("failed to build the label patch"),
+            })?;
+
+        match self
+            .api
+            .patch(node, &PatchParams::default(), &Patch::Json::<Node>(patch))
+            .await
+        {
+            Ok(_) => {
+                info!("node {node}: labels {}", describe_updates(updates));
+                Ok(())
+            }
+            Err(err) => Err(GuardedPatchError {
+                is_conflict: is_precondition_failure(&err),
+                error: anyhow::Error::new(err).context(format!(
+                    "failed to write labels {} on node {node}",
+                    describe_updates(updates)
+                )),
+            }),
         }
     }
 
@@ -199,7 +412,11 @@ impl NodeOps {
             let labels = fetched.metadata.labels.unwrap_or_default();
             // Any value means someone has been here: a `true` must not be
             // downgraded mid-upgrade, and a `false` is already the claim.
-            if labels.contains_key(KATA_RUNTIME_LABEL) {
+            let missing: Vec<&str> = [KATA_RUNTIME_LABEL, self.instance_label.as_str()]
+                .into_iter()
+                .filter(|key| !labels.contains_key(*key))
+                .collect();
+            if missing.is_empty() {
                 return;
             }
 
@@ -210,18 +427,23 @@ impl NodeOps {
                 .unwrap_or_default();
             // `add` needs its parent to exist; a Node without labels is only ever
             // seen in tests, but the patch has to be valid for it too.
-            let add = if labels.is_empty() {
-                json!({"op": "add", "path": "/metadata/labels",
-                       "value": {KATA_RUNTIME_LABEL: KATA_RUNTIME_PENDING}})
+            let mut ops =
+                vec![json!({"op": "test", "path": "/metadata/resourceVersion", "value": version})];
+            if labels.is_empty() {
+                let claimed: BTreeMap<&str, &str> = missing
+                    .iter()
+                    .map(|key| (*key, KATA_RUNTIME_PENDING))
+                    .collect();
+                ops.push(json!({"op": "add", "path": "/metadata/labels", "value": claimed}));
             } else {
-                json!({"op": "add", "path": format!("/metadata/labels/{}", escape_pointer(KATA_RUNTIME_LABEL)),
-                       "value": KATA_RUNTIME_PENDING})
-            };
+                for key in &missing {
+                    ops.push(json!({"op": "add",
+                                    "path": format!("/metadata/labels/{}", escape_pointer(key)),
+                                    "value": KATA_RUNTIME_PENDING}));
+                }
+            }
 
-            let patch: json_patch::Patch = match serde_json::from_value(json!([
-                {"op": "test", "path": "/metadata/resourceVersion", "value": version},
-                add,
-            ])) {
+            let patch: json_patch::Patch = match serde_json::from_value(json!(ops)) {
                 Ok(patch) => patch,
                 Err(err) => {
                     warn!("node {node}: could not build the claim patch ({err})");
@@ -352,27 +574,46 @@ impl NodeOps {
     /// the kubelet's own restart. So the label has to be seen to hold, and be
     /// re-applied when it drifts.
     async fn label_until_stable(&self, node: &str, value: &str) -> Result<()> {
+        // Both labels, because the RuntimeClasses select both: a marker the kubelet
+        // clobbered leaves the node advertised but unusable by this install.
+        let wanted = [KATA_RUNTIME_LABEL, self.instance_label.as_str()];
+        let updates: Vec<(String, Option<String>)> = wanted
+            .iter()
+            .map(|key| (key.to_string(), Some(value.to_string())))
+            .collect();
+
         for attempt in 1..=LABEL_APPLY_ATTEMPTS {
-            self.set_label(node, Some(value)).await?;
+            self.patch_labels(node, &updates).await?;
 
             let mut stable = 0;
             while stable < LABEL_STABILITY_CHECKS {
                 tokio::time::sleep(LABEL_CHECK_INTERVAL).await;
 
-                match self.read_label(node).await {
-                    Ok(Some(observed)) if observed == value => stable += 1,
-                    Ok(observed) => {
+                match self.read_labels(node).await {
+                    Ok(labels) => {
+                        let drifted: Vec<String> = wanted
+                            .iter()
+                            .filter(|key| labels.get(**key).map(String::as_str) != Some(value))
+                            .map(|key| format!("{key}={:?}", labels.get(*key).map(String::as_str)))
+                            .collect();
+
+                        if drifted.is_empty() {
+                            stable += 1;
+                            continue;
+                        }
+
                         warn!(
-                            "node {node}: {KATA_RUNTIME_LABEL} drifted to {observed:?} after \
-                             {stable}/{LABEL_STABILITY_CHECKS} stable observation(s); re-applying \
-                             (attempt {attempt}/{LABEL_APPLY_ATTEMPTS})"
+                            "node {node}: {} after {stable}/{LABEL_STABILITY_CHECKS} stable \
+                             observation(s); re-applying (attempt \
+                             {attempt}/{LABEL_APPLY_ATTEMPTS})",
+                            drifted.join(", ")
                         );
                         break;
                     }
                     Err(err) => {
                         warn!(
-                            "node {node}: could not confirm {KATA_RUNTIME_LABEL} ({err:#}); \
-                             re-applying (attempt {attempt}/{LABEL_APPLY_ATTEMPTS})"
+                            "node {node}: could not confirm its labels ({err:#}); re-applying \
+                             (attempt {attempt}/{LABEL_APPLY_ATTEMPTS})"
                         );
                         break;
                     }
@@ -380,51 +621,53 @@ impl NodeOps {
             }
 
             if stable >= LABEL_STABILITY_CHECKS {
-                info!("node {node}: {KATA_RUNTIME_LABEL}={value} is holding");
+                info!("node {node}: {} are holding", describe_updates(&updates));
                 return Ok(());
             }
         }
 
         anyhow::bail!(
-            "node {node} did not hold {KATA_RUNTIME_LABEL}={value} for \
-             {LABEL_STABILITY_CHECKS} consecutive checks over {LABEL_APPLY_ATTEMPTS} attempts; \
-             something on the node keeps removing it, and workloads would not be scheduled there"
+            "node {node} did not hold {} for {LABEL_STABILITY_CHECKS} consecutive checks over \
+             {LABEL_APPLY_ATTEMPTS} attempts; something on the node keeps removing them, and \
+             workloads would not be scheduled there",
+            describe_updates(&updates)
         )
     }
 
     /// Set (or, with `None`, remove) the Kata runtime label on `node`.
-    async fn set_label(&self, node: &str, value: Option<&str>) -> Result<()> {
+    /// Apply label writes in one request, `None` removing a label.
+    async fn patch_labels(&self, node: &str, updates: &[(String, Option<String>)]) -> Result<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
         // A JSON merge patch removes a key by setting it to null; omitting it
         // would leave it untouched.
-        let patch = match value {
-            Some(value) => json!({"metadata": {"labels": {KATA_RUNTIME_LABEL: value}}}),
-            None => json!({"metadata": {"labels": {KATA_RUNTIME_LABEL: serde_json::Value::Null}}}),
-        };
+        let labels: serde_json::Map<String, serde_json::Value> = updates
+            .iter()
+            .map(|(key, value)| {
+                let value = match value {
+                    Some(value) => serde_json::Value::String(value.clone()),
+                    None => serde_json::Value::Null,
+                };
+                (key.clone(), value)
+            })
+            .collect();
+        let patch = json!({"metadata": {"labels": labels}});
+
+        let described = describe_updates(updates);
 
         self.api
             .patch(node, &PatchParams::default(), &Patch::Merge(&patch))
             .await
-            .with_context(|| match value {
-                Some(value) => format!("failed to label node {node} {KATA_RUNTIME_LABEL}={value}"),
-                None => format!("failed to remove label {KATA_RUNTIME_LABEL} from node {node}"),
-            })?;
+            .with_context(|| format!("failed to write labels {described} on node {node}"))?;
 
-        match value {
-            Some(value) => info!("node {node}: labelled {KATA_RUNTIME_LABEL}={value}"),
-            None => info!("node {node}: removed label {KATA_RUNTIME_LABEL}"),
-        }
+        info!("node {node}: labels {described}");
         Ok(())
     }
 
-    async fn read_label(&self, node: &str) -> Result<Option<String>> {
-        Ok(self
-            .get(node)
-            .await?
-            .metadata
-            .labels
-            .as_ref()
-            .and_then(|labels| labels.get(KATA_RUNTIME_LABEL))
-            .cloned())
+    async fn read_labels(&self, node: &str) -> Result<BTreeMap<String, String>> {
+        Ok(self.get(node).await?.metadata.labels.unwrap_or_default())
     }
 
     /// Best-effort on purpose: the runtime is installed and the node is labelled
@@ -629,6 +872,24 @@ impl NodeOps {
     }
 }
 
+/// A label write that was rejected, and whether re-reading the node could make it
+/// succeed.
+struct GuardedPatchError {
+    is_conflict: bool,
+    error: anyhow::Error,
+}
+
+fn describe_updates(updates: &[(String, Option<String>)]) -> String {
+    updates
+        .iter()
+        .map(|(key, value)| match value {
+            Some(value) => format!("{key}={value}"),
+            None => format!("{key} (removed)"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// A label key as a JSON Pointer token: `~` and `/` are the two characters with a
 /// meaning of their own there (RFC 6901).
 fn escape_pointer(token: &str) -> String {
@@ -817,6 +1078,88 @@ mod tests {
             ),
             HandlerVerdict::NotServing
         );
+    }
+
+    #[test]
+    fn an_install_is_named_after_its_suffix() {
+        assert_eq!(
+            instance_label(None),
+            "kata-deploy.katacontainers.io/default"
+        );
+        assert_eq!(
+            instance_label(Some("dev")),
+            "kata-deploy.katacontainers.io/dev"
+        );
+    }
+
+    /// The shared label may only be taken away when it is nobody else's.
+    #[test]
+    fn only_another_installs_mark_counts() {
+        let ours = instance_label(Some("dev"));
+        let mark = |keys: &[&str]| -> BTreeMap<String, String> {
+            keys.iter()
+                .map(|key| (key.to_string(), "true".to_string()))
+                .collect()
+        };
+
+        assert_eq!(
+            shared_label_after(&mark(&[&ours]), &ours),
+            SharedLabel::Remove
+        );
+        assert_eq!(
+            shared_label_after(
+                &mark(&[&ours, KATA_RUNTIME_LABEL, "kubernetes.io/hostname"]),
+                &ours
+            ),
+            SharedLabel::Remove,
+            "neither the shared label nor an unrelated one is another install's mark"
+        );
+        assert_eq!(
+            shared_label_after(&mark(&[&ours, &instance_label(None)]), &ours),
+            SharedLabel::Keep
+        );
+        assert_eq!(
+            shared_label_after(&mark(&[&instance_label(Some("prod"))]), &ours),
+            SharedLabel::Keep
+        );
+    }
+
+    /// Installs that have claimed the node but not finished on it must not keep it
+    /// advertised as able to run Kata - and must still be able to find it.
+    #[test]
+    fn unfinished_installs_hold_the_key_without_the_promise() {
+        let ours = instance_label(Some("dev"));
+        let labels = BTreeMap::from([
+            (ours.clone(), "true".to_string()),
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Demote);
+
+        // However many of them there are.
+        let labels = BTreeMap::from([
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+            (
+                instance_label(Some("prod")),
+                KATA_RUNTIME_PENDING.to_string(),
+            ),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Demote);
+    }
+
+    /// One install serving Kata is enough to keep the shared label, however many
+    /// unfinished ones are read before it - and labels are read in key order, so
+    /// "default" here is read before "prod".
+    #[test]
+    fn a_serving_install_outweighs_unfinished_ones() {
+        let ours = instance_label(Some("dev"));
+        let labels = BTreeMap::from([
+            (instance_label(None), KATA_RUNTIME_PENDING.to_string()),
+            (instance_label(Some("prod")), "true".to_string()),
+        ]);
+
+        assert_eq!(shared_label_after(&labels, &ours), SharedLabel::Keep);
     }
 
     /// The label key has a `/` in it, which is a path separator inside a JSON


### PR DESCRIPTION
The shared `katacontainers.io/kata-runtime` label says that a node can run Kata, but it cannot say which Helm installation owns that capability. With multiple installations, uninstalling one release can therefore withdraw scheduling from another release that still serves the node.

Give every installation its own marker label and make its RuntimeClasses select both that marker and the shared readiness label. Cleanup removes the shared label only after the last installation releases the node. The default, unsuffixed installation receives a stable `default` marker so it follows the same ownership rules.

Persist the release suffix and deployment mode in chart state and reject in-place identity changes that could orphan nodes. Built-in and custom RuntimeClasses use the same ownership gate.