### PR TITLE
runtime-rs: Support pod-level Checkpoint/Restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,8 +1234,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim-protos"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714d7ff4f5e9d5f9b57d27152d70c8cab6639284e5c4f7dfaca774a7b94fa52"
+source = "git+https://github.com/Apokleos/rust-extensions?branch=ckpt-restore#8515b391aeac177288d1c9f7940b671e401a27d2"
 dependencies = [
  "async-trait",
  "protobuf",
@@ -7383,6 +7382,7 @@ dependencies = [
  "oci-spec 0.10.0",
  "protobuf",
  "runtime-spec",
+ "serde_json",
  "serial_test 0.10.0",
  "service",
  "sha2 0.11.0",
@@ -8817,6 +8817,7 @@ dependencies = [
  "sendfd",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "slog",
  "slog-scope",
  "strum 0.24.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ which = "4.3.0"
 gpt = "4.1.0"
 devicemapper = { git = "https://github.com/stratis-storage/devicemapper-rs", rev = "078e70ceecf0d08eb0c800626827c9bc0a9a8adc" }
 
+[patch.crates-io]
+containerd-shim-protos = { git = "https://github.com/Apokleos/rust-extensions", branch = "ckpt-restore" }
+
 # Per-package release profile overrides for kata-deploy. The kata-deploy
 # binary runs once at pod start and then idles waiting for SIGTERM, so we
 # size-optimise it (opt-level = "z") and keep codegen-units = 1 to give

--- a/src/libs/protocols/protos/agent.proto
+++ b/src/libs/protocols/protos/agent.proto
@@ -66,6 +66,7 @@ service AgentService {
 
 	// misc (TODO: some rpcs can be replaced by hyperstart-exec)
 	rpc CreateSandbox(CreateSandboxRequest) returns (google.protobuf.Empty);
+	rpc RebindSandbox(RebindSandboxRequest) returns (google.protobuf.Empty);
 	rpc DestroySandbox(DestroySandboxRequest) returns (google.protobuf.Empty);
 	rpc OnlineCPUMem(OnlineCPUMemRequest) returns (google.protobuf.Empty);
 	rpc ReseedRandomDev(ReseedRandomDevRequest) returns (google.protobuf.Empty);
@@ -79,6 +80,23 @@ service AgentService {
 	rpc GetVolumeStats(VolumeStatsRequest) returns (VolumeStatsResponse);
 	rpc ResizeVolume(ResizeVolumeRequest) returns (google.protobuf.Empty);
 	rpc SetPolicy(SetPolicyRequest) returns (google.protobuf.Empty);
+}
+
+message ContainerIDMapping {
+	string old_id = 1;
+	string new_id = 2;
+	bytes hosts_file = 3;
+	bool has_hosts_file = 4;
+	bytes process = 5;
+	bytes linux_resources = 6;
+	bool has_linux_resources = 7;
+}
+
+message RebindSandboxRequest {
+	string sandbox_id = 1;
+	repeated ContainerIDMapping containers = 2;
+	string hostname = 3;
+	repeated string dns = 4;
 }
 
 message CreateContainerRequest {

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::sync::atomic::Ordering;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tracing::instrument;
@@ -92,6 +94,39 @@ macro_rules! impl_agent {
                 let resp = client.$name(new_ttrpc_ctx(timeout * MILLISECOND_TO_NANOSECOND), &r).await?;
                 Ok(resp.into())
             })*
+
+            async fn wait_process(
+                &self,
+                req: crate::WaitProcessRequest,
+            ) -> Result<crate::WaitProcessResponse> {
+                let req = req.into();
+                loop {
+                    let generation = self.reconnect_generation.load(Ordering::Acquire);
+                    let client = match self.get_agent_client().await {
+                        Some((client, _, _)) => client,
+                        None => {
+                            let reconnected = self.reconnected.notified();
+                            if self.reconnecting.load(Ordering::Acquire) {
+                                reconnected.await;
+                                continue;
+                            }
+                            return Err(anyhow::anyhow!("get client"));
+                        }
+                    };
+                    match client.wait_process(new_ttrpc_ctx(0), &req).await {
+                        Ok(resp) => return Ok(resp.into()),
+                        Err(err) => {
+                            if self.reconnect_generation.load(Ordering::Acquire) == generation {
+                                return Err(err.into());
+                            }
+                            let reconnected = self.reconnected.notified();
+                            if self.reconnecting.load(Ordering::Acquire) {
+                                reconnected.await;
+                            }
+                        }
+                    }
+                }
+            }
         }
     };
 }
@@ -102,7 +137,6 @@ impl_agent!(
     remove_container | crate::RemoveContainerRequest | crate::Empty | None,
     exec_process | crate::ExecProcessRequest | crate::Empty | None,
     signal_process | crate::SignalProcessRequest | crate::Empty | None,
-    wait_process | crate::WaitProcessRequest | crate::WaitProcessResponse | Some(0),
     update_container | crate::UpdateContainerRequest | crate::Empty | None,
     stats_container | crate::ContainerID | crate::StatsContainerResponse | None,
     pause_container | crate::ContainerID | crate::Empty | None,
@@ -118,6 +152,7 @@ impl_agent!(
     list_interfaces | crate::Empty | crate::Interfaces | None,
     list_routes | crate::Empty | crate::Routes | None,
     create_sandbox | crate::CreateSandboxRequest | crate::Empty | None,
+    rebind_sandbox | crate::RebindSandboxRequest | crate::Empty | None,
     destroy_sandbox | crate::Empty | crate::Empty | None,
     copy_file | crate::CopyFileRequest | crate::Empty | None,
     get_oom_event | crate::Empty | crate::OomEventResponse | Some(0),
@@ -126,6 +161,8 @@ impl_agent!(
     get_volume_stats | crate::VolumeStatsRequest | crate::VolumeStatsResponse | None,
     resize_volume | crate::ResizeVolumeRequest | crate::Empty | None,
     online_cpu_mem | crate::OnlineCPUMemRequest | crate::Empty | None,
+    reseed_random_dev | crate::ReseedRandomDevRequest | crate::Empty | None,
+    set_guest_date_time | crate::SetGuestDateTimeRequest | crate::Empty | None,
     get_metrics | crate::Empty | crate::MetricsResponse | None,
     get_guest_details | crate::GetGuestDetailsRequest | crate::GuestDetailsResponse | None,
     add_swap | crate::AddSwapRequest | crate::Empty | None,

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -9,13 +9,17 @@ mod trans;
 
 use std::{
     os::unix::io::RawFd,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use anyhow::{Context, Result};
 use kata_types::config::Agent as AgentConfig;
+use nix::sys::socket::{shutdown, Shutdown};
 use protocols::{agent_ttrpc_async as agent_ttrpc, health_ttrpc_async as health_ttrpc};
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 use ttrpc::asynchronous::Client;
 
 use crate::{log_forwarder::LogForwarder, sock};
@@ -59,6 +63,9 @@ unsafe impl Sync for KataAgent {}
 #[derive(Debug)]
 pub struct KataAgent {
     pub(crate) inner: Arc<RwLock<KataAgentInner>>,
+    reconnecting: AtomicBool,
+    reconnect_generation: AtomicU64,
+    reconnected: Notify,
 }
 
 impl KataAgent {
@@ -71,6 +78,9 @@ impl KataAgent {
                 config,
                 log_forwarder: LogForwarder::new(),
             })),
+            reconnecting: AtomicBool::new(false),
+            reconnect_generation: AtomicU64::new(0),
+            reconnected: Notify::new(),
         }
     }
 
@@ -124,6 +134,8 @@ impl KataAgent {
         let c = Client::new(stream.into_ttrpc_socket());
         inner.client = Some(c);
         inner.client_fd = client_fd;
+        self.reconnecting.store(false, Ordering::Release);
+        self.reconnected.notify_waiters();
         Ok(())
     }
 
@@ -164,8 +176,17 @@ impl KataAgent {
 
     /// Disconnect from the agent gRPC server and clean up related resources.
     pub(crate) async fn disconnect(&self) -> Result<()> {
+        self.reconnect_generation.fetch_add(1, Ordering::AcqRel);
+        self.reconnecting.store(true, Ordering::Release);
         let mut inner = self.inner.write().await;
         inner.log_forwarder.stop();
+
+        // Long-running WaitProcess calls retain ttrpc client clones. Shut down
+        // the transport so the guest agent returns to accept before a VM
+        // snapshot; WaitProcess retries after the planned reconnect.
+        if inner.client_fd >= 0 {
+            shutdown(inner.client_fd, Shutdown::Both).context("shutdown agent client socket")?;
+        }
 
         // If there is a valid client, drop it (closes the connection).
         inner.client.take();

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -335,6 +335,31 @@ impl From<ContainerID> for agent::ResumeContainerRequest {
     }
 }
 
+impl From<crate::RebindSandboxRequest> for agent::RebindSandboxRequest {
+    fn from(from: crate::RebindSandboxRequest) -> Self {
+        Self {
+            sandbox_id: from.sandbox_id,
+            hostname: from.hostname,
+            dns: from.dns,
+            containers: from
+                .containers
+                .into_iter()
+                .map(|mapping| agent::ContainerIDMapping {
+                    old_id: mapping.old_id,
+                    new_id: mapping.new_id,
+                    has_hosts_file: mapping.hosts_file.is_some(),
+                    hosts_file: mapping.hosts_file.unwrap_or_default(),
+                    process: mapping.process,
+                    has_linux_resources: mapping.linux_resources.is_some(),
+                    linux_resources: mapping.linux_resources.unwrap_or_default(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
 impl From<SignalProcessRequest> for agent::SignalProcessRequest {
     fn from(from: SignalProcessRequest) -> Self {
         Self {

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -22,6 +22,23 @@ impl Empty {
     }
 }
 
+#[derive(PartialEq, Clone, Default)]
+pub struct ContainerIDMapping {
+    pub old_id: String,
+    pub new_id: String,
+    pub hosts_file: Option<Vec<u8>>,
+    pub process: Vec<u8>,
+    pub linux_resources: Option<Vec<u8>>,
+}
+
+#[derive(PartialEq, Clone, Default)]
+pub struct RebindSandboxRequest {
+    pub sandbox_id: String,
+    pub containers: Vec<ContainerIDMapping>,
+    pub hostname: String,
+    pub dns: Vec<String>,
+}
+
 #[derive(Default, Debug, Clone, PartialEq)]
 pub enum FSGroupChangePolicy {
     #[default]

--- a/src/runtime-rs/crates/runtimes/common/src/checkpoint_restore.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/checkpoint_restore.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::types::{
+    CheckpointSandboxRequest, RestoreSandboxInfo, RestoreSandboxRequest, RestoredSandboxTask,
+    SandboxCheckpointTask, SandboxRestoreTask,
+};
+
+pub const RESTORE_PHASE_OPTION: &str = "io.containerd.pod-restore.phase";
+pub const RESTORE_PHASE_PREPARE: &str = "prepare";
+pub const RESTORE_PHASE_COMPLETE: &str = "complete";
+
+/// Optional Pod-level checkpoint/restore operations supplied by a sandbox runtime.
+#[async_trait]
+pub trait SandboxCheckpointRestore: Send + Sync {
+    async fn validate_checkpoint_sandbox(&self, req: &CheckpointSandboxRequest) -> Result<()>;
+    async fn checkpoint_sandbox(&self, req: &CheckpointSandboxRequest) -> Result<()>;
+    async fn restore_sandbox(&self, req: &RestoreSandboxRequest) -> Result<RestoreSandboxInfo>;
+    async fn prepare_restore_sandbox(
+        &self,
+        req: &RestoreSandboxRequest,
+    ) -> Result<RestoreSandboxInfo>;
+    async fn complete_restore_sandbox(
+        &self,
+        req: &RestoreSandboxRequest,
+    ) -> Result<RestoreSandboxInfo>;
+    async fn cleanup_sandbox_checkpoint(&self, req: &CheckpointSandboxRequest) -> Result<()>;
+}
+
+/// Optional task operations needed to checkpoint and restore an entire sandbox.
+#[async_trait]
+pub trait ContainerCheckpointRestore: Send + Sync {
+    async fn prepare_checkpoint_tasks(&self, tasks: &mut [SandboxCheckpointTask]) -> Result<()>;
+    async fn pause_checkpoint_tasks(&self, tasks: &[SandboxCheckpointTask]) -> Result<()>;
+    async fn resume_checkpoint_tasks(&self, tasks: &[SandboxCheckpointTask]) -> Result<()>;
+    async fn restore_tasks(
+        &self,
+        tasks: &[SandboxRestoreTask],
+        restored: &[RestoredSandboxTask],
+    ) -> Result<()>;
+}
+
+/// A complete Pod-level checkpoint/restore capability for one runtime instance.
+#[derive(Clone)]
+pub struct CheckpointRestoreRuntime {
+    pub sandbox: Arc<dyn SandboxCheckpointRestore>,
+    pub container_manager: Arc<dyn ContainerCheckpointRestore>,
+}

--- a/src/runtime-rs/crates/runtimes/common/src/error.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/error.rs
@@ -22,6 +22,14 @@ pub enum Error {
     AgentConnectionClosed,
     #[error("process already terminated")]
     ProcessAlreadyTerminated,
+    #[error("invalid sandbox checkpoint/restore request: {0}")]
+    InvalidSandboxOperation(String),
+    #[error("sandbox checkpoint/restore precondition failed: {0}")]
+    SandboxOperationPrecondition(String),
+    #[error("sandbox checkpoint/restore is unsupported: {0}")]
+    SandboxOperationUnsupported(String),
+    #[error("sandbox checkpoint/restore deadline exceeded: {0}")]
+    SandboxOperationDeadline(String),
 }
 
 /// Common error messages indicating normal OOM shutdowns due to network issues.

--- a/src/runtime-rs/crates/runtimes/common/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/lib.rs
@@ -6,6 +6,11 @@
 
 mod container_manager;
 pub use container_manager::ContainerManager;
+mod checkpoint_restore;
+pub use checkpoint_restore::{
+    CheckpointRestoreRuntime, ContainerCheckpointRestore, SandboxCheckpointRestore,
+    RESTORE_PHASE_COMPLETE, RESTORE_PHASE_OPTION, RESTORE_PHASE_PREPARE,
+};
 pub mod error;
 pub mod message;
 mod runtime_handler;

--- a/src/runtime-rs/crates/runtimes/common/src/runtime_handler.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/runtime_handler.rs
@@ -6,7 +6,9 @@
 
 use std::sync::Arc;
 
-use crate::{message::Message, types::SandboxConfig, ContainerManager, Sandbox};
+use crate::{
+    message::Message, types::SandboxConfig, CheckpointRestoreRuntime, ContainerManager, Sandbox,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use kata_types::config::TomlConfig;
@@ -17,6 +19,7 @@ use tokio::sync::mpsc::Sender;
 pub struct RuntimeInstance {
     pub sandbox: Arc<dyn Sandbox>,
     pub container_manager: Arc<dyn ContainerManager>,
+    pub checkpoint_restore: Option<CheckpointRestoreRuntime>,
 }
 
 #[async_trait]

--- a/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
@@ -13,6 +13,7 @@ pub mod utils;
 use std::{
     collections::{hash_map::RandomState, HashMap},
     fmt,
+    time::{Duration, SystemTime},
 };
 
 use crate::SandboxNetworkEnv;
@@ -155,6 +156,8 @@ pub enum SandboxRequest {
     SandboxStatus(SandboxStatusRequest),
     Ping(SandboxID),
     ShutdownSandbox(SandboxID),
+    CheckpointSandbox(CheckpointSandboxRequest),
+    RestoreSandbox(Box<RestoreSandboxRequest>),
 }
 
 /// Response: sandbox response to shim
@@ -169,6 +172,66 @@ pub enum SandboxResponse {
     SandboxStatus(SandboxStatusInfo),
     Ping,
     ShutdownSandbox,
+    CheckpointSandbox,
+    RestoreSandbox(RestoreSandboxInfo),
+}
+
+#[derive(Clone, Debug)]
+pub struct SandboxCheckpointTask {
+    pub checkpoint_key: String,
+    pub task_id: String,
+    // Resolved by the runtime container manager before tasks are frozen. This
+    // is runtime-local metadata and is not part of the Sandbox API.
+    pub rootfs_device_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckpointSandboxRequest {
+    pub sandbox_id: String,
+    pub output_path: String,
+    pub tasks: Vec<SandboxCheckpointTask>,
+    pub options: HashMap<String, String>,
+    // Derived from the transport context. It is not a Sandbox API field.
+    pub operation_timeout: Option<Duration>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SandboxRestoreTask {
+    pub checkpoint_key: String,
+    pub task_id: String,
+    pub bundle: String,
+    pub terminal: bool,
+    pub stdin: Option<String>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub options_type_url: String,
+    pub options: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RestoreSandboxRequest {
+    pub sandbox_config: SandboxConfig,
+    pub checkpoint_path: String,
+    pub options: HashMap<String, String>,
+    pub tasks: Vec<SandboxRestoreTask>,
+    // Derived from the transport context. It is not a Sandbox API field.
+    pub operation_timeout: Option<Duration>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RestoredSandboxTask {
+    pub checkpoint_key: String,
+    pub task_id: String,
+    pub rootfs_device_id: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct RestoreSandboxInfo {
+    pub pid: u32,
+    pub created_at: SystemTime,
+    pub spec_type_url: String,
+    pub spec: Vec<u8>,
+    pub tasks: Vec<RestoredSandboxTask>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/runtime-rs/crates/runtimes/common/src/types/trans_from_shim.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/trans_from_shim.rs
@@ -5,10 +5,10 @@
 //
 
 use super::{
-    ContainerConfig, ContainerID, ContainerProcess, ExecProcessRequest, KillRequest,
-    ResizePTYRequest, SandboxConfig, SandboxID, SandboxNetworkEnv, SandboxRequest,
-    SandboxStatusRequest, ShutdownRequest, StopSandboxRequest, TaskRequest, UpdateRequest,
-    DEFAULT_SHM_SIZE,
+    CheckpointSandboxRequest, ContainerConfig, ContainerID, ContainerProcess, ExecProcessRequest,
+    KillRequest, ResizePTYRequest, RestoreSandboxRequest, SandboxCheckpointTask, SandboxConfig,
+    SandboxID, SandboxNetworkEnv, SandboxRequest, SandboxRestoreTask, SandboxStatusRequest,
+    ShutdownRequest, StopSandboxRequest, TaskRequest, UpdateRequest, DEFAULT_SHM_SIZE,
 };
 
 use kata_types::mount::Mount;
@@ -26,6 +26,25 @@ use anyhow::{anyhow, Context, Result};
 use containerd_shim_protos::{api, sandbox_api};
 
 pub const SANDBOX_API_V1: &str = "runtime.v1.PodSandboxConfig";
+
+fn resolv_conf_lines(
+    servers: Vec<String>,
+    searches: Vec<String>,
+    options: Vec<String>,
+) -> Vec<String> {
+    let mut lines = servers
+        .into_iter()
+        .filter(|server| !server.is_empty())
+        .map(|server| format!("nameserver {server}"))
+        .collect::<Vec<_>>();
+    if !searches.is_empty() {
+        lines.push(format!("search {}", searches.join(" ")));
+    }
+    if !options.is_empty() {
+        lines.push(format!("options {}", options.join(" ")));
+    }
+    lines
+}
 
 fn trans_from_shim_mount(from: &api::Mount) -> Mount {
     let options = from.options.to_vec();
@@ -60,12 +79,12 @@ impl TryFrom<sandbox_api::CreateSandboxRequest> for SandboxRequest {
 
         let config = cri_api_v1::PodSandboxConfig::parse_from_bytes(&from.options.value)?;
 
-        let mut dns: Vec<String> = vec![];
-        config.dns_config.map(|mut dns_config| {
-            dns.append(&mut dns_config.servers);
-            dns.append(&mut dns_config.servers);
-            dns.append(&mut dns_config.options);
-        });
+        let dns = config
+            .dns_config
+            .map(|dns_config| {
+                resolv_conf_lines(dns_config.servers, dns_config.searches, dns_config.options)
+            })
+            .unwrap_or_default();
 
         Ok(SandboxRequest::CreateSandbox(Box::new(SandboxConfig {
             sandbox_id: from.sandbox_id.clone(),
@@ -152,6 +171,94 @@ impl TryFrom<sandbox_api::ShutdownSandboxRequest> for SandboxRequest {
         Ok(SandboxRequest::ShutdownSandbox(SandboxID {
             sandbox_id: from.sandbox_id,
         }))
+    }
+}
+
+impl TryFrom<sandbox_api::CheckpointSandboxRequest> for SandboxRequest {
+    type Error = anyhow::Error;
+
+    fn try_from(from: sandbox_api::CheckpointSandboxRequest) -> Result<Self> {
+        Ok(SandboxRequest::CheckpointSandbox(
+            CheckpointSandboxRequest {
+                sandbox_id: from.sandbox_id,
+                output_path: from.output_path,
+                tasks: from
+                    .tasks
+                    .into_iter()
+                    .map(|task| SandboxCheckpointTask {
+                        checkpoint_key: task.checkpoint_key,
+                        task_id: task.task_id,
+                        rootfs_device_id: None,
+                    })
+                    .collect(),
+                options: from.options,
+                operation_timeout: None,
+            },
+        ))
+    }
+}
+
+impl TryFrom<sandbox_api::RestoreSandboxRequest> for SandboxRequest {
+    type Error = anyhow::Error;
+
+    fn try_from(from: sandbox_api::RestoreSandboxRequest) -> Result<Self> {
+        let type_url = from.sandbox_options.type_url.clone();
+        if type_url != SANDBOX_API_V1 {
+            return Err(anyhow!("unsupported type url: {type_url}"));
+        }
+        let config = cri_api_v1::PodSandboxConfig::parse_from_bytes(&from.sandbox_options.value)?;
+        let dns = config
+            .dns_config
+            .into_option()
+            .map(|dns_config| {
+                resolv_conf_lines(dns_config.servers, dns_config.searches, dns_config.options)
+            })
+            .unwrap_or_default();
+        let sandbox_id = from.sandbox_id;
+        let sandbox_config = SandboxConfig {
+            sandbox_id: sandbox_id.clone(),
+            hostname: config.hostname,
+            dns,
+            network_env: SandboxNetworkEnv {
+                netns: (!from.netns_path.is_empty()).then_some(from.netns_path),
+                network_created: false,
+            },
+            annotations: config.annotations.clone(),
+            hooks: None,
+            state: runtime_spec::State {
+                version: Default::default(),
+                id: sandbox_id,
+                status: runtime_spec::ContainerState::Creating,
+                pid: 0,
+                bundle: from.bundle_path,
+                annotations: config.annotations,
+            },
+            shm_size: DEFAULT_SHM_SIZE,
+        };
+        let tasks = from
+            .tasks
+            .into_iter()
+            .map(|task| SandboxRestoreTask {
+                checkpoint_key: task.checkpoint_key,
+                task_id: task.task_id,
+                bundle: task.bundle,
+                terminal: task.terminal,
+                stdin: (!task.stdin.is_empty()).then_some(task.stdin),
+                stdout: (!task.stdout.is_empty()).then_some(task.stdout),
+                stderr: (!task.stderr.is_empty()).then_some(task.stderr),
+                options_type_url: task.options.type_url.clone(),
+                options: task.options.value.to_vec(),
+            })
+            .collect();
+        Ok(SandboxRequest::RestoreSandbox(Box::new(
+            RestoreSandboxRequest {
+                sandbox_config,
+                checkpoint_path: from.checkpoint_path,
+                options: from.options,
+                tasks,
+                operation_timeout: None,
+            },
+        )))
     }
 }
 

--- a/src/runtime-rs/crates/runtimes/common/src/types/trans_into_shim.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/trans_into_shim.rs
@@ -143,6 +143,58 @@ impl TryFrom<SandboxResponse> for sandbox_api::ShutdownSandboxResponse {
     }
 }
 
+impl TryFrom<SandboxResponse> for sandbox_api::CheckpointSandboxResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(from: SandboxResponse) -> Result<Self> {
+        match from {
+            SandboxResponse::CheckpointSandbox => Ok(Self::new()),
+            _ => Err(anyhow!(Error::UnexpectedSandboxResponse(
+                from,
+                type_name::<Self>().to_string()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<SandboxResponse> for sandbox_api::RestoreSandboxResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(from: SandboxResponse) -> Result<Self> {
+        match from {
+            SandboxResponse::RestoreSandbox(resp) => {
+                let spec = if resp.spec.is_empty() && resp.spec_type_url.is_empty() {
+                    None
+                } else {
+                    let mut spec = protobuf::well_known_types::any::Any::new();
+                    spec.type_url = resp.spec_type_url;
+                    spec.value = resp.spec;
+                    Some(spec)
+                };
+                Ok(Self {
+                    pid: resp.pid,
+                    created_at: option_system_time_into(Some(resp.created_at)),
+                    spec: spec.into(),
+                    tasks: resp
+                        .tasks
+                        .into_iter()
+                        .map(|task| sandbox_api::RestoredSandboxTask {
+                            checkpoint_key: task.checkpoint_key,
+                            task_id: task.task_id,
+                            ..Default::default()
+                        })
+                        .collect(),
+                    ..Default::default()
+                })
+            }
+            _ => Err(anyhow!(Error::UnexpectedSandboxResponse(
+                from,
+                type_name::<Self>().to_string()
+            ))),
+        }
+    }
+}
+
 impl From<ProcessExitStatus> for api::WaitResponse {
     fn from(from: ProcessExitStatus) -> Self {
         Self {

--- a/src/runtime-rs/crates/runtimes/common/src/types/utils.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/utils.rs
@@ -5,6 +5,7 @@
 
 use std::convert::TryInto;
 use std::time;
+use std::time::Duration;
 
 fn system_time_into(time: time::SystemTime) -> ::protobuf::well_known_types::timestamp::Timestamp {
     let mut proto_time = ::protobuf::well_known_types::timestamp::Timestamp::new();
@@ -25,4 +26,13 @@ pub fn option_system_time_into(
         Some(v) => ::protobuf::MessageField::some(system_time_into(v)),
         None => ::protobuf::MessageField::none(),
     }
+}
+
+pub fn sandbox_operation_timeout(timeout_nano: i64) -> Option<Duration> {
+    if timeout_nano <= 0 {
+        return None;
+    }
+    let transport_timeout = Duration::from_nanos(timeout_nano as u64);
+    let cleanup_margin = Duration::from_millis(500).min(transport_timeout / 2);
+    Some(transport_timeout.saturating_sub(cleanup_margin))
 }

--- a/src/runtime-rs/crates/runtimes/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/src/lib.rs
@@ -18,3 +18,6 @@ pub use shim_interface;
 mod shim_metrics;
 mod shim_mgmt;
 pub mod tracer;
+
+#[cfg(feature = "virt")]
+pub use virt_container;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -6,13 +6,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use common::{
-    message::{Action, Message},
-    types::{
-        ContainerProcess, PlatformInfo, ProcessType, SandboxConfig, SandboxRequest,
-        SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest, TaskResponse,
-        DEFAULT_SHM_SIZE,
+    RESTORE_PHASE_COMPLETE, RESTORE_PHASE_OPTION, RuntimeHandler, RuntimeInstance, Sandbox, SandboxNetworkEnv, error::Error as CommonError, message::{Action, Message}, types::{
+        ContainerProcess, DEFAULT_SHM_SIZE, PlatformInfo, ProcessType, RestoreSandboxInfo, SandboxConfig, SandboxRequest, SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest, TaskResponse,
     },
-    RuntimeHandler, RuntimeInstance, Sandbox, SandboxNetworkEnv,
 };
 
 use containerd_shim_protos::events::task::{TaskCreate, TaskDelete, TaskStart};
@@ -288,6 +284,7 @@ impl RuntimeHandlerManagerInner {
 
 pub struct RuntimeHandlerManager {
     inner: Arc<RwLock<RuntimeHandlerManagerInner>>,
+    sandbox_operation_guard: Arc<RwLock<()>>,
 }
 
 // todo: a more detailed impl for fmt::Debug
@@ -303,6 +300,7 @@ impl RuntimeHandlerManager {
             inner: Arc::new(RwLock::new(RuntimeHandlerManagerInner::new(
                 id, msg_sender,
             )?)),
+            sandbox_operation_guard: Arc::new(RwLock::new(())),
         })
     }
 
@@ -487,7 +485,92 @@ impl RuntimeHandlerManager {
                 .await
                 .context("init sandboxed runtime")?;
 
-            Ok(SandboxResponse::CreateSandbox)
+            return Ok(SandboxResponse::CreateSandbox);
+        }
+
+        let is_observer = matches!(
+            &req,
+            SandboxRequest::Platform(_)
+                | SandboxRequest::WaitSandbox(_)
+                | SandboxRequest::SandboxStatus(_)
+                | SandboxRequest::Ping(_)
+        );
+        if is_observer {
+            return self
+                .handler_sandbox_request(req)
+                .await
+                .context("handler request");
+        }
+
+        let is_ckpt_restore = matches!(
+            &req,
+            SandboxRequest::CheckpointSandbox(_) | SandboxRequest::RestoreSandbox(_)
+        );
+        if !is_ckpt_restore {
+            let _operation_guard = self.sandbox_operation_guard.read().await;
+            return self
+                .handler_sandbox_request(req)
+                .await
+                .context("handler request");
+        }
+
+        let _operation_guard = self.sandbox_operation_guard.write().await;
+        if let SandboxRequest::RestoreSandbox(req) = req {
+            let runtime_id = self.inner.read().await.id.clone();
+            if req.sandbox_config.sandbox_id != runtime_id {
+                return Err(CommonError::InvalidSandboxOperation(format!(
+                    "restore sandbox id {} does not match shim id {}",
+                    req.sandbox_config.sandbox_id, runtime_id
+                ))
+                .into());
+            }
+            let restore_phase = req.options.get(RESTORE_PHASE_OPTION).map(String::as_str);
+            if restore_phase != Some(RESTORE_PHASE_COMPLETE) {
+                self.sandbox_init_runtime_instance(req.sandbox_config.clone())
+                    .await
+                    .context("initialize runtime for sandbox restore")?;
+            }
+            let instance = self
+                .get_runtime_instance()
+                .await
+                .context("get runtime instance for sandbox restore")?;
+
+            let restore_future = async {
+                let _checkpoint_restore = instance.checkpoint_restore.as_ref().ok_or_else(|| {
+                    CommonError::SandboxOperationUnsupported(
+                        "sandbox restore is unsupported by this runtime".to_string(),
+                    )
+                })?;
+                let info: Option<RestoreSandboxInfo> = None;
+
+
+                // TODO: do real work here
+
+                Ok::<_, anyhow::Error>(info)
+            };
+
+            let restore_result = if let Some(timeout) = req.operation_timeout {
+                match tokio::time::timeout(timeout, restore_future).await {
+                    Ok(result) => result,
+                    Err(_) => Err(CommonError::SandboxOperationDeadline(format!(
+                        "sandbox restore exceeded its {:?} runtime budget",
+                        timeout
+                    ))
+                    .into()),
+                }
+            } else {
+                restore_future.await
+            };
+
+            match restore_result {
+                Ok(info) => Ok(SandboxResponse::RestoreSandbox(info.unwrap())),
+                Err(restore_err) => match instance.sandbox.shutdown().await {
+                    Ok(()) => Err(restore_err),
+                    Err(rollback_err) => Err(restore_err).with_context(|| {
+                        format!("failed to discard restored sandbox: {rollback_err:#}")
+                    }),
+                },
+            }
         } else {
             self.handler_sandbox_request(req)
                 .await
@@ -497,6 +580,19 @@ impl RuntimeHandlerManager {
 
     #[instrument(parent = &*(ROOTSPAN))]
     pub async fn handler_task_message(&self, req: TaskRequest) -> Result<TaskResponse> {
+        let task_is_observer = matches!(
+            &req,
+            TaskRequest::WaitProcess(_)
+                | TaskRequest::StateProcess(_)
+                | TaskRequest::StatsContainer(_)
+                | TaskRequest::Pid
+                | TaskRequest::ConnectContainer(_)
+        );
+        let _operation_guard = if task_is_observer {
+            None
+        } else {
+            Some(self.sandbox_operation_guard.read().await)
+        };
         if let TaskRequest::CreateContainer(container_config) = req {
             // get oci spec
             let bundler_path = format!(
@@ -644,6 +740,20 @@ impl RuntimeHandlerManager {
 
                 Ok(SandboxResponse::ShutdownSandbox)
             }
+            SandboxRequest::CheckpointSandbox(mut _req) => {
+                let _checkpoint_restore = instance.checkpoint_restore.as_ref().ok_or_else(|| {
+                    CommonError::SandboxOperationUnsupported(
+                        "sandbox checkpoint is unsupported by this runtime".to_string(),
+                    )
+                })?;
+
+                // TODO; do real work here
+
+                Ok(SandboxResponse::CheckpointSandbox)
+            }
+            SandboxRequest::RestoreSandbox(_) => Err(anyhow!(
+                "restore request reached initialized sandbox dispatcher"
+            )),
         }
     }
 

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -145,7 +145,13 @@ impl ServiceManager {
 
             let task_service: Arc<dyn shim_async::Task + Send + Sync> =
                 Arc::new(TaskService::new(self.handler.clone()));
-            let s = s.register_service(shim_async::create_task(task_service));
+            let mut task_services = shim_async::create_task(task_service.clone());
+            let mut task_service_map = shim_async::create_task(task_service);
+            let task_service_map = task_service_map
+                .remove("containerd.task.v2.Task")
+                .context("generated Task v2 service is missing")?;
+            task_services.insert("containerd.task.v3.Task".to_string(), task_service_map);
+            let s = s.register_service(task_services);
             self.server = Some(s);
         }
         Ok(())

--- a/src/runtime-rs/crates/service/src/sandbox_service.rs
+++ b/src/runtime-rs/crates/service/src/sandbox_service.rs
@@ -10,10 +10,27 @@ use std::{
 };
 
 use async_trait::async_trait;
+use common::error::Error as CommonError;
 use common::types::{SandboxRequest, SandboxResponse};
+use common::types::utils::sandbox_operation_timeout;
 use containerd_shim_protos::{sandbox_api, sandbox_async};
 use runtimes::RuntimeHandlerManager;
 use ttrpc::{self, r#async::TtrpcContext};
+
+/// map common runtime error to ttrpc CODE
+fn map_runtime_error(err: anyhow::Error) -> ttrpc::Error {
+    let code = match err.downcast_ref::<CommonError>() {
+        Some(CommonError::InvalidSandboxOperation(_)) => ttrpc::Code::INVALID_ARGUMENT,
+        Some(CommonError::SandboxOperationPrecondition(_)) => ttrpc::Code::FAILED_PRECONDITION,
+        Some(CommonError::SandboxOperationUnsupported(_)) => ttrpc::Code::UNIMPLEMENTED,
+        Some(CommonError::SandboxOperationDeadline(_)) => ttrpc::Code::DEADLINE_EXCEEDED,
+        _ => ttrpc::Code::INTERNAL,
+    };
+    ttrpc::Error::RpcStatus(ttrpc::get_status(
+        code,
+        format!("failed to handle sandbox message: {err:#}"),
+    ))
+}
 
 pub(crate) struct SandboxService {
     handler: Arc<RuntimeHandlerManager>,
@@ -35,18 +52,41 @@ impl SandboxService {
         TtrpcResp: TryFrom<SandboxResponse>,
         <TtrpcResp as TryFrom<SandboxResponse>>::Error: std::fmt::Debug,
     {
-        let r = req.try_into().map_err(|err| {
-            ttrpc::Error::Others(format!("failed to translate from shim {err:?}"))
+        let mut r = req.try_into().map_err(|err| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(
+                ttrpc::Code::INVALID_ARGUMENT,
+                format!("failed to translate sandbox request: {err:?}"),
+            ))
         })?;
+        let is_transactional_operation = matches!(
+            &r,
+            SandboxRequest::CheckpointSandbox(_) | SandboxRequest::RestoreSandbox(_)
+        );
+        if let SandboxRequest::CheckpointSandbox(checkpoint) = &mut r {
+            checkpoint.operation_timeout = sandbox_operation_timeout(ctx.timeout_nano);
+        }
+        if let SandboxRequest::RestoreSandbox(restore) = &mut r {
+            restore.operation_timeout = sandbox_operation_timeout(ctx.timeout_nano);
+        }
         let logger = sl!().new(o!("stream id" =>  ctx.mh.stream_id));
         debug!(logger, "====> sandbox service {:?}", &r);
-        let resp = self
-            .handler
-            .handler_sandbox_message(r)
-            .await
-            .map_err(|err| {
-                ttrpc::Error::Others(format!("failed to handle sandbox message {err:?}"))
-            })?;
+        let response = if is_transactional_operation {
+            // ttrpc drops the handler future when its transport deadline expires.
+            // Detach checkpoint/restore execution so its resume/rollback path
+            // still runs and no half-finished sandbox is left behind.
+            let handler = self.handler.clone();
+            tokio::spawn(async move { handler.handler_sandbox_message(r).await })
+                .await
+                .map_err(|err| {
+                    ttrpc::Error::RpcStatus(ttrpc::get_status(
+                        ttrpc::Code::INTERNAL,
+                        format!("sandbox operation worker failed: {err}"),
+                    ))
+                })?
+        } else {
+            self.handler.handler_sandbox_message(r).await
+        };
+        let resp = response.map_err(map_runtime_error)?;
         debug!(logger, "<==== sandbox service {:?}", &resp);
         resp.try_into()
             .map_err(|err| ttrpc::Error::Others(format!("failed to translate to shim {err:?}")))
@@ -72,5 +112,7 @@ impl_service!(
     wait_sandbox | sandbox_api::WaitSandboxRequest | sandbox_api::WaitSandboxResponse,
     sandbox_status | sandbox_api::SandboxStatusRequest | sandbox_api::SandboxStatusResponse,
     ping_sandbox | sandbox_api::PingRequest | sandbox_api::PingResponse,
-    shutdown_sandbox | sandbox_api::ShutdownSandboxRequest | sandbox_api::ShutdownSandboxResponse
+    shutdown_sandbox | sandbox_api::ShutdownSandboxRequest | sandbox_api::ShutdownSandboxResponse,
+    checkpoint_sandbox | sandbox_api::CheckpointSandboxRequest | sandbox_api::CheckpointSandboxResponse,
+    restore_sandbox | sandbox_api::RestoreSandboxRequest | sandbox_api::RestoreSandboxResponse
 );


### PR DESCRIPTION
Currently, it's under heavily developed. And any feedbacks with comments are welcome.
And it's just a initial commit and others will be pushed later.

As the containerd side should be restructed based on an early PR for pod-level C/R, I will release the reset parts later when I tested it successfully.

Fixes: https://github.com/kata-containers/kata-containers/issues/13653

References
- https://github.com/containerd/containerd/issues/13970
- https://github.com/containerd/containerd/issues/13979
