### PR TITLE
agent: attach exec to init.scope as well as init

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -19,6 +19,7 @@ use cgroups::{
     DeviceResource, HugePageResource, MaxValue, NetworkPriority,
 };
 
+use crate::cgroups::nested::exec_cgroup;
 use crate::cgroups::{rule_for_all_devices, Manager as CgroupManager};
 use crate::container::DEFAULT_DEVICES;
 use anyhow::{anyhow, Context, Result};
@@ -44,8 +45,6 @@ use std::sync::{Arc, RwLock};
 use super::DevicesCgroupInfo;
 
 const GUEST_CPUS_PATH: &str = "/sys/devices/system/cpu/online";
-const ROOT_SUBCGROUP: &str = "/";
-const INIT_SUBCGROUP: &str = "/init/";
 
 // Convenience function to obtain the scope logger.
 fn sl() -> slog::Logger {
@@ -85,18 +84,12 @@ macro_rules! set_resource {
 }
 
 impl CgroupManager for Manager {
-    fn apply(&self, pid: pid_t) -> Result<()> {
-        let cgroup_pid = CgroupPid::from(pid as u64);
-        if cgroup_has_init_subcgroup(&self.cpath) {
-            let cpath = self.cgroup_path_with_subcgroup(INIT_SUBCGROUP);
-            load_cgroup(cgroups::hierarchies::auto(), &cpath)
-                .add_task_by_tgid(cgroup_pid)
-                .with_context(|| format!("add task {} to cgroup {}", pid, cpath))?;
-        } else {
-            self.cgroup
-                .add_task_by_tgid(cgroup_pid)
-                .with_context(|| format!("add task {} to cgroup {}", pid, self.cpath))?;
-        }
+    fn apply(&self, pid: pid_t, init_pid: pid_t) -> Result<()> {
+        let path = exec_cgroup(pid, init_pid, &self.cpath);
+        let cgroup = load_cgroup(cgroups::hierarchies::auto(), &path);
+        cgroup
+            .add_task_by_tgid(CgroupPid::from(pid as u64))
+            .context(format!("add task {} to cgroup {}", pid, cgroup.path()))?;
         Ok(())
     }
 
@@ -1024,15 +1017,9 @@ pub fn get_paths() -> Result<HashMap<String, String>> {
     Ok(m)
 }
 
+#[cfg(test)]
 fn cgroup_path_under_root(root: impl AsRef<Path>, cpath: &str) -> PathBuf {
     root.as_ref().join(cpath.trim_start_matches('/'))
-}
-
-fn cgroup_has_init_subcgroup(cpath: &str) -> bool {
-    cgroups::hierarchies::is_cgroup2_unified_mode()
-        && cgroup_path_under_root(cgroups::hierarchies::auto().root(), cpath)
-            .join("init")
-            .exists()
 }
 
 pub fn get_mounts(paths: &HashMap<String, String>) -> Result<HashMap<String, String>> {
@@ -1071,7 +1058,7 @@ fn new_cgroup(h: Box<dyn cgroups::Hierarchy>, path: &str) -> Result<Cgroup> {
 }
 
 #[inline]
-fn load_cgroup(h: Box<dyn cgroups::Hierarchy>, path: &str) -> Cgroup {
+pub(crate) fn load_cgroup(h: Box<dyn cgroups::Hierarchy>, path: &str) -> Cgroup {
     let valid_path = path.trim_start_matches('/').to_string();
     cgroups::Cgroup::load(h, valid_path.as_str())
 }
@@ -1189,27 +1176,6 @@ impl Manager {
             cgroup: cg,
             devcg_allowed_all: false,
         })
-    }
-
-    pub fn subcgroup(&self) -> &str {
-        // Check if we're running with cgroup v2 delegation by verifying:
-        // 1. We're using cgroups v2 (which restricts direct process control)
-        // 2. An "init" subdirectory exists for delegated process attachment
-        //    (for example, Docker-in-Docker or systemd in a container)
-        if cgroup_has_init_subcgroup(&self.cpath) {
-            INIT_SUBCGROUP
-        } else {
-            ROOT_SUBCGROUP
-        }
-    }
-
-    fn cgroup_path_with_subcgroup(&self, subcgroup: &str) -> String {
-        let subcgroup = subcgroup.trim_matches('/');
-        if subcgroup.is_empty() {
-            self.cpath.clone()
-        } else {
-            Path::new(&self.cpath).join(subcgroup).display().to_string()
-        }
     }
 
     fn get_paths_and_mounts(
@@ -1428,7 +1394,7 @@ mod tests {
     use oci_spec::runtime as oci;
     use test_utils::skip_if_not_root;
 
-    use super::{cgroup_path_under_root, default_allowed_devices, load_cgroup};
+    use super::{cgroup_path_under_root, default_allowed_devices};
     use crate::cgroups::fs::{
         line_to_vec, lines_to_map, Manager, DEFAULT_ALLOWED_DEVICES, WILDCARD,
     };
@@ -1443,27 +1409,6 @@ mod tests {
                 "/docker.slice/docker-containers.slice/container"
             ),
             PathBuf::from("/sys/fs/cgroup/docker.slice/docker-containers.slice/container")
-        );
-    }
-
-    #[test]
-    fn test_cgroup_path_with_subcgroup_preserves_absolute_cpath() {
-        let manager = Manager {
-            paths: HashMap::new(),
-            mounts: HashMap::new(),
-            cpath: "/docker.slice/docker-containers.slice/container".to_string(),
-            cgroup: load_cgroup(cgroups::hierarchies::auto(), "/"),
-            pod_cgroup: None,
-            devcg_allowed_all: false,
-        };
-
-        assert_eq!(
-            manager.cgroup_path_with_subcgroup("/init/"),
-            "/docker.slice/docker-containers.slice/container/init"
-        );
-        assert_eq!(
-            manager.cgroup_path_with_subcgroup("/"),
-            "/docker.slice/docker-containers.slice/container"
         );
     }
 

--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -29,7 +29,7 @@ pub struct Manager {
 }
 
 impl CgroupManager for Manager {
-    fn apply(&self, _: pid_t) -> Result<()> {
+    fn apply(&self, _: pid_t, _: pid_t) -> Result<()> {
         Ok(())
     }
 

--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -14,6 +14,7 @@ use cgroups::freezer::FreezerState;
 
 pub mod fs;
 pub mod mock;
+pub mod nested;
 pub mod notifier;
 pub mod systemd;
 
@@ -27,7 +28,7 @@ pub struct DevicesCgroupInfo {
 }
 
 pub trait Manager {
-    fn apply(&self, _pid: i32) -> Result<()> {
+    fn apply(&self, _pid: i32, _init_pid: i32) -> Result<()> {
         Err(anyhow!("not supported!".to_string()))
     }
 

--- a/src/agent/rustjail/src/cgroups/nested.rs
+++ b/src/agent/rustjail/src/cgroups/nested.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Resolve the cgroup v2 leaf used to attach an exec process.
+// After systemd (init.scope) or DinD (init) nest PID 1, the container
+// cgroup is an inner node and cgroup.procs writes to it fail with EBUSY.
+
+use crate::cgroups_rs as cgroups;
+use libc::pid_t;
+use std::fs;
+
+fn sl() -> slog::Logger {
+    slog_scope::logger().new(o!("subsystem" => "cgroups"))
+}
+
+// Hierarchy-relative path the exec process should join.
+pub fn exec_cgroup(pid: pid_t, init_pid: pid_t, container_cgroup: &str) -> String {
+    let container_cgroup = normalize_cgroup_path(container_cgroup);
+
+    if !cgroups::hierarchies::is_cgroup2_unified_mode() {
+        return container_cgroup.to_string();
+    }
+
+    if init_pid <= 0 || pid == init_pid {
+        return container_cgroup.to_string();
+    }
+
+    let contents = match fs::read_to_string(format!("/proc/{init_pid}/cgroup")) {
+        Ok(contents) => contents,
+        Err(err) => {
+            debug!(sl(), "read /proc/{}/cgroup: {}", init_pid, err);
+            return container_cgroup.to_string();
+        }
+    };
+
+    if let Some(path) = cgroup_from_cgroup_file(&contents, container_cgroup) {
+        debug!(
+            sl(),
+            "exec cgroup from init pid {}: {} (container {})", init_pid, path, container_cgroup
+        );
+        return path;
+    }
+
+    debug!(
+        sl(),
+        "no exec cgroup from init pid {}, using container", init_pid
+    );
+    container_cgroup.to_string()
+}
+
+// /proc/<pid>/cgroup is either the full hierarchy path (--cgroupns=host)
+// or already relative to the container cgroup (--cgroupns=private).
+// If the path is not under the container, exists() tells a private-ns
+// view from init having moved elsewhere.
+fn cgroup_from_cgroup_file(contents: &str, container_cgroup: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let init = normalize_cgroup_path(line.strip_prefix("0::")?);
+        if init == container_cgroup || init.is_empty() {
+            return Some(container_cgroup.to_string());
+        }
+        if let Some(rel) = init.strip_prefix(container_cgroup) {
+            if let Some(rel) = rel.strip_prefix('/') {
+                return Some(join_cgroup(container_cgroup, rel));
+            }
+        }
+        let under_container = join_cgroup(container_cgroup, init);
+        if cgroup_exists(&under_container) || !cgroup_exists(init) {
+            Some(under_container)
+        } else {
+            Some(init.to_string())
+        }
+    })
+}
+
+fn join_cgroup(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        child.to_string()
+    } else if child.is_empty() {
+        parent.to_string()
+    } else {
+        format!("{parent}/{child}")
+    }
+}
+
+fn cgroup_exists(path: &str) -> bool {
+    cgroups::Cgroup::load(cgroups::hierarchies::auto(), path).exists()
+}
+
+// /proc and OCI cgroup paths are relative to the hierarchy; a leading
+// '/' is the cgroup root, not the filesystem root.
+pub(crate) fn normalize_cgroup_path(path: &str) -> &str {
+    path.trim().trim_matches('/')
+}

--- a/src/agent/rustjail/src/cgroups/nested.rs
+++ b/src/agent/rustjail/src/cgroups/nested.rs
@@ -93,3 +93,211 @@ fn cgroup_exists(path: &str) -> bool {
 pub(crate) fn normalize_cgroup_path(path: &str) -> &str {
     path.trim().trim_matches('/')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use test_utils::skip_if_not_root;
+
+    #[test]
+    fn test_cgroup_from_cgroup_file() {
+        let test_cases = vec![
+            (
+                "0::/system.slice/cri-containerd-abc.scope/init.scope\n",
+                "system.slice/cri-containerd-abc.scope",
+                Some("system.slice/cri-containerd-abc.scope/init.scope"),
+            ),
+            (
+                "0::/system.slice/cri-containerd-abc.scope/init.scope\n",
+                "/system.slice/cri-containerd-abc.scope",
+                Some("system.slice/cri-containerd-abc.scope/init.scope"),
+            ),
+            (
+                "0::/\n",
+                "system.slice/cri-containerd-abc.scope",
+                Some("system.slice/cri-containerd-abc.scope"),
+            ),
+            (
+                "0::/kubepods/besteffort/podx/ctry/init\n",
+                "/kubepods/besteffort/podx/ctry",
+                Some("kubepods/besteffort/podx/ctry/init"),
+            ),
+            (
+                "0::/system.slice/foo.scope\n",
+                "system.slice/foo.scope",
+                Some("system.slice/foo.scope"),
+            ),
+            (
+                "0::/system.slice/foo.scope/\n",
+                "system.slice/foo.scope",
+                Some("system.slice/foo.scope"),
+            ),
+            (
+                "0::/a/b.slice/init.scope/payload.service\n",
+                "/a/b.slice",
+                Some("a/b.slice/init.scope/payload.service"),
+            ),
+            (
+                "12:memory:/\n11:cpu,cpuacct:/\n",
+                "system.slice/foo.scope",
+                None,
+            ),
+            ("", "system.slice/foo.scope", None),
+            (
+                "12:memory:/\n0::/a/b/init.scope\n",
+                "/a/b",
+                Some("a/b/init.scope"),
+            ),
+        ];
+
+        for (contents, container_cgroup, expected) in test_cases {
+            assert_eq!(
+                cgroup_from_cgroup_file(contents, normalize_cgroup_path(container_cgroup))
+                    .as_deref(),
+                expected,
+                "contents={:?} container={}",
+                contents,
+                container_cgroup
+            );
+        }
+    }
+
+    #[test]
+    fn test_live_cgroup_v2_init_scope_lookup() {
+        use std::process::{Command, Stdio};
+
+        skip_if_not_root!();
+        if !cgroups::hierarchies::is_cgroup2_unified_mode() {
+            println!("INFO: skipping live cgroup test; not cgroup v2");
+            return;
+        }
+
+        let root = cgroups::hierarchies::auto().root();
+        let name = format!(
+            "kata-nest-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        );
+        let parent = root.join(&name);
+        if let Err(err) = fs::create_dir(&parent) {
+            println!(
+                "INFO: skipping live cgroup test; cannot create {:?}: {}",
+                parent, err
+            );
+            return;
+        }
+
+        let init_scope = parent.join("init.scope");
+        fs::create_dir(&init_scope).unwrap();
+
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let child_pid = child.id() as i32;
+
+        defer!({
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = fs::remove_dir(&init_scope);
+            let _ = fs::remove_dir(&parent);
+        });
+
+        fs::write(init_scope.join("cgroup.procs"), child_pid.to_string()).unwrap();
+
+        let looked_up = exec_cgroup(i32::MAX, child_pid, &name);
+        assert_eq!(looked_up, format!("{name}/init.scope"));
+
+        if fs::write(parent.join("cgroup.subtree_control"), "+pids").is_ok() {
+            let mut extra = Command::new("sleep")
+                .arg("5")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap();
+            let extra_pid = extra.id() as i32;
+            let err = fs::write(parent.join("cgroup.procs"), extra_pid.to_string()).unwrap_err();
+            assert_eq!(err.raw_os_error(), Some(libc::EBUSY));
+            fs::write(init_scope.join("cgroup.procs"), extra_pid.to_string()).unwrap();
+            extra.kill().ok();
+            let _ = extra.wait();
+        }
+    }
+
+    #[test]
+    fn test_live_cgroup_v2_init_moved_outside() {
+        use std::process::{Command, Stdio};
+
+        skip_if_not_root!();
+        if !cgroups::hierarchies::is_cgroup2_unified_mode() {
+            println!("INFO: skipping live cgroup test; not cgroup v2");
+            return;
+        }
+
+        let root = cgroups::hierarchies::auto().root();
+        let stamp = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        );
+        let container = root.join(format!("kata-nest-test-{stamp}"));
+        let outside = root.join(format!("kata-nest-out-{stamp}"));
+        if let Err(err) = fs::create_dir(&container) {
+            println!(
+                "INFO: skipping live cgroup test; cannot create {:?}: {}",
+                container, err
+            );
+            return;
+        }
+        if let Err(err) = fs::create_dir(&outside) {
+            let _ = fs::remove_dir(&container);
+            println!(
+                "INFO: skipping live cgroup test; cannot create {:?}: {}",
+                outside, err
+            );
+            return;
+        }
+
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let child_pid = child.id() as i32;
+
+        defer!({
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = fs::remove_dir(&outside);
+            let _ = fs::remove_dir(&container);
+        });
+
+        if let Err(err) = fs::write(outside.join("cgroup.procs"), child_pid.to_string()) {
+            println!(
+                "INFO: skipping live cgroup test; cannot move pid into {:?}: {}",
+                outside, err
+            );
+            return;
+        }
+
+        let looked_up = exec_cgroup(
+            i32::MAX,
+            child_pid,
+            container.file_name().unwrap().to_str().unwrap(),
+        );
+        assert_eq!(looked_up, outside.file_name().unwrap().to_str().unwrap());
+    }
+}

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::cgroups::nested::{exec_cgroup, normalize_cgroup_path};
 use crate::cgroups::Manager as CgroupManager;
 use crate::cgroups_rs as cgroups;
 use crate::protocols::agent::CgroupStats;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use cgroups::freezer::FreezerState;
+use cgroups::CgroupPid;
 use libc::{self, pid_t};
 use oci::LinuxResources;
 use oci_spec::runtime as oci;
@@ -18,7 +20,7 @@ use std::convert::TryInto;
 use std::string::String;
 use std::vec;
 
-use super::super::fs::Manager as FsManager;
+use super::super::fs::{load_cgroup, Manager as FsManager};
 
 use super::cgroups_path::CgroupsPath;
 use super::common::{CgroupHierarchy, Properties};
@@ -41,10 +43,21 @@ pub struct Manager {
 }
 
 impl CgroupManager for Manager {
-    fn apply(&self, pid: pid_t) -> Result<()> {
+    fn apply(&self, pid: pid_t, init_pid: pid_t) -> Result<()> {
         if self.dbus_client.unit_exists()? {
-            let subcgroup = self.fs_manager.subcgroup();
-            self.dbus_client.add_process(pid, subcgroup)?;
+            let path = exec_cgroup(pid, init_pid, &self.cpath);
+            let container_cgroup = normalize_cgroup_path(&self.cpath);
+            if path == container_cgroup {
+                self.dbus_client.add_process(pid, "/")?;
+            } else if let Some(rel) = path.strip_prefix(&format!("{container_cgroup}/")) {
+                self.dbus_client.add_process(pid, rel)?;
+            } else {
+                // AttachProcessesToUnit only accepts a unit-relative subcgroup.
+                let cgroup = load_cgroup(cgroups::hierarchies::auto(), &path);
+                cgroup
+                    .add_task_by_tgid(CgroupPid::from(pid as u64))
+                    .with_context(|| format!("add task {} to cgroup {}", pid, cgroup.path()))?;
+            }
         } else {
             self.dbus_client.start_unit(
                 (pid as u32).try_into().unwrap(),

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1232,6 +1232,7 @@ impl BaseContainer for LinuxContainer {
             &st,
             &mut pipe_w,
             &mut pipe_r,
+            self.init_process_pid,
         )
         .await
         .map_err(|e| {
@@ -1587,6 +1588,7 @@ async fn join_namespaces(
     st: &OCIState,
     pipe_w: &mut PipeStream,
     pipe_r: &mut PipeStream,
+    init_pid: pid_t,
 ) -> Result<()> {
     let logger = logger.new(o!("action" => "join-namespaces"));
 
@@ -1642,10 +1644,8 @@ async fn join_namespaces(
     // apply cgroups
     // For FsManger, it's no matter about the order of apply and set.
     // For SystemdManger, apply must be precede set because we can only create a systemd unit with specific processes(pids).
-    if res.is_some() {
-        info!(logger, "apply processes to cgroups!");
-        cm.apply(p.pid)?;
-    }
+    info!(logger, "apply processes to cgroups!");
+    cm.apply(p.pid, init_pid)?;
 
     if p.init {
         if let Some(resource) = res {

--- a/tests/integration/kubernetes/k8s-privileged.bats
+++ b/tests/integration/kubernetes/k8s-privileged.bats
@@ -12,14 +12,20 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	setup_common || die "setup_common failed"
 
-    pod_name="privileged"
+	pod_name="privileged"
 	yaml_file="${pod_config_dir}/pod-privileged.yaml"
+	nesting_pod_name="cgroup-v2-nesting"
+	nesting_yaml_file="${pod_config_dir}/pod-cgroup-v2-nesting.yaml"
 
-    cmd_nsenter=(nsenter --mount=/proc/1/ns/mnt true)
+	cmd_nsenter=(nsenter --mount=/proc/1/ns/mnt true)
+	cmd_nested_cgroup=(sh -c 'test "$(cut -d: -f3 /proc/self/cgroup)" = "/kata-exec-test"')
 
-    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 	add_exec_to_policy_settings "${policy_settings_dir}" "${cmd_nsenter[@]}"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${cmd_nested_cgroup[@]}"
+	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
 	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+	auto_generate_policy "${policy_settings_dir}" "${nesting_yaml_file}"
 }
 
 # This should succeed because the CI uses kata-deploy which sets
@@ -27,12 +33,29 @@ setup() {
 @test "Privileged pod runs and is able to execute privileged operations" {
 	kubectl apply -f "${yaml_file}"
 	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
-    kubectl exec "${pod_name}" -- "${cmd_nsenter[@]}"
+	kubectl exec "${pod_name}" -- "${cmd_nsenter[@]}"
+}
+
+@test "Exec into a cgroup v2 nested container" {
+	kubectl apply -f "${nesting_yaml_file}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${nesting_pod_name}"
+
+	waitForProcess "${wait_time}" "${sleep_time}" \
+		"kubectl logs ${nesting_pod_name} | grep -E '^READY$|SKIP: not cgroup v2'"
+
+	logs=$(kubectl logs "${nesting_pod_name}")
+	if echo "${logs}" | grep -q "SKIP: not cgroup v2"; then
+		skip "guest is not using cgroup v2"
+	fi
+
+	# The exec process must join PID 1's leaf, not the inner parent node.
+	kubectl exec "${nesting_pod_name}" -- "${cmd_nested_cgroup[@]}"
 }
 
 teardown() {
 	echo "Pod logs:"
 	kubectl logs "${pod_name}" || true
+	kubectl logs "${nesting_pod_name}" || true
 
 	delete_tmp_policy_settings_dir "${policy_settings_dir}"
 	teardown_common "${node}" "${node_start_time:-}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-cgroup-v2-nesting.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-cgroup-v2-nesting.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cgroup-v2-nesting
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+  - image: quay.io/prometheus/busybox:latest
+    name: container
+    securityContext:
+      privileged: true
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      set -eu
+      parent=/sys/fs/cgroup
+      leaf="${parent}/kata-exec-test"
+      if [ ! -f "${parent}/cgroup.controllers" ]; then
+        echo "SKIP: not cgroup v2"
+        exec sleep 3600
+      fi
+      mkdir "${leaf}"
+      echo $$ > "${leaf}/cgroup.procs"
+      read -r controller _ < "${parent}/cgroup.controllers"
+      test -n "${controller}"
+      echo "+${controller}" > "${parent}/cgroup.subtree_control"
+      echo READY
+      exec sleep 3600


### PR DESCRIPTION
cgroup v2 rejects processes in inner nodes once controllers are
enabled. systemd and Docker-in-Docker move PID 1 into a child
(`init.scope` / `init`), so exec must follow that leaf instead of the
container root.

The previous hardcoded `init/` check only covered DinD. As runc does,
first try the configured cgroup. If that fails, read
`/proc/<init-pid>/cgroup` and retry there. This applies to both the
cgroupfs and systemd managers and also handles init moving outside the
configured container cgroup.

Integration tests cover the `/init` and `/init.scope` layouts. Live
rustjail tests cover nested and moved-outside cgroups.

Runc implements the same fallback:
https://github.com/opencontainers/runc/blob/7495faeac77318158e6d5faece1b0b0d53e6ced4/libcontainer/process_linux.go#L293-L347

Generalizes #13272.
Supersedes #10949.
Fixes #10733.