### PR TITLE
packaging: verify virtiofsd release archive checksum

### DIFF
--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -20,6 +20,7 @@ source "${script_dir}/../../scripts/lib.sh"
 virtiofsd_repo="${virtiofsd_repo:-}"
 virtiofsd_version="${virtiofsd_version:-}"
 virtiofsd_zip="${virtiofsd_zip:-}"
+virtiofsd_zip_sha256="${virtiofsd_zip_sha256:-}"
 
 [[ -n "${virtiofsd_repo}" ]] || die "failed to get virtiofsd repo"
 [[ -n "${virtiofsd_version}" ]] || die "failed to get virtiofsd version"
@@ -42,6 +43,8 @@ pull_virtiofsd_released_binary() {
 
 	pushd virtiofsd
 	curl --fail -L "${virtiofsd_zip}" -o virtiofsd.zip || return 1
+	printf "%s  %s\n" "${virtiofsd_zip_sha256}" "virtiofsd.zip" | \
+		sha256sum -c || die "virtiofsd release archive checksum mismatch"
 	unzip virtiofsd.zip
 	mv -f target/x86_64-unknown-linux-musl/release/virtiofsd virtiofsd
 	chmod +x virtiofsd

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -22,12 +22,14 @@ virtiofsd_repo="${virtiofsd_repo:-}"
 virtiofsd_version="${virtiofsd_version:-}"
 virtiofsd_toolchain="${virtiofsd_toolchain:-}"
 virtiofsd_zip="${virtiofsd_zip:-}"
+virtiofsd_zip_sha256="${virtiofsd_zip_sha256:-}"
 package_output_dir="${package_output_dir:-}"
 
 [[ -n "${virtiofsd_repo}" ]] || virtiofsd_repo=$(get_from_kata_deps ".externals.virtiofsd.url")
 [[ -n "${virtiofsd_version}" ]] || virtiofsd_version=$(get_from_kata_deps ".externals.virtiofsd.version")
 [[ -n "${virtiofsd_toolchain}" ]] || virtiofsd_toolchain=$(get_from_kata_deps ".externals.virtiofsd.toolchain")
 [[ -n "${virtiofsd_zip}" ]] || virtiofsd_zip=$(get_from_kata_deps ".externals.virtiofsd.meta.binary")
+[[ -n "${virtiofsd_zip_sha256}" ]] || virtiofsd_zip_sha256=$(get_from_kata_deps ".externals.virtiofsd.meta.binary_sha256")
 
 [[ -n "${virtiofsd_repo}" ]] || die "Failed to get virtiofsd repo"
 [[ -n "${virtiofsd_version}" ]] || die "Failed to get virtiofsd version or commit"
@@ -69,6 +71,7 @@ docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	--env virtiofsd_repo="${virtiofsd_repo}" \
 	--env virtiofsd_version="${virtiofsd_version}" \
 	--env virtiofsd_zip="${virtiofsd_zip}" \
+	--env virtiofsd_zip_sha256="${virtiofsd_zip_sha256}" \
 	--env ARCH="${ARCH}" \
 	--user "$(id -u)":"$(id -g)" \
 	"${container_image}" \

--- a/versions.yaml
+++ b/versions.yaml
@@ -405,6 +405,8 @@ externals:
       #
       # yamllint disable-line rule:line-length
       binary: "https://gitlab.com/-/project/21523468/uploads/f505704014ae7a816e515f2a05a93d8b/virtiofsd-v1.14.0.zip"
+      # yamllint disable-line rule:line-length
+      binary_sha256: "2e4fe9571f492b00baa34bc4e708e950039c5da05b830b31a8d179cb6ac8978e"
 
 languages:
   description: |


### PR DESCRIPTION
## Summary

The x86_64 `virtiofsd` build currently downloads and extracts a prebuilt release archive, but doesn't verify its contents. This PR modifies the pipleine to store the hash for the existing v1.14.0 archive alongside its URL in `versions.yaml`, forward it through the build container, and verify it before extraction.
