### PR TITLE
runtime-rs: ch: cold-plug block devices requested before boot

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -123,6 +123,7 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
         let fs = n.shared_fs_devices;
         let net = n.network_devices;
         let host_devices = n.host_devices;
+        let boot_disks = n.boot_disks;
         let protection_dev = n.protection_device;
 
         let template_memory = if cfg.vm_template.boot_to_be_template {
@@ -175,6 +176,12 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
 
             disks.push(disk);
         };
+
+        // Append the cold-plugged block devices (such as the initdata image)
+        // after the VM rootfs so that the rootfs keeps the first slot.
+        if let Some(boot_disks) = boot_disks {
+            disks.extend(boot_disks);
+        }
 
         let disks = if !disks.is_empty() { Some(disks) } else { None };
 

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -542,6 +542,8 @@ pub struct NamedHypervisorConfig {
     pub network_devices: Option<Vec<NetConfig>>,
     pub host_devices: Option<Vec<DeviceConfig>>,
 
+    pub boot_disks: Option<Vec<DiskConfig>>,
+
     // Set to the available guest protection *iff* BOTH of the following
     // conditions are true:
     //

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -53,16 +53,17 @@ impl CloudHypervisorInner {
             // If the VM is not running, add the device to the pending list to
             // be handled later.
             //
-            // Note that the only device types considered are DeviceType::ShareFs
-            // and DeviceType::Network since:
+            // Note that:
             //
             // - ShareFs (virtiofsd) is only needed in an non-DM and non-TDX scenario
             //   for the container rootfs.
             //
-            // - For all other scenarios, the container rootfs is handled by a
-            //   DeviceType::BlockModern and this method is called *after* the
-            //   VM has started so the device does not need to be added to the
-            //   pending list.
+            // - A DeviceType::BlockModern requested before the VM is running
+            //   has to be cold-plugged, meaning it is turned into an entry of
+            //   VmConfig.disks (see 'convert.rs'). This is required for devices
+            //   the guest needs early on in its boot, such as the initdata
+            //   image. Container rootfs block devices are unaffected as they
+            //   are added *after* the VM has started and hence hot-plugged.
             //
             // - The VM rootfs is handled without waiting for calls to this
             //   method as the file in question (image= or initrd=) is available
@@ -76,6 +77,7 @@ impl CloudHypervisorInner {
                 DeviceType::Network(_) => self.pending_devices.insert(0, device.clone()),
                 DeviceType::Vfio(_) => self.pending_devices.insert(0, device.clone()),
                 DeviceType::Protection(_) => self.pending_devices.insert(0, device.clone()),
+                DeviceType::BlockModern(_) => self.pending_devices.insert(0, device.clone()),
                 _ => {
                     debug!(
                         sl!(),
@@ -278,6 +280,34 @@ impl CloudHypervisorInner {
         Ok(DeviceType::HybridVsock(device))
     }
 
+    fn make_disk_config(&self, config: &BlockConfigModern) -> Result<DiskConfig> {
+        let mut disk_config = DiskConfig::try_from(config.clone())?;
+
+        disk_config.direct = config
+            .is_direct
+            .unwrap_or(self.config.blockdev_info.block_device_cache_direct);
+
+        disk_config.rate_limiter_config = RateLimiterConfig::new(
+            self.config.blockdev_info.disk_rate_limiter_bw_max_rate,
+            self.config.blockdev_info.disk_rate_limiter_ops_max_rate,
+            self.config
+                .blockdev_info
+                .disk_rate_limiter_bw_one_time_burst,
+            self.config
+                .blockdev_info
+                .disk_rate_limiter_ops_one_time_burst,
+        );
+
+        Ok(disk_config)
+    }
+
+    fn is_vm_boot_file(&self, path: &str) -> bool {
+        let boot_info = &self.config.boot_info;
+
+        (!boot_info.image.is_empty() && path == boot_info.image)
+            || (!boot_info.initrd.is_empty() && path == boot_info.initrd)
+    }
+
     async fn handle_block_device(
         &mut self,
         device: Arc<Mutex<BlockDeviceModern>>,
@@ -288,22 +318,7 @@ impl CloudHypervisorInner {
             (dev.device_id.clone(), dev.config.clone())
         };
 
-        let mut disk_config = DiskConfig::try_from(config.clone())?;
-        disk_config.direct = config
-            .is_direct
-            .unwrap_or(self.config.blockdev_info.block_device_cache_direct);
-
-        let block_rate_limit = RateLimiterConfig::new(
-            self.config.blockdev_info.disk_rate_limiter_bw_max_rate,
-            self.config.blockdev_info.disk_rate_limiter_ops_max_rate,
-            self.config
-                .blockdev_info
-                .disk_rate_limiter_bw_one_time_burst,
-            self.config
-                .blockdev_info
-                .disk_rate_limiter_ops_one_time_burst,
-        );
-        disk_config.rate_limiter_config = block_rate_limit;
+        let disk_config = self.make_disk_config(&config)?;
 
         let response = cloud_hypervisor_vm_blockdev_add(&self.api_socket, disk_config).await?;
 
@@ -359,11 +374,13 @@ impl CloudHypervisorInner {
         Option<Vec<NetConfig>>,
         Option<Vec<DeviceConfig>>,
         Option<ProtectionDevConfig>,
+        Option<Vec<DiskConfig>>,
     )> {
         let mut shared_fs_devices = Vec::<FsConfig>::new();
         let mut network_devices = Vec::<NetConfig>::new();
         let mut host_devices = Vec::<DeviceConfig>::new();
         let mut protection_device = ProtectionDevConfig::default();
+        let mut boot_disks = Vec::<DiskConfig>::new();
 
         while let Some(dev) = self.pending_devices.pop() {
             match dev {
@@ -482,6 +499,30 @@ impl CloudHypervisorInner {
                         _ => info!(sl!(), "CH: unsupported protection device type"),
                     }
                 }
+                DeviceType::BlockModern(block_device) => {
+                    let config = block_device.lock().await.config.clone();
+
+                    if self.is_vm_boot_file(&config.path_on_host) {
+                        // Already handled through the VmConfig payload/disks.
+                        continue;
+                    }
+
+                    // The disk configuration has no serial field, so a device
+                    // the guest finds by serial would be unusable.
+                    if !config.serial_override.is_empty() {
+                        warn!(
+                            sl!(),
+                            "not cold-plugging block device {:?}: its serial {:?} cannot be expressed",
+                            config.path_on_host,
+                            config.serial_override
+                        );
+                        continue;
+                    }
+
+                    info!(sl!(), "cold-plugging block device {:?}", &config);
+
+                    boot_disks.push(self.make_disk_config(&config)?);
+                }
                 _ => continue,
             }
         }
@@ -491,6 +532,7 @@ impl CloudHypervisorInner {
             Some(network_devices),
             Some(host_devices),
             Some(protection_device),
+            Some(boot_disks),
         ))
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -334,8 +334,11 @@ impl CloudHypervisorInner {
         // Convert pairs into the actual queue count.
         clh_net_config.num_queues = netdev.config.queue_num.max(1) * 2;
 
-        let files = open_named_tuntap(&netdev.config.host_dev_name, netdev.config.queue_num.max(1) as u32)
-            .context("open named tuntap")?;
+        let files = open_named_tuntap(
+            &netdev.config.host_dev_name,
+            netdev.config.queue_num.max(1) as u32,
+        )
+        .context("open named tuntap")?;
 
         let fds = files.iter().map(|f| f.as_raw_fd()).collect();
 

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -192,7 +192,7 @@ impl CloudHypervisorInner {
     }
 
     async fn boot_vm(&mut self) -> Result<()> {
-        let (shared_fs_devices, network_devices, host_devices, protection_device) =
+        let (shared_fs_devices, network_devices, host_devices, protection_device, boot_disks) =
             self.get_shared_devices().await?;
 
         let sandbox_path = get_sandbox_path(&self.id);
@@ -218,6 +218,7 @@ impl CloudHypervisorInner {
             guest_protection_to_use: self.guest_protection_to_use.clone(),
             shared_fs_devices,
             host_devices,
+            boot_disks,
             protection_device,
             ..Default::default()
         };

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -871,6 +871,8 @@ impl VirtSandbox {
             is_readonly: true,
             driver_option: block_driver.clone(),
             blkdev_aio: BlockDeviceAio::Native,
+            num_queues: hypervisor_config.blockdev_info.num_queues,
+            queue_size: hypervisor_config.blockdev_info.queue_size,
             ..Default::default()
         };
         let initdata_config = InitDataConfig(block_config, initdata_digest);

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -211,6 +211,9 @@ function deploy_kata() {
 	if [[ "${KATA_HYPERVISOR}" = "qemu" ]]; then
 		ANNOTATIONS="image initrd kernel default_vcpus"
 	fi
+	if [[ "${KATA_HYPERVISOR}" = "clh-runtime-rs" ]]; then
+		ANNOTATIONS+=" cc_init_data"
+	fi
 	# The NVIDIA runtime classes ship with the hypervisor annotations disabled,
 	# so the ones a few tests depend on have to be opted into here.
 	if is_nvidia_hypervisor "${KATA_HYPERVISOR}" || is_confidential_gpu_hypervisor "${KATA_HYPERVISOR}"; then

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -597,7 +597,7 @@ hard_coded_policy_tests_enabled() {
 	# CI is testing hard-coded policies just on a the platforms listed here. Outside of CI,
 	# users can enable testing of the same policies (plus the auto-generated policies) by
 	# specifying AUTO_GENERATE_POLICY=yes.
-	local -r enabled_hypervisors=("qemu-coco-dev" "qemu-snp" "qemu-snp-runtime-rs" "qemu-tdx" "qemu-tdx-runtime-rs" "qemu-coco-dev-runtime-rs")
+	local -r enabled_hypervisors=("qemu-coco-dev" "qemu-snp" "qemu-snp-runtime-rs" "qemu-tdx" "qemu-tdx-runtime-rs" "qemu-coco-dev-runtime-rs" "clh-runtime-rs" "clh-azure-runtime-rs")
 	for enabled_hypervisor in "${enabled_hypervisors[@]}"
 	do
 		if [[ "${enabled_hypervisor}" == "${KATA_HYPERVISOR}" ]]; then


### PR DESCRIPTION
- runtime-rs: ch: cold-plug block devices requested before boot (this allows us to pass the initdata device to the guest)
- tests: k8s: run the hard-coded policy tests on the CLH runtime-rs classes

Fixes https://github.com/kata-containers/kata-containers/issues/12720