### PR TITLE
oci: parse CRI-O PodLinuxResources annotation for sandbox sizing

### DIFF
--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -1527,6 +1527,23 @@ func (a *annotationConfiguration) setFloat32WithCheck(f func(float32) error) err
 	return nil
 }
 
+// CRI-O annotation keys for sandbox resource sizing.
+const (
+	// crioPodLinuxResourcesKey is the CRI-O annotation key for pod-level
+	// Linux container resources (CPU period, quota, shares, memory).
+	// The value is a JSON-encoded LinuxContainerResources object.
+	// https://github.com/cri-o/cri-o/pull/6913
+	crioPodLinuxResourcesKey = "io.kubernetes.cri-o.PodLinuxResources"
+)
+
+// crioPodLinuxResources is the JSON structure of the PodLinuxResources annotation.
+type crioPodLinuxResources struct {
+	CPUPeriod        int64 `json:"cpu_period"`
+	CPUQuota         int64 `json:"cpu_quota"`
+	CPUShares        int64 `json:"cpu_shares"`
+	MemoryLimitBytes int64 `json:"memory_limit_in_bytes"`
+}
+
 // CalculateSandboxSizing will calculate the number of CPUs and amount of Memory that should
 // be added to the VM if sandbox annotations are provided with this sizing details
 func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
@@ -1577,6 +1594,32 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 		if err != nil {
 			ociLog.Warningf("sandbox-sizing: failure to parse SandboxMem: %s", annotation)
 			memory = 0
+		}
+	}
+
+	// Fall back to CRI-O PodLinuxResources annotation if containerd annotations
+	// are not set. CRI-O encodes pod resources as a single JSON annotation
+	// (io.kubernetes.cri-o.PodLinuxResources) instead of separate key-value
+	// pairs for each resource.
+	if period == 0 && quota == 0 && memory == 0 {
+		if annotation, ok := spec.Annotations[crioPodLinuxResourcesKey]; ok {
+			var podResources crioPodLinuxResources
+			if err := json.Unmarshal([]byte(annotation), &podResources); err == nil {
+				if podResources.CPUPeriod > 0 {
+					period = uint64(podResources.CPUPeriod)
+				}
+				if podResources.CPUQuota > 0 {
+					quota = podResources.CPUQuota
+				}
+				if podResources.CPUShares > 0 {
+					shares = podResources.CPUShares
+				}
+				if podResources.MemoryLimitBytes > 0 {
+					memory = podResources.MemoryLimitBytes
+				}
+			} else {
+				ociLog.Warningf("sandbox-sizing: failure to parse CRI-O PodLinuxResources: %s", err)
+			}
 		}
 	}
 

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -1333,6 +1334,26 @@ func getCtrResourceSpec(memory, quota int64, period uint64) *specs.Spec {
 
 }
 
+func makeCRIOSizingAnnotations(memory, quota, period string) *specs.Spec {
+	spec := specs.Spec{
+		Annotations: make(map[string]string),
+	}
+	// CRI-O encodes pod resources as a single JSON annotation
+	resources := crioPodLinuxResources{
+		CPUPeriod:        mustParseInt(period),
+		CPUQuota:         mustParseInt(quota),
+		MemoryLimitBytes: mustParseInt(memory),
+	}
+	data, _ := json.Marshal(resources)
+	spec.Annotations[crioPodLinuxResourcesKey] = string(data)
+	return &spec
+}
+
+func mustParseInt(s string) int64 {
+	v, _ := strconv.ParseInt(s, 10, 64)
+	return v
+}
+
 func makeSizingAnnotations(memory, quota, period string) *specs.Spec {
 	spec := specs.Spec{
 		Annotations: make(map[string]string),
@@ -1501,6 +1522,41 @@ func TestCalculateSandboxSizing(t *testing.T) {
 			expectedMem: 0,
 		},
 	}
+
+		// CRI-O PodLinuxResources annotation (JSON-encoded)
+		{
+			spec:        makeCRIOSizingAnnotations("1048576", "200", "100"),
+			expectedCPU: 2,
+			expectedMem: 1,
+		},
+		{
+			spec:        makeCRIOSizingAnnotations("1024", "200", "1"),
+			expectedCPU: 200,
+			expectedMem: 0,
+		},
+		{
+			spec:        makeCRIOSizingAnnotations("-1048576", "-100", "1"),
+			expectedCPU: 0,
+			expectedMem: 0,
+		},
+		// CRI-O annotation with all resources set
+		{
+			spec:        makeCRIOSizingAnnotations("2097152", "400", "200"),
+			expectedCPU: 4,
+			expectedMem: 2,
+		},
+		// Empty CRI-O JSON should not affect sizing
+		{
+			spec:        &specs.Spec{Annotations: map[string]string{crioPodLinuxResourcesKey: "{}"}},
+			expectedCPU: 0,
+			expectedMem: 0,
+		},
+		// Malformed CRI-O JSON should not affect sizing
+		{
+			spec:        &specs.Spec{Annotations: map[string]string{crioPodLinuxResourcesKey: "not-json"}},
+			expectedCPU: 0,
+			expectedMem: 0,
+		},
 
 	for _, tt := range testCases {
 


### PR DESCRIPTION
### Description

When `static_sandbox_resource_mgmt=true`, Kata Containers does not size the sandbox VM from pod resources supplied by CRI-O. The Go runtime's `CalculateSandboxSizing()` reads only containerd's `io.kubernetes.cri.sandbox-*` annotations, but not CRI-O's `io.kubernetes.cri-o.PodLinuxResources` annotation.

CRI-O encodes pod-level CPU and memory resources as a single JSON annotation (`io.kubernetes.cri-o.PodLinuxResources`) instead of separate key-value pairs like containerd. This annotation was added in [cri-o/cri-o#6913](https://github.com/cri-o/cri-o/pull/6913) but Kata was never updated to consume it.

### What this PR does

- Adds a `crioPodLinuxResourcesKey` constant and `crioPodLinuxResources` struct for JSON deserialization of CRI-O's `PodLinuxResources` annotation
- Modifies `CalculateSandboxSizing()` to fall back to CRI-O's `PodLinuxResources` annotation when containerd annotations are not set
- Adds test cases covering CRI-O annotation parsing (valid values, negative values, empty JSON, malformed JSON)

### Related issue

Fixes #13634

---

**Note**: This fix addresses the Go runtime only. The Rust runtime-rs (`src/runtime-rs/`) has the same limitation and will be addressed in a follow-up PR.