### PR TITLE
agent: harden capability and namespace handling

### DIFF
--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -33,28 +33,46 @@ fn to_capshashset(cfd_log: RawFd, capabilities: &Option<HashSet<LinuxCapability>
     r
 }
 
-pub fn get_all_caps() -> CapsHashSet {
-    let mut caps_set =
-        runtime::procfs_all_supported(None).unwrap_or_else(|_| runtime::thread_all_supported());
+pub fn get_all_caps() -> Result<CapsHashSet> {
+    // This runs after joining the container mount namespace, so procfs may be
+    // controlled by the workload. Query the kernel directly before installing
+    // the workload seccomp filter, which may reject selected PR_CAPBSET_READ calls.
+    let caps_set = runtime::thread_all_supported();
     if caps_set.is_empty() {
-        caps_set = caps::all();
+        return Err(anyhow!(
+            "failed to enumerate supported capabilities with PR_CAPBSET_READ"
+        ));
     }
-    caps_set
+    Ok(caps_set)
 }
 
 pub fn reset_effective() -> Result<()> {
-    let all = get_all_caps();
+    let all = get_all_caps()?;
     caps::set(None, CapSet::Effective, &all).map_err(|e| anyhow!(e.to_string()))?;
     Ok(())
 }
 
-pub fn drop_privileges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
-    let all = get_all_caps();
+pub fn restrict_bounding_set(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
+    let all = get_all_caps()?;
+    let allowed_bounding = to_capshashset(cfd_log, caps.bounding());
 
-    for c in all.difference(&to_capshashset(cfd_log, caps.bounding())) {
+    for c in all.difference(&allowed_bounding) {
         caps::drop(None, CapSet::Bounding, *c).map_err(|e| anyhow!(e.to_string()))?;
     }
 
+    // Verify the kernel's post-drop bounding set is no broader than the OCI allowlist.
+    let remaining_bounding =
+        caps::read(None, CapSet::Bounding).map_err(|e| anyhow!(e.to_string()))?;
+    if !remaining_bounding.is_subset(&allowed_bounding) {
+        return Err(anyhow!(
+            "failed to remove disallowed capabilities from the bounding set"
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn drop_privileges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
     caps::set(
         None,
         CapSet::Effective,

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -264,6 +264,10 @@ pub struct LinuxContainer {
     pub status: ContainerStatus,
     pub created: SystemTime,
     pub logger: Logger,
+    // The map only owns the files; later execs use the corresponding agent proc-fd
+    // paths stored in the OCI spec. Keeping the files open makes those paths continue
+    // to resolve to the original namespaces.
+    pinned_namespace_fds: HashMap<oci::LinuxNamespaceType, fs::File>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -722,9 +726,15 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
         }
     }
 
-    // Without NoNewPrivileges, we need to set seccomp
-    // before dropping capabilities because the calling thread
-    // must have the CAP_SYS_ADMIN.
+    // Restrict the bounding set before installing the workload seccomp filter.
+    // A filter can reject selected PR_CAPBSET_READ operations and make kernel
+    // capability discovery appear incomplete.
+    if let Some(caps) = oci_process.capabilities().as_ref() {
+        capabilities::restrict_bounding_set(cfd_log, caps)?;
+    }
+
+    // Without NoNewPrivileges, install seccomp while the calling thread still
+    // has effective CAP_SYS_ADMIN. The bounding set is already restricted.
     #[cfg(feature = "seccomp")]
     if !oci_process.no_new_privileges().unwrap_or_default() {
         if let Some(ref scmp) = linux.seccomp() {
@@ -732,7 +742,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
         }
     }
 
-    // Drop capabilities
+    // Drop remaining capabilities
     if oci_process.capabilities().is_some() {
         let c = oci_process.capabilities().as_ref().unwrap();
         capabilities::drop_privileges(cfd_log, c)?;
@@ -1237,7 +1247,16 @@ impl BaseContainer for LinuxContainer {
 
         if p.init {
             let spec = self.config.spec.as_mut().unwrap();
-            update_namespaces(&self.logger, spec, p.pid)?;
+            if let Err(e) =
+                update_namespaces(&self.logger, spec, p.pid, &mut self.pinned_namespace_fds)
+            {
+                // Pinning failed before the init process was added to self.processes.
+                // Kill it so an untracked child is not left blocked on the exec FIFO.
+                let _ = signal::kill(Pid::from_raw(p.pid), Some(Signal::SIGKILL)).map_err(
+                    |kill_error| warn!(logger, "failed to kill process: {:?}", kill_error),
+                );
+                return Err(e);
+            }
         }
         self.processes.insert(p.exec_id.clone(), p);
 
@@ -1424,7 +1443,12 @@ fn do_exec(args: &[String]) -> ! {
     unreachable!()
 }
 
-pub fn update_namespaces(logger: &Logger, spec: &mut Spec, init_pid: RawFd) -> Result<()> {
+pub fn update_namespaces(
+    logger: &Logger,
+    spec: &mut Spec,
+    init_pid: RawFd,
+    pinned_namespace_fds: &mut HashMap<oci::LinuxNamespaceType, fs::File>,
+) -> Result<()> {
     info!(logger, "updating namespaces");
     let linux = spec
         .linux_mut()
@@ -1445,7 +1469,26 @@ pub fn update_namespaces(logger: &Logger, spec: &mut Spec, init_pid: RawFd) -> R
                     .as_ref()
                     .is_none_or(|p| p.as_os_str().is_empty())
                 {
-                    namespace.set_path(Some(PathBuf::from(&ns_path)));
+                    // This path disappears when the init process exits. If its numeric PID is later
+                    // reused, the same path can identify an unrelated process's namespace. Open it
+                    // now to pin the original namespace independently of the init process's lifetime.
+                    let fd = fcntl::open(
+                        ns_path.as_str(),
+                        OFlag::O_RDONLY | OFlag::O_CLOEXEC,
+                        Mode::empty(),
+                    )
+                    .with_context(|| format!("failed to pin namespace {}", ns_path))?;
+                    let file = fs::File::from(fd);
+
+                    // Later namespace setup runs in a separately exec'd helper. This O_CLOEXEC FD
+                    // remains owned by the agent, so address it through the agent's proc directory;
+                    // `/proc/self/fd` in the helper would refer to the helper's descriptor table.
+                    let agent_pid = std::process::id();
+                    let namespace_fd = file.as_raw_fd();
+                    let pinned_path = PathBuf::from(format!("/proc/{agent_pid}/fd/{namespace_fd}"));
+
+                    namespace.set_path(Some(pinned_path));
+                    pinned_namespace_fds.insert(namespace.typ(), file);
                 }
             }
         }
@@ -1762,6 +1805,7 @@ impl LinuxContainer {
                 .unwrap()
                 .as_secs(),
             logger: logger.new(o!("module" => "rustjail", "subsystem" => "container", "cid" => id)),
+            pinned_namespace_fds: HashMap::new(),
         })
     }
 }
@@ -1798,7 +1842,10 @@ mod tests {
     use super::*;
     use crate::process::Process;
     use nix::unistd::Uid;
-    use oci::{LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxResourcesBuilder, Root, SpecBuilder};
+    use oci::{
+        LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxNamespaceBuilder, LinuxResourcesBuilder, Root,
+        SpecBuilder,
+    };
     use oci_spec::runtime as oci;
     use std::fs;
     use std::os::unix::fs::MetadataExt;
@@ -1906,6 +1953,48 @@ mod tests {
 
         let ns = TYPETONAME.get(&oci::LinuxNamespaceType::Cgroup);
         assert!(ns.is_some());
+    }
+
+    #[test]
+    fn test_update_namespaces_pins_namespace_fds() {
+        let mount_namespace = LinuxNamespaceBuilder::default()
+            .typ(oci::LinuxNamespaceType::Mount)
+            .build()
+            .unwrap();
+        let mut spec = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![mount_namespace])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        let mut pinned_namespace_fds = HashMap::new();
+
+        update_namespaces(
+            &sl(),
+            &mut spec,
+            std::process::id() as RawFd,
+            &mut pinned_namespace_fds,
+        )
+        .unwrap();
+
+        let namespace = &spec
+            .linux()
+            .as_ref()
+            .unwrap()
+            .namespaces()
+            .as_ref()
+            .unwrap()[0];
+        let pinned_path = namespace.path().as_ref().unwrap();
+        let agent_pid = std::process::id();
+        assert!(pinned_path.starts_with(format!("/proc/{agent_pid}/fd")));
+        assert_eq!(pinned_namespace_fds.len(), 1);
+        assert_eq!(
+            fs::metadata(pinned_path).unwrap().ino(),
+            fs::metadata("/proc/self/ns/mnt").unwrap().ino()
+        );
     }
 
     fn create_dummy_opts() -> CreateOpts {


### PR DESCRIPTION
## Summary

- enumerate supported capabilities with the kernel `PR_CAPBSET_READ` interface instead of workload-visible procfs
- fail when capability discovery returns no capabilities and verify that the post-drop bounding set contains only OCI-allowed capabilities
- pin namespaces created for the container init process with agent-owned file descriptors
- store agent proc-fd paths in the OCI spec so later execs join the pinned namespaces rather than resolving `/proc/<init-pid>/ns/*` again
- add a regression test that verifies the stored proc-fd path resolves to the original namespace

## Security impact

This addresses both trust-boundary failures involved in the `cap_last_cap` exec escalation:

1. capability discovery no longer trusts `/proc/sys/kernel/cap_last_cap` after entering a workload-controlled mount namespace; and
2. later execs resolve agent-owned namespace descriptors, so an exited init process or reused PID cannot redirect namespace selection.

## Validation

- `cargo check -p rustjail --all-features`
- `rustfmt --check --edition 2021 src/agent/rustjail/src/capabilities.rs src/agent/rustjail/src/container.rs`
- `git diff --check`
- `container::tests::test_update_namespaces_pins_namespace_fds` with the separate test-only `OwnedFd` compatibility fixes from kata-containers/kata-containers#13614
- reproduced the advisory PoC with guest seccomp disabled through runtime configuration: the unpatched agent expanded `CapBnd`, `CapEff`, and `CapPrm` from `00000000a80425fb` to `000001ffffffffff`, including `CAP_SYS_ADMIN` and `CAP_SYS_PTRACE`
- with the patched agent, the same exec stayed in the pinned mount namespace, observed the real `cap_last_cap`, and retained `00000000a80425fb` without `CAP_SYS_ADMIN` or `CAP_SYS_PTRACE`
- a separate ordinary exec against the patched agent completed successfully
