### PR TITLE
kata-monitor: watch both Go and runtime-rs sandbox paths

### DIFF
--- a/docs/design/kata-2-0-metrics.md
+++ b/docs/design/kata-2-0-metrics.md
@@ -65,7 +65,12 @@ Only one `kata-monitor` process runs in each node.
 
 `kata-monitor` uses a different communication channel than the one used by the container engine (`containerd`/`CRI-O`) to communicate with the Kata shim. The Kata shim exposes a dedicated socket address reserved to `kata-monitor`.
 
-The shim's metrics socket file is created under the virtcontainers sandboxes directory, i.e. `vc/sbs/${PODID}/shim-monitor.sock`.
+The shim's metrics socket file is created under the sandboxes directory for the active runtime:
+
+- Go runtime: `/run/vc/sbs/${PODID}/shim-monitor.sock`
+- runtime-rs: `/run/kata/${PODID}/shim-monitor.sock`
+
+`kata-monitor` watches **both** paths so it can collect metrics from either runtime (or both on the same node) without a runtime-type selection flag.
 
 > **Note**: If there is no Prometheus server configured, i.e., there are no scrape operations, `kata-monitor` will not collect any metrics.
 

--- a/src/runtime/cmd/kata-monitor/README.md
+++ b/src/runtime/cmd/kata-monitor/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 `kata-monitor` is a daemon able to collect and expose metrics related to all the Kata Containers workloads running on the same host.
-Once started, it detects all the running Kata Containers runtimes (`containerd-shim-kata-v2`) in the system and exposes few http endpoints to allow the retrieval of the available data.
+Once started, it detects Kata sandboxes from both the Go runtime (`/run/vc/sbs`) and runtime-rs (`/run/kata`) and exposes a few HTTP endpoints to retrieve the available data.
 The main endpoint is the `/metrics` one which aggregates metrics from all the kata workloads.
 Available metrics include:
   * Kata runtime metrics

--- a/src/runtime/pkg/kata-monitor/monitor.go
+++ b/src/runtime/pkg/kata-monitor/monitor.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -78,6 +79,40 @@ func removeFromSandboxList(sandboxList []string, sandboxToRemove string) []strin
 	return sandboxList
 }
 
+// syncSandboxFSPath registers a watch on path (if not already watched) and
+// returns sandbox IDs found during the initial directory sync.
+func (km *KataMonitor) syncSandboxFSPath(watcher *fsnotify.Watcher, path string, watched map[string]struct{}) ([]string, error) {
+	if _, ok := watched[path]; ok {
+		return nil, nil
+	}
+
+	if err := watcher.Add(path); err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		_ = watcher.Remove(path)
+		return nil, err
+	}
+
+	watched[path] = struct{}{}
+	monitorLog.Debugf("started fs monitoring @%s", path)
+
+	var sandboxes []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		if km.sandboxCache.putIfNotExists(id, sandboxCRIMetadata{}) {
+			sandboxes = append(sandboxes, id)
+		}
+	}
+	monitorLog.WithField("path", path).WithField("sandboxes", sandboxes).Debug("initial sync of sandbox directory completed")
+	return sandboxes, nil
+}
+
 // startPodCacheUpdater will boot a thread to manage sandbox cache
 func (km *KataMonitor) startPodCacheUpdater() {
 	sbsWatcher, err := fsnotify.NewWatcher()
@@ -86,54 +121,54 @@ func (km *KataMonitor) startPodCacheUpdater() {
 		os.Exit(1)
 	}
 	defer sbsWatcher.Close()
-	for {
-		err = sbsWatcher.Add(getSandboxFS())
-		if err != nil {
-			// if there are no kata pods (yet), the kata /run/vc directory may not be there: retry later
-			monitorLog.WithError(err).Warnf("cannot monitor %s, retry in %d sec.", getSandboxFS(), fsMonitorRetryDelaySeconds)
-			time.Sleep(fsMonitorRetryDelaySeconds * time.Second)
-			continue
+
+	sandboxFSPaths := getSandboxFSPaths()
+	watchedPaths := make(map[string]struct{}, len(sandboxFSPaths))
+	sandboxList := []string{}
+
+	tryWatchAll := func() {
+		for _, path := range sandboxFSPaths {
+			added, syncErr := km.syncSandboxFSPath(sbsWatcher, path, watchedPaths)
+			if syncErr != nil {
+				// Path may not exist yet when no sandboxes of that runtime are present.
+				monitorLog.WithError(syncErr).Warnf("cannot monitor %s, retry in %d sec.", path, fsMonitorRetryDelaySeconds)
+				continue
+			}
+			sandboxList = append(sandboxList, added...)
 		}
-		monitorLog.Debugf("started fs monitoring @%s", getSandboxFS())
-		break
-	}
-	// Initial sync with the kata sandboxes already running
-	sbsFile, err := os.Open(getSandboxFS())
-	if err != nil {
-		monitorLog.WithError(err).Fatal("cannot open sandboxes fs")
-		os.Exit(1)
-	}
-	sandboxList, err := sbsFile.Readdirnames(0)
-	if err != nil {
-		monitorLog.WithError(err).Fatal("cannot read sandboxes fs")
-		os.Exit(1)
-	}
-	for _, sandbox := range sandboxList {
-		km.sandboxCache.putIfNotExists(sandbox, sandboxCRIMetadata{})
 	}
 
-	monitorLog.Debug("initial sync of sbs directory completed")
-	monitorLog.Tracef("pod list from sbs: %v", sandboxList)
+	tryWatchAll()
+	if len(watchedPaths) == 0 {
+		monitorLog.Warnf("no sandbox storage paths available yet; will retry every %d sec.", fsMonitorRetryDelaySeconds)
+	}
 
 	// We try to get CRI (kubernetes) metadata from the container manager for each new kata sandbox we detect.
 	// It may take a while for data to be available, so we always wait podCacheRefreshDelaySeconds before checking.
 	cacheUpdateTimer := time.NewTimer(podCacheRefreshDelaySeconds * time.Second)
 	cacheUpdateTimerIsSet := true
+	watchRetryTicker := time.NewTicker(fsMonitorRetryDelaySeconds * time.Second)
+	defer watchRetryTicker.Stop()
+
 	for {
 		select {
 		case event, ok := <-sbsWatcher.Events:
 			if !ok {
-				monitorLog.WithError(err).Fatal("cannot watch sandboxes fs")
+				monitorLog.Fatal("cannot watch sandboxes fs")
 				os.Exit(1)
 			}
 			monitorLog.WithField("event", event).Debug("got sandbox event")
-			switch event.Op {
-			case fsnotify.Create:
-				splitPath := strings.Split(event.Name, string(os.PathSeparator))
-				id := splitPath[len(splitPath)-1]
+			switch {
+			case event.Op&fsnotify.Create == fsnotify.Create:
+				id := filepath.Base(event.Name)
+				info, statErr := os.Stat(event.Name)
+				if statErr != nil || !info.IsDir() {
+					continue
+				}
 				if !km.sandboxCache.putIfNotExists(id, sandboxCRIMetadata{}) {
 					monitorLog.WithField("pod", id).Warn(
 						"CREATE event but pod already present in the sandbox cache")
+					continue
 				}
 				sandboxList = append(sandboxList, id)
 				monitorLog.WithField("pod", id).Info("sandbox cache: added pod")
@@ -144,15 +179,26 @@ func (km *KataMonitor) startPodCacheUpdater() {
 						"cache update timer fires in %d secs", podCacheRefreshDelaySeconds)
 				}
 
-			case fsnotify.Remove:
-				splitPath := strings.Split(event.Name, string(os.PathSeparator))
-				id := splitPath[len(splitPath)-1]
+			case event.Op&fsnotify.Remove == fsnotify.Remove:
+				// A watched root may disappear (e.g. last sandbox cleaned up the tree).
+				// Drop it from watchedPaths so the retry ticker can re-attach later.
+				if _, ok := watchedPaths[event.Name]; ok {
+					delete(watchedPaths, event.Name)
+					monitorLog.WithField("path", event.Name).Warn("sandbox storage path removed; will retry watch")
+					continue
+				}
+				id := filepath.Base(event.Name)
 				if !km.sandboxCache.deleteIfExists(id) {
 					monitorLog.WithField("pod", id).Warn(
 						"REMOVE event but pod was missing from the sandbox cache")
 				}
 				sandboxList = removeFromSandboxList(sandboxList, id)
 				monitorLog.WithField("pod", id).Info("sandbox cache: removed pod")
+			}
+
+		case <-watchRetryTicker.C:
+			if len(watchedPaths) < len(sandboxFSPaths) {
+				tryWatchAll()
 			}
 
 		case <-cacheUpdateTimer.C:

--- a/src/runtime/pkg/kata-monitor/shim_client.go
+++ b/src/runtime/pkg/kata-monitor/shim_client.go
@@ -34,8 +34,16 @@ func getSandboxIDFromReq(r *http.Request) (string, error) {
 	return "", fmt.Errorf("sandbox not found in %+v", r.URL.Query())
 }
 
-func getSandboxFS() string {
-	return shim.GetSandboxesStoragePath()
+// getSandboxFSPaths returns all sandbox storage paths that kata-monitor must
+// watch.
+//
+// The Go runtime stores sandboxes under /run/vc/sbs; runtime-rs under
+// /run/kata.
+func getSandboxFSPaths() []string {
+	return []string{
+		shim.GetSandboxesStoragePath(),
+		shim.GetSandboxesStoragePathRust(),
+	}
 }
 
 func getFilterFamilyFromReq(r *http.Request) ([]string, error) {

--- a/src/runtime/pkg/kata-monitor/shim_client_test.go
+++ b/src/runtime/pkg/kata-monitor/shim_client_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kata Containers Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package katamonitor
+
+import (
+	"testing"
+
+	shim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSandboxFSPaths(t *testing.T) {
+	assert := assert.New(t)
+
+	paths := getSandboxFSPaths()
+	assert.Equal([]string{
+		shim.GetSandboxesStoragePath(),
+		shim.GetSandboxesStoragePathRust(),
+	}, paths)
+	assert.Contains(paths, "/run/vc/sbs")
+	assert.Contains(paths, "/run/kata")
+}


### PR DESCRIPTION
Discover sandboxes under /run/vc/sbs and /run/kata so metrics collection works for either runtime (or both) without a runtime-type selection flag.

Note: I'm fully aware of Ya'nan's PR porting kata-monitor to rust, but that one seems to be stale and only addresses runtime-rs. While that one does not land, users need something working for them to monitor runtime-rs with the current kata-monitor implementation.

https://github.com/kata-containers/kata-containers/issues/12666