### PR TITLE
tests: nvidia: budget the NIM model load from container start

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -23,8 +23,15 @@ export TEE
 
 POD_NAME_EMBEDQA="nvidia-nim-llama-3-2-nv-embedqa-1b-v2"
 POD_NAME_INSTRUCT="nvidia-nim-llama-3-2-1b-instruct"
-# Instruct/embedqa startupProbe windows (initialDelaySeconds +
-# periodSeconds * failureThreshold) are aligned to these ready waits.
+# Booting the sandbox, and pulling the image inside the guest on a
+# shared_fs="none" node, happens before NIM can start loading the model. That
+# phase gets its own budget so that a slow sandbox does not consume the
+# model-load budget below.
+NIM_CONTAINER_START_TIMEOUT_PREDEFINED=180s
+# Model-load budgets, counted from the moment the container starts running.  The
+# startupProbe windows in the pod manifests (initialDelaySeconds + periodSeconds
+# * failureThreshold) are kept wider than these, so that kubelet does not kill a
+# pod that is still making progress.
 POD_READY_TIMEOUT_EMBEDQA_PREDEFINED=500s
 POD_READY_TIMEOUT_INSTRUCT_PREDEFINED=600s
 if [[ "${TEE}" = "true" ]]; then
@@ -32,11 +39,15 @@ if [[ "${TEE}" = "true" ]]; then
     POD_NAME_INSTRUCT="${POD_NAME_INSTRUCT}-tee"
 fi
 if [[ "${TEE}" = "true" ]] || is_runtime_rs; then
+    NIM_CONTAINER_START_TIMEOUT_PREDEFINED=420s
+    # These variants keep the model cache in an emptyDir, so every run pays for
+    # a full NGC download. Cold start measured on the SNP node is ~810s.
     POD_READY_TIMEOUT_EMBEDQA_PREDEFINED=1000s
-    POD_READY_TIMEOUT_INSTRUCT_PREDEFINED=1000s
+    POD_READY_TIMEOUT_INSTRUCT_PREDEFINED=1200s
 fi
 export POD_NAME_EMBEDQA
 export POD_NAME_INSTRUCT
+export NIM_CONTAINER_START_TIMEOUT=${NIM_CONTAINER_START_TIMEOUT:-${NIM_CONTAINER_START_TIMEOUT_PREDEFINED}}
 export POD_READY_TIMEOUT_EMBEDQA=${POD_READY_TIMEOUT_EMBEDQA:-${POD_READY_TIMEOUT_EMBEDQA_PREDEFINED}}
 export POD_READY_TIMEOUT_INSTRUCT=${POD_READY_TIMEOUT_INSTRUCT:-${POD_READY_TIMEOUT_INSTRUCT_PREDEFINED}}
 export SKIP_MULTI_GPU_TESTS
@@ -141,12 +152,43 @@ setup_kbs_credentials() {
     setup_kbs_nim_image_policy
 }
 
+# Wait for a NIM pod to become ready, reporting how long each phase took.
+#
+# 'kubectl wait' counts from the moment it is called, while the startupProbe
+# budget only starts once the container is running. Waiting for the container
+# separately keeps the model-load budget aligned with the startupProbe window,
+# instead of spending part of it on sandbox startup.
+wait_for_nim_pod_ready() {
+    local pod="$1"
+    local ready_timeout="$2"
+    local start_timeout="${NIM_CONTAINER_START_TIMEOUT%s}"
+    local since="${SECONDS}"
+    local started_at=""
+
+    while ((SECONDS - since < start_timeout)); do
+        started_at="$(kubectl get pod "${pod}" -o jsonpath='{.status.containerStatuses[0].state.running.startedAt}' 2>/dev/null || true)"
+        [[ -n "${started_at}" ]] && break
+        sleep 5
+    done
+    [[ -n "${started_at}" ]] ||
+        die "${pod}: container did not start within ${NIM_CONTAINER_START_TIMEOUT}"
+    echo "# ${pod}: container started after $((SECONDS - since))s" >&3
+
+    since="${SECONDS}"
+    if ! kubectl wait --for=condition=Ready --timeout="${ready_timeout}" pod "${pod}"; then
+        echo "# ${pod}: not ready $((SECONDS - since))s after the container started," \
+            "restarts: $(kubectl get pod "${pod}" -o jsonpath='{.status.containerStatuses[0].restartCount}')" >&3
+        return 1
+    fi
+    echo "# ${pod}: ready $((SECONDS - since))s after the container started" >&3
+}
+
 create_inference_pod() {
     envsubst <"${POD_INSTRUCT_YAML_IN}" >"${POD_INSTRUCT_YAML}"
     auto_generate_policy "${policy_settings_dir}" "${POD_INSTRUCT_YAML}"
 
     kubectl apply -f "${POD_INSTRUCT_YAML}"
-    kubectl wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_INSTRUCT}" pod "${POD_NAME_INSTRUCT}"
+    wait_for_nim_pod_ready "${POD_NAME_INSTRUCT}" "${POD_READY_TIMEOUT_INSTRUCT}"
 
     # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
     kubectl get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}'
@@ -162,7 +204,7 @@ create_embedqa_pod() {
     auto_generate_policy "${policy_settings_dir}" "${POD_EMBEDQA_YAML}"
 
     kubectl apply -f "${POD_EMBEDQA_YAML}"
-    kubectl wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_EMBEDQA}" pod "${POD_NAME_EMBEDQA}"
+    wait_for_nim_pod_ready "${POD_NAME_EMBEDQA}" "${POD_READY_TIMEOUT_EMBEDQA}"
 
     # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
     kubectl get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}'

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct-runtime-rs.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct-runtime-rs.yaml.in
@@ -53,7 +53,8 @@ spec:
       periodSeconds: 10
       timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 90
+      # 1320s window, wider than POD_READY_TIMEOUT_INSTRUCT in k8s-nvidia-nim.bats
+      failureThreshold: 126
     env:
       - name: NGC_API_KEY
         valueFrom:

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct-tee.yaml.in
@@ -60,7 +60,8 @@ spec:
       periodSeconds: 10
       timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 90
+      # 1320s window, wider than POD_READY_TIMEOUT_INSTRUCT in k8s-nvidia-nim.bats
+      failureThreshold: 126
     env:
       - name: NGC_API_KEY
         valueFrom:

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-1b-instruct.yaml.in
@@ -47,7 +47,8 @@ spec:
       periodSeconds: 10
       timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 54
+      # 720s window, wider than POD_READY_TIMEOUT_INSTRUCT in k8s-nvidia-nim.bats
+      failureThreshold: 66
     env:
       - name: NGC_API_KEY
         valueFrom:


### PR DESCRIPTION
`kubectl wait` starts counting when it is called, but NIM cannot begin loading the model until the sandbox has booted and, on TEE, the image has been pulled inside the guest.  On the SNP node that phase takes over three minutes, leaving only ~800s of the 1000s budget for the model itself, while a cold-cache start there measures ~810s.  Both SNP jobs therefore missed readiness by a margin of seconds: in the runtime-rs run the server started serving 8s after the wait had already expired, and was then torn down.

Wait for the container to be running under its own budget, and only then apply the model-load budget, so that sandbox startup no longer eats into it.  Report how long each phase took, and the restart count on failure, so that the next timeout can be attributed without digging through pod events.

The instruct startupProbe windows are widened to stay larger than the model-load budget, keeping kubelet from killing a pod that is still making progress, and the test step timeout is raised because the worst case now takes longer.

Assisted-by: Cursor <cursoragent@cursor.com>