### PR TITLE
agent: watcher: share ownership preservation helper

### DIFF
--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -88,6 +88,20 @@ impl Drop for Storage {
     }
 }
 
+// Preserve the source's uid and gid on the destination without following
+// symlinks, so that a symlink's own ownership is preserved and a dangling
+// destination symlink cannot fail the operation with ENOENT.
+fn preserve_ownership(metadata: &std::fs::Metadata, path: &Path) -> Result<()> {
+    nix::unistd::fchownat(
+        nix::fcntl::AT_FDCWD,
+        path,
+        Some(Uid::from_raw(metadata.uid())),
+        Some(Gid::from_raw(metadata.gid())),
+        nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
+    )
+    .with_context(|| format!("Unable to set ownership for {}", path.display()))
+}
+
 async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<()> {
     let metadata = fs::symlink_metadata(&from).await?;
     if metadata.file_type().is_symlink() {
@@ -101,13 +115,7 @@ async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<()> {
         fs::copy(&from, &to).await?;
     }
     // preserve the source uid and gid to the destination.
-    nix::unistd::fchownat(
-        nix::fcntl::AT_FDCWD,
-        to.as_ref(),
-        Some(Uid::from_raw(metadata.uid())),
-        Some(Gid::from_raw(metadata.gid())),
-        nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
-    )?;
+    preserve_ownership(&metadata, to.as_ref())?;
 
     Ok(())
 }
@@ -141,12 +149,7 @@ impl Storage {
                     format!("Unable to set permissions for {}", dest_file_path.display())
                 })?;
             // preserve the source directory uid and gid to the destination.
-            nix::unistd::chown(
-                &dest_file_path,
-                Some(Uid::from_raw(metadata.uid())),
-                Some(Gid::from_raw(metadata.gid())),
-            )
-            .with_context(|| format!("Unable to set ownership for {}", dest_file_path.display()))?;
+            preserve_ownership(&metadata, &dest_file_path)?;
 
             return Ok(());
         }
@@ -1067,11 +1070,21 @@ mod tests {
         assert_eq!(fs::metadata(&dst_file).unwrap().gid(), gid.as_raw());
 
         // verify copy of a symlink
+        let link_uid = Uid::from_raw(11);
+        let link_gid = Gid::from_raw(201);
         let src_symlink_file = source_dir.path().join("symlink_file.txt");
         let dst_symlink_file = dest_dir.path().join("symlink_file.txt");
         tokio::fs::symlink(&src_file, &src_symlink_file)
             .await
             .unwrap();
+        nix::unistd::fchownat(
+            nix::fcntl::AT_FDCWD,
+            &src_symlink_file,
+            Some(link_uid),
+            Some(link_gid),
+            nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
+        )
+        .unwrap();
         copy(&src_symlink_file, &dst_symlink_file).await.unwrap();
         // verify destination:
         assert!(fs::symlink_metadata(&dst_symlink_file)
@@ -1080,6 +1093,16 @@ mod tests {
             .is_symlink());
         assert_eq!(fs::read_link(&dst_symlink_file).unwrap(), src_file);
         assert_eq!(fs::read_to_string(&dst_symlink_file).unwrap(), "foo");
+        // the copied symlink itself carries the source symlink's ownership...
+        assert_eq!(
+            fs::symlink_metadata(&dst_symlink_file).unwrap().uid(),
+            link_uid.as_raw()
+        );
+        assert_eq!(
+            fs::symlink_metadata(&dst_symlink_file).unwrap().gid(),
+            link_gid.as_raw()
+        );
+        // ...and the file it points to retains its own ownership.
         assert_eq!(fs::metadata(&dst_symlink_file).unwrap().uid(), uid.as_raw());
         assert_eq!(fs::metadata(&dst_symlink_file).unwrap().gid(), gid.as_raw());
     }
@@ -1111,7 +1134,7 @@ mod tests {
             .is_symlink());
         assert_eq!(fs::read_link(&dst_symlink).unwrap(), link_target);
 
-        // dst_symlink is dargling
+        // dst_symlink is dangling
         assert_eq!(
             fs::metadata(&dst_symlink).unwrap_err().kind(),
             std::io::ErrorKind::NotFound


### PR DESCRIPTION
Follow-up to #13625, which switched `copy()` to `fchownat` with `AT_SYMLINK_NOFOLLOW`.

Two small things remained:
- `update_target()`'s directory branch still preserves ownership with a separate follow-symlink `chown`, duplicating the logic
- the `copy()` call reports no failing path on error

This moves ownership preservation into a shared `preserve_ownership()` helper used by both call sites 

## Validation
- `make check` (fmt + clippy) — clean
- `sudo -E PATH="$PATH" make test` — `test_copy` and `test_copy_with_dangling_symlink` pass