### PR TITLE
packaging: update OVMF for Intel TDX

### DIFF
--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -26,7 +26,7 @@ architecture="${architecture:-X64}"
 if [[ "${ovmf_build}" == "arm64" ]]; then
 	architecture="AARCH64"
 fi
-toolchain="${toolchain:-GCC5}"
+toolchain="${toolchain:-GCC}"
 build_target="${build_target:-RELEASE}"
 
 [[ -n "${ovmf_repo}" ]] || die "failed to get ovmf repo"

--- a/versions.yaml
+++ b/versions.yaml
@@ -366,7 +366,7 @@ externals:
       package_output_dir: "AmdSev"
     tdx:
       description: "UEFI for Intel TDX virtual machines."
-      version: "edk2-stable202511"
+      version: "edk2-stable202605"
       package: "OvmfPkg/IntelTdx/IntelTdxX64.dsc"
       package_output_dir: "IntelTdx"
     arm64:


### PR DESCRIPTION
Bump OVMF to the latest May 2026 release for Intel TDX.