### PR TITLE
versions: bump TDX OVMF to edk2-stable202605

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -366,7 +366,7 @@ externals:
       package_output_dir: "AmdSev"
     tdx:
       description: "UEFI for Intel TDX virtual machines."
-      version: "edk2-stable202511"
+      version: "edk2-stable202605"
       package: "OvmfPkg/IntelTdx/IntelTdxX64.dsc"
       package_output_dir: "IntelTdx"
     arm64:


### PR DESCRIPTION
Superseded by #13631 (same `edk2-stable202605` TDX OVMF pin).