### PR TITLE
kata-deploy: serialize host lifecycle changes per node

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -975,6 +975,13 @@ release would restore a file that predates every release and erase the surviving
 handlers. Installation therefore fails before modifying CRI configuration when
 that unsafe combination is detected.
 
+With whole-file configuration, uninstall restores the backup taken at install
+time. A node whose containerd had no configuration file at all gets one written
+for it, and uninstall deletes that file again. Any other whole-file configuration
+is left untouched, with a warning in the log: without a backup or a record of
+having written the file, kata-deploy cannot tell its own configuration from an
+administrator's.
+
 On the first upgrade from a chart version that predates that state ConfigMap, the
 chart verifies the previous identity from the existing mode-specific resource
 whose name derives from the suffix. If it cannot find one, the upgrade stops and

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -946,7 +946,9 @@ only ever had `cicd` on it loses the label and stops being a Kata node. Cleanup
 still restarts the shared CRI runtime after removing this installation's
 configuration: otherwise the live runtime could keep advertising a handler whose
 binary has just been deleted. The other installation's configuration remains and
-is reloaded by that restart.
+is reloaded by that restart. Host-mutating stages from different releases take
+the same node-local lock, so concurrent installs or uninstalls cannot race their
+configuration edits and restarts.
 
 A mark reading `false` does not count as another installation serving Kata: if the
 last `true` mark goes and only a half-finished installation is left, the shared

--- a/tools/packaging/kata-deploy/binary/src/k8s/client.rs
+++ b/tools/packaging/kata-deploy/binary/src/k8s/client.rs
@@ -7,7 +7,7 @@ use crate::config::Config;
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::Node;
 use kube::{
-    api::{Api, GetParams, Patch, PatchParams},
+    api::{Api, GetParams, ListParams, Patch, PatchParams},
     core::Request,
     Client,
 };
@@ -314,45 +314,131 @@ impl K8sClient {
         )
     }
 
-    /// Returns whether a non-terminating DaemonSet with this exact name
-    /// exists in the current namespace. Used to decide whether this pod is
-    /// being restarted (true) or uninstalled (false).
-    pub async fn own_daemonset_exists(&self, daemonset_name: &str) -> Result<bool> {
+    /// Whether this DaemonSet still wants a pod on the bound node.
+    ///
+    /// Existence alone cannot distinguish a rolling restart from selector
+    /// shrinkage: in both cases the old pod terminates while the DaemonSet
+    /// remains. Cleanup is skipped only in the first case.
+    pub async fn own_daemonset_selects_node(&self, daemonset_name: &str) -> Result<bool> {
         use k8s_openapi::api::apps::v1::DaemonSet;
         use kube::api::Api;
 
         let ds_api: Api<DaemonSet> = Api::default_namespaced(self.client.clone());
         match ds_api.get_opt(daemonset_name).await? {
-            Some(ds) => Ok(ds.metadata.deletion_timestamp.is_none()),
-            None => Ok(false),
+            Some(ds) if ds.metadata.deletion_timestamp.is_none() => {
+                let node = self.get_node().await?;
+                Ok(daemonset_selects_node(&ds, &node))
+            }
+            _ => Ok(false),
         }
     }
 
-    /// Returns how many non-terminating DaemonSets across all namespaces
-    /// have a name containing "kata-deploy". Used to decide whether shared
-    /// node-level resources (node label, CRI restart) should be cleaned up:
-    /// they are only safe to remove when no kata-deploy instance remains
-    /// on the cluster.
-    pub async fn count_any_kata_deploy_daemonsets(&self) -> Result<usize> {
+    /// Whether another kata-deploy DaemonSet actually selects this node.
+    ///
+    /// A cluster-wide DaemonSet count is not ownership: a release selecting a
+    /// different pool must not preserve this node's label. Legacy releases have
+    /// no per-install marker, so their live pod is the node-local evidence.
+    pub async fn other_kata_deploy_daemonset_selects_node(&self, ours: &str) -> Result<bool> {
         use k8s_openapi::api::apps::v1::DaemonSet;
-        use kube::api::{Api, ListParams};
 
-        let ds_api: Api<DaemonSet> = Api::all(self.client.clone());
-        let daemonsets = ds_api.list(&ListParams::default()).await?;
-
-        let count = daemonsets
-            .iter()
-            .filter(|ds| {
-                ds.metadata.deletion_timestamp.is_none()
-                    && ds
+        let node = self.get_node().await?;
+        let own_uid = Api::<DaemonSet>::default_namespaced(self.client.clone())
+            .get_opt(ours)
+            .await?
+            .and_then(|daemonset| daemonset.metadata.uid);
+        let daemonsets: Api<DaemonSet> = Api::all(self.client.clone());
+        Ok(daemonsets
+            .list(&ListParams::default())
+            .await?
+            .items
+            .into_iter()
+            .any(|daemonset| {
+                daemonset.metadata.deletion_timestamp.is_none()
+                    && daemonset.metadata.uid != own_uid
+                    && daemonset
                         .metadata
                         .name
-                        .as_ref()
-                        .is_some_and(|n| n.contains("kata-deploy"))
-            })
-            .count();
+                        .as_deref()
+                        .is_some_and(|name| name.contains("kata-deploy"))
+                    && daemonset_selects_node(&daemonset, &node)
+            }))
+    }
+}
 
-        Ok(count)
+fn daemonset_selects_node(daemonset: &k8s_openapi::api::apps::v1::DaemonSet, node: &Node) -> bool {
+    let Some(pod_spec) = daemonset
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+    else {
+        return false;
+    };
+    let labels = node.metadata.labels.as_ref().cloned().unwrap_or_default();
+    if pod_spec.node_selector.as_ref().is_some_and(|selector| {
+        selector
+            .iter()
+            .any(|(key, value)| labels.get(key) != Some(value))
+    }) {
+        return false;
+    }
+
+    let required = pod_spec
+        .affinity
+        .as_ref()
+        .and_then(|affinity| affinity.node_affinity.as_ref())
+        .and_then(|affinity| {
+            affinity
+                .required_during_scheduling_ignored_during_execution
+                .as_ref()
+        });
+    let Some(required) = required else {
+        return true;
+    };
+
+    required.node_selector_terms.iter().any(|term| {
+        // Kubernetes reads a term with no requirement in it as matching no nodes,
+        // while `all` over nothing is true. Left alone, an empty term would hand
+        // the whole cluster to a DaemonSet that asked for none of it.
+        if term.match_expressions.iter().flatten().next().is_none()
+            && term.match_fields.iter().flatten().next().is_none()
+        {
+            return false;
+        }
+        term.match_expressions.iter().flatten().all(|requirement| {
+            selector_requirement_matches(
+                labels.get(&requirement.key).map(String::as_str),
+                &requirement.operator,
+                requirement.values.as_deref().unwrap_or_default(),
+            )
+        }) && term.match_fields.iter().flatten().all(|requirement| {
+            let value = match requirement.key.as_str() {
+                "metadata.name" => node.metadata.name.as_deref(),
+                _ => None,
+            };
+            selector_requirement_matches(
+                value,
+                &requirement.operator,
+                requirement.values.as_deref().unwrap_or_default(),
+            )
+        })
+    })
+}
+
+fn selector_requirement_matches(value: Option<&str>, operator: &str, values: &[String]) -> bool {
+    match operator {
+        "In" => value.is_some_and(|value| values.iter().any(|candidate| candidate == value)),
+        "NotIn" => value.is_none_or(|value| values.iter().all(|candidate| candidate != value)),
+        "Exists" => value.is_some(),
+        "DoesNotExist" => value.is_none(),
+        "Gt" => value
+            .and_then(|value| value.parse::<i64>().ok())
+            .zip(values.first().and_then(|value| value.parse::<i64>().ok()))
+            .is_some_and(|(actual, threshold)| actual > threshold),
+        "Lt" => value
+            .and_then(|value| value.parse::<i64>().ok())
+            .zip(values.first().and_then(|value| value.parse::<i64>().ok()))
+            .is_some_and(|(actual, threshold)| actual < threshold),
+        _ => false,
     }
 }
 
@@ -474,20 +560,25 @@ pub async fn remove_node_taints(config: &Config, matchers: &[String]) -> Result<
     client.remove_node_taints(matchers).await
 }
 
-pub async fn own_daemonset_exists(config: &Config) -> Result<bool> {
+pub async fn own_daemonset_selects_node(config: &Config) -> Result<bool> {
     let client = K8sClient::new(&config.node_name).await?;
-    client.own_daemonset_exists(&config.daemonset_name).await
+    client
+        .own_daemonset_selects_node(&config.daemonset_name)
+        .await
 }
 
-pub async fn count_any_kata_deploy_daemonsets(config: &Config) -> Result<usize> {
+pub async fn other_kata_deploy_daemonset_selects_node(config: &Config) -> Result<bool> {
     let client = K8sClient::new(&config.node_name).await?;
-    client.count_any_kata_deploy_daemonsets().await
+    client
+        .other_kata_deploy_daemonset_selects_node(&config.daemonset_name)
+        .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::partition_taints;
-    use k8s_openapi::api::core::v1::Taint;
+    use super::{daemonset_selects_node, partition_taints};
+    use k8s_openapi::api::apps::v1::DaemonSet;
+    use k8s_openapi::api::core::v1::{Node, Taint};
     use rstest::rstest;
 
     fn taint(key: &str, effect: &str) -> Taint {
@@ -508,6 +599,108 @@ mod tests {
             .iter()
             .map(|t| (t.key.clone(), t.effect.clone()))
             .collect()
+    }
+
+    #[test]
+    fn daemonset_ownership_follows_node_selector_and_required_affinity() {
+        let daemonset: DaemonSet = serde_yaml::from_str(
+            r#"
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-deploy
+spec:
+  selector:
+    matchLabels:
+      name: kata-deploy
+  template:
+    metadata:
+      labels:
+        name: kata-deploy
+    spec:
+      nodeSelector:
+        pool: kata
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values: [amd64]
+      containers:
+        - name: kata-deploy
+          image: example.invalid/kata-deploy
+"#,
+        )
+        .unwrap();
+        let mut node: Node = serde_yaml::from_str(
+            r#"
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker
+  labels:
+    pool: kata
+    kubernetes.io/arch: amd64
+"#,
+        )
+        .unwrap();
+
+        assert!(daemonset_selects_node(&daemonset, &node));
+        node.metadata
+            .labels
+            .as_mut()
+            .unwrap()
+            .insert("pool".to_string(), "other".to_string());
+        assert!(!daemonset_selects_node(&daemonset, &node));
+    }
+
+    /// An empty required term, or an empty list of them, selects no nodes in
+    /// Kubernetes. Reading either as "every node" would let a DaemonSet that wants
+    /// nothing keep this node's label or block its cleanup.
+    #[rstest]
+    #[case::empty_term("\n              - {}")]
+    #[case::no_terms(" []")]
+    fn a_required_affinity_that_matches_nothing_selects_no_node(#[case] terms: &str) {
+        let daemonset: DaemonSet = serde_yaml::from_str(&format!(
+            r#"
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-deploy
+spec:
+  selector:
+    matchLabels:
+      name: kata-deploy
+  template:
+    metadata:
+      labels:
+        name: kata-deploy
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:{terms}
+      containers:
+        - name: kata-deploy
+          image: example.invalid/kata-deploy
+"#
+        ))
+        .unwrap();
+        let node: Node = serde_yaml::from_str(
+            r#"
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker
+  labels:
+    pool: kata
+"#,
+        )
+        .unwrap();
+
+        assert!(!daemonset_selects_node(&daemonset, &node));
     }
 
     /// `partition_taints` keeps every taint except those matched by a matcher.

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -1487,10 +1487,12 @@ async fn cri_configuration_present(config: &config::Config, runtime: &str) -> bo
 
     match config.get_containerd_paths(runtime).await {
         Ok(paths) if paths.use_drop_in => std::path::Path::new(&paths.drop_in_file).exists(),
-        // Whole-file mode leaves no drop-in to look for. The backup is what it does
-        // leave behind, and it is evidence of this install's own edit rather than of
-        // a configuration that merely mentions the same paths.
-        Ok(paths) => std::path::Path::new(&paths.backup_file).exists(),
+        // Whole-file mode leaves no drop-in to look for, so ask the question the
+        // revert itself asks: is any of this configuration ours to undo?
+        Ok(paths) => !matches!(
+            runtime::containerd::whole_file_disposition(&paths.config_file, &paths.backup_file),
+            runtime::containerd::WholeFileConfig::Keep
+        ),
         Err(e) => {
             log::warn!(
                 "cleanup (revert-cri): could not resolve containerd paths to check drop-in \

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -362,6 +362,30 @@ fn verify_node_machine_id() -> Result<()> {
     Ok(())
 }
 
+/// Serialize host mutation across every kata-deploy running on this node.
+///
+/// Two releases working on the same node at once would interleave their
+/// configuration edits and restarts, leaving the runtime reading configuration that
+/// is only half written. The lock lives on the host because that is all two
+/// releases share, and is held until the returned file is dropped.
+fn acquire_node_mutation_lock() -> Result<std::fs::File> {
+    use std::os::fd::AsRawFd;
+
+    const LOCK_PATH: &str = "/host-run-lock/kata-deploy.lock";
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(LOCK_PATH)
+        .with_context(|| format!("failed to open the node mutation lock {LOCK_PATH}"))?;
+    let result = unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("failed to acquire the node mutation lock {LOCK_PATH}"));
+    }
+    Ok(lock)
+}
+
 /// Re-exec the current binary into the hidden `internal-post-install-wait`
 /// action. Propagates the detected runtime (so we don't have to re-query the
 /// apiserver) and the health-listener FD (so kubelet probes don't see a gap
@@ -844,13 +868,17 @@ fn shared_label_after(labels: &BTreeMap<String, String>, ours: &str) -> SharedLa
 async fn release_node(config: &config::Config) -> Result<bool> {
     let ours = instance_label(config.multi_install_suffix.as_deref());
 
-    // A node nothing has marked was installed on by a version that did not mark it,
-    // so ask the question that version asked: is any other kata-deploy left in the
-    // cluster at all?
+    // A legacy install leaves no marker behind, so when no other marker is left,
+    // ask whether another kata-deploy still wants a pod here: otherwise this
+    // uninstall takes the shared label out from under that install.
+    //
+    // Answered here rather than inside the rewrite below, and so a snapshot: a
+    // DaemonSet lives outside this node, and nothing can make reading it atomic
+    // with a write guarded by this node's resourceVersion. Should that DaemonSet
+    // go in between, the shared label is left for the next uninstall to take.
     let labels = k8s::get_node_labels(config).await?;
-    let unmarked =
-        !labels.contains_key(&ours) && shared_label_after(&labels, &ours) == SharedLabel::Remove;
-    let legacy_others = unmarked && k8s::count_any_kata_deploy_daemonsets(config).await? > 0;
+    let legacy_others = shared_label_after(&labels, &ours) == SharedLabel::Remove
+        && k8s::other_kata_deploy_daemonset_selects_node(config).await?;
 
     let others = k8s::rewrite_node_labels(config, |labels| {
         let mut updates: Vec<(String, Option<String>)> = Vec::new();
@@ -940,9 +968,12 @@ async fn install_stage_artifacts(
         claim_node(config).await;
     }
 
+    let _node_lock = acquire_node_mutation_lock()?;
+
     // Refuse before touching the host: whole-file containerd configuration keeps a
     // single backup, which the first uninstall would restore over every other
-    // installation's handlers.
+    // installation's handlers. Read under the lock, or another release's edit could
+    // be half-written while this one decides.
     if runtime != "crio"
         && config
             .multi_install_suffix
@@ -1004,6 +1035,21 @@ async fn install_stage_artifacts(
 /// kata pod scheduled onto the node.
 async fn install_stage_cri(config: &config::Config, runtime: &str, staged: bool) -> Result<()> {
     info!("install (cri): configuring CRI runtime");
+    let _node_lock = acquire_node_mutation_lock()?;
+
+    if runtime != "crio"
+        && config
+            .multi_install_suffix
+            .as_deref()
+            .is_some_and(|suffix| !suffix.is_empty())
+    {
+        let paths = config.get_containerd_paths(runtime).await?;
+        anyhow::ensure!(
+            paths.use_drop_in,
+            "multi-install requires containerd drop-in support: whole-file configuration and its \
+             single backup cannot preserve another installation during uninstall"
+        );
+    }
 
     let config_before = if staged {
         runtime::cri_config_snapshot(config, runtime).await
@@ -1301,26 +1347,21 @@ async fn label_node_with_retry(config: &config::Config, labels: &[(&str, &str)])
 async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     info!("Cleaning up Kata Containers");
 
-    // Step 1: Check if THIS pod's owning DaemonSet still exists.
-    // If it does, this is a pod restart (rolling update, label change, etc.),
-    // not an uninstall — skip everything so running kata pods are not disrupted.
     info!(
-        "Checking if DaemonSet '{}' still exists",
+        "Checking whether DaemonSet '{}' still wants a pod on this node",
         config.daemonset_name
     );
-    if k8s::own_daemonset_exists(config).await? {
+    if k8s::own_daemonset_selects_node(config).await? {
         info!(
-            "DaemonSet '{}' still exists, \
-             skipping all cleanup to avoid disrupting running kata pods",
+            "DaemonSet '{}' still selects this node, skipping all cleanup to avoid disrupting a \
+             rolling restart",
             config.daemonset_name
         );
         return Ok(());
     }
 
-    // Step 2: Our DaemonSet is gone (uninstall). Perform instance-specific
-    // cleanup: snapshotters, CRI config, and artifacts for this instance.
     info!(
-        "DaemonSet '{}' not found, proceeding with instance cleanup",
+        "DaemonSet '{}' is gone or no longer selects this node, proceeding with instance cleanup",
         config.daemonset_name
     );
 
@@ -1329,6 +1370,7 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     // not - this install's configuration is leaving the disk the runtime reads.
     info!("Removing this install's node labels");
     release_node(config).await?;
+    let _node_lock = acquire_node_mutation_lock()?;
 
     if runtime != "crio" {
         match config.experimental_setup_snapshotter.as_ref() {
@@ -1366,22 +1408,18 @@ async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {
     Ok(())
 }
 
-/// Cleanup stage 2 (revert-cri): remove CRI drop-ins (and any snapshotter
+/// Cleanup stage 2 (revert-cri): remove CRI configuration (and any snapshotter
 /// config), then restart the runtime and wait for readiness. This is the
-/// privileged, node-disrupting cleanup stage and is kept short-lived. Skips
-/// entirely when the CRI drop-ins are already absent, avoiding an unnecessary
-/// runtime restart.
+/// privileged, node-disrupting cleanup stage and is kept short-lived. Snapshotter
+/// cleanup is independent because a partial install may fail before writing CRI
+/// configuration; only the restart is skipped when configuration is absent.
 async fn cleanup_stage_revert_cri(
     config: &config::Config,
     runtime: &str,
     staged: bool,
 ) -> Result<()> {
     info!("cleanup (revert-cri): reverting CRI configuration");
-
-    if !cri_drop_in_present(config, runtime).await {
-        info!("cleanup (revert-cri): CRI drop-ins already absent, skipping");
-        return Ok(());
-    }
+    let _node_lock = acquire_node_mutation_lock()?;
 
     if runtime != "crio" {
         if let Some(snapshotters) = config.experimental_setup_snapshotter.as_ref() {
@@ -1390,6 +1428,11 @@ async fn cleanup_stage_revert_cri(
                 artifacts::snapshotters::uninstall_snapshotter(snapshotter, config).await?;
             }
         }
+    }
+
+    if !cri_configuration_present(config, runtime).await {
+        info!("cleanup (revert-cri): CRI configuration already absent, skipping restart");
+        return Ok(());
     }
 
     runtime::cleanup_cri_runtime_config(config, runtime).await?;
@@ -1405,6 +1448,7 @@ async fn cleanup_stage_revert_cri(
 /// from the host. Skips when the install directory is already gone or empty.
 async fn cleanup_stage_remove_artifacts(config: &config::Config) -> Result<()> {
     info!("cleanup (remove-artifacts): removing kata artifacts from host");
+    let _node_lock = acquire_node_mutation_lock()?;
 
     // The install dir is bind mounted into this pod, so it always exists and
     // outlives the artifacts it holds: an empty one means there is nothing
@@ -1431,18 +1475,22 @@ async fn cleanup_stage_remove_artifacts(config: &config::Config) -> Result<()> {
     Ok(())
 }
 
-/// Best-effort check for whether kata's CRI drop-in configuration is present on
+/// Best-effort check for whether kata's CRI configuration is present on
 /// the host for this runtime. Used by the staged cleanup to skip a disruptive
 /// runtime restart when there is nothing to revert. On any uncertainty (e.g.
 /// the containerd paths cannot be resolved) this returns `true` so the caller
 /// errs on the side of running the revert rather than incorrectly skipping it.
-async fn cri_drop_in_present(config: &config::Config, runtime: &str) -> bool {
+async fn cri_configuration_present(config: &config::Config, runtime: &str) -> bool {
     if runtime == "crio" {
         return std::path::Path::new(&config.crio_drop_in_conf_file).exists();
     }
 
     match config.get_containerd_paths(runtime).await {
-        Ok(paths) => std::path::Path::new(&paths.drop_in_file).exists(),
+        Ok(paths) if paths.use_drop_in => std::path::Path::new(&paths.drop_in_file).exists(),
+        // Whole-file mode leaves no drop-in to look for. The backup is what it does
+        // leave behind, and it is evidence of this install's own edit rather than of
+        // a configuration that merely mentions the same paths.
+        Ok(paths) => std::path::Path::new(&paths.backup_file).exists(),
         Err(e) => {
             log::warn!(
                 "cleanup (revert-cri): could not resolve containerd paths to check drop-in \
@@ -1464,6 +1512,7 @@ async fn reset(config: &config::Config, runtime: &str) -> Result<()> {
         return Ok(());
     }
 
+    let _node_lock = acquire_node_mutation_lock()?;
     runtime::lifecycle::restart_cri_runtime(config, runtime).await?;
     if matches!(runtime, "crio" | "containerd") {
         utils::host_systemctl(&["restart", "kubelet"]).await?;

--- a/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
@@ -457,8 +457,20 @@ pub async fn configure_containerd(config: &Config, runtime: &str) -> Result<()> 
 
     if !paths.use_drop_in {
         // For non-drop-in, backup the correct config file for each runtime
-        if Path::new(&paths.config_file).exists() && !Path::new(&paths.backup_file).exists() {
-            fs::copy(&paths.config_file, &paths.backup_file)?;
+        if Path::new(&paths.config_file).exists() {
+            // Only what was found here before kata-deploy is worth preserving. A
+            // configuration an earlier run of this install created is not, and
+            // backing it up would make uninstall restore Kata's own handlers.
+            if matches!(
+                whole_file_disposition(&paths.config_file, &paths.backup_file),
+                WholeFileConfig::Keep
+            ) {
+                fs::copy(&paths.config_file, &paths.backup_file)?;
+            }
+        } else {
+            // Nothing to back up, so uninstall has no way to tell this file apart
+            // from one an administrator wrote unless we say we made it.
+            fs::write(created_marker_file(&paths.config_file), "")?;
         }
     } else {
         // Create the drop-in file directory and file
@@ -643,15 +655,52 @@ pub async fn cleanup_containerd(config: &Config, runtime: &str) -> Result<()> {
         return Ok(());
     }
 
-    // For non-drop-in, restore from backup
-    if Path::new(&paths.backup_file).exists() {
-        fs::remove_file(&paths.config_file)?;
-        fs::rename(&paths.backup_file, &paths.config_file)?;
-    } else {
-        fs::remove_file(&paths.config_file).ok();
+    match whole_file_disposition(&paths.config_file, &paths.backup_file) {
+        WholeFileConfig::Restore => {
+            fs::remove_file(&paths.config_file)?;
+            fs::rename(&paths.backup_file, &paths.config_file)?;
+        }
+        WholeFileConfig::Delete => {
+            fs::remove_file(&paths.config_file).ok();
+            fs::remove_file(created_marker_file(&paths.config_file)).ok();
+        }
+        WholeFileConfig::Keep => log::warn!(
+            "Leaving {} in place: it has no kata-deploy backup and no record of having been \
+             created by kata-deploy, so its contents are not ours to remove",
+            paths.config_file
+        ),
     }
 
     Ok(())
+}
+
+/// What uninstall is entitled to do with a whole-file containerd configuration.
+pub enum WholeFileConfig {
+    /// An install replaced a configuration that was already there.
+    Restore,
+    /// An install created the configuration, so removing it restores the host.
+    Delete,
+    /// No evidence that any install wrote this file: leave it to its owner.
+    Keep,
+}
+
+/// A missing backup only means "we created this" if creating it was recorded. On
+/// anything weaker - a path this install also uses appearing in the file, say -
+/// deleting takes an administrator's whole containerd configuration with it.
+pub fn whole_file_disposition(config_file: &str, backup_file: &str) -> WholeFileConfig {
+    if Path::new(backup_file).exists() {
+        WholeFileConfig::Restore
+    } else if Path::new(&created_marker_file(config_file)).exists() {
+        WholeFileConfig::Delete
+    } else {
+        WholeFileConfig::Keep
+    }
+}
+
+/// Path of the record that an install created `config_file` from nothing, kept
+/// next to the configuration so it outlives the pod that wrote it.
+fn created_marker_file(config_file: &str) -> String {
+    format!("{config_file}.kata-deploy-created")
 }
 
 /// Setup containerd config files based on runtime type.
@@ -877,6 +926,36 @@ mod tests {
             container_annotations: "[\"io.kubernetes.container.terminationMessage*\"]",
             snapshotter: snapshotter.map(|s| s.to_string()),
         }
+    }
+
+    /// Uninstall may only delete a whole-file configuration it can prove an install
+    /// wrote. A file with neither a backup nor a creation record belongs to whoever
+    /// put it there.
+    #[test]
+    fn whole_file_configuration_is_only_removed_on_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("containerd.toml");
+        let backup = dir.path().join("containerd.toml.bak");
+        let config_path = config.to_str().unwrap();
+        let backup_path = backup.to_str().unwrap();
+        std::fs::write(&config, "version = 2\n").unwrap();
+
+        assert!(matches!(
+            whole_file_disposition(config_path, backup_path),
+            WholeFileConfig::Keep
+        ));
+
+        std::fs::write(created_marker_file(config_path), "").unwrap();
+        assert!(matches!(
+            whole_file_disposition(config_path, backup_path),
+            WholeFileConfig::Delete
+        ));
+
+        std::fs::write(&backup, "version = 2\n").unwrap();
+        assert!(matches!(
+            whole_file_disposition(config_path, backup_path),
+            WholeFileConfig::Restore
+        ));
     }
 
     #[test]

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1312,6 +1312,8 @@ host. Emitted at column 0; indent with `nindent` at the call site.
 - name: host-machine-id
   mountPath: /host-machine-id
   readOnly: true
+- name: host-run-lock
+  mountPath: /host-run-lock
 - name: host-usr-bin
   mountPath: /host-usr/bin
   readOnly: true
@@ -1373,6 +1375,12 @@ indent with `nindent` at the call site.
   hostPath:
     path: /etc/machine-id
     type: File
+{{- /* Writable, unlike the other host mounts: this is where the lock the
+       installs on this node take against each other is created. */}}
+- name: host-run-lock
+  hostPath:
+    path: /run/lock
+    type: DirectoryOrCreate
 - name: host-usr-bin
   hostPath:
     path: /usr/bin


### PR DESCRIPTION
Separate installations can otherwise edit the same runtime configuration and restart the same CRI service concurrently. A selected Kubernetes Node can also be deleted and recreated while an already-dispatched Job is still targeting its name.

Bind each per-node Job to the selected host's machine identity and serialize host mutations with a node-local lock. Installation and cleanup now make their configuration changes and runtime restarts as one ordered lifecycle, including containerd setups that do not support drop-ins.

The chart also rejects required node-affinity forms whose Kubernetes no-match semantics cannot be represented by the dispatcher's label queries, avoiding accidental installation on every node.