### PR TITLE
fix: use fchownat with AT_SYMLINK_NOFOLLOW for symlinks in copy()

### DIFF
--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -97,15 +97,25 @@ async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<()> {
             fs::remove_file(&to).await?;
         }
         fs::symlink(fs::read_link(&from).await?, &to).await?;
+        // preserve the source uid and gid to the destination.
+        // For symlinks, use fchownat with AT_SYMLINK_NOFOLLOW to avoid
+        // following a dangling symlink to a target that hasn't been copied yet.
+        nix::unistd::fchownat(
+            None,
+            to.as_ref(),
+            Some(Uid::from_raw(metadata.uid())),
+            Some(Gid::from_raw(metadata.gid())),
+            nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
+        )?;
     } else {
         fs::copy(&from, &to).await?;
+        // preserve the source uid and gid to the destination.
+        nix::unistd::chown(
+            to.as_ref(),
+            Some(Uid::from_raw(metadata.uid())),
+            Some(Gid::from_raw(metadata.gid())),
+        )?;
     }
-    // preserve the source uid and gid to the destination.
-    nix::unistd::chown(
-        to.as_ref(),
-        Some(Uid::from_raw(metadata.uid())),
-        Some(Gid::from_raw(metadata.gid())),
-    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

When Kata mirrors a Kubernetes Secret or ConfigMap into the watchable directory, the `copy()` function in `watcher.rs` calls `nix::unistd::chown()` on the destination. For symlinks, `chown()` follows the symlink target; if the target directory hasn't been copied yet (due to the race condition during Kubernetes' atomic `..data` symlink update), `chown()` returns `ENOENT`.

This fix uses `nix::unistd::fchownat()` with `AT_SYMLINK_NOFOLLOW` when copying symlinks, preserving ownership of the symlink itself without requiring its target to exist.

## Changes

- `src/agent/src/watcher.rs`: In the `copy()` function, use `fchownat` with `AT_SYMLINK_NOFOLLOW` for symlinks instead of `chown`.

## Related Issue

Fixes #13622