### PR TITLE
runtime-rs: Attempt to connect at least once in hybrid_vsock

### DIFF
--- a/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
@@ -32,7 +32,7 @@ impl HybridVsock {
 impl Sock for HybridVsock {
     async fn connect(&self, config: &ConnectConfig) -> Result<Stream> {
         let mut last_err = None;
-        let retry_times = config.reconnect_timeout_ms / config.dial_timeout_ms;
+        let retry_times = 1 + (config.reconnect_timeout_ms / config.dial_timeout_ms);
 
         for i in 0..retry_times {
             match connect_helper(&self.uds, self.port).await {


### PR DESCRIPTION
If `dial_timeout_ms` > `reconnect_timeout_ms`, hybrid_vsock will not try to connect at all. This is because it underestimates the number of attempts it can make given those two parameters. By improving the formula, we can ensure hybrid_vsock always attempts at least one connection while still being faithful to the config parameters `reconnect_timeout_ms` and `dial_timeout_ms`.
    
The code previously used `N = reconnect_timeout_ms / dial_timeout_ms`. This formula represents how many connection attempts can be made following a connection failure and dial_timeout sleep. However, it doesn't account for the initial connection attempt which isn't associated to a dial_timeout sleep. That is why `1 + reconnect_timeout_ms / dial_timeout_ms` formula was chosen.
    
Fixes #13667.
    
Signed-off-by: Shane Creighton-Young <shaneecy@gmail.com>