### PR TITLE
agent: fix OwnedFd usage in rustjail tests

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -1490,11 +1490,7 @@ mod tests {
             let msg = format!("test[{}]: {:?}", i, d);
             let tempdir = tempdir().unwrap();
 
-            let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
-            defer!({
-                unistd::close(rfd).unwrap();
-                unistd::close(wfd).unwrap();
-            });
+            let (_rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
 
             let source_path = tempdir.path().join(d.source).to_str().unwrap().to_string();
             if d.make_source_directory {
@@ -1510,7 +1506,7 @@ mod tests {
             mount.set_options(Some(vec![]));
 
             let result = mount_from(
-                wfd,
+                wfd.as_raw_fd(),
                 &mount,
                 tempdir.path().to_str().unwrap(),
                 d.flags,

--- a/src/agent/rustjail/src/pipestream.rs
+++ b/src/agent/rustjail/src/pipestream.rs
@@ -180,8 +180,10 @@ mod tests {
     #[tokio::test]
     // Shutdown should never close the inner fd.
     async fn test_pipestream_shutdown() {
-        let (_, wfd1) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
-        let mut writer1 = PipeStream::new(wfd1).unwrap();
+        // Keep the read end open so the write descriptor is reused only if
+        // shutdown() incorrectly closes it.
+        let (_rfd1, wfd1) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
+        let mut writer1 = PipeStream::new(wfd1.into_raw_fd()).unwrap();
 
         // if close fd in shutdown, the fd will be reused
         // and the test will failed
@@ -191,8 +193,8 @@ mod tests {
 
         let (rfd2, wfd2) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap(); // reuse fd number, rfd2 == wfd1
 
-        let mut reader2 = PipeStream::new(rfd2).unwrap();
-        let mut writer2 = PipeStream::new(wfd2).unwrap();
+        let mut reader2 = PipeStream::new(rfd2.into_raw_fd()).unwrap();
+        let mut writer2 = PipeStream::new(wfd2.into_raw_fd()).unwrap();
 
         // deregister writer1, then reader2 which has the same fd will be deregistered from epoll
         drop(writer1);

--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -292,6 +292,8 @@ mod tests {
     }
 
     fn get_pipe_size(fd: RawFd) -> i32 {
+        // Adapt the raw fd returned by production code without taking ownership in this test.
+        let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
         fcntl(fd, FcntlArg::F_GETPIPE_SZ).unwrap()
     }
 


### PR DESCRIPTION
## Summary

- update rustjail tests for `nix` APIs that now return `OwnedFd`
- transfer pipe ownership explicitly when constructing `PipeStream`
- borrow raw descriptors only for test helpers that do not take ownership
- rely on `OwnedFd` drop semantics for test cleanup

All changes are confined to existing `#[cfg(test)]` modules. Production code and public APIs are unchanged.

## Validation

- `cargo test -p rustjail --lib --no-run`
- `cargo test -p rustjail --lib pipestream::tests::test_pipestream_shutdown`
- `cargo test -p rustjail --lib process::tests::test_create_extended_pipe`
- `cargo test -p rustjail --lib mount::tests::test_mount_from`
- `git diff --check`
