### PR TITLE
kata-deploy: make dispatcher rollouts converge safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,6 +3775,7 @@ dependencies = [
  "rstest",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
+ "sha2 0.11.0",
  "tokio",
 ]
 

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -220,10 +220,10 @@ Three things need the Kubernetes API, so none of them happen inside a per-node J
   *before* that node's Job starts taking the node apart — and the label itself goes
   only once that Job has succeeded.
 
-    The claim is best-effort by design: a node that cannot be claimed is still
-    worth installing on, so a failure there is logged and the install proceeds.
-    Uninstall then relies on what the node does carry — see
-    [Choosing which nodes are cleaned up on uninstall](#choosing-which-nodes-are-cleaned-up-on-uninstall).
+    In `job` mode the claim is mandatory: the dispatcher refuses to start a
+    host-mutating Job unless both labels were written atomically. Otherwise a
+    half-failed install could modify a host that the default uninstall selector
+    cannot discover. In `daemonset` mode the claim stays best-effort.
 
     The handler check has one limit worth knowing: `.status.runtimeHandlers` is
     populated by kubelet from Kubernetes 1.30 on. A node that does not report the
@@ -416,6 +416,11 @@ An empty `nodeSelector` therefore does **not** mean "every node": step 2 still
 applies, and that is what keeps Kata off control-plane nodes by default without
 any label filtering.
 
+On upgrade, `job` mode also compares that desired set with the nodes carrying
+this installation's marker. Nodes in `owned - desired` run the cleanup pipeline
+before the desired nodes are installed, so narrowing or changing a selector does
+not leave the old nodes labelled and configured forever.
+
 ```yaml title="values.yaml"
 # Install on nodes carrying a specific label:
 nodeSelector:
@@ -478,15 +483,16 @@ is permanent — nothing installs the node later — so a silent success would l
 the fleet without Kata and nothing to point at.
 
 Finding one eligible node is not the end of the wait either. Eligibility arrives
-per node, so the dispatcher keeps looking until a whole pass adds nothing new
-(or the wait expires) — otherwise it would install on whichever node was labelled
-first and quietly leave the rest of the fleet out. This costs one extra poll on a
-cluster where every node is eligible from the start.
+per node, so the dispatcher waits until the set stays unchanged for
+`job.nodeSettleSeconds` (default `15`) or the overall wait expires. A single
+unchanged poll is not enough: the next node may be labelled a second later.
 
 ```yaml title="values.yaml"
 job:
   # Give a slow-labelling cluster longer (see the timeout warning below)...
   waitForNodesSeconds: 300
+  # Require a 30-second quiet period after the last newly eligible node.
+  nodeSettleSeconds: 30
   # ...or resolve once and treat "no eligible node" as a no-op, the way a
   # DaemonSet with no matching node quietly installs nothing.
   # waitForNodesSeconds: 0
@@ -591,13 +597,9 @@ find. Where several installations share a node, neither the demotion nor the rem
 happens while another one is still holding it — see
 [How installations keep out of each other's way on a node](#how-installations-keep-out-of-each-others-way-on-a-node).
 
-!!! warning "Claiming is best-effort, so this is not a guarantee"
-
-    A node whose claim could not be written (a rejected patch, an API server that
-    was unreachable at that moment) carries no label, and the default selector
-    cannot see it. If an install failed and you are unsure whether every node was
-    reached, name the nodes explicitly under `job.cleanup.nodes`, or widen the
-    selector to the nodes the install targeted.
+In `job` mode claiming is a precondition for dispatch: if the labels cannot be
+written, that node fails before any host mutation begins. This keeps the default
+cleanup selector complete even when the API server rejects or times out a patch.
 
 Cleanup pods also tolerate **every** taint, unlike the install's, which carry the
 `tolerations` you configured. Where an install may run is your decision; where an
@@ -956,8 +958,8 @@ label its own uninstall can find.
 
     Nodes installed by a version that did not write marks carry none, and an
     uninstall cannot attribute such a node to one release. Run `helm upgrade` on
-    every installation before uninstalling one of them, so each release has first
-    marked the nodes it owns.
+    every installation without changing its node selection before uninstalling or
+    narrowing one of them, so each release has first marked the nodes it owns.
 
 `env.multiInstallSuffix` is immutable for the life of a Helm release. The chart
 stores the first value under a suffix-independent ConfigMap name and rejects an

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -129,6 +129,18 @@ rbac_doc() {
 	echo "${jobs}" | grep -q 'cleanup-stage-remove-artifacts'
 }
 
+@test "Helm template (job mode): a per-node Job can tell which host it woke up on" {
+	local stage pod_spec
+	for stage in install cleanup; do
+		pod_spec=$(per_node_pod_spec "${stage}")
+		# A Job is bound to a node by name, and a name can outlive the machine that
+		# answered to it. Without the host's own identity to compare against, the
+		# machine ID the dispatcher passes down would be unverifiable.
+		echo "${pod_spec}" | grep -q 'path: /etc/machine-id'
+		echo "${pod_spec}" | grep -q 'mountPath: /host-machine-id'
+	done
+}
+
 @test "Helm template (job mode): the privileged ServiceAccount is not created at all" {
 	local rbac
 	rbac=$(render_job_mode kata-rbac.yaml)
@@ -238,8 +250,9 @@ EOF
 	echo "${noderole}" | grep -q 'resources: \["nodes"\]'
 	echo "${noderole}" | grep -q 'verbs: \["list", "get", "patch"\]'
 
-	# Nothing beyond nodes and their kubelet proxy, and no verb that could delete
-	# or create one.
+	# Job mode never reasons about DaemonSets: all releases in one cluster use the
+	# same deployment mode.
+	refute_match "${noderole}" 'daemonsets'
 	refute_match "${noderole}" 'pods'
 	refute_match "${noderole}" '"delete"'
 	refute_match "${noderole}" '"create"'
@@ -251,7 +264,7 @@ EOF
 	role=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-role')
 	[[ -n "${role}" ]]
 	echo "${role}" | grep -q 'resources: \["jobs"\]'
-	echo "${role}" | grep -q 'verbs: \["create", "get", "delete"\]'
+	echo "${role}" | grep -q 'verbs: \["create", "get", "list", "delete"\]'
 	echo "${role}" | grep -q '^kind: Role$'
 }
 

--- a/tests/functional/kata-deploy/kata-deploy-scheduling.bats
+++ b/tests/functional/kata-deploy/kata-deploy-scheduling.bats
@@ -679,6 +679,13 @@ EOF
 
 	echo "${rendered}" | grep -q -- '--nodes=worker-1,worker-2'
 	refute_match "${rendered}" '--node-selector='
+
+	# Naming a node is an admission override, so its Job tolerates every taint. A
+	# key or an effect on that entry would narrow it back down.
+	render_job_templates --set 'job.nodes[0]=worker-1'
+	local install
+	install=$(extract_pernode_job install)
+	[[ "$(echo "${install}" | tolerations_of)" == "operator: Exists" ]]
 }
 
 @test "Helm template (job mode): install waits for nodes to become eligible" {
@@ -691,6 +698,8 @@ EOF
 	# selection matches are written by NFD, which starts with this very release.
 	# Resolving nodes off the first snapshot would install nowhere and exit 0.
 	echo "${rendered}" | grep -q -- '--wait-for-nodes-secs=120'
+	echo "${rendered}" | grep -q -- '--node-settle-secs=15'
+	echo "${rendered}" | grep -q -- '--cleanup-job-template=/etc/kata-job/cleanup-job.yaml'
 
 	rendered=$(helm template kata-deploy "${CHART_PATH}" \
 		--set deploymentMode=job \
@@ -799,6 +808,20 @@ EOF
 		--set 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].operator=In'
 	[ "${status}" -ne 0 ]
 	echo "${output}" | grep -q "matchFields cannot be used"
+}
+
+@test "Helm template (job mode): empty required affinity cannot invert to every node" {
+	run helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set-json 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms=[]'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'nodeSelectorTerms must not be empty'
+
+	run helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set-json 'affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms=[{}]'
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'an empty nodeSelectorTerm matches no nodes'
 }
 
 @test "Helm template (job mode): the dispatcher can be confined to trusted nodes" {

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -150,6 +150,16 @@ async fn main() -> Result<()> {
     }
 
     let config = config::Config::from_env()?;
+    if matches!(
+        args.action,
+        Action::InstallStageHostCheck
+            | Action::InstallStageArtifacts
+            | Action::InstallStageCri
+            | Action::CleanupStageRevertCri
+            | Action::CleanupStageRemoveArtifacts
+    ) {
+        verify_node_machine_id()?;
+    }
     let action_str = match args.action {
         Action::Install => "install",
         Action::Cleanup => "cleanup",
@@ -325,6 +335,30 @@ async fn main() -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Confirm this pod is on the node the dispatcher meant.
+///
+/// A Job is bound to a node by name, and a name can outlive the machine that
+/// carried it, so refuse to mutate a host whose machine ID is not the one the
+/// dispatcher passed down. An older chart passes none, and then there is nothing to
+/// compare against.
+fn verify_node_machine_id() -> Result<()> {
+    const EXPECTED_ENV: &str = "KATA_DEPLOY_NODE_MACHINE_ID";
+    const HOST_MACHINE_ID: &str = "/host-machine-id";
+
+    let Ok(expected) = std::env::var(EXPECTED_ENV) else {
+        return Ok(());
+    };
+    let actual = std::fs::read_to_string(HOST_MACHINE_ID)
+        .with_context(|| format!("failed to read the host identity from {HOST_MACHINE_ID}"))?;
+    anyhow::ensure!(
+        actual.trim() == expected.trim(),
+        "target node identity changed before host mutation: expected machine ID {}, found {}",
+        expected.trim(),
+        actual.trim()
+    );
     Ok(())
 }
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1001,13 +1001,20 @@ the install does not tolerate, mirroring what the scheduler does for a DaemonSet
 {{- $eq := .Values.nodeSelector | default dict -}}
 {{- $terms := list -}}
 {{- $nodeAffinity := (.Values.affinity | default dict).nodeAffinity | default dict -}}
+{{- $hasRequired := hasKey $nodeAffinity "requiredDuringSchedulingIgnoredDuringExecution" -}}
 {{- with $nodeAffinity -}}
 {{- $required := .requiredDuringSchedulingIgnoredDuringExecution | default dict -}}
 {{- $terms = $required.nodeSelectorTerms | default list -}}
 {{- end -}}
+{{- if and $hasRequired (not $terms) -}}
+{{- fail "affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms must not be empty with deploymentMode: job. Kubernetes defines an empty required term list as matching no nodes; remove requiredDuringSchedulingIgnoredDuringExecution to select every otherwise eligible node." -}}
+{{- end -}}
 {{- range $term := $terms -}}
 {{- if $term.matchFields -}}
 {{- fail "affinity.nodeAffinity: matchFields cannot be used with deploymentMode: job. Node selection is a label-selector LIST against the Kubernetes API server, which cannot match on fields. To target nodes by name, use job.nodes instead." -}}
+{{- end -}}
+{{- if not ($term.matchExpressions | default list) -}}
+{{- fail "affinity.nodeAffinity: an empty nodeSelectorTerm matches no nodes in Kubernetes and cannot be represented as an API label selector in job mode. Remove the empty term or add a matchExpressions requirement." -}}
 {{- end -}}
 {{- end -}}
 {{- if index .Values "node-feature-discovery" "enabled" -}}
@@ -1151,6 +1158,12 @@ spec:
              restarts the CRI runtime, which takes the node NotReady long enough
              for the taint manager to evict it mid-install. */}}
       tolerations:
+{{- if $root.Values.job.nodes }}
+        {{- /* Explicit names are a deliberate admission override. nodeName gets
+               past the scheduler, but an untolerated NoExecute taint can still
+               evict the bound pod before it finishes. */}}
+        - operator: Exists
+{{- else }}
         - key: node.kubernetes.io/not-ready
           operator: Exists
           effect: NoExecute
@@ -1169,6 +1182,7 @@ spec:
         - key: node.kubernetes.io/unschedulable
           operator: Exists
           effect: NoSchedule
+{{- end }}
 {{- with $root.Values.tolerations }}
 {{- toYaml . | nindent 8 }}
 {{- end }}
@@ -1295,6 +1309,9 @@ host. Emitted at column 0; indent with `nindent` at the call site.
 - name: boot
   mountPath: /boot
   readOnly: true
+- name: host-machine-id
+  mountPath: /host-machine-id
+  readOnly: true
 - name: host-usr-bin
   mountPath: /host-usr/bin
   readOnly: true
@@ -1352,6 +1369,10 @@ indent with `nindent` at the call site.
 - name: boot
   hostPath:
     path: /boot
+- name: host-machine-id
+  hostPath:
+    path: /etc/machine-id
+    type: File
 - name: host-usr-bin
   hostPath:
     path: /usr/bin

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -95,6 +95,7 @@ spec:
           command:
             - /usr/bin/kata-deploy-job-dispatcher
             - "--job-template=/etc/kata-job/install-job.yaml"
+            - "--cleanup-job-template=/etc/kata-job/cleanup-job.yaml"
             - "--name-prefix={{ $base }}-install"
             - "--owner-job-name={{ $dispatcherName }}"
             - "--parallelism={{ $root.Values.job.parallelism }}"
@@ -112,6 +113,7 @@ acting on the first snapshot it happens to see. Not passed with an explicit
 job.nodes list, which names nodes outright and needs no discovery.
 */}}
             - "--wait-for-nodes-secs={{ $root.Values.job.waitForNodesSeconds | default 0 }}"
+            - "--node-settle-secs={{ $root.Values.job.nodeSettleSeconds | default 15 }}"
 {{- end }}
 {{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "install") | nindent 12 }}
           env:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -122,7 +122,7 @@ rules:
 # The dispatcher only ever creates, polls, and deletes per-node Jobs in its own namespace.
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["create", "get", "delete"]
+  verbs: ["create", "get", "list", "delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -69,7 +69,8 @@ job:
   #
   # The only job-mode-specific override is an explicit list of node names, which
   # takes precedence over the selection above and is used verbatim (including
-  # tainted nodes, since naming a node is unambiguous):
+  # tainted nodes, since naming a node is unambiguous). Those install Jobs receive
+  # a catch-all toleration so a NoExecute taint cannot evict a directly bound pod:
   #   job:
   #     nodes: ["worker-1", "worker-2"]
   nodes: []
@@ -96,6 +97,14 @@ job:
   # this alone just trades a dispatcher error that names the selectors it tried
   # for Helm's opaque "timed out waiting for the condition".
   waitForNodesSeconds: 120
+  # How long the eligible-node set must remain unchanged before dispatch starts
+  # (seconds). Labels commonly arrive one node at a time; this quiet period keeps
+  # the first labelled node from making the dispatcher miss the rest.
+  nodeSettleSeconds: 15
+  # On upgrade, nodes carrying this installation's marker but no longer matching
+  # the selection run the cleanup pipeline before the desired nodes are installed.
+  # This makes selector changes converge in both directions instead of leaving
+  # removed nodes permanently configured and advertised.
   # How long to wait for a node to report Ready again after its install Job
   # finished, before advertising it as Kata-capable.
   #

--- a/tools/packaging/kata-deploy/job-dispatcher/Cargo.toml
+++ b/tools/packaging/kata-deploy/job-dispatcher/Cargo.toml
@@ -34,6 +34,7 @@ kube = { version = "2.0", default-features = false, features = [
 ] }
 log.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 serde_yaml = "0.9"
 tokio = { workspace = true, features = [
     "rt-multi-thread",

--- a/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/job.rs
@@ -6,13 +6,13 @@ use crate::nodes::NodeFacts;
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{EnvVar, PodSpec};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
-use std::collections::hash_map::DefaultHasher;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::hash::{Hash, Hasher};
 
 /// Carries `.status.nodeInfo.containerRuntimeVersion` into the per-node Job, so it
 /// need not read the Node object to detect the runtime.
 pub const CONTAINER_RUNTIME_VERSION_ENV: &str = "CONTAINER_RUNTIME_VERSION";
+pub const NODE_MACHINE_ID_ENV: &str = "KATA_DEPLOY_NODE_MACHINE_ID";
 
 /// Label applied to every per-node Job, set to the dispatcher's name prefix.
 /// Used as a server-side selector so the dispatcher only ever sees the Jobs it
@@ -58,22 +58,28 @@ pub fn sanitize_node(node: &str) -> String {
 /// Short, stable hex digest of an arbitrary string. Used to keep generated
 /// Job names unique when the sanitized/truncated form would otherwise collide.
 fn short_hash(s: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    s.hash(&mut hasher);
-    format!("{:08x}", (hasher.finish() & 0xffff_ffff) as u32)
+    let digest = Sha256::digest(s.as_bytes());
+    digest[..12]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 /// Build a deterministic, RFC1123-label-safe Job name (`<= 63` chars) for a
 /// node. When `<prefix>-<sanitized-node>` fits it is used verbatim; otherwise
-/// it is truncated and a short hash of the *full* node name is appended so two
-/// different long node names cannot collide.
+/// it is truncated and a short hash of the full prefix-plus-node identity is
+/// appended so neither long node names nor long release prefixes can collide.
+///
+/// The derivation is free to change between releases: Jobs from an earlier run
+/// are found through [`OWNER_LABEL`] and their `ownerReference`, never by
+/// recomputing what they would be called today.
 pub fn job_name(prefix: &str, node: &str) -> String {
     let sanitized = sanitize_node(node);
     let base = format!("{prefix}-{sanitized}");
-    if base.len() <= MAX_LABEL_LEN {
+    if sanitized == node && base.len() <= MAX_LABEL_LEN {
         return base;
     }
-    let hash = short_hash(node);
+    let hash = short_hash(&format!("{prefix}\0{node}"));
     // Reserve room for "-" + hash.
     let keep = MAX_LABEL_LEN.saturating_sub(hash.len() + 1);
     let truncated = base.chars().take(keep).collect::<String>();
@@ -89,15 +95,25 @@ pub fn job_name(prefix: &str, node: &str) -> String {
 /// a Helm release/suffix) without risking an invalid or over-long label.
 pub fn sanitize_label_value(value: &str) -> String {
     let sanitized = sanitize_node(value);
-    if sanitized.len() <= MAX_LABEL_LEN {
+    if sanitized == value && sanitized.len() <= MAX_LABEL_LEN {
         return sanitized;
     }
-    sanitized
+    let hash = short_hash(value);
+    let keep = MAX_LABEL_LEN.saturating_sub(hash.len() + 1);
+    let prefix = sanitized
         .chars()
-        .take(MAX_LABEL_LEN)
+        .take(keep)
         .collect::<String>()
         .trim_end_matches('-')
-        .to_string()
+        .to_string();
+    format!(
+        "{}-{hash}",
+        if prefix.is_empty() {
+            "dispatcher"
+        } else {
+            &prefix
+        }
+    )
 }
 
 /// True if `job` carries [`OWNER_LABEL`] set to exactly `owner_value`. Used to
@@ -140,7 +156,7 @@ pub fn build_node_job(
 
     let labels = job.metadata.labels.get_or_insert_with(BTreeMap::new);
     labels.insert(OWNER_LABEL.to_string(), owner_value.to_string());
-    labels.insert(NODE_LABEL.to_string(), sanitize_node(node));
+    labels.insert(NODE_LABEL.to_string(), sanitize_label_value(node));
 
     let annotations = job.metadata.annotations.get_or_insert_with(BTreeMap::new);
     annotations.insert(NODE_ANNOTATION.to_string(), node.to_string());
@@ -175,9 +191,9 @@ pub fn build_node_job(
 /// processes, any of them may need the runtime, and an existing value is left
 /// alone so an explicit override in the chart still wins.
 fn inject_node_facts(pod_spec: &mut PodSpec, facts: &NodeFacts) {
-    let Some(version) = facts.container_runtime_version.as_deref() else {
+    if facts.container_runtime_version.is_none() && facts.machine_id.is_none() {
         return;
-    };
+    }
 
     let containers = pod_spec
         .init_containers
@@ -187,17 +203,27 @@ fn inject_node_facts(pod_spec: &mut PodSpec, facts: &NodeFacts) {
 
     for container in containers {
         let env = container.env.get_or_insert_with(Vec::new);
-        if env
-            .iter()
-            .any(|var| var.name == CONTAINER_RUNTIME_VERSION_ENV)
-        {
-            continue;
+        if let Some(version) = facts.container_runtime_version.as_deref() {
+            if !env
+                .iter()
+                .any(|var| var.name == CONTAINER_RUNTIME_VERSION_ENV)
+            {
+                env.push(EnvVar {
+                    name: CONTAINER_RUNTIME_VERSION_ENV.to_string(),
+                    value: Some(version.to_string()),
+                    value_from: None,
+                });
+            }
         }
-        env.push(EnvVar {
-            name: CONTAINER_RUNTIME_VERSION_ENV.to_string(),
-            value: Some(version.to_string()),
-            value_from: None,
-        });
+        if let Some(machine_id) = facts.machine_id.as_deref() {
+            if !env.iter().any(|var| var.name == NODE_MACHINE_ID_ENV) {
+                env.push(EnvVar {
+                    name: NODE_MACHINE_ID_ENV.to_string(),
+                    value: Some(machine_id.to_string()),
+                    value_from: None,
+                });
+            }
+        }
     }
 }
 
@@ -244,10 +270,17 @@ mod tests {
 
     #[rstest]
     #[case("kata-deploy-install", "kata-deploy-install")]
-    #[case("Kata_Deploy.Install", "kata-deploy-install")]
-    #[case("--weird--", "weird")]
     fn test_sanitize_label_value_short(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(sanitize_label_value(input), expected);
+    }
+
+    #[test]
+    fn normalization_cannot_merge_release_identities() {
+        let dotted = sanitize_label_value("kata.foo");
+        let dashed = sanitize_label_value("kata-foo");
+        assert_ne!(dotted, dashed);
+        assert!(dotted.starts_with("kata-foo-"));
+        assert_eq!(dashed, "kata-foo");
     }
 
     #[test]
@@ -274,9 +307,16 @@ mod tests {
 
     #[rstest]
     #[case("kata-deploy-install", "worker-0", "kata-deploy-install-worker-0")]
-    #[case("kata-deploy-cleanup", "Worker.0", "kata-deploy-cleanup-worker-0")]
     fn test_job_name_short(#[case] prefix: &str, #[case] node: &str, #[case] expected: &str) {
         assert_eq!(job_name(prefix, node), expected);
+    }
+
+    #[test]
+    fn normalized_node_names_cannot_merge_job_names() {
+        assert_ne!(
+            job_name("kata-deploy-install", "worker.a"),
+            job_name("kata-deploy-install", "worker-a")
+        );
     }
 
     #[test]
@@ -304,6 +344,17 @@ mod tests {
             name_a, name_b,
             "different node names must yield different job names"
         );
+    }
+
+    #[test]
+    fn long_release_prefixes_cannot_merge_job_names() {
+        let shared = "kata-deploy-install-with-a-very-long-shared-prefix-";
+        let name_a = job_name(&format!("{shared}alpha"), "worker-0");
+        let name_b = job_name(&format!("{shared}bravo"), "worker-0");
+
+        assert_ne!(name_a, name_b);
+        assert!(name_a.len() <= MAX_LABEL_LEN);
+        assert!(name_b.len() <= MAX_LABEL_LEN);
     }
 
     #[test]
@@ -337,6 +388,7 @@ spec:
         let facts = NodeFacts {
             name: "node1".to_string(),
             container_runtime_version: Some("containerd://2.1.5".to_string()),
+            machine_id: Some("machine-1".to_string()),
         };
 
         let job = build_node_job(
@@ -411,6 +463,7 @@ spec:
             &NodeFacts {
                 name: "node1".to_string(),
                 container_runtime_version: None,
+                machine_id: None,
             },
         );
 
@@ -444,6 +497,7 @@ spec:
         let facts = NodeFacts {
             name: "node1".to_string(),
             container_runtime_version: Some("cri-o://1.31.0".to_string()),
+            machine_id: Some("machine-1".to_string()),
         };
         let job = build_node_job(&template, "j", "node1", "owner", None, &facts);
         let pod_spec = job.spec.unwrap().template.spec.unwrap();
@@ -459,6 +513,12 @@ spec:
                     .and_then(|var| var.value.clone())
                     .as_deref(),
                 Some("cri-o://1.31.0")
+            );
+            assert_eq!(
+                env.iter()
+                    .find(|var| var.name == NODE_MACHINE_ID_ENV)
+                    .and_then(|var| var.value.as_deref()),
+                Some("machine-1")
             );
         }
     }

--- a/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/main.rs
@@ -34,7 +34,7 @@ use kube::Client;
 use log::{error, info};
 use node_filter::{describe_taint, partition_by_tolerations, suggested_toleration, SkippedNode};
 use nodes::{instance_label, NodeFacts, NodeOps};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
@@ -45,8 +45,9 @@ use tokio::task::JoinSet;
 /// rejecting it - would otherwise be polled forever, and the run would end only
 /// when something killed the dispatcher, with no result reported for any node.
 const JOB_READ_ERROR_BUDGET: Duration = Duration::from_secs(300);
+const JOB_GET_TIMEOUT: Duration = Duration::from_secs(15);
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(
     author,
     version,
@@ -57,6 +58,11 @@ struct Args {
     /// The dispatcher clones it per node and sets metadata.name + nodeName.
     #[arg(long)]
     job_template: String,
+
+    /// Cleanup Job template used on upgrade for nodes this installation owns but
+    /// which no longer match the desired node selection.
+    #[arg(long)]
+    cleanup_job_template: Option<String>,
 
     /// Prefix for generated per-node Job names. Also recorded as the
     /// "kata-deploy-job-dispatcher/owner" label so the dispatcher tracks only its own Jobs.
@@ -117,6 +123,14 @@ struct Args {
     /// silent no-op that would leave every node uninstalled.
     #[arg(long, default_value_t = 0)]
     wait_for_nodes_secs: u64,
+
+    /// Seconds the eligible-node set must remain unchanged before it is accepted.
+    ///
+    /// Labels arrive node by node. Treating one unchanged poll as convergence can
+    /// miss a node labelled immediately after that poll even when most of
+    /// --wait-for-nodes-secs remains.
+    #[arg(long, default_value_t = 15)]
+    node_settle_secs: u64,
 
     /// Optional owner Job name (in the dispatcher's namespace). When set, every
     /// per-node Job gets an ownerReference to it so they are garbage-collected
@@ -202,6 +216,12 @@ struct Args {
     /// Page size used when listing nodes (server-side pagination).
     #[arg(long, default_value_t = 500)]
     node_page_size: u32,
+
+    /// Not a flag: set on the copy of these arguments that cleans nodes this
+    /// install owns but no longer selects, where a node back in the selection is
+    /// one to leave alone rather than one to act on.
+    #[arg(skip)]
+    removed_node_cleanup: bool,
 }
 
 // The dispatcher is overwhelmingly I/O-bound (apiserver round-trips); two worker
@@ -230,13 +250,18 @@ async fn main() -> Result<()> {
 
     let node_ops = Arc::new(node_ops_from_args(&client, &args)?);
 
-    let nodes = resolve_nodes(&client, &args, &template_tolerations(&template)).await?;
-    if nodes.is_empty() {
-        info!("no target nodes matched the selection; nothing to do");
-        return Ok(());
-    }
-
-    let facts = collect_node_facts(&node_ops, &nodes).await;
+    let mut nodes = resolve_nodes(&client, &args, &template_tolerations(&template)).await?;
+    // The matched set, not the admitted one: this decides which nodes the release
+    // still owns, and a taint only says a pod cannot run there right now. Reading
+    // an untolerated taint as "no longer mine" would uninstall from every node
+    // somebody cordoned between two upgrades.
+    let desired_nodes = if args.nodes.is_some() {
+        nodes.clone()
+    } else {
+        let api: Api<Node> = Api::all(client.clone());
+        let (matched, _, _) = select_nodes(&api, &args, &template_tolerations(&template)).await?;
+        matched
+    };
 
     let owner = match args.owner_job_name.as_deref() {
         Some(name) => Some(owner_ref_for_job(&client, &namespace, name).await?),
@@ -244,6 +269,57 @@ async fn main() -> Result<()> {
     };
 
     let jobs: Api<Job> = Api::namespaced(client.clone(), &namespace);
+
+    if let Some(cleanup_path) = args.cleanup_job_template.as_deref() {
+        let cleanup_raw = std::fs::read_to_string(cleanup_path)
+            .with_context(|| format!("failed to read cleanup job template {cleanup_path}"))?;
+        let cleanup_template: Job = serde_yaml::from_str(&cleanup_raw)
+            .with_context(|| format!("failed to parse cleanup job template {cleanup_path}"))?;
+        let removed =
+            nodes_owned_but_not_desired(&client, &node_ops.instance_label, &desired_nodes).await?;
+        if !removed.is_empty() {
+            info!(
+                "{} node(s) no longer match this installation's selection; cleaning them before \
+                 installing the desired set",
+                removed.len()
+            );
+            let mut cleanup_args = args.clone();
+            cleanup_args.name_prefix = format!("{}-removed", args.name_prefix);
+            cleanup_args.cleanup_job_template = None;
+            cleanup_args.removed_node_cleanup = true;
+            let mut cleanup_ops = (*node_ops).clone();
+            cleanup_ops.label_value = None;
+            cleanup_ops.remove_label = true;
+            cleanup_ops.claim_pending = false;
+            cleanup_ops.remove_taints.clear();
+            cleanup_ops.wait_ready = None;
+            cleanup_ops.require_handlers.clear();
+            cleanup_ops.kubelet_timeout_warn = None;
+            run_fanout(
+                &jobs,
+                &cleanup_template,
+                &removed,
+                &cleanup_args,
+                &namespace,
+                cleanup_args.parallelism.clamp(1, removed.len()),
+                owner.as_ref(),
+                Arc::new(cleanup_ops),
+                &client,
+            )
+            .await
+            .context("failed to clean nodes removed from the desired selection")?;
+
+            // Cleanup may take long enough for a removed node to re-enter the
+            // selection. It was left untouched by the guarded cleanup path, so
+            // include it in this upgrade's install pass.
+            nodes = resolve_nodes(&client, &args, &template_tolerations(&template)).await?;
+        }
+    }
+
+    if nodes.is_empty() {
+        info!("no target nodes matched the selection; nothing to install");
+        return Ok(());
+    }
 
     let parallelism = args.parallelism.clamp(1, nodes.len());
     info!(
@@ -261,7 +337,7 @@ async fn main() -> Result<()> {
         parallelism,
         owner.as_ref(),
         node_ops.clone(),
-        &facts,
+        &client,
     )
     .await
 }
@@ -300,54 +376,6 @@ fn node_ops_from_args(client: &Client, args: &Args) -> Result<NodeOps> {
     }
 
     Ok(ops)
-}
-
-/// Nodes resolved from a selector were already listed in full, so their facts are
-/// free; explicitly named nodes (`--nodes`) are fetched here.
-///
-/// A node missing from the result is not dispatched to. The per-node Jobs detect
-/// their CRI runtime from this version string and hold no credentials to look it
-/// up themselves, so dispatching one anyway would start a privileged pod that is
-/// certain to fail on the first thing it does.
-async fn collect_node_facts(ops: &NodeOps, nodes: &[Node]) -> HashMap<String, NodeFacts> {
-    let mut facts = HashMap::new();
-
-    for node in nodes {
-        let Some(name) = node.metadata.name.clone() else {
-            continue;
-        };
-        // A node the selector produced carries its full object; a named one is a
-        // stub holding just the name.
-        let known = node.status.is_some() || node.metadata.labels.is_some();
-        if known {
-            record_facts(&mut facts, NodeFacts::from_node(node));
-            continue;
-        }
-
-        match ops.get(&name).await {
-            Ok(fetched) => {
-                record_facts(&mut facts, NodeFacts::from_node(&fetched));
-            }
-            Err(err) => {
-                error!("node {name}: could not read its runtime details ({err:#})");
-            }
-        }
-    }
-
-    facts
-}
-
-fn record_facts(facts: &mut HashMap<String, NodeFacts>, node_facts: NodeFacts) {
-    if node_facts.container_runtime_version.is_none() {
-        error!(
-            "node {}: reports no containerRuntimeVersion, so the per-node Job would have no way \
-             to tell which CRI runtime to configure",
-            node_facts.name
-        );
-        return;
-    }
-
-    facts.insert(node_facts.name.clone(), node_facts);
 }
 
 /// Resolve the namespace to create Jobs in: explicit flag, then $POD_NAMESPACE,
@@ -419,9 +447,16 @@ async fn resolve_nodes(
             .collect();
         names.sort();
         names.dedup();
-        // Named nodes are taken at face value - naming a node is unambiguous - so
-        // these are stubs; whatever else is needed about them is fetched later.
-        return Ok(names.into_iter().map(node_stub).collect());
+        let api: Api<Node> = Api::all(client.clone());
+        let mut nodes = Vec::with_capacity(names.len());
+        for name in names {
+            nodes.push(
+                api.get(&name)
+                    .await
+                    .with_context(|| format!("failed to resolve explicitly named node {name}"))?,
+            );
+        }
+        return Ok(nodes);
     }
 
     let api: Api<Node> = Api::all(client.clone());
@@ -429,6 +464,7 @@ async fn resolve_nodes(
     let deadline = Instant::now() + Duration::from_secs(args.wait_for_nodes_secs);
     let mut announced_wait = false;
     let mut previous: Option<Vec<String>> = None;
+    let mut stable_since: Option<Instant> = None;
 
     let report_skipped = |skipped: &[SkippedNode]| {
         for node in skipped {
@@ -442,7 +478,7 @@ async fn resolve_nodes(
     };
 
     loop {
-        let (admitted, skipped) = select_nodes(&api, args, tolerations).await?;
+        let (_, admitted, skipped) = select_nodes(&api, args, tolerations).await?;
         let expired = Instant::now() >= deadline;
 
         if !admitted.is_empty() {
@@ -451,26 +487,42 @@ async fn resolve_nodes(
                 .filter_map(|node| node.metadata.name.clone())
                 .collect();
             names.sort();
+            let changed = previous.as_deref() != Some(names.as_slice());
+            if changed {
+                previous = Some(names.clone());
+                stable_since = Some(Instant::now());
+            }
+            let settled = args.wait_for_nodes_secs == 0
+                || stable_since.is_some_and(|since| {
+                    since.elapsed() >= Duration::from_secs(args.node_settle_secs)
+                });
 
             // The set the first pass sees is not the set to install on: the labels
             // a selector matches are written per node by an add-on that is itself
             // still starting, so returning on the first match would install on
             // whichever node won that race and silently leave the rest out. Wait
             // until a whole pass adds nothing.
-            if expired || previous.as_deref() == Some(names.as_slice()) {
+            if expired || settled {
                 report_skipped(&skipped);
                 return Ok(admitted);
             }
 
-            info!(
-                "{} node(s) eligible so far ({}); re-checking once more in case others are still \
-                 becoming eligible",
-                names.len(),
-                names.join(", ")
-            );
-            previous = Some(names);
+            if changed {
+                info!(
+                    "{} node(s) eligible so far ({}); waiting for the set to remain unchanged for \
+                     {}s",
+                    names.len(),
+                    names.join(", "),
+                    args.node_settle_secs
+                );
+            }
             tokio::time::sleep(poll).await;
             continue;
+        }
+
+        if previous.as_deref() != Some(&[]) {
+            previous = Some(Vec::new());
+            stable_since = Some(Instant::now());
         }
 
         if expired {
@@ -499,18 +551,51 @@ async fn select_nodes(
     api: &Api<Node>,
     args: &Args,
     tolerations: &[Toleration],
-) -> Result<(Vec<Node>, Vec<SkippedNode>)> {
+) -> Result<(Vec<Node>, Vec<Node>, Vec<SkippedNode>)> {
     let mut matched: Vec<Node> = Vec::new();
     for selector in selector_passes(&args.node_selector) {
         matched.extend(list_nodes(api, args, selector).await?);
     }
 
     if args.ignore_node_taints {
-        return Ok((dedup_by_name(matched, None), Vec::new()));
+        let matched = dedup_by_name(matched, None);
+        return Ok((matched.clone(), matched, Vec::new()));
     }
 
     let (admitted, skipped) = partition_by_tolerations(&matched, tolerations);
-    Ok((dedup_by_name(matched, Some(&admitted)), skipped))
+    Ok((
+        dedup_by_name(matched.clone(), None),
+        dedup_by_name(matched, Some(&admitted)),
+        skipped,
+    ))
+}
+
+async fn nodes_owned_but_not_desired(
+    client: &Client,
+    instance_label: &str,
+    desired: &[Node],
+) -> Result<Vec<Node>> {
+    let desired: HashSet<&str> = desired
+        .iter()
+        .filter_map(|node| node.metadata.name.as_deref())
+        .collect();
+    let owned = Api::<Node>::all(client.clone())
+        .list(&ListParams::default().labels(instance_label))
+        .await
+        .with_context(|| {
+            format!("failed to list nodes carrying this install's marker {instance_label}")
+        })?;
+
+    Ok(owned
+        .items
+        .into_iter()
+        .filter(|node| {
+            node.metadata
+                .name
+                .as_deref()
+                .is_some_and(|name| !desired.contains(name))
+        })
+        .collect())
 }
 
 /// Collapse the per-selector duplicates a union produces, keeping the objects
@@ -538,18 +623,6 @@ fn dedup_by_name(nodes: Vec<Node>, keep: Option<&[String]>) -> Vec<Node> {
 
     unique.sort_by(|a, b| a.metadata.name.cmp(&b.metadata.name));
     unique
-}
-
-/// A Node carrying nothing but its name, for nodes named explicitly rather than
-/// selected (and therefore never listed).
-fn node_stub(name: String) -> Node {
-    Node {
-        metadata: kube::core::ObjectMeta {
-            name: Some(name),
-            ..Default::default()
-        },
-        ..Default::default()
-    }
 }
 
 /// Decide what "nothing is eligible" means once we have stopped looking.
@@ -603,6 +676,42 @@ fn describe_selectors(selectors: &[String]) -> String {
         .map(|s| format!("[{s}]"))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+async fn node_still_selected(client: &Client, args: &Args, node: &str) -> Result<bool> {
+    if let Some(nodes) = args.nodes.as_deref() {
+        return Ok(nodes
+            .split(',')
+            .map(str::trim)
+            .any(|candidate| candidate == node));
+    }
+
+    let api = Api::<Node>::all(client.clone());
+    let node_field = format!("metadata.name={node}");
+    let field_selector = match args.node_field_selector.as_deref() {
+        Some(existing) if !existing.is_empty() => format!("{existing},{node_field}"),
+        _ => node_field,
+    };
+    for selector in selector_passes(&args.node_selector) {
+        // No selector means every node, which is an absent labelSelector rather
+        // than an empty one: what an empty string means is up to the apiserver.
+        let params = ListParams {
+            limit: Some(1),
+            label_selector: selector.map(str::to_string),
+            field_selector: Some(field_selector.clone()),
+            ..Default::default()
+        };
+        if !api
+            .list(&params)
+            .await
+            .with_context(|| format!("failed to revalidate node selection for {node}"))?
+            .items
+            .is_empty()
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// One paginated LIST of nodes matching `label_selector` (ANDed with the global
@@ -681,13 +790,9 @@ async fn run_fanout(
     parallelism: usize,
     owner: Option<&OwnerReference>,
     node_ops: Arc<NodeOps>,
-    facts: &HashMap<String, NodeFacts>,
+    client: &Client,
 ) -> Result<()> {
-    let names: Vec<String> = nodes
-        .iter()
-        .filter_map(|node| node.metadata.name.clone())
-        .collect();
-    let mut queue: VecDeque<&String> = names.iter().collect();
+    let mut queue: VecDeque<Node> = nodes.iter().cloned().collect();
     // job name -> node name
     let mut in_flight: HashMap<String, String> = HashMap::new();
     let mut succeeded = 0usize;
@@ -699,6 +804,7 @@ async fn run_fanout(
     // prefix; sanitize it once so it is a valid label value / DNS-1123 prefix
     // regardless of what the caller passed (e.g. a Helm release suffix).
     let owner_value = sanitize_label_value(&args.name_prefix);
+    clear_stale_jobs(jobs, &owner_value, owner).await?;
 
     // A node's post-success work (readiness, handlers, label, taints) can take
     // minutes, so it runs off to the side. It holds a slot until it finishes -
@@ -711,29 +817,113 @@ async fn run_fanout(
 
     loop {
         while in_flight.len() + post_work.len() < parallelism {
-            let Some(node) = queue.pop_front() else {
+            let Some(expected_node) = queue.pop_front() else {
                 break;
             };
+            let Some(node) = expected_node.metadata.name.as_deref() else {
+                error!("selected a Node object without metadata.name; refusing to dispatch it");
+                continue;
+            };
 
-            // A failure here fails the node rather than proceeding: for cleanup
-            // that would mean dismantling Kata on a node still advertising it.
-            if let Err(err) = node_ops.before_dispatch(node).await {
-                error!("node {node}: {err:#}");
-                failed.push(node.clone());
+            let fresh = match node_ops.get(node).await {
+                Ok(fresh) => fresh,
+                Err(err) => {
+                    error!(
+                        "node {node}: could not re-read it immediately before dispatch ({err:#})"
+                    );
+                    failed.push(node.to_string());
+                    continue;
+                }
+            };
+            let Some(expected_uid) = expected_node.metadata.uid.as_deref() else {
+                error!("node {node}: selected Node has no UID; refusing to dispatch");
+                failed.push(node.to_string());
+                continue;
+            };
+            if fresh.metadata.uid.as_deref() != Some(expected_uid) {
+                error!(
+                    "node {node}: the selected Node UID was {expected_uid}, but the object now \
+                     has UID {:?}; refusing to mutate a replacement node under stale identity",
+                    fresh.metadata.uid
+                );
+                failed.push(node.to_string());
+                continue;
+            }
+            let still_selected = node_still_selected(client, args, node).await?;
+            if args.removed_node_cleanup && still_selected {
+                info!(
+                    "node {node}: re-entered the desired selection before removed-node cleanup; \
+                     leaving it installed"
+                );
+                succeeded += 1;
+                continue;
+            }
+            if !args.removed_node_cleanup && !still_selected {
+                // Left as it is rather than uninstalled here: a selection that
+                // changed under a running rollout is not an instruction to
+                // dismantle a node. The next run starts by cleaning the nodes it
+                // owns but no longer wants, and picks this one up if it is still
+                // out.
+                error!(
+                    "node {node}: no longer matches the node selection immediately before \
+                     dispatch; refusing to mutate stale selection, leaving the node as it is"
+                );
+                failed.push(node.to_string());
+                continue;
+            }
+            // Whoever passed --ignore-node-taints asked for every node in the
+            // selection to be acted on whatever it is tainted with, so this
+            // check would go back on that promise.
+            if !args.ignore_node_taints {
+                let (admitted, skipped) = partition_by_tolerations(
+                    std::slice::from_ref(&fresh),
+                    &template_tolerations(template),
+                );
+                if admitted.is_empty() {
+                    error!(
+                        "node {node}: acquired untolerated taint {} before dispatch; refusing to \
+                         start a Job that the taint manager would evict",
+                        skipped
+                            .first()
+                            .map(|item| describe_taint(&item.taint))
+                            .unwrap_or_else(|| "<unknown>".to_string())
+                    );
+                    failed.push(node.to_string());
+                    continue;
+                }
+            }
+
+            let node_facts = NodeFacts::from_node(&fresh);
+            if node_facts.container_runtime_version.is_none() {
+                error!(
+                    "node {node}: reports no containerRuntimeVersion immediately before dispatch, \
+                     so the per-node Job cannot know which CRI runtime to configure"
+                );
+                failed.push(node.to_string());
+                continue;
+            }
+            if node_facts.machine_id.is_none() {
+                error!(
+                    "node {node}: reports no machineID immediately before dispatch, so a \
+                     token-free privileged Job cannot defend against Node name reuse"
+                );
+                failed.push(node.to_string());
                 continue;
             }
 
-            let Some(node_facts) = facts.get(node.as_str()) else {
-                error!(
-                    "node {node}: not dispatching a Job to it, since its runtime details could \
-                     not be established (reported above)"
-                );
-                failed.push(node.clone());
-                continue;
-            };
+            // A failure here fails the node rather than proceeding: for cleanup
+            // that would mean dismantling Kata on a node still advertising it.
+            match node_ops.before_dispatch(node, expected_uid).await {
+                Ok(()) => {}
+                Err(err) => {
+                    error!("node {node}: {err:#}");
+                    failed.push(node.to_string());
+                    continue;
+                }
+            }
 
             let name = job_name(&owner_value, node);
-            let node_job = build_node_job(template, &name, node, &owner_value, owner, node_facts);
+            let node_job = build_node_job(template, &name, node, &owner_value, owner, &node_facts);
             match jobs.create(&post, &node_job).await {
                 Ok(_) => info!("created job {name} (node {node})"),
                 // A Job with this name already exists. Job names are derived from
@@ -750,18 +940,18 @@ async fn run_fanout(
                         }
                         Err(err) => {
                             error!("node {node}: {err:#}");
-                            failed.push(node.clone());
+                            failed.push(node.to_string());
                             continue;
                         }
                     }
                 }
                 Err(e) => {
                     error!("failed to create job {name} (node {node}): {e}");
-                    failed.push(node.clone());
+                    failed.push(node.to_string());
                     continue;
                 }
             }
-            in_flight.insert(name, node.clone());
+            in_flight.insert(name, node.to_string());
         }
 
         if in_flight.is_empty() && post_work.is_empty() {
@@ -779,55 +969,100 @@ async fn run_fanout(
 
         tokio::time::sleep(poll).await;
 
-        // Poll each in-flight Job via GET so we only need the `get` verb on
-        // batch/jobs (not `list`), matching the least-privilege Role.
+        // Concurrently, so one slow apiserver request cannot hold every other node
+        // behind it. Each read has a short timeout of its own, and the budget below
+        // tolerates transient failures without letting one unreadable Job keep the
+        // rollout alive forever.
         let mut finished: Vec<String> = Vec::new();
+        let mut reads = JoinSet::new();
         for (name, node) in &in_flight {
-            let j = match jobs.get(name).await {
-                Ok(j) => j,
+            unreadable.entry(name.clone()).or_insert_with(Instant::now);
+            let api = jobs.clone();
+            let name = name.clone();
+            let node = node.clone();
+            reads.spawn(async move {
+                let result = tokio::time::timeout(JOB_GET_TIMEOUT, api.get(&name)).await;
+                (name, node, result)
+            });
+        }
+
+        while let Some(joined) = reads.join_next().await {
+            let (name, node, result) =
+                joined.context("a Job status polling task terminated unexpectedly")?;
+            let j = match result {
+                Ok(Ok(j)) => j,
                 // Deleted under us - garbage collection catching up with a
                 // previous dispatcher, or someone clearing Jobs by hand. Waiting
                 // for a Job that no longer exists never ends, so the node fails
                 // and a later run retries it.
-                Err(kube::Error::Api(e)) if e.code == 404 => {
+                Ok(Err(kube::Error::Api(e))) if e.code == 404 => {
                     error!(
                         "node {node}: job {name} no longer exists, so its result cannot be \
                          established; treating the node as failed"
                     );
-                    failed.push(node.clone());
-                    finished.push(name.clone());
+                    failed.push(node);
+                    finished.push(name);
                     continue;
                 }
-                Err(e) => {
-                    let since = *unreadable.entry(name.clone()).or_insert_with(Instant::now);
+                Ok(Err(e)) => {
+                    let since = unreadable[&name];
                     if since.elapsed() >= JOB_READ_ERROR_BUDGET {
                         error!(
                             "node {node}: job {name} has been unreadable for {}s ({e}), so its \
                              result cannot be established; treating the node as failed",
                             since.elapsed().as_secs()
                         );
-                        failed.push(node.clone());
-                        finished.push(name.clone());
+                        failed.push(node);
+                        finished.push(name);
                     } else {
                         error!("failed to get job {name} (node {node}): {e}");
                     }
                     continue;
                 }
+                Err(_) => {
+                    let since = unreadable[&name];
+                    if since.elapsed() >= JOB_READ_ERROR_BUDGET {
+                        error!(
+                            "node {node}: job {name} has been unreadable for {}s because its GET \
+                             requests keep timing out after {}s; treating the node as failed",
+                            since.elapsed().as_secs(),
+                            JOB_GET_TIMEOUT.as_secs()
+                        );
+                        failed.push(node);
+                        finished.push(name);
+                    } else {
+                        error!(
+                            "timed out after {}s getting job {name} (node {node})",
+                            JOB_GET_TIMEOUT.as_secs()
+                        );
+                    }
+                    continue;
+                }
             };
-            unreadable.remove(name);
+            unreadable.remove(&name);
             match interpret_status(&j) {
                 JobOutcome::Succeeded => {
                     finished.push(name.clone());
                     info!("node {node}: job {name} succeeded");
+                    let Some(expected_uid) = nodes
+                        .iter()
+                        .find(|candidate| candidate.metadata.name.as_deref() == Some(node.as_str()))
+                        .and_then(|candidate| candidate.metadata.uid.clone())
+                    else {
+                        error!("node {node}: selected Node UID disappeared from dispatcher state");
+                        failed.push(node);
+                        continue;
+                    };
                     let ops = node_ops.clone();
                     let target = node.clone();
-                    let handle = post_work.spawn(async move { ops.after_success(&target).await });
-                    post_nodes.insert(handle.id(), node.clone());
+                    let handle = post_work
+                        .spawn(async move { ops.after_success(&target, &expected_uid).await });
+                    post_nodes.insert(handle.id(), node);
                 }
                 JobOutcome::Failed => {
-                    failed.push(node.clone());
-                    finished.push(name.clone());
                     error!("node {node}: job {name} failed");
+                    failed.push(node);
+                    finished.push(name);
                 }
                 JobOutcome::Running => {}
             }
@@ -866,6 +1101,116 @@ async fn run_fanout(
 
     info!("all {succeeded} node(s) completed successfully");
     Ok(())
+}
+
+async fn clear_stale_jobs(
+    jobs: &Api<Job>,
+    owner_value: &str,
+    owner: Option<&OwnerReference>,
+) -> Result<()> {
+    let Some(owner) = owner else {
+        return Ok(());
+    };
+    let selector = format!("{OWNER_LABEL}={owner_value}");
+    let stale = stale_job_names(jobs, &selector, owner_value, owner).await?;
+
+    let mut pending: VecDeque<String> = stale.into();
+    let mut deletes = JoinSet::new();
+    const DELETE_CONCURRENCY: usize = 16;
+    while !pending.is_empty() || !deletes.is_empty() {
+        while deletes.len() < DELETE_CONCURRENCY {
+            let Some(name) = pending.pop_front() else {
+                break;
+            };
+            info!("deleting stale per-node job {name} before opening rollout slots");
+            let jobs = jobs.clone();
+            deletes.spawn(async move {
+                match jobs.delete(&name, &DeleteParams::foreground()).await {
+                    Ok(_) => Ok(()),
+                    Err(kube::Error::Api(status)) if status.code == 404 => Ok(()),
+                    Err(err) => Err(err)
+                        .with_context(|| format!("failed to delete stale per-node job {name}")),
+                }
+            });
+        }
+        if let Some(result) = deletes.join_next().await {
+            result.context("stale Job deletion task failed")??;
+        }
+    }
+
+    for _ in 0..REPLACE_ATTEMPTS {
+        let remaining = stale_job_exists(jobs, &selector, owner_value, owner).await?;
+        if !remaining {
+            return Ok(());
+        }
+        tokio::time::sleep(REPLACE_INTERVAL).await;
+    }
+
+    bail!(
+        "stale per-node Jobs were still terminating after {}s; refusing to start more privileged \
+         Jobs beyond the configured parallelism",
+        (REPLACE_ATTEMPTS as u64) * REPLACE_INTERVAL.as_secs()
+    )
+}
+
+async fn stale_job_names(
+    jobs: &Api<Job>,
+    selector: &str,
+    owner_value: &str,
+    owner: &OwnerReference,
+) -> Result<Vec<String>> {
+    let mut token: Option<String> = None;
+    let mut names = Vec::new();
+    loop {
+        let mut params = ListParams::default().labels(selector).limit(500);
+        if let Some(value) = token.as_deref() {
+            params = params.continue_token(value);
+        }
+        let page = jobs
+            .list(&params)
+            .await
+            .with_context(|| format!("failed to list per-node Jobs owned by {owner_value}"))?;
+        names.extend(
+            page.items
+                .into_iter()
+                .filter(|job| job_disposition(job, owner_value, Some(owner)) == Disposition::Stale)
+                .filter_map(|job| job.metadata.name),
+        );
+        token = page.metadata.continue_;
+        if token.as_deref().is_none_or(str::is_empty) {
+            return Ok(names);
+        }
+    }
+}
+
+async fn stale_job_exists(
+    jobs: &Api<Job>,
+    selector: &str,
+    owner_value: &str,
+    owner: &OwnerReference,
+) -> Result<bool> {
+    let mut token: Option<String> = None;
+    loop {
+        let mut params = ListParams::default().labels(selector).limit(500);
+        if let Some(value) = token.as_deref() {
+            params = params.continue_token(value);
+        }
+        let page = jobs
+            .list(&params)
+            .await
+            .with_context(|| format!("failed to wait for stale Jobs owned by {owner_value}"))?;
+        if page
+            .items
+            .iter()
+            .any(|job| job_disposition(job, owner_value, Some(owner)) == Disposition::Stale)
+        {
+            return Ok(true);
+        }
+        token = page.metadata.continue_;
+        if token.as_deref().is_none_or(str::is_empty) {
+            return Ok(false);
+        }
+    }
 }
 
 enum Adoption {

--- a/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
+++ b/tools/packaging/kata-deploy/job-dispatcher/src/nodes.rs
@@ -115,6 +115,7 @@ pub struct NodeFacts {
     pub name: String,
     /// `.status.nodeInfo.containerRuntimeVersion`, e.g. `containerd://2.1.5-k3s1`.
     pub container_runtime_version: Option<String>,
+    pub machine_id: Option<String>,
 }
 
 impl NodeFacts {
@@ -126,15 +127,23 @@ impl NodeFacts {
             .and_then(|status| status.node_info.as_ref())
             .map(|info| info.container_runtime_version.clone())
             .filter(|version| !version.is_empty());
+        let machine_id = node
+            .status
+            .as_ref()
+            .and_then(|status| status.node_info.as_ref())
+            .map(|info| info.machine_id.clone())
+            .filter(|id| !id.is_empty());
 
         Self {
             name,
             container_runtime_version,
+            machine_id,
         }
     }
 }
 
 /// The node-level work the dispatcher performs around each per-node Job.
+#[derive(Clone)]
 pub struct NodeOps {
     api: Api<Node>,
     client: Client,
@@ -177,6 +186,16 @@ impl NodeOps {
             .with_context(|| format!("failed to get node {node}"))
     }
 
+    async fn ensure_uid(&self, node: &str, expected_uid: &str) -> Result<()> {
+        let current = self.get(node).await?;
+        anyhow::ensure!(
+            current.metadata.uid.as_deref() == Some(expected_uid),
+            "node {node} changed identity: expected UID {expected_uid}, found {:?}",
+            current.metadata.uid
+        );
+        Ok(())
+    }
+
     /// Demoting first is what makes cleanup safe: nothing new is scheduled onto a
     /// node whose label no longer says `true` (the RuntimeClasses require exactly
     /// that value), so the node stops taking Kata workloads before anything on it
@@ -186,16 +205,18 @@ impl NodeOps {
     /// selects on. A cleanup Job that fails - or is never created - would otherwise
     /// leave a node with Kata still installed that the next `helm uninstall` cannot
     /// even see. The key goes once the node's cleanup Job has actually succeeded.
-    pub async fn before_dispatch(&self, node: &str) -> Result<()> {
+    pub async fn before_dispatch(&self, node: &str, expected_uid: &str) -> Result<()> {
+        self.ensure_uid(node, expected_uid).await?;
         if self.remove_label {
-            self.demote(node).await?;
+            self.demote(node, expected_uid).await?;
         }
         if self.claim_pending {
-            self.claim(node).await;
+            self.claim(node, expected_uid).await?;
         }
         if let Some(threshold) = self.kubelet_timeout_warn {
             self.warn_on_low_kubelet_timeout(node, threshold).await;
         }
+        self.ensure_uid(node, expected_uid).await?;
         Ok(())
     }
 
@@ -203,13 +224,15 @@ impl NodeOps {
     /// restarted) before it is advertised as Kata-capable, and the start-up
     /// taints may only be lifted once that advertisement is in place - they are
     /// what keeps workloads off the node until then.
-    pub async fn after_success(&self, node: &str) -> Result<()> {
+    pub async fn after_success(&self, node: &str, expected_uid: &str) -> Result<()> {
+        self.ensure_uid(node, expected_uid).await?;
         // Cleanup: the node kept the label's key through its Job so that a failure
         // anywhere in it would still be found by the next uninstall. That reason is
         // spent now, and leaving the key behind would have a later uninstall clean
         // a node that has nothing left on it.
         if self.remove_label {
-            return self.release(node).await;
+            self.release(node, expected_uid).await?;
+            return self.ensure_uid(node, expected_uid).await;
         }
 
         let Some(value) = self.label_value.clone() else {
@@ -220,9 +243,12 @@ impl NodeOps {
             self.wait_till_ready(node, timeout).await?;
         }
 
+        self.ensure_uid(node, expected_uid).await?;
         self.verify_handlers(node).await?;
-        self.label_until_stable(node, &value).await?;
-        self.lift_taints(node).await;
+        self.ensure_uid(node, expected_uid).await?;
+        self.label_until_stable(node, &value, expected_uid).await?;
+        self.ensure_uid(node, expected_uid).await?;
+        self.lift_taints(node, expected_uid).await;
 
         Ok(())
     }
@@ -231,8 +257,8 @@ impl NodeOps {
     /// an uninstall selects on. A node that never had the label is left alone: it
     /// was never installed on, and adding a key here would only invite the next
     /// uninstall to come back for it.
-    async fn demote(&self, node: &str) -> Result<()> {
-        self.rewrite_labels(node, |labels, ours| {
+    async fn demote(&self, node: &str, expected_uid: &str) -> Result<()> {
+        self.rewrite_labels(node, expected_uid, |labels, ours| {
             let mut updates: Vec<(String, Option<String>)> = Vec::new();
 
             if labels.contains_key(ours) {
@@ -243,7 +269,8 @@ impl NodeOps {
             // this install's workloads off the node. The shared label is another
             // question: an install still serving Kata here needs it.
             let shared = labels.get(KATA_RUNTIME_LABEL).map(String::as_str);
-            match (shared, shared_label_after(labels, ours)) {
+            let verdict = shared_label_after(labels, ours);
+            match (shared, verdict) {
                 (None, _) | (Some(KATA_RUNTIME_PENDING), _) => (),
                 (Some(_), SharedLabel::Keep) => info!(
                     "node {node}: leaving {KATA_RUNTIME_LABEL} in place, another kata-deploy \
@@ -263,14 +290,15 @@ impl NodeOps {
     /// Give the node back: this install's marker goes, and the label it shares with
     /// every other install goes with it only if no other install is left holding
     /// this node.
-    async fn release(&self, node: &str) -> Result<()> {
-        self.rewrite_labels(node, |labels, ours| {
+    async fn release(&self, node: &str, expected_uid: &str) -> Result<()> {
+        self.rewrite_labels(node, expected_uid, |labels, ours| {
             let mut updates: Vec<(String, Option<String>)> = Vec::new();
             if labels.contains_key(ours) {
                 updates.push((ours.to_string(), None));
             }
 
-            match shared_label_after(labels, ours) {
+            let verdict = shared_label_after(labels, ours);
+            match verdict {
                 SharedLabel::Keep => info!(
                     "node {node}: keeping {KATA_RUNTIME_LABEL}, another kata-deploy install is \
                      still serving Kata from this node"
@@ -311,12 +339,16 @@ impl NodeOps {
     /// unconditional write could act on a node that has already moved on: two
     /// uninstalls each seeing the other's mark, each removing their own, leaving a
     /// node advertising Kata with nothing installed.
-    async fn rewrite_labels<F>(&self, node: &str, decide: F) -> Result<()>
+    async fn rewrite_labels<F>(&self, node: &str, expected_uid: &str, decide: F) -> Result<()>
     where
         F: Fn(&BTreeMap<String, String>, &str) -> Vec<(String, Option<String>)>,
     {
         for attempt in 1..=LABEL_PATCH_ATTEMPTS {
             let fetched = self.get(node).await?;
+            anyhow::ensure!(
+                fetched.metadata.uid.as_deref() == Some(expected_uid),
+                "node {node} changed identity before its labels could be rewritten"
+            );
             let version = fetched
                 .metadata
                 .resource_version
@@ -329,7 +361,10 @@ impl NodeOps {
                 return Ok(());
             }
 
-            match self.patch_labels_guarded(node, &version, &updates).await {
+            match self
+                .patch_labels_guarded(node, expected_uid, &version, &updates)
+                .await
+            {
                 Ok(()) => return Ok(()),
                 Err(err) if err.is_conflict => {
                     info!(
@@ -351,11 +386,14 @@ impl NodeOps {
     async fn patch_labels_guarded(
         &self,
         node: &str,
+        expected_uid: &str,
         version: &str,
         updates: &[(String, Option<String>)],
     ) -> std::result::Result<(), GuardedPatchError> {
-        let mut ops =
-            vec![json!({"op": "test", "path": "/metadata/resourceVersion", "value": version})];
+        let mut ops = vec![
+            json!({"op": "test", "path": "/metadata/uid", "value": expected_uid}),
+            json!({"op": "test", "path": "/metadata/resourceVersion", "value": version}),
+        ];
         for (key, value) in updates {
             let path = format!("/metadata/labels/{}", escape_pointer(key));
             match value {
@@ -391,23 +429,19 @@ impl NodeOps {
         }
     }
 
-    /// Best-effort, like the in-pod claim it replaces: this only widens what a
-    /// later uninstall can find, so a node that cannot be claimed is still worth
-    /// installing on.
-    ///
     /// Conditional on the label still being absent when the write lands. Two
     /// dispatchers can be mid-flight over one node - an upgrade racing the install
     /// it replaces - and claiming a node another one has just finished labelling
     /// `true` would de-advertise a node that is serving Kata.
-    async fn claim(&self, node: &str) {
+    async fn claim(&self, node: &str, expected_uid: &str) -> Result<()> {
         for attempt in 1..=CLAIM_PATCH_ATTEMPTS {
-            let fetched = match self.get(node).await {
-                Ok(fetched) => fetched,
-                Err(err) => {
-                    warn!("node {node}: could not read its labels to claim it ({err:#})");
-                    return;
-                }
-            };
+            let fetched = self.get(node).await.with_context(|| {
+                format!("could not read node {node} to claim it before install")
+            })?;
+            anyhow::ensure!(
+                fetched.metadata.uid.as_deref() == Some(expected_uid),
+                "node {node} changed identity before it could be claimed"
+            );
 
             let labels = fetched.metadata.labels.unwrap_or_default();
             // Any value means someone has been here: a `true` must not be
@@ -417,7 +451,7 @@ impl NodeOps {
                 .filter(|key| !labels.contains_key(*key))
                 .collect();
             if missing.is_empty() {
-                return;
+                return Ok(());
             }
 
             let version = fetched
@@ -427,8 +461,10 @@ impl NodeOps {
                 .unwrap_or_default();
             // `add` needs its parent to exist; a Node without labels is only ever
             // seen in tests, but the patch has to be valid for it too.
-            let mut ops =
-                vec![json!({"op": "test", "path": "/metadata/resourceVersion", "value": version})];
+            let mut ops = vec![
+                json!({"op": "test", "path": "/metadata/uid", "value": expected_uid}),
+                json!({"op": "test", "path": "/metadata/resourceVersion", "value": version}),
+            ];
             if labels.is_empty() {
                 let claimed: BTreeMap<&str, &str> = missing
                     .iter()
@@ -443,13 +479,8 @@ impl NodeOps {
                 }
             }
 
-            let patch: json_patch::Patch = match serde_json::from_value(json!(ops)) {
-                Ok(patch) => patch,
-                Err(err) => {
-                    warn!("node {node}: could not build the claim patch ({err})");
-                    return;
-                }
-            };
+            let patch: json_patch::Patch = serde_json::from_value(json!(ops))
+                .context("could not build the node claim patch")?;
 
             match self
                 .api
@@ -458,7 +489,7 @@ impl NodeOps {
             {
                 Ok(_) => {
                     info!("node {node}: marked as being installed on");
-                    return;
+                    return Ok(());
                 }
                 Err(err) if is_precondition_failure(&err) => {
                     info!(
@@ -467,20 +498,21 @@ impl NodeOps {
                     );
                 }
                 Err(err) => {
-                    warn!(
-                        "node {node}: could not mark it as being installed on ({err}). Should \
-                         this install fail before the node is labelled, `helm uninstall` will not \
-                         clean this node up"
-                    );
-                    return;
+                    return Err(err).with_context(|| {
+                        format!(
+                            "could not claim node {node} before install; refusing to mutate a host \
+                             that a later uninstall could not discover"
+                        )
+                    });
                 }
             }
         }
 
-        warn!(
-            "node {node}: gave up marking it as being installed on after \
-             {CLAIM_PATCH_ATTEMPTS} attempts; something keeps changing its labels"
-        );
+        anyhow::bail!(
+            "gave up claiming node {node} after {CLAIM_PATCH_ATTEMPTS} attempts: something keeps \
+             changing its labels; refusing to mutate a host that a later uninstall could not \
+             discover"
+        )
     }
 
     /// Refuse to advertise a node whose CRI runtime is not serving what the
@@ -573,7 +605,7 @@ impl NodeOps {
     /// undoing ours. `Ready` does not rule that out: the observation can predate
     /// the kubelet's own restart. So the label has to be seen to hold, and be
     /// re-applied when it drifts.
-    async fn label_until_stable(&self, node: &str, value: &str) -> Result<()> {
+    async fn label_until_stable(&self, node: &str, value: &str, expected_uid: &str) -> Result<()> {
         // Both labels, because the RuntimeClasses select both: a marker the kubelet
         // clobbered leaves the node advertised but unusable by this install.
         let wanted = [KATA_RUNTIME_LABEL, self.instance_label.as_str()];
@@ -583,13 +615,14 @@ impl NodeOps {
             .collect();
 
         for attempt in 1..=LABEL_APPLY_ATTEMPTS {
-            self.patch_labels(node, &updates).await?;
+            self.rewrite_labels(node, expected_uid, |_, _| updates.clone())
+                .await?;
 
             let mut stable = 0;
             while stable < LABEL_STABILITY_CHECKS {
                 tokio::time::sleep(LABEL_CHECK_INTERVAL).await;
 
-                match self.read_labels(node).await {
+                match self.read_labels(node, expected_uid).await {
                     Ok(labels) => {
                         let drifted: Vec<String> = wanted
                             .iter()
@@ -634,52 +667,29 @@ impl NodeOps {
         )
     }
 
-    /// Set (or, with `None`, remove) the Kata runtime label on `node`.
-    /// Apply label writes in one request, `None` removing a label.
-    async fn patch_labels(&self, node: &str, updates: &[(String, Option<String>)]) -> Result<()> {
-        if updates.is_empty() {
-            return Ok(());
-        }
-
-        // A JSON merge patch removes a key by setting it to null; omitting it
-        // would leave it untouched.
-        let labels: serde_json::Map<String, serde_json::Value> = updates
-            .iter()
-            .map(|(key, value)| {
-                let value = match value {
-                    Some(value) => serde_json::Value::String(value.clone()),
-                    None => serde_json::Value::Null,
-                };
-                (key.clone(), value)
-            })
-            .collect();
-        let patch = json!({"metadata": {"labels": labels}});
-
-        let described = describe_updates(updates);
-
-        self.api
-            .patch(node, &PatchParams::default(), &Patch::Merge(&patch))
-            .await
-            .with_context(|| format!("failed to write labels {described} on node {node}"))?;
-
-        info!("node {node}: labels {described}");
-        Ok(())
-    }
-
-    async fn read_labels(&self, node: &str) -> Result<BTreeMap<String, String>> {
-        Ok(self.get(node).await?.metadata.labels.unwrap_or_default())
+    async fn read_labels(
+        &self,
+        node: &str,
+        expected_uid: &str,
+    ) -> Result<BTreeMap<String, String>> {
+        let fetched = self.get(node).await?;
+        anyhow::ensure!(
+            fetched.metadata.uid.as_deref() == Some(expected_uid),
+            "node {node} changed identity while its labels were being verified"
+        );
+        Ok(fetched.metadata.labels.unwrap_or_default())
     }
 
     /// Best-effort on purpose: the runtime is installed and the node is labelled
     /// by now, and a taint left in place only keeps workloads away - the safe
     /// direction - so a failure here warns and leaves a later run to retry rather
     /// than failing an otherwise complete install.
-    async fn lift_taints(&self, node: &str) {
+    async fn lift_taints(&self, node: &str, expected_uid: &str) {
         if self.remove_taints.is_empty() {
             return;
         }
 
-        match self.try_lift_taints(node).await {
+        match self.try_lift_taints(node, expected_uid).await {
             Ok(removed) if removed.is_empty() => {
                 info!(
                     "node {node}: no matching start-up taint to remove ({})",
@@ -704,9 +714,13 @@ impl NodeOps {
     /// added in the meantime, in the direction that admits workloads. A JSON Patch
     /// that tests the resourceVersion it read makes that a rejected write instead,
     /// and rejection just means reading again.
-    async fn try_lift_taints(&self, node: &str) -> Result<Vec<String>> {
+    async fn try_lift_taints(&self, node: &str, expected_uid: &str) -> Result<Vec<String>> {
         for attempt in 1..=TAINT_PATCH_ATTEMPTS {
             let fetched = self.get(node).await?;
+            anyhow::ensure!(
+                fetched.metadata.uid.as_deref() == Some(expected_uid),
+                "node {node} changed identity before its taints could be removed"
+            );
             let version = fetched
                 .metadata
                 .resource_version
@@ -726,6 +740,7 @@ impl NodeOps {
             }
 
             let patch: json_patch::Patch = serde_json::from_value(json!([
+                {"op": "test", "path": "/metadata/uid", "value": expected_uid},
                 {"op": "test", "path": "/metadata/resourceVersion", "value": version},
                 {"op": "replace", "path": "/spec/taints", "value": retained},
             ]))


### PR DESCRIPTION
A dispatcher run currently assumes that node discovery, node identity, and the Jobs it creates remain stable for the lifetime of the rollout. Those assumptions break during node replacement, delayed NFD labelling, upgrades with stale Jobs, or selector changes.

Wait for the eligible node set to settle, revalidate each node before mutating it, and bind generated Jobs to collision-resistant release and node identities. Stale-Job cleanup is paginated and bounded instead of amplifying API traffic across the whole cluster.

When a node leaves the desired selector, reconcile the installation away from it. Taints remain admission state rather than ownership state, so a temporarily untolerated node is not mistaken for a node the release should uninstall.