### PR TITLE
runtime: allow direct-assigned volumes when block device use is disabled

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -615,20 +615,20 @@ func filterDevices(c *Container, devices []ContainerDevice) (ret []ContainerDevi
 	return
 }
 
+func allowBlockDeviceForMount(disableBlockDeviceUse bool, emptyDirMode string, mountSource string, hasDirectVolume bool) bool {
+	if !disableBlockDeviceUse || hasDirectVolume {
+		return true
+	}
+
+	return isBlockEmptyDirMode(emptyDirMode) && IsDiskEmptyDir(mountSource)
+}
+
 // Add any mount based block devices to the device manager and Save the
 // device ID for the particular mount. This'll occur when the mountpoint source
 // is a block device.
 func (c *Container) createBlockDevices(ctx context.Context) error {
 	// iterate all mounts and create block device if it's block based.
 	for i := range c.mounts {
-		// If block devices are disabled, we selectively only hotplug if
-		// the mount is a block-based emptyDir, to avoid
-		// cases that could regress 20ca4d2.
-		if !c.checkBlockDeviceSupport(ctx) && (!isBlockEmptyDirMode(c.sandbox.config.EmptyDirMode) || !IsDiskEmptyDir(c.mounts[i].Source)) {
-			c.Logger().Warn("Block device not supported")
-			continue
-		}
-
 		if len(c.mounts[i].BlockDeviceID) > 0 {
 			// Non-empty m.BlockDeviceID indicates there's already one device
 			// associated with the mount,so no need to create a new device for it
@@ -647,6 +647,22 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 		if e != nil && !os.IsNotExist(e) {
 			c.Logger().WithError(e).WithField("mount-source", c.mounts[i].Source).
 				Error("failed to parse the mount info file for a direct assigned volume")
+			continue
+		}
+
+		// If block devices are disabled, we selectively only hotplug if
+		// the mount is a block-based emptyDir or a direct-assigned volume, to avoid
+		// cases that could regress 20ca4d2.
+		if !c.checkBlockDeviceCapabilities(ctx) {
+			c.Logger().Warn("Block device not supported")
+			continue
+		}
+
+		hasDirectVolume := mntInfo != nil && mntInfo.Device != ""
+		if !allowBlockDeviceForMount(c.sandbox.config.HypervisorConfig.DisableBlockDeviceUse,
+			c.sandbox.config.EmptyDirMode, c.mounts[i].Source, hasDirectVolume) {
+			c.Logger().WithField("mount-source", c.mounts[i].Source).
+				Warn("Block device use is disabled")
 			continue
 		}
 
@@ -1281,17 +1297,16 @@ func (c *Container) rollbackFailingContainerCreation(ctx context.Context) {
 	}
 }
 
+func (c *Container) checkBlockDeviceCapabilities(ctx context.Context) bool {
+	agentCaps := c.sandbox.agent.capabilities()
+	hypervisorCaps := c.sandbox.hypervisor.Capabilities(ctx)
+
+	return agentCaps.IsBlockDeviceSupported() && hypervisorCaps.IsBlockDeviceHotplugSupported()
+}
+
 func (c *Container) checkBlockDeviceSupport(ctx context.Context) bool {
-	if !c.sandbox.config.HypervisorConfig.DisableBlockDeviceUse {
-		agentCaps := c.sandbox.agent.capabilities()
-		hypervisorCaps := c.sandbox.hypervisor.Capabilities(ctx)
-
-		if agentCaps.IsBlockDeviceSupported() && hypervisorCaps.IsBlockDeviceHotplugSupported() {
-			return true
-		}
-	}
-
-	return false
+	return !c.sandbox.config.HypervisorConfig.DisableBlockDeviceUse &&
+		c.checkBlockDeviceCapabilities(ctx)
 }
 
 // Sort the devices starting with device #1 being the VFIO control group

--- a/src/runtime/virtcontainers/container_linux_test.go
+++ b/src/runtime/virtcontainers/container_linux_test.go
@@ -7,6 +7,7 @@ package virtcontainers
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,8 +17,11 @@ import (
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/manager"
+	volume "github.com/kata-containers/kata-containers/src/runtime/pkg/direct-volume"
 	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist"
+	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -300,4 +304,163 @@ func TestContainerRootfsPath(t *testing.T) {
 
 	container.hotplugDrive(sandbox.ctx)
 	assert.Equal(t, container.rootfsSuffix, "rootfs")
+}
+
+func TestContainerRootfsBlockDeviceUseDisabled(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(testDisabledAsNonRoot)
+	}
+
+	testRawFile, loopDev, fakeRootfs, err := testSetupFakeRootfs(t)
+	defer cleanupFakeRootfsSetup(testRawFile, loopDev, fakeRootfs)
+	assert.NoError(t, err)
+
+	savedCheckStorageDriver := checkStorageDriver
+	checkStorageDriver = func(major, minor int) (bool, error) {
+		return true, nil
+	}
+	defer func() {
+		checkStorageDriver = savedCheckStorageDriver
+	}()
+
+	sandbox := &Sandbox{
+		ctx:        context.Background(),
+		id:         testSandboxID,
+		devManager: manager.NewDeviceManager(config.VirtioBlock, false, "", 0, nil),
+		hypervisor: &blockCapsHypervisor{supported: true},
+		agent:      &blockCapsAgent{supported: true},
+		config: &SandboxConfig{
+			HypervisorConfig: HypervisorConfig{
+				DisableBlockDeviceUse: true,
+			},
+		},
+	}
+	container := &Container{
+		sandbox: sandbox,
+		id:      "rootfsblockdeviceusetest",
+		rootFs:  RootFs{Target: fakeRootfs, Mounted: true},
+	}
+
+	assert.NoError(t, container.hotplugDrive(sandbox.ctx))
+	assert.Empty(t, container.state.BlockDeviceID)
+}
+
+type blockCapsAgent struct {
+	mockAgent
+	supported bool
+}
+
+func (a *blockCapsAgent) capabilities() types.Capabilities {
+	caps := types.Capabilities{}
+	if a.supported {
+		caps.SetBlockDeviceSupport()
+	}
+	return caps
+}
+
+type blockCapsHypervisor struct {
+	mockHypervisor
+	supported bool
+}
+
+func (h *blockCapsHypervisor) Capabilities(ctx context.Context) types.Capabilities {
+	caps := types.Capabilities{}
+	if h.supported {
+		caps.SetBlockDeviceHotplugSupport()
+	}
+	return caps
+}
+
+func TestCreateBlockDevicesDirectVolume(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(testDisabledAsNonRoot)
+	}
+
+	tests := []struct {
+		name                  string
+		directVolume          bool
+		disableBlockDeviceUse bool
+		agentSupport          bool
+		hypervisorSupport     bool
+		mountInfo             string
+		expectDevice          bool
+	}{
+		{name: "direct volume with block device use disabled", directVolume: true, disableBlockDeviceUse: true, agentSupport: true, hypervisorSupport: true, expectDevice: true},
+		{name: "block file mount with block device use disabled", disableBlockDeviceUse: true, agentSupport: true, hypervisorSupport: true},
+		{name: "block file mount with block device use enabled", agentSupport: true, hypervisorSupport: true, expectDevice: true},
+		{name: "direct volume without agent support", directVolume: true, disableBlockDeviceUse: true, hypervisorSupport: true},
+		{name: "direct volume without hypervisor hotplug support", directVolume: true, disableBlockDeviceUse: true, agentSupport: true},
+		{name: "direct volume with an empty device", directVolume: true, disableBlockDeviceUse: true, agentSupport: true, hypervisorSupport: true, mountInfo: `{"volume-type":"block","device":"","fstype":"ext4"}`},
+		{name: "direct volume with malformed mount info", directVolume: true, disableBlockDeviceUse: true, agentSupport: true, hypervisorSupport: true, mountInfo: `{`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			tmpDir := t.TempDir()
+			deviceFile := filepath.Join(tmpDir, "disk.img")
+			assert.NoError(os.WriteFile(deviceFile, []byte("disk"), 0600))
+
+			source := deviceFile
+			options := []string{vcAnnotations.IsFileBlockDevice}
+
+			if tt.directVolume {
+				source = filepath.Join(tmpDir, "volume")
+				assert.NoError(os.Mkdir(source, DirMode))
+				options = nil
+
+				if tt.mountInfo != "" {
+					volumeDir := filepath.Join("/run/kata-containers/shared/direct-volumes",
+						b64.URLEncoding.EncodeToString([]byte(source)))
+					assert.NoError(os.MkdirAll(volumeDir, DirMode))
+					assert.NoError(os.WriteFile(filepath.Join(volumeDir, "mountInfo.json"), []byte(tt.mountInfo), 0600))
+				} else {
+					err := volume.AddMountInfo(source, volume.MountInfo{
+						VolumeType: "block",
+						Device:     deviceFile,
+						FsType:     "ext4",
+					})
+					assert.NoError(err)
+				}
+				defer volume.Remove(source)
+			}
+
+			sandbox := &Sandbox{
+				ctx:        context.Background(),
+				id:         testSandboxID,
+				devManager: manager.NewDeviceManager(config.VirtioBlock, false, "", 0, nil),
+				hypervisor: &blockCapsHypervisor{supported: tt.hypervisorSupport},
+				agent:      &blockCapsAgent{supported: tt.agentSupport},
+				config: &SandboxConfig{
+					EmptyDirMode: EmptyDirModeSharedFs,
+					HypervisorConfig: HypervisorConfig{
+						DisableBlockDeviceUse: tt.disableBlockDeviceUse,
+					},
+				},
+			}
+
+			container := &Container{
+				sandbox:   sandbox,
+				sandboxID: testSandboxID,
+				id:        "blockdevicetestcontainer",
+				mounts: []Mount{{
+					Source:      source,
+					Destination: "/data",
+					Type:        "bind",
+					Options:     options,
+				}},
+			}
+
+			assert.NoError(container.createBlockDevices(sandbox.ctx))
+
+			if tt.expectDevice {
+				assert.NotEmpty(container.mounts[0].BlockDeviceID)
+				assert.Equal(deviceFile, container.mounts[0].Source)
+			} else {
+				assert.Empty(container.mounts[0].BlockDeviceID)
+				assert.Equal(source, container.mounts[0].Source)
+			}
+		})
+	}
 }

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -433,3 +433,32 @@ func TestConfigValid(t *testing.T) {
 	result = config.valid()
 	assert.True(result)
 }
+
+func TestAllowBlockDeviceForMount(t *testing.T) {
+	const emptyDirSource = "/var/lib/kubelet/pods/pod-uid/volumes/kubernetes.io~empty-dir/scratch"
+	const bindSource = "/var/lib/kubelet/pods/pod-uid/volumes/kubernetes.io~csi/data"
+
+	tests := []struct {
+		name                  string
+		disableBlockDeviceUse bool
+		emptyDirMode          string
+		mountSource           string
+		hasDirectVolume       bool
+		expected              bool
+	}{
+		{"block device use enabled", false, EmptyDirModeSharedFs, bindSource, false, true},
+		{"direct volume with block device use disabled", true, EmptyDirModeSharedFs, bindSource, true, true},
+		{"ordinary mount with block device use disabled", true, EmptyDirModeSharedFs, bindSource, false, false},
+		{"block emptyDir with block device use disabled", true, EmptyDirModeVirtioBlkPlain, emptyDirSource, false, true},
+		{"encrypted block emptyDir with block device use disabled", true, EmptyDirModeVirtioBlkEncrypted, emptyDirSource, false, true},
+		{"block emptyDir mode with an ordinary mount", true, EmptyDirModeVirtioBlkPlain, bindSource, false, false},
+		{"shared-fs emptyDir with block device use disabled", true, EmptyDirModeSharedFs, emptyDirSource, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := allowBlockDeviceForMount(tt.disableBlockDeviceUse, tt.emptyDirMode, tt.mountSource, tt.hasDirectVolume)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description

I have a use-case where I would like to generally keep `disable_block_device_use = true` by default for security reasons (described in https://github.com/kata-containers/kata-containers/security/advisories/GHSA-5fc8-gg7w-3g5c +  https://github.com/kata-containers/kata-containers/commit/20ca4d2) but I would still like to be able to have direct-assigned volumes plugged as block devices and not use virtiofs for performance reasons.

Direct-assigned volumes should be safe to hotplug because the CSI driver writes an explicit volume -> device mapping in `mountInfo.json` so there's no risk of inadvertently exposing host data (that's what the commit was trying to protect from)

This PR makes Kata read `mountInfo.json` first and if an explicit direct-assigned volume is present, it's honored even when `disable_block_device_use = true`. Everything else is unchanged: the rootfs guessing stays disabled, and ordinary bind mounts still get no block device. I got an AI agent write a bunch of unit tests to confirm that it's working as intended (so most of this PR is tests essentially)

btw I saw that someone else tried to implement a similar functionality in https://github.com/kata-containers/kata-containers/pull/12863 but my change is way more minimal, because here I'm _only_ allowing direct-assigned volumes and everything else stays blocked. IIUC there was some concern in that PR review because the logic was relying on the `IsFileBlockDevice` annotation for safety decisions but that shouldn't happen here because we are only relying on `mountInfo.json`