### PR TITLE
runtime-rs: stop VM on sandbox-id Kill and Wait miss

### DIFF
--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -8,9 +8,9 @@ use anyhow::{anyhow, Context, Result};
 use common::{
     message::{Action, Message},
     types::{
-        ContainerProcess, PlatformInfo, ProcessType, SandboxConfig, SandboxRequest,
-        SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest, TaskResponse,
-        DEFAULT_SHM_SIZE,
+        ContainerProcess, PlatformInfo, ProcessExitStatus, ProcessType, SandboxConfig,
+        SandboxRequest, SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest,
+        TaskResponse, DEFAULT_SHM_SIZE,
     },
     RuntimeHandler, RuntimeInstance, Sandbox, SandboxNetworkEnv,
 };
@@ -687,6 +687,18 @@ impl RuntimeHandlerManager {
             }
             TaskRequest::KillProcess(req) => {
                 cm.kill_process(&req).await.context("kill process")?;
+                // containerd StopPodSandbox Kills the sandbox/pause task id
+                // (ctr tasks: sid RUNNING pid=qemu). The shim has no guest
+                // container for that id ("Signal 9 ignored"), so nobody
+                // called stop() and Wait blocked on the live QEMU.
+                // is_sandbox_container compares container_id to sid and
+                // does not need the container map.
+                if cm.is_sandbox_container(&req.process).await {
+                    sandbox
+                        .stop()
+                        .await
+                        .context("stop sandbox on sandbox-id kill")?;
+                }
                 Ok(TaskResponse::KillProcess)
             }
             TaskRequest::ShutdownContainer(req) => {
@@ -701,8 +713,25 @@ impl RuntimeHandlerManager {
                 Ok(TaskResponse::ShutdownContainer)
             }
             TaskRequest::WaitProcess(process_id) => {
-                let exit_status = cm.wait_process(&process_id).await.context("wait process")?;
-                if cm.is_sandbox_container(&process_id).await {
+                let is_sandbox = cm.is_sandbox_container(&process_id).await;
+                let exit_status = match cm.wait_process(&process_id).await {
+                    Ok(status) => status,
+                    Err(err) if is_sandbox => {
+                        // Pause task exists in containerd but was never in
+                        // the shim container map (start failed after QEMU
+                        // pid was published). Wait would error and
+                        // containerd waitpid's QEMU forever.
+                        warn!(
+                            sl!(),
+                            "wait sandbox container missing ({:#}); stopping VM", err
+                        );
+                        let mut status = ProcessExitStatus::new();
+                        status.update_exit_code(137);
+                        status
+                    }
+                    Err(err) => return Err(err).context("wait process"),
+                };
+                if is_sandbox {
                     sandbox.stop().await.context("stop sandbox")?;
 
                     // Release sandbox resources (cgroup, network, mounts, ...)


### PR DESCRIPTION
## Summary

`containerd` `StopPodSandbox` Kills the sandbox/pause task id (the QEMU
pid published at Start). runtime-rs has no guest container for that id,
so Kill is ignored (`Signal 9 ignored due to container not existing`)
and nobody calls `sandbox.stop()`. `WaitProcess` then errors and
containerd `waitpid`s live QEMU. The pod stays `Terminating`.
`crictl stopp --timeout 120s` returns `DeadlineExceeded`.

This PR:

- On sandbox-id `Kill`, call `sandbox.stop()` even when the container
  map has no entry. `is_sandbox_container` compares `container_id` to
  `sid` and does not need the map.
- On `WaitProcess`, if the sandbox container is missing, return exit
  137 and still run the existing sandbox-id `stop` + `cleanup` path.

Does **not** call `stop()` on every container SIGKILL. An init
CrashLoop would mark the sandbox `Stopped` and the next
`CreateContainer` would fail with `sandbox already stopped`.

Fixes #13665

Related: #13564 (teardown). Complementary to #13597 (non-blocking
`stop()` once it is called). Distinct from #13641 (inotify D-state):
on this path QEMU stayed Running because `stop()` was never invoked.

Independent of the #13595–#13598 stack. Please review this commit
alone.

## Test plan

- [x] CPU TDX smoke (`kata-qemu-tdx`): sandbox-id Kill called
      `stop()`; Running→Stopped in ~415 ms; no D-state; pod left
      Terminating
- [x] Production: Kata 4.0 runtime-rs, Intel TDX + NVIDIA GPU,
      HGX B200. After this change in the shim overlay, a ~1.2 TiB
      CC guest (`glm-5-2-nvfp4-sglang-0`) reached `2/2 Running`.
      Earlier stock-shim StopPodSandbox left QEMU live (taps/GPUs
      held; later `TUNSETIFF EBUSY` / leftover QEMU)
- [ ] Kata CI (`runtime-rs` / QEMU)

Made with [Cursor](https://cursor.com)