### PR TITLE
tests: add a test to cover uds with emptyDir

### DIFF
--- a/tests/integration/kubernetes/k8s-uds-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-uds-shared-volume.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	pod_name="test-uds-shared-volume"
+	server_container="uds-server"
+	client_container="uds-client"
+	curl_command=(curl --silent --show-error --unix-socket /uds/echo.sock "http://localhost/")
+
+	setup_common || die "setup_common failed"
+
+	yaml_file="${pod_config_dir}/test-pod-uds-shared-volume.yaml"
+	set_nginx_image "${pod_config_dir}/pod-uds-shared-volume.yaml" "${yaml_file}"
+
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${curl_command[@]}"
+	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+}
+
+@test "Containers communicate over a unix domain socket on a shared emptyDir volume" {
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+
+	kubectl create -f "${yaml_file}"
+
+	# The server's readiness probe only passes once it has bound the socket on
+	# the volume, so waiting for the pod covers the socket creation.
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	container_exec "${pod_name}" "${client_container}" "${curl_command[@]}" \
+		| grep "uds reply from the shared emptyDir"
+}
+
+teardown() {
+	# A volume that cannot hold a socket keeps the pod NotReady, and only the
+	# server's log says why, as an nginx bind() error.
+	[[ -n "${BATS_TEST_COMPLETED:-}" ]] || kubectl logs "${pod_name}" -c "${server_container}" || true
+
+	[[ -z "${yaml_file:-}" ]] || rm -f "${yaml_file}"
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -113,6 +113,7 @@ else
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \
 		"k8s-shared-volume.bats" \
+		"k8s-uds-shared-volume.bats" \
 		"k8s-volume.bats" \
 		"k8s-vm-templating.bats" \
 		"k8s-nginx-connectivity.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-uds-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-uds-shared-volume.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright (c) NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two containers of the same pod talking to each other over a unix domain
+# socket bound on an emptyDir volume that both of them mount.
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-uds-shared-volume
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  volumes:
+  # The medium is pinned to Memory: a socket needs the tmpfs the agent creates
+  # inside the guest, and cannot be bound on a disk-backed emptyDir, which the
+  # guest gets from the host over the shared filesystem or as a block device.
+  - name: uds-vol
+    emptyDir:
+      medium: Memory
+  containers:
+  - name: uds-server
+    image: ${NGINX_IMAGE}
+    volumeMounts:
+    - name: uds-vol
+      mountPath: /uds
+    command:
+    - /bin/sh
+    - -c
+    - |
+      cat > /etc/nginx/conf.d/uds.conf <<'CONF'
+      server {
+          listen unix:/uds/echo.sock;
+          location / {
+              return 200 "uds reply from the shared emptyDir\n";
+          }
+      }
+      CONF
+      exec nginx -g "daemon off;"
+    # The socket has to be bound before the pod is Ready, so the test does not
+    # have to poll for it. A volume that cannot hold a socket keeps the pod
+    # NotReady instead of failing the exec later on.
+    readinessProbe:
+      exec:
+        command: ["test", "-S", "/uds/echo.sock"]
+      periodSeconds: 2
+  - name: uds-client
+    image: quay.io/kata-containers/alpine-bash-curl:latest
+    volumeMounts:
+    - name: uds-vol
+      mountPath: /uds
+    command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
The test will ensure that two containers of a pod can communicate over a unix domain socket placed on a memory backed emptyDir volume.

Fixes #13618