### PR TITLE
runtime: keep exec output streaming after stdin closes

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/stream.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream.go
@@ -116,6 +116,12 @@ func ioCopy(shimLog *logrus.Entry, exitch, stdinCloser chan struct{}, tty *ttyIO
 			wg.Done()
 			shimLog.Debug("stdin io stream copy exited")
 		}()
+	} else {
+		// Nothing is ever forwarded to the process' stdin, so it is
+		// already safe to close it.  Without this, a CloseIO() request
+		// for such a process would wait on stdinCloser forever, while
+		// holding the service lock.
+		close(stdinCloser)
 	}
 
 	if tty.io.Stdout() != nil {

--- a/src/runtime/pkg/containerd-shim-v2/stream_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream_test.go
@@ -96,6 +96,46 @@ func TestNewTtyIOFifoReopen(t *testing.T) {
 	checkFifoRead(errr)
 }
 
+// A process created without a stdin stream never gets a stdin io copy
+// goroutine, so ioCopy() has to release stdinCloser itself.  Otherwise
+// CloseIO() waits on it forever, with the service lock held.
+func TestIoCopyClosesStdinCloserWithoutStdin(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	fifoPath := t.TempDir()
+	stdoutPath := filepath.Join(fifoPath, "stdout")
+
+	stdoutR, err := fifo.OpenFifo(ctx, stdoutPath, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700)
+	assert.NoError(err)
+	defer stdoutR.Close()
+
+	tty, err := newTtyIO(ctx, "", "", "", stdoutPath, "", false)
+	assert.NoError(err)
+	defer tty.close()
+	assert.Nil(tty.io.Stdin())
+
+	exitioch := make(chan struct{})
+	stdinCloser := make(chan struct{})
+	stdoutPipe, stdoutPipeW := io.Pipe()
+
+	go ioCopy(logrus.WithContext(ctx), exitioch, stdinCloser, tty, nil, stdoutPipe, nil)
+
+	select {
+	case <-stdinCloser:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for stdinCloser to be closed")
+	}
+
+	// let ioCopy() finish before the fifos are closed under it
+	stdoutPipeW.Close()
+	select {
+	case <-exitioch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for ioCopy() to exit")
+	}
+}
+
 func TestIoCopy(t *testing.T) {
 	// This test fails on aarch64 regularly, temporarily skip it
 	if runtime.GOARCH == "arm64" {

--- a/src/runtime/virtcontainers/iostream.go
+++ b/src/runtime/virtcontainers/iostream.go
@@ -9,13 +9,24 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync/atomic"
 )
 
 type iostream struct {
 	sandbox   *Sandbox
 	container *Container
 	process   string
-	closed    bool
+
+	// stdinClosed is set once the guest side of the process' stdin has
+	// been closed.  It only gates the stdin writer: the process keeps
+	// running and keeps producing output after its stdin is gone, so
+	// closing stdin must not stop the stdout/stderr readers.
+	//
+	// This matters for exec sessions that don't ask for a stdin stream:
+	// containerd then closes the process' stdin as soon as it is started
+	// (the k8s WebSocket exec API hands it a stdin reader that returns
+	// EOF right away), and any output produced afterwards would be lost.
+	stdinClosed atomic.Bool
 }
 
 // io.WriteCloser
@@ -38,7 +49,6 @@ func newIOStream(s *Sandbox, c *Container, proc string) *iostream {
 		sandbox:   s,
 		container: c,
 		process:   proc,
-		closed:    false, // needed to workaround buggy structcheck
 	}
 }
 
@@ -55,7 +65,7 @@ func (s *iostream) stderr() io.Reader {
 }
 
 func (s *stdinStream) Write(data []byte) (n int, err error) {
-	if s.closed {
+	if s.stdinClosed.Load() {
 		return 0, errors.New("stream closed")
 	}
 
@@ -64,33 +74,25 @@ func (s *stdinStream) Write(data []byte) (n int, err error) {
 }
 
 func (s *stdinStream) Close() error {
-	if s.closed {
+	if s.stdinClosed.Load() {
 		return errors.New("stream closed")
 	}
 
 	// can not pass context to Close(), so use background context
 	err := s.sandbox.agent.closeProcessStdin(context.Background(), s.container, s.process)
 	if err == nil {
-		s.closed = true
+		s.stdinClosed.Store(true)
 	}
 
 	return err
 }
 
 func (s *stdoutStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStdout(context.Background(), s.container, s.process, data)
 }
 
 func (s *stderrStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStderr(context.Background(), s.container, s.process, data)
 }

--- a/src/runtime/virtcontainers/iostream_test.go
+++ b/src/runtime/virtcontainers/iostream_test.go
@@ -46,11 +46,13 @@ func TestIOStream(t *testing.T) {
 	_, err = stdin.Write(buffer)
 	assert.NotNil(t, err, "stdin write closed should fail")
 
+	// The process outlives its stdin, so its output must still be
+	// readable once stdin has been closed.
 	_, err = stdout.Read(buffer)
-	assert.NotNil(t, err, "stdout read closed should fail")
+	assert.Nil(t, err, "stdout read after stdin close failed: %s", err)
 
 	_, err = stderr.Read(buffer)
-	assert.NotNil(t, err, "stderr read closed should fail")
+	assert.Nil(t, err, "stderr read after stdin close failed: %s", err)
 
 	err = stdin.Close()
 	assert.NotNil(t, err, "stdin close closed should fail")


### PR DESCRIPTION
When Kubernetes exec is opened without stdin, the WebSocket path immediately returns EOF for its ignored stdin channel. Containerd consequently calls `CloseIO()` while the process is still running.

The Go runtime previously represented stdin, stdout, and stderr with one shared `closed` flag. Closing stdin therefore caused subsequent stdout and stderr reads to fail locally, truncating exec output after its first burst.

runtime-rs changes are not needed as the equivalent runtime-rs paths maintain independent stream state.

Fixes #13640.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented I/O shutdown from waiting indefinitely when no standard input stream is available.
  * Standard output and standard error remain readable after standard input is closed.

* **Tests**
  * Added coverage for clean shutdown without standard input.
  * Updated stream behavior tests to verify output remains available after input closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->