### PR TITLE
runtime-rs: remote hypervisor fixes

### DIFF
--- a/src/libs/kata-types/src/annotations/crio.rs
+++ b/src/libs/kata-types/src/annotations/crio.rs
@@ -12,3 +12,5 @@ pub const SANDBOX: &str = "sandbox";
 pub const CONTAINER: &str = "container";
 
 pub const SANDBOX_ID_LABEL_KEY: &str = "io.kubernetes.cri-o.SandboxID";
+pub const SANDBOX_NAME_LABEL_KEY: &str = "io.kubernetes.cri-o.KubeName";
+pub const SANDBOX_NAMESPACE_LABEL_KEY: &str = "io.kubernetes.cri-o.Namespace";

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -250,6 +250,12 @@ impl Agent {
         if self.dial_timeout_ms == 0 {
             return Err(std::io::Error::other("dial_timeout_ms couldn't be 0."));
         }
+        if self.reconnect_timeout_ms < self.dial_timeout_ms {
+            return Err(std::io::Error::other(
+                "reconnect_timeout_ms must be >= dial_timeout_ms (reconnect_timeout_ms is the \
+                 overall agent connection budget; dial_timeout_ms is the sleep between retries)",
+            ));
+        }
 
         Ok(())
     }

--- a/src/libs/kata-types/src/config/hypervisor/remote.rs
+++ b/src/libs/kata-types/src/config/hypervisor/remote.rs
@@ -72,6 +72,13 @@ impl ConfigPlugin for RemoteConfig {
             }
         }
 
+        // The remote hypervisor uses CAA for networking via a VXLAN tunnel.
+        // The runtime must not do its own network setup (internetworking_model
+        // must be "none"), and must not clear the netns path that CAA needs
+        // for tunnel setup (disable_new_netns must be false).
+        conf.runtime.internetworking_model = "none".to_string();
+        conf.runtime.disable_new_netns = false;
+
         Ok(())
     }
 

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -333,11 +333,11 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 10)
 dial_timeout_ms = 10
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -333,11 +333,11 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 10)
 dial_timeout_ms = 10
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -310,11 +310,11 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 10)
 dial_timeout_ms = 10
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
@@ -274,11 +274,11 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 10)
 dial_timeout_ms = 1000
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -545,11 +545,11 @@ kernel_modules = []
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 100)
 dial_timeout_ms = 100
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 450)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -554,11 +554,11 @@ kernel_modules = []
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 10)
 dial_timeout_ms = 10
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -528,11 +528,11 @@ kernel_modules = []
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 100)
 dial_timeout_ms = 100
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 450)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -575,11 +575,11 @@ kernel_modules = []
 # through "kata-runtime exec <sandbox-id>" command
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 100)
 dial_timeout_ms = 100
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 450)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -553,11 +553,11 @@ kernel_modules = []
 
 debug_console_enabled = false
 
-# Agent dial timeout in millisecond.
+# Sleep between agent connection retries, in milliseconds.
 # (default: 100)
 dial_timeout_ms = 100
 
-# Agent reconnect timeout in millisecond.
+# Overall time budget for establishing the agent connection, in milliseconds.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 450)
 # If you find pod cannot connect to the agent when starting, please
 # consider increasing this value to increase the retry times.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -150,9 +150,16 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Agent connection dialing timeout value in milliseconds
-# (default: 30000)
-dial_timeout_ms = 30000
+# Overall budget for establishing the agent connection, in milliseconds.
+# The runtime retries until this budget is exhausted.
+# (default: 3000, but 30s is appropriate for remote VMs)
+reconnect_timeout_ms = 30000
+
+# Sleep between individual agent connection retries, in milliseconds.
+# Note: unlike the Go runtime's dial_timeout (which is the overall budget),
+# this is just the inter-retry delay.
+# (default: 10)
+dial_timeout_ms = 100
 
 # Create Container Request Timeout
 # This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -204,7 +204,9 @@ enable_debug = false
 #     proxies. Supports a single network interface per network namespace.
 #     Experimental feature, IPv4 only.
 #
-# Note: The remote hypervisor, uses it's own network, so "none" is required
+# Note: The remote hypervisor uses CAA for networking via a VXLAN tunnel —
+# the runtime must not set up its own network devices. "none" is required;
+# adjust_config() enforces this.
 internetworking_model = "none"
 
 name = "virt_container"
@@ -240,7 +242,8 @@ jaeger_password = ""
 # `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
-# Note: The remote hypervisor has a different networking model, which requires true
+# Note: Must be false for the remote hypervisor — CAA needs the netns path
+# for VXLAN tunnel setup. adjust_config() enforces this.
 disable_new_netns = false
 
 # if enabled, the runtime will add all the kata processes inside one dedicated cgroup.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -150,16 +150,16 @@ enable_tracing = false
 
 debug_console_enabled = false
 
-# Overall budget for establishing the agent connection, in milliseconds.
-# The runtime retries until this budget is exhausted.
-# (default: 3000, but 30s is appropriate for remote VMs)
-reconnect_timeout_ms = 30000
-
-# Sleep between individual agent connection retries, in milliseconds.
+# Sleep between agent connection retries, in milliseconds.
 # Note: unlike the Go runtime's dial_timeout (which is the overall budget),
 # this is just the inter-retry delay.
 # (default: 10)
 dial_timeout_ms = 100
+
+# Overall time budget for establishing the agent connection, in milliseconds.
+# Retry count = reconnect_timeout_ms / dial_timeout_ms.
+# (default: 3000, but 30s is appropriate for remote VMs)
+reconnect_timeout_ms = 30000
 
 # Create Container Request Timeout
 # This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -299,7 +299,7 @@ kernel_modules = []
 
 debug_console_enabled = false
 
-# Agent connection dialing timeout value in milliseconds
+# Sleep between agent connection retries, in milliseconds.
 # (default: 45000)
 dial_timeout_ms = 45000
 

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kata_types::{
     annotations::{
-        cri_containerd::{SANDBOX_NAMESPACE_LABEL_KEY, SANDBOX_NAME_LABEL_KEY},
+        cri_containerd, crio,
         KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPUS, KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPU_MODEL,
         KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY, KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS,
         KATA_ANNO_CFG_HYPERVISOR_IMAGE_PATH, KATA_ANNO_CFG_HYPERVISOR_INIT_DATA,
@@ -98,16 +98,18 @@ impl RemoteInner {
         let mut annotations: HashMap<String, String> = HashMap::new();
         let config = &self.config;
         annotations.insert(
-            SANDBOX_NAME_LABEL_KEY.to_string(),
+            cri_containerd::SANDBOX_NAME_LABEL_KEY.to_string(),
             oci_annotations
-                .get(SANDBOX_NAME_LABEL_KEY)
+                .get(cri_containerd::SANDBOX_NAME_LABEL_KEY)
+                .or_else(|| oci_annotations.get(crio::SANDBOX_NAME_LABEL_KEY))
                 .cloned()
                 .unwrap_or_default(),
         );
         annotations.insert(
-            SANDBOX_NAMESPACE_LABEL_KEY.to_string(),
+            cri_containerd::SANDBOX_NAMESPACE_LABEL_KEY.to_string(),
             oci_annotations
-                .get(SANDBOX_NAMESPACE_LABEL_KEY)
+                .get(cri_containerd::SANDBOX_NAMESPACE_LABEL_KEY)
+                .or_else(|| oci_annotations.get(crio::SANDBOX_NAMESPACE_LABEL_KEY))
                 .cloned()
                 .unwrap_or_default(),
         );

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -25,7 +25,7 @@ use protocols::{
     remote_ttrpc_async::HypervisorClient,
 };
 use std::{collections::HashMap, time};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use ttrpc::context::{self};
 use ttrpc::r#async::Client;
 
@@ -45,7 +45,6 @@ pub struct RemoteInner {
     pub(crate) client: Option<Client>,
 
     exit_notify: Option<mpsc::Sender<i32>>,
-    exit_waiter: Mutex<(mpsc::Receiver<i32>, i32)>,
 }
 
 impl std::fmt::Debug for RemoteInner {
@@ -60,9 +59,7 @@ impl std::fmt::Debug for RemoteInner {
 }
 
 impl RemoteInner {
-    pub fn new() -> Self {
-        let (exit_notify, exit_waiter) = mpsc::channel(1);
-
+    pub fn new(exit_notify: mpsc::Sender<i32>) -> Self {
         Self {
             id: "".to_string(),
             config: HypervisorConfig::default(),
@@ -71,7 +68,6 @@ impl RemoteInner {
             client: None,
 
             exit_notify: Some(exit_notify),
-            exit_waiter: Mutex::new((exit_waiter, 0)),
         }
     }
 
@@ -229,16 +225,6 @@ impl RemoteInner {
         todo!()
     }
 
-    pub(crate) async fn wait_vm(&self) -> Result<i32> {
-        info!(sl!(), "Wait Remote VM");
-        let mut waiter = self.exit_waiter.lock().await;
-        if let Some(exitcode) = waiter.0.recv().await {
-            waiter.1 = exitcode;
-        }
-
-        Ok(waiter.1)
-    }
-
     pub(crate) async fn resume_vm(&self) -> Result<()> {
         warn!(sl!(), "RemoteInner::resume_vm(): NOT YET IMPLEMENTED");
         todo!()
@@ -382,7 +368,7 @@ impl RemoteInner {
 #[async_trait]
 impl Persist for RemoteInner {
     type State = HypervisorState;
-    type ConstructorArgs = ();
+    type ConstructorArgs = mpsc::Sender<i32>;
 
     /// Save a state of hypervisor
     async fn save(&self) -> Result<Self::State> {
@@ -397,11 +383,9 @@ impl Persist for RemoteInner {
 
     /// Restore hypervisor
     async fn restore(
-        _hypervisor_args: Self::ConstructorArgs,
+        exit_notify: Self::ConstructorArgs,
         hypervisor_state: Self::State,
     ) -> Result<Self> {
-        let (exit_notify, exit_waiter) = mpsc::channel(1);
-
         Ok(RemoteInner {
             id: hypervisor_state.id,
             config: hypervisor_state.config,
@@ -409,7 +393,6 @@ impl Persist for RemoteInner {
             netns: hypervisor_state.netns,
             client: None,
             exit_notify: Some(exit_notify),
-            exit_waiter: Mutex::new((exit_waiter, 0)),
         })
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -218,9 +218,13 @@ impl RemoteInner {
             id: self.id.clone(),
             ..Default::default()
         };
-        let _resp = client.stop_vm(ctx, &req).await?;
+        if let Err(e) = client.stop_vm(ctx, &req).await {
+            warn!(sl!(), "StopVM RPC failed (VM may already be gone): {}", e);
+        }
 
-        self.exit_notify.take().unwrap().send(1).await?;
+        if let Some(sender) = self.exit_notify.take() {
+            let _ = sender.send(1).await;
+        }
         Ok(())
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -177,19 +177,23 @@ impl RemoteInner {
             .await
             .map_err(|e| anyhow::anyhow!("error creating VM: {e}"))?;
         info!(sl!(), "Preparing REMOTE VM resp: {:?}", resp.clone());
-        self.agent_socket_path = resp.agentSocketPath;
+        if resp.agentSocketPath.is_empty() {
+            return Err(anyhow::anyhow!("CAA did not return agent socket path"));
+        }
+        self.agent_socket_path = resp.agentSocketPath.clone();
         self.netns = netns;
         Ok(())
     }
 
-    pub(crate) async fn start_vm(&mut self, timeout: i32) -> Result<()> {
+    pub(crate) async fn start_vm(&mut self, mut timeout: i32) -> Result<()> {
         info!(sl!(), "Starting REMOTE VM");
 
-        let mut min_timeout = DEFAULT_MIN_TIMEOUT;
-        if self.config.remote_info.hypervisor_timeout > 0 {
-            min_timeout = self.config.remote_info.hypervisor_timeout.min(timeout);
-        }
-        let timeout = min_timeout;
+        let configured_timeout = if self.config.remote_info.hypervisor_timeout > 0 {
+            self.config.remote_info.hypervisor_timeout
+        } else {
+            DEFAULT_MIN_TIMEOUT
+        };
+        timeout = timeout.max(configured_timeout);
 
         let client = self.get_ttrpc_client().await?;
 

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -221,18 +221,15 @@ impl RemoteInner {
     }
 
     pub(crate) async fn pause_vm(&self) -> Result<()> {
-        warn!(sl!(), "RemoteInner::pause_vm(): NOT YET IMPLEMENTED");
-        todo!()
+        Err(anyhow::anyhow!("pause not supported for remote hypervisor"))
     }
 
     pub(crate) async fn resume_vm(&self) -> Result<()> {
-        warn!(sl!(), "RemoteInner::resume_vm(): NOT YET IMPLEMENTED");
-        todo!()
+        Err(anyhow::anyhow!("resume not supported for remote hypervisor"))
     }
 
     pub(crate) async fn save_vm(&self) -> Result<()> {
-        warn!(sl!(), "RemoteInner::save_vm(): NOT YET IMPLEMENTED");
-        todo!()
+        Err(anyhow::anyhow!("save not supported for remote hypervisor"))
     }
 
     pub(crate) async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
@@ -255,8 +252,8 @@ impl RemoteInner {
     }
 
     pub(crate) async fn disconnect(&mut self) {
-        warn!(sl!(), "RemoteInner::disconnect(): NOT YET IMPLEMENTED");
-        todo!()
+        info!(sl!(), "RemoteInner::disconnect(): dropping ttrpc client");
+        self.client.take();
     }
 
     pub fn hypervisor_config(&self) -> HypervisorConfig {
@@ -288,7 +285,6 @@ impl RemoteInner {
     }
 
     pub(crate) async fn cleanup(&self) -> Result<()> {
-        info!(sl!(), "RemoteInner::cleanup(): NOT YET IMPLEMENTED");
         Ok(())
     }
 
@@ -302,13 +298,11 @@ impl RemoteInner {
     }
 
     pub(crate) async fn get_pids(&self) -> Result<Vec<u32>> {
-        warn!(sl!(), "RemoteInner::get_pids(): NOT YET IMPLEMENTED");
-        todo!()
+        Ok(vec![])
     }
 
     pub(crate) async fn check(&self) -> Result<()> {
-        warn!(sl!(), "RemoteInner::check(): NOT YET IMPLEMENTED");
-        todo!()
+        Ok(())
     }
 
     pub(crate) async fn get_jailer_root(&self) -> Result<String> {
@@ -325,19 +319,14 @@ impl RemoteInner {
     }
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
-        warn!(
-            sl!(),
-            "RemoteInner::get_hypervisor_metrics(): NOT YET IMPLEMENTED"
-        );
-        todo!()
+        Err(anyhow::anyhow!(
+            "hypervisor metrics not supported for remote hypervisor"
+        ))
     }
 
     pub(crate) fn set_capabilities(&mut self, _flag: CapabilityBits) {
-        warn!(
-            sl!(),
-            "RemoteInner::set_capabilities(): NOT YET IMPLEMENTED"
-        );
-        todo!()
+        let mut caps = Capabilities::default();
+        caps.set(_flag);
     }
 
     pub(crate) fn set_guest_memory_block_size(&mut self, _size: u32) {

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -284,8 +284,11 @@ impl RemoteInner {
     }
 
     pub(crate) async fn get_ns_path(&self) -> Result<String> {
-        info!(sl!(), "RemoteInner::get_ns_path()");
-        Ok(self.netns.clone().unwrap_or_default())
+        // There is no local VMM process whose /proc/<pid>/ns we could
+        // point to.  Return the shim's own ns directory so that the
+        // caller's format!("{}/net", path) produces a valid path and
+        // NetnsGuard enters our own namespace (a no-op).
+        Ok(format!("/proc/{}/ns", nix::unistd::getpid()))
     }
 
     pub(crate) async fn cleanup(&self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
@@ -13,13 +13,14 @@ use persist::sandbox_persist::Persist;
 use std::collections::HashMap;
 
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, Mutex, RwLock};
 
 mod inner;
 
 #[derive(Debug)]
 pub struct Remote {
     inner: Arc<RwLock<RemoteInner>>,
+    exit_waiter: Mutex<(mpsc::Receiver<i32>, i32)>,
 }
 
 impl Default for Remote {
@@ -30,8 +31,11 @@ impl Default for Remote {
 
 impl Remote {
     pub fn new() -> Self {
+        let (exit_notify, exit_waiter) = mpsc::channel(1);
+
         Self {
-            inner: Arc::new(RwLock::new(RemoteInner::new())),
+            inner: Arc::new(RwLock::new(RemoteInner::new(exit_notify))),
+            exit_waiter: Mutex::new((exit_waiter, 0)),
         }
     }
 
@@ -67,8 +71,12 @@ impl Hypervisor for Remote {
     }
 
     async fn wait_vm(&self) -> Result<i32> {
-        let inner = self.inner.read().await;
-        inner.wait_vm().await
+        info!(sl!(), "Wait Remote VM");
+        let mut waiter = self.exit_waiter.lock().await;
+        if let Some(exitcode) = waiter.0.recv().await {
+            waiter.1 = exitcode;
+        }
+        Ok(waiter.1)
     }
 
     async fn pause_vm(&self) -> Result<()> {
@@ -208,12 +216,14 @@ impl Persist for Remote {
 
     /// Restore a component from a specified state.
     async fn restore(
-        hypervisor_args: Self::ConstructorArgs,
+        _hypervisor_args: Self::ConstructorArgs,
         hypervisor_state: Self::State,
     ) -> Result<Self> {
-        let inner = RemoteInner::restore(hypervisor_args, hypervisor_state).await?;
+        let (exit_notify, exit_waiter) = mpsc::channel(1);
+        let inner = RemoteInner::restore(exit_notify, hypervisor_state).await?;
         Ok(Self {
             inner: Arc::new(RwLock::new(inner)),
+            exit_waiter: Mutex::new((exit_waiter, 0)),
         })
     }
 }


### PR DESCRIPTION
This PR brings the remote hypervisor (AKA peer pods) implementation in runtime-rs to the point where peer-pods-relevant tests in the openshift-tests-private suite pass.

Some tests in that suite didn't pass but were verified as not passing for reasons unrelated to peer pods, mostly due to host machine limitations.  Libvirt provider was used during testing so tests weren't run in actual cloud which however is not expected to make a huge difference.

As expected, no major implementation part was missing but quite a bunch of adjustments had to be made - from cri-o incompatibility, a piece of implementation existing but being wrong to adjusting configuration and properly handling unsupported functionality.  Each particular change is described in detail in the pertinent commit message.