### PR TITLE
runtime-rs: enable TDX container creation using dragonball 

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -138,6 +138,7 @@ impl ConfigPlugin for DragonballConfig {
                 ));
             }
 
+            #[cfg(not(target_arch = "x86_64"))]
             if !db.boot_info.firmware.is_empty() {
                 return Err(std::io::Error::other(
                     "Firmware for dragonball hypervisor should be empty",

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -5,6 +5,8 @@
 //
 
 use super::vmm_instance::VmmInstance;
+#[cfg(target_arch = "x86_64")]
+use crate::ANON;
 use crate::{
     device::DeviceType, firecracker::sl, hypervisor_persist::HypervisorState,
     kernel_param::KernelParams, MemoryConfig, VmmState, DEV_HUGEPAGES, HUGETLBFS, HUGE_SHMEM,
@@ -12,6 +14,8 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+#[cfg(target_arch = "x86_64")]
+use dragonball::api::v1::ConfidentialVmType;
 use dragonball::{
     api::v1::{BootSourceConfig, VcpuResizeInfo},
     device_manager::{balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo},
@@ -93,6 +97,13 @@ pub struct DragonballInner {
 
 impl DragonballInner {
     pub fn new(exit_notify: mpsc::Sender<i32>) -> DragonballInner {
+        Self::new_with_hypervisor_config(exit_notify, HypervisorConfig::default())
+    }
+
+    pub fn new_with_hypervisor_config(
+        exit_notify: mpsc::Sender<i32>,
+        config: HypervisorConfig,
+    ) -> DragonballInner {
         let mut capabilities = Capabilities::new();
         capabilities.set(
             CapabilityBits::BlockDeviceSupport
@@ -102,16 +113,29 @@ impl DragonballInner {
                 | CapabilityBits::HybridVsockSupport
                 | CapabilityBits::GuestMemoryProbe,
         );
+
+        #[cfg(target_arch = "x86_64")]
+        let confidential_vm_type = if config.security_info.confidential_guest {
+            Some(ConfidentialVmType::TDX)
+        } else {
+            None
+        };
+
         DragonballInner {
             id: "".to_string(),
             vm_path: "".to_string(),
             jailer_root: "".to_string(),
             netns: None,
-            config: Default::default(),
+            config,
             pending_devices: vec![],
             state: VmmState::NotReady,
             jailed: false,
-            vmm_instance: VmmInstance::new("", exit_notify),
+            vmm_instance: VmmInstance::new(
+                "",
+                exit_notify,
+                #[cfg(target_arch = "x86_64")]
+                confidential_vm_type,
+            ),
             run_dir: "".to_string(),
             cached_block_devices: Default::default(),
             capabilities,
@@ -236,6 +260,14 @@ impl DragonballInner {
                 HugePageType::Hugetlbfs => (String::from(HUGETLBFS), String::from(DEV_HUGEPAGES)),
             }
         } else {
+            #[cfg(target_arch = "x86_64")]
+            if self.config.security_info.confidential_guest {
+                (String::from(ANON), String::from(""))
+            } else {
+                (String::from(SHMEM), String::from(""))
+            }
+
+            #[cfg(not(target_arch = "x86_64"))]
             (String::from(SHMEM), String::from(""))
         };
         let vm_config = VmConfigInfo {
@@ -288,6 +320,8 @@ impl DragonballInner {
         // set boot source
         let kernel_path = self.config.boot_info.kernel.as_str();
         let initrd_path = self.config.boot_info.initrd.as_str();
+        #[cfg(target_arch = "x86_64")]
+        let firmware_path = self.config.boot_info.firmware.as_str();
 
         info!(
             sl!(),
@@ -306,11 +340,22 @@ impl DragonballInner {
             );
         }
 
+        #[cfg(target_arch = "x86_64")]
+        let firmware = if self.config.security_info.confidential_guest && !firmware_path.is_empty()
+        {
+            Some(firmware_path.to_string())
+        } else {
+            None
+        };
+        #[cfg(not(target_arch = "x86_64"))]
+        let firmware = None;
+
         let mut boot_cfg = BootSourceConfig {
             kernel_path: self
                 .get_resource(kernel_path, DRAGONBALL_KERNEL)
                 .context("get kernel resource")?,
             initrd_path: initrd,
+            firmware_path: firmware,
             ..Default::default()
         };
 
@@ -586,7 +631,12 @@ impl Persist for DragonballInner {
             netns: hypervisor_state.netns,
             config: hypervisor_state.config,
             state: VmmState::NotReady,
-            vmm_instance: VmmInstance::new("", hypervisor_args),
+            vmm_instance: VmmInstance::new(
+                "",
+                hypervisor_args,
+                #[cfg(target_arch = "x86_64")]
+                None,
+            ),
             run_dir: hypervisor_state.run_dir,
             pending_devices: vec![],
             cached_block_devices: hypervisor_state.cached_block_devices,

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -155,6 +155,8 @@ impl DragonballInner {
                     .context("add vhost-user-net device")?;
                 Ok(DeviceType::VhostUserNetwork(dev))
             }
+            #[cfg(target_arch = "x86_64")]
+            DeviceType::Protection(dev) => Ok(DeviceType::Protection(dev)),
             _ => Err(anyhow!("unsupported device {:?}", device)),
         }
     }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -57,6 +57,18 @@ impl Dragonball {
         }
     }
 
+    pub fn new_with_hypervisor_config(config: HypervisorConfig) -> Self {
+        let (exit_notify, exit_waiter) = mpsc::channel(1);
+
+        Self {
+            inner: Arc::new(RwLock::new(DragonballInner::new_with_hypervisor_config(
+                exit_notify,
+                config,
+            ))),
+            exit_waiter: Mutex::new((exit_waiter, 0)),
+        }
+    }
+
     pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -15,6 +15,8 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use crossbeam_channel::{unbounded, Receiver, Sender};
+#[cfg(target_arch = "x86_64")]
+use dragonball::api::v1::ConfidentialVmType;
 use dragonball::{
     api::v1::{
         BlockDeviceConfigInfo, BootSourceConfig, FsDeviceConfigInfo, FsMountConfigInfo,
@@ -56,11 +58,17 @@ pub struct VmmInstance {
 }
 
 impl VmmInstance {
-    pub fn new(id: &str, exit_notify: mpsc::Sender<i32>) -> Self {
+    pub fn new(
+        id: &str,
+        exit_notify: mpsc::Sender<i32>,
+        #[cfg(target_arch = "x86_64")] confidential_vm_type: Option<ConfidentialVmType>,
+    ) -> Self {
+        #[cfg(not(target_arch = "x86_64"))]
+        let confidential_vm_type = None;
         let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo::new(
             String::from(id),
             DRAGONBALL_VERSION.to_string(),
-            None,
+            confidential_vm_type,
         )));
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK)

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -91,6 +91,8 @@ const SHMEM: &str = "shmem";
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 const HUGE_SHMEM: &str = "hugeshmem";
+#[cfg(all(feature = "dragonball", target_arch = "x86_64"))]
+const ANON: &str = "anon";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 pub const HYPERVISOR_QEMU: &str = "qemu";

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -238,10 +238,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
             any(target_arch = "x86_64", target_arch = "aarch64")
         ))]
         HYPERVISOR_DRAGONBALL => {
-            let hypervisor = Dragonball::new();
-            hypervisor
-                .set_hypervisor_config(hypervisor_config.clone())
-                .await;
+            let hypervisor = Dragonball::new_with_hypervisor_config(hypervisor_config.clone());
             if toml_config.runtime.use_passfd_io {
                 hypervisor
                     .set_passfd_listener_port(toml_config.runtime.passfd_listener_port)


### PR DESCRIPTION
For containers using dragonball as hypervisor, this PR allows TDX VM creation while confidential_guest is set to true in configuration toml, and path to firmware (tdshim) can also be configured.

For TDX container, mem type would be set to anonymous by default, since TDX does not allow named mem files.