### PR TITLE
tests: nvidia: enable rootless NVIDIA QEMU configurations

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -539,6 +539,7 @@ endif
     DEFSTATICRESOURCEMGMT_NV := true
     DEFVFIOMODE_NV := guest-kernel
     DEFSECCOMPSANDBOXPARAM_NV := on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny
+    DEFROOTLESS_NV := true
     DEFKUBELETROOTDIR := /var/lib/kubelet
     DEFPODRESOURCEAPISOCK_NV := "$(DEFKUBELETROOTDIR)/pod-resources/kubelet.sock"
     # NVIDIA profile: rootfs filesystem type (erofs for read-only, compressed images)
@@ -931,6 +932,7 @@ USER_VARS += DEFENABLEVCPUSPINNING_NV
 USER_VARS += DEFSTATICRESOURCEMGMT_NV
 USER_VARS += DEFVFIOMODE_NV
 USER_VARS += DEFSECCOMPSANDBOXPARAM_NV
+USER_VARS += DEFROOTLESS_NV
 USER_VARS += DEFKUBELETROOTDIR
 USER_VARS += DEFPODRESOURCEAPISOCK_NV
 USER_VARS += DEFROOTFSTYPE_NV

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -33,7 +33,7 @@ vm_rootfs_driver = "@VMROOTFSDRIVER_NV@"
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.
-rootless = false
+rootless = @DEFROOTLESS_NV@
 
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -33,7 +33,7 @@ vm_rootfs_driver = "@VMROOTFSDRIVER_NV@"
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.
-rootless = false
+rootless = @DEFROOTLESS_NV@
 
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -74,7 +74,7 @@ vm_rootfs_driver = "@VMROOTFSDRIVER_NV@"
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.
-rootless = false
+rootless = @DEFROOTLESS_NV@
 
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -50,7 +50,7 @@ vm_rootfs_driver = "@VMROOTFSDRIVER_NV@"
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.
-rootless = false
+rootless = @DEFROOTLESS_NV@
 
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -9,7 +9,7 @@ use crate::{Hypervisor, MemoryConfig, VcpuThreadIds};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kata_types::capabilities::{Capabilities, CapabilityBits};
-use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
+use kata_types::config::hypervisor::{Hypervisor as HypervisorConfig, RootlessUser};
 use persist::sandbox_persist::Persist;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -119,6 +119,14 @@ impl Hypervisor for CloudHypervisor {
     async fn update_device(&self, device: DeviceType) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.update_device(device).await
+    }
+
+    async fn set_rootless_user(&self, user: RootlessUser) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        let mut config = inner.hypervisor_config();
+        config.security_info.rootless_user = Some(user);
+        inner.set_hypervisor_config(config);
+        Ok(())
     }
 
     async fn get_agent_socket(&self) -> Result<String> {

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -48,7 +48,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hypervisor_persist::HypervisorState;
 use kata_types::capabilities::{Capabilities, CapabilityBits};
-use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
+use kata_types::config::hypervisor::{Hypervisor as HypervisorConfig, RootlessUser};
 
 pub use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 
@@ -173,6 +173,12 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
     async fn set_guest_memory_block_size(&self, size: u32);
     async fn guest_memory_block_size(&self) -> u32;
     async fn get_passfd_listener_addr(&self) -> Result<(String, u32)>;
+
+    async fn set_rootless_user(&self, _user: RootlessUser) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "updating the rootless user is not supported for this hypervisor"
+        ))
+    }
 
     /// Resolve the in-guest PCIe path for a cold-plugged physical-endpoint VF
     /// by querying QMP (query-pci + device search by QEMU device ID).

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -36,7 +36,7 @@ pub mod remote;
 pub mod selinux;
 pub use kernel_param::Param;
 pub mod utils;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 #[cfg(all(
     feature = "cloud-hypervisor",
@@ -178,6 +178,13 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
         Err(anyhow::anyhow!(
             "updating the rootless user is not supported for this hypervisor"
         ))
+    }
+
+    /// Return the host Unix socket used by this VMM for TDX quote generation.
+    /// A VMM that uses another transport, or does not support guest quote
+    /// generation, returns `None`.
+    async fn tdx_quote_socket_path(&self, _config: &TdxConfig) -> Result<Option<PathBuf>> {
+        Ok(None)
     }
 
     /// Resolve the in-guest PCIe path for a cold-plugged physical-endpoint VF

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -15,6 +15,7 @@ use crate::{Hypervisor, MemoryConfig};
 use crate::{HypervisorConfig, VcpuThreadIds};
 use inner::QemuInner;
 use kata_types::capabilities::{Capabilities, CapabilityBits};
+use kata_types::config::hypervisor::RootlessUser;
 use persist::sandbox_persist::Persist;
 
 use anyhow::{Context, Result};
@@ -120,6 +121,14 @@ impl Hypervisor for Qemu {
     async fn update_device(&self, device: DeviceType) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.update_device(device).await
+    }
+
+    async fn set_rootless_user(&self, user: RootlessUser) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        let mut config = inner.hypervisor_config();
+        config.security_info.rootless_user = Some(user);
+        inner.set_hypervisor_config(config);
+        Ok(())
     }
 
     async fn get_agent_socket(&self) -> Result<String> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -11,7 +11,8 @@ mod qmp;
 use crate::device::pci_path::PciPath;
 use crate::device::DeviceType;
 use crate::hypervisor_persist::HypervisorState;
-use crate::{Hypervisor, MemoryConfig};
+use crate::utils::SocketAddress;
+use crate::{Hypervisor, MemoryConfig, TdxConfig};
 use crate::{HypervisorConfig, VcpuThreadIds};
 use inner::QemuInner;
 use kata_types::capabilities::{Capabilities, CapabilityBits};
@@ -22,6 +23,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::sync::{mpsc, Mutex};
@@ -129,6 +131,15 @@ impl Hypervisor for Qemu {
         config.security_info.rootless_user = Some(user);
         inner.set_hypervisor_config(config);
         Ok(())
+    }
+
+    async fn tdx_quote_socket_path(&self, config: &TdxConfig) -> Result<Option<PathBuf>> {
+        // QEMU's TDX guest object consumes TdxConfig::qgs_port through its
+        // `quote-generation-socket` property. Other hypervisor backends do not
+        // currently consume qgs_port when adding a TDX protection device, so
+        // for the time being endpoint selection remains VMM-specific.
+        let socket = SocketAddress::new(config.qgs_port);
+        Ok((socket.typ == "unix").then(|| PathBuf::from(socket.path)))
     }
 
     async fn get_agent_socket(&self) -> Result<String> {

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -6,11 +6,11 @@
 
 use std::{
     collections::HashSet,
-    fs::{metadata, set_permissions, File, OpenOptions, Permissions},
+    fs::{metadata as fs_metadata, set_permissions, File, OpenOptions, Permissions},
     io,
     os::{
         fd::{BorrowedFd, RawFd},
-        unix::fs::{MetadataExt, PermissionsExt},
+        unix::fs::{FileTypeExt, MetadataExt, PermissionsExt},
     },
     path::{Path, PathBuf},
     process::Command,
@@ -153,6 +153,123 @@ where
     Ok(())
 }
 
+// Return the non-root owning group that grants `required_permissions`, or
+// None when the resource's other permissions already grant that access.
+pub fn select_rootless_access_group(
+    path: &Path,
+    mode: u32,
+    gid: u32,
+    required_permissions: u32,
+) -> Result<Option<u32>> {
+    if required_permissions == 0 || required_permissions & !0o7 != 0 {
+        return Err(anyhow!(
+            "invalid rootless VMM permissions {:o} for {}",
+            required_permissions,
+            path.display()
+        ));
+    }
+
+    if mode & required_permissions == required_permissions {
+        return Ok(None);
+    }
+
+    let group_permissions = required_permissions << 3;
+    if mode & group_permissions != group_permissions {
+        return Err(anyhow!(
+            "rootless VMM requires group permissions {:03o} on {} (mode {:04o})",
+            group_permissions,
+            path.display(),
+            mode & 0o7777,
+        ));
+    }
+
+    if gid == 0 {
+        return Err(anyhow!(
+            "rootless VMM refuses group-root access to {}",
+            path.display()
+        ));
+    }
+
+    Ok(Some(gid))
+}
+
+/// Authorize a rootless VMM to access a character device.
+///
+/// Verifies its Unix permissions and adds its non-root owning group to `user`
+/// when that group is required for access.
+pub fn authorize_rootless_device(
+    path: &Path,
+    user: &mut RootlessUser,
+    required_permissions: u32,
+) -> Result<()> {
+    let metadata = fs_metadata(path)
+        .with_context(|| format!("get metadata for rootless device {}", path.display()))?;
+    if !metadata.file_type().is_char_device() {
+        return Err(anyhow!(
+            "rootless VMM device {} is not a character device",
+            path.display()
+        ));
+    }
+
+    authorize_rootless_resource_access(
+        path,
+        metadata.uid(),
+        metadata.gid(),
+        metadata.mode(),
+        required_permissions,
+        user,
+    )
+}
+
+fn authorize_rootless_resource_access(
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    required_permissions: u32,
+    user: &mut RootlessUser,
+) -> Result<()> {
+    if rootless_user_has_permission(user, uid, gid, mode, required_permissions) {
+        return Ok(());
+    }
+
+    if uid == user.uid || gid == user.gid || user.groups.contains(&gid) {
+        return Err(anyhow!(
+            "rootless VMM cannot access {} with required permissions {:o} (mode {:04o}); configure host ownership and permissions before starting the sandbox",
+            path.display(),
+            required_permissions,
+            mode & 0o7777,
+        ));
+    }
+
+    if let Some(gid) = select_rootless_access_group(path, mode, gid, required_permissions)? {
+        if !user.groups.contains(&gid) {
+            user.groups.push(gid);
+        }
+    }
+
+    Ok(())
+}
+
+// Evaluate `permission` using Unix owner, group, then other-mode semantics.
+fn rootless_user_has_permission(
+    user: &RootlessUser,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    permission: u32,
+) -> bool {
+    let permission = if uid == user.uid {
+        permission << 6
+    } else if gid == user.gid || user.groups.contains(&gid) {
+        permission << 3
+    } else {
+        permission
+    };
+
+    mode & permission == permission
+}
+
 pub fn open_named_tuntap(if_name: &str, queues: u32) -> Result<Vec<File>> {
     let (multi_vq, vq_pairs) = if queues > 1 {
         (true, queues as usize)
@@ -269,7 +386,7 @@ pub fn chown_to_parent<P: AsRef<Path>>(path: P) -> io::Result<()> {
 
 fn first_valid_executable_path(paths: &[&str]) -> Result<String> {
     for p in paths {
-        if let Ok(m) = metadata(p) {
+        if let Ok(m) = fs_metadata(p) {
             if m.is_file() && m.mode() & 0o111 != 0 {
                 return Ok(p.to_string());
             }
@@ -550,7 +667,7 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::MetadataExt;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use nix::unistd::chown;
     use nix::unistd::geteuid;
@@ -568,6 +685,55 @@ mod tests {
     use super::set_process_credentials_with;
     use super::vmm_user_runtime_dir;
     use super::SocketAddress;
+    use super::{authorize_rootless_resource_access, select_rootless_access_group};
+
+    fn rootless_user() -> RootlessUser {
+        RootlessUser {
+            uid: 1000,
+            gid: 1000,
+            groups: Vec::new(),
+            user_name: "kata-test".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_select_rootless_access_group() {
+        let path = Path::new("/dev/test");
+
+        assert_eq!(
+            select_rootless_access_group(path, 0o666, 0, 0o6).unwrap(),
+            None
+        );
+        assert_eq!(
+            select_rootless_access_group(path, 0o660, 2000, 0o6).unwrap(),
+            Some(2000)
+        );
+
+        let error = select_rootless_access_group(path, 0o640, 2000, 0o6)
+            .expect_err("group without write permission must be rejected");
+        assert!(error.to_string().contains("requires group permissions 060"));
+
+        let error = select_rootless_access_group(path, 0o660, 0, 0o6)
+            .expect_err("group root must be rejected");
+        assert!(error.to_string().contains("refuses group-root access"));
+    }
+
+    #[test]
+    fn test_authorize_rootless_resource_access() {
+        let path = Path::new("/run/test.sock");
+        let mut user = rootless_user();
+
+        authorize_rootless_resource_access(path, 0, 2000, 0o660, 0o2, &mut user).unwrap();
+        assert_eq!(user.groups, vec![2000]);
+
+        let error = authorize_rootless_resource_access(path, 0, 2001, 0o640, 0o2, &mut user)
+            .expect_err("group without write permission must be rejected");
+        assert!(error.to_string().contains("requires group permissions 020"));
+
+        let mut user = rootless_user();
+        authorize_rootless_resource_access(path, 0, 2000, 0o666, 0o2, &mut user).unwrap();
+        assert!(user.groups.is_empty());
+    }
 
     // The Set* prefix mirrors the setgroups/setgid/setuid syscalls these
     // variants stand for, so keep it despite clippy::enum_variant_names.
@@ -587,7 +753,7 @@ mod tests {
         SetUid,
     }
 
-    fn rootless_user() -> RootlessUser {
+    fn credential_user() -> RootlessUser {
         RootlessUser {
             uid: 1001,
             gid: 1002,
@@ -601,7 +767,7 @@ mod tests {
     #[case::without_supplementary_groups(Vec::new())]
     fn test_set_process_credentials_order(#[case] groups: Vec<u32>) {
         let operations = RefCell::new(Vec::new());
-        let mut user = rootless_user();
+        let mut user = credential_user();
         user.groups = groups.clone();
 
         set_process_credentials_with(
@@ -650,7 +816,7 @@ mod tests {
     ) {
         let calls = Cell::new(0);
         let result = set_process_credentials_with(
-            &rootless_user(),
+            &credential_user(),
             |_| {
                 calls.set(calls.get() + 1);
                 if failed_step == CredentialStep::SetGroups {

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -155,7 +155,7 @@ where
 
 // Return the non-root owning group that grants `required_permissions`, or
 // None when the resource's other permissions already grant that access.
-pub fn select_rootless_access_group(
+fn select_rootless_access_group(
     path: &Path,
     mode: u32,
     gid: u32,
@@ -219,6 +219,68 @@ pub fn authorize_rootless_device(
         required_permissions,
         user,
     )
+}
+
+/// Authorize a rootless VMM to access a Unix domain socket.
+///
+/// Validates socket access and traversal of every parent directory, updating
+/// `user` only after all checks succeed.
+pub fn authorize_rootless_socket(
+    path: &Path,
+    user: &mut RootlessUser,
+    required_permissions: u32,
+) -> Result<()> {
+    let metadata = fs_metadata(path)
+        .with_context(|| format!("get metadata for rootless socket {}", path.display()))?;
+    if !metadata.file_type().is_socket() {
+        return Err(anyhow!(
+            "rootless VMM endpoint {} is not a Unix socket",
+            path.display()
+        ));
+    }
+
+    let mut candidate = user.clone();
+    authorize_rootless_resource_access(
+        path,
+        metadata.uid(),
+        metadata.gid(),
+        metadata.mode(),
+        required_permissions,
+        &mut candidate,
+    )?;
+
+    let mut parent = path.parent();
+    while let Some(directory) = parent {
+        let metadata = fs_metadata(directory).with_context(|| {
+            format!(
+                "get metadata for rootless socket parent {}",
+                directory.display()
+            )
+        })?;
+        if !metadata.is_dir() {
+            return Err(anyhow!(
+                "rootless VMM socket parent {} is not a directory",
+                directory.display()
+            ));
+        }
+        if !rootless_user_has_permission(
+            &candidate,
+            metadata.uid(),
+            metadata.gid(),
+            metadata.mode(),
+            0o1,
+        ) {
+            return Err(anyhow!(
+                "rootless VMM cannot traverse socket parent {} (mode {:04o}); configure host ownership and permissions before starting the sandbox",
+                directory.display(),
+                metadata.mode() & 0o7777,
+            ));
+        }
+        parent = directory.parent();
+    }
+
+    user.groups = candidate.groups;
+    Ok(())
 }
 
 fn authorize_rootless_resource_access(

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -18,8 +18,8 @@ use common::{
 use containerd_shim_protos::events::task::{TaskCreate, TaskDelete, TaskStart};
 use hypervisor::{
     utils::{
-        create_dir_all_with_inherit_owner, create_vmm_user, remove_dir_all_if_exists,
-        remove_vmm_user, vmm_user_runtime_dir,
+        authorize_rootless_device, create_dir_all_with_inherit_owner, create_vmm_user,
+        remove_dir_all_if_exists, remove_vmm_user, vmm_user_runtime_dir,
     },
     Param,
 };
@@ -52,7 +52,7 @@ use std::{
     collections::HashMap,
     env,
     ops::Deref,
-    os::unix::fs::{chown, MetadataExt},
+    os::unix::fs::chown,
     path::{Path, PathBuf},
     sync::Arc,
     time::SystemTime,
@@ -1028,11 +1028,15 @@ impl Drop for RootlessSetupGuard {
 }
 
 fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<RootlessSetupGuard> {
-    let user_name = create_vmm_user().context("failed to create vmm user")?;
-    let mut guard = RootlessSetupGuard::new(user_name.clone());
+    let vmm_user_name = create_vmm_user().context("failed to create vmm user")?;
+    let mut guard = RootlessSetupGuard::new(vmm_user_name.clone());
 
-    let user = User::from_name(&user_name)?
-        .ok_or_else(|| anyhow!("failed to get user by name {}, user not found", user_name))?;
+    let user = User::from_name(&vmm_user_name)?.ok_or_else(|| {
+        anyhow!(
+            "failed to get user by name {}, user not found",
+            vmm_user_name
+        )
+    })?;
 
     let uid = user.uid.as_raw();
     let gid = user.gid.as_raw();
@@ -1063,16 +1067,18 @@ fn configure_non_root_hypervisor(config: &mut Hypervisor) -> Result<RootlessSetu
     // Update the rootless dir prefix for guest_swap_path
     config.memory_info.guest_swap_path = prefix_with_rootless_dir("/run/kata-containers/swap");
 
-    let kvm_path = PathBuf::from("/dev/kvm");
-    let metadata = std::fs::metadata(&kvm_path)?;
-    let kvm_gid = metadata.gid();
-
-    config.security_info.rootless_user = Some(RootlessUser {
+    let mut rootless_vmm_credentials = RootlessUser {
         uid,
         gid,
-        groups: vec![kvm_gid],
-        user_name,
-    });
+        groups: Vec::new(),
+        user_name: vmm_user_name,
+    };
+    // The VMM opens /dev/kvm after dropping credentials. QEMU inherits vhost
+    // network and vsock FDs at exec; Cloud Hypervisor receives network tap FDs
+    // over its API.
+    authorize_rootless_device(Path::new("/dev/kvm"), &mut rootless_vmm_credentials, 0o6)?;
+
+    config.security_info.rootless_user = Some(rootless_vmm_credentials);
 
     Ok(guard)
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -51,8 +51,8 @@ use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
     utils::{
-        authorize_rootless_device, get_hvsock_path, remove_vmm_user_runtime_dir,
-        uses_native_ccw_bus, vmm_user_runtime_dir,
+        authorize_rootless_device, authorize_rootless_socket, get_hvsock_path,
+        remove_vmm_user_runtime_dir, uses_native_ccw_bus, vmm_user_runtime_dir,
     },
     HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID,
 };
@@ -857,6 +857,13 @@ impl VirtSandbox {
             }
             ProtectionDeviceConfig::Se => {
                 authorize_rootless_device(Path::new("/dev/uv"), &mut user, 0o6)?;
+            }
+            ProtectionDeviceConfig::Tdx(config) => {
+                if let Some(path) = self.hypervisor.tdx_quote_socket_path(config).await? {
+                    authorize_rootless_socket(&path, &mut user, 0o2)?;
+                } else {
+                    return Ok(());
+                }
             }
             _ => return Ok(()),
         }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -51,7 +51,8 @@ use hypervisor::{openvmm::OpenVmm, HYPERVISOR_NAME_OPENVMM};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{
     utils::{
-        get_hvsock_path, remove_vmm_user_runtime_dir, uses_native_ccw_bus, vmm_user_runtime_dir,
+        authorize_rootless_device, get_hvsock_path, remove_vmm_user_runtime_dir,
+        uses_native_ccw_bus, vmm_user_runtime_dir,
     },
     HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID,
 };
@@ -70,6 +71,7 @@ use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_BLK_PCI};
 use kata_types::config::{hypervisor::Factory, TomlConfig};
 use kata_types::initdata::{calculate_initdata_digest, ProtectedPlatform};
+use kata_types::rootless::is_rootless;
 use oci_spec::runtime as oci;
 use persist::{self, sandbox_persist::Persist};
 use pod_resources_rs::handle_cdi_devices;
@@ -322,6 +324,9 @@ impl VirtSandbox {
             .await
             .context("failed to prepare protection device config")?
         {
+            self.prepare_rootless_protection_access(&protection_dev_config)
+                .await
+                .context("failed to prepare rootless protection access")?;
             resource_configs.push(ResourceConfig::Protection(protection_dev_config));
         }
 
@@ -826,6 +831,38 @@ impl VirtSandbox {
             GuestProtection::NoProtection => Ok(None),
             _ => Err(anyhow!("confidential_guest requested by configuration but no supported protection available"))
         }
+    }
+
+    async fn prepare_rootless_protection_access(
+        &self,
+        protection: &ProtectionDeviceConfig,
+    ) -> Result<()> {
+        // Protection-specific host resources are known only after the host
+        // protection mechanism has been detected.
+        if !is_rootless() {
+            return Ok(());
+        }
+
+        let mut user = self
+            .hypervisor
+            .hypervisor_config()
+            .await
+            .security_info
+            .rootless_user
+            .ok_or_else(|| anyhow!("rootless user must be specified for a rootless VMM"))?;
+
+        match protection {
+            ProtectionDeviceConfig::SevSnp(config) if config.is_snp => {
+                authorize_rootless_device(Path::new("/dev/sev"), &mut user, 0o6)?;
+            }
+            ProtectionDeviceConfig::Se => {
+                authorize_rootless_device(Path::new("/dev/uv"), &mut user, 0o6)?;
+            }
+            _ => return Ok(()),
+        }
+
+        // Update the user with groups discovered after initial rootless setup.
+        self.hypervisor.set_rootless_user(user).await
     }
 
     async fn prepare_initdata_device_config(

--- a/tests/integration/kubernetes/k8s-rootless-vmm.bats
+++ b/tests/integration/kubernetes/k8s-rootless-vmm.bats
@@ -83,9 +83,10 @@ qemu_rootless_skip_reason() {
 		return 0
 	fi
 
-	# CoCo-dev does not enable a TEE or require TEE host resources. Keep
-	# actual confidential handlers excluded until rootless QEMU can access
-	# resources such as /dev/sev and the configured TDX QGS endpoint.
+	# CoCo-dev does not enable a TEE and remains covered. Runtime-rs now
+	# validates access required by real confidential handlers, but CI hosts do
+	# not yet have deployment-provisioned /dev/sev and QGS permissions. Keep
+	# those handlers excluded until deployment provides that access contract.
 	if is_confidential_runtime_class "${KATA_HYPERVISOR}" &&
 		[[ "${KATA_HYPERVISOR}" != qemu-coco-dev* ]]; then
 		echo "rootless QEMU confidential host-resource access is not enabled yet"

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -161,8 +161,7 @@ else
 		"k8s-nvidia-numa.bats" \
 		"k8s-nvidia-cuda.bats" \
 		"k8s-nvidia-dcgm.bats" \
-		"k8s-nvidia-vllm.bats" \
-		"k8s-rootless-vmm.bats")
+		"k8s-nvidia-vllm.bats")
 
 	# Setting K8S_TEST_NV explicitly still runs the NIM tests by hand.
 	if is_nightly_run; then


### PR DESCRIPTION
**ATTENTION:** This PR depends on unmerged work from #13424. Only the final two commits are new and need review:
1. `runtime-rs: enable rootless NVIDIA QEMU configs`
2. `tests: rely on NVIDIA job-wide rootless coverage`

The goal is to shift runtime-rs NVIDIA handler to a rootless configuration. Remaining work tracked in #13424 is required to enable end-to-end tests to pass.
