### PR TITLE
agent: fall back to fsmount when overlay options exceed 4K

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,6 +3603,7 @@ dependencies = [
  "rstest",
  "rtnetlink 0.14.1",
  "runtime-spec",
+ "rustix 0.38.44",
  "rustjail",
  "s390_pv_core",
  "safe-path",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -91,6 +91,8 @@ async-compression = { version = "0.4.22", features = ["tokio", "gzip"] }
 
 container-device-interface.workspace = true
 
+rustix = { version = "0.38.44", features = ["mount"] }
+
 [target.'cfg(target_arch = "s390x")'.dependencies]
 pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504a9a2977d49989a5e5b7c1c8e07dc0fa41", package = "s390_pv_core" }
 

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -6,16 +6,25 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::os::fd::AsFd;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use kata_sys_util::mount::{create_mount_destination, parse_mount_options};
+use kata_sys_util::mount::{
+    create_mount_destination, parse_mount_flags, parse_mount_options, Error as MountError,
+};
 use kata_types::mount::{StorageDevice, StorageHandlerManager, KATA_SHAREDFS_GUEST_PREMOUNT_TAG};
+use nix::mount::MsFlags;
 use nix::unistd::{Gid, Uid};
 use protocols::agent::Storage;
 use protocols::types::FSGroupChangePolicy;
+use rustix::fs::CWD;
+use rustix::mount::{
+    fsconfig_create, fsconfig_set_flag, fsconfig_set_string, fsmount, fsopen, move_mount,
+    FsMountFlags, FsOpenFlags, MountAttrFlags, MoveMountFlags,
+};
 use slog::Logger;
 use tokio::sync::Mutex;
 use tracing::instrument;
@@ -395,6 +404,83 @@ pub(crate) fn common_storage_handler(logger: &Logger, storage: &Storage) -> Resu
     Ok(storage.mount_point.clone())
 }
 
+fn split_lowerdirs(lowerdirs: &str) -> Vec<String> {
+    let mut dirs = vec![String::new()];
+    let mut chars = lowerdirs.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            if let Some(next @ (':' | '\\')) = chars.peek().copied() {
+                dirs.last_mut().unwrap().push(next);
+                chars.next();
+                continue;
+            }
+        } else if ch == ':' {
+            dirs.push(String::new());
+            continue;
+        }
+        dirs.last_mut().unwrap().push(ch);
+    }
+
+    dirs
+}
+
+fn mount_overlay_new_api(storage: &Storage) -> Result<()> {
+    let fs_fd = fsopen("overlay", FsOpenFlags::FSOPEN_CLOEXEC)?;
+    let mut flags = MsFlags::empty();
+
+    for option in &storage.options {
+        if let Some(lowerdirs) = option.strip_prefix("lowerdir=") {
+            for lowerdir in split_lowerdirs(lowerdirs) {
+                fsconfig_set_string(fs_fd.as_fd(), "lowerdir+", lowerdir)?;
+            }
+        } else if !option.contains('=') {
+            if let Some(next) = parse_mount_flags(flags, option) {
+                flags = next;
+            } else {
+                fsconfig_set_flag(fs_fd.as_fd(), option)?;
+            }
+        } else if let Some((key, value)) = option.split_once('=') {
+            fsconfig_set_string(fs_fd.as_fd(), key, value)?;
+        }
+    }
+
+    let mut attrs = MountAttrFlags::empty();
+    if flags.contains(MsFlags::MS_RDONLY) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_RDONLY);
+    }
+    if flags.contains(MsFlags::MS_NOSUID) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_NOSUID);
+    }
+    if flags.contains(MsFlags::MS_NODEV) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_NODEV);
+    }
+    if flags.contains(MsFlags::MS_NOEXEC) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_NOEXEC);
+    }
+    if flags.contains(MsFlags::MS_NODIRATIME) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_NODIRATIME);
+    }
+    if flags.contains(MsFlags::MS_STRICTATIME) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_STRICTATIME);
+    } else if flags.contains(MsFlags::MS_NOATIME) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_NOATIME);
+    } else if flags.contains(MsFlags::MS_RELATIME) {
+        attrs.insert(MountAttrFlags::MOUNT_ATTR_RELATIME);
+    }
+
+    fsconfig_create(fs_fd.as_fd())?;
+    let mount_fd = fsmount(fs_fd.as_fd(), FsMountFlags::FSMOUNT_CLOEXEC, attrs)?;
+    move_mount(
+        mount_fd.as_fd(),
+        "",
+        CWD,
+        storage.mount_point.as_str(),
+        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+    )?;
+    Ok(())
+}
+
 // mount_storage performs the mount described by the storage structure.
 #[instrument]
 fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
@@ -412,12 +498,25 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
         return Ok(());
     }
 
-    let (flags, options) = parse_mount_options(&storage.options)?;
     let mount_path = Path::new(&storage.mount_point);
     let src_path = Path::new(&storage.source);
     create_mount_destination(src_path, mount_path, "", &storage.fstype)
         .context("Could not create mountpoint")?;
 
+    let mount_options = parse_mount_options(&storage.options);
+    if storage.fstype == "overlay"
+        && matches!(&mount_options, Err(MountError::MountOptionTooBig))
+        && storage.options.iter().any(|option| {
+            option
+                .strip_prefix("lowerdir=")
+                .is_some_and(|lowerdirs| split_lowerdirs(lowerdirs).len() > 1)
+        })
+    {
+        mount_overlay_new_api(storage).context("failed to mount overlay with new mount API")?;
+        return Ok(());
+    }
+
+    let (flags, options) = mount_options?;
     info!(logger, "mounting storage";
         "mount-source" => src_path.display(),
         "mount-destination" => mount_path.display(),

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -433,7 +433,7 @@ pub fn parse_mount_options<T: AsRef<str>>(options: &[T]) -> Result<(MsFlags, Str
     Ok((flags, data))
 }
 
-fn parse_mount_flags(mut flags: MsFlags, flag_str: &str) -> Option<MsFlags> {
+pub fn parse_mount_flags(mut flags: MsFlags, flag_str: &str) -> Option<MsFlags> {
     // Following mount options are applicable to fstab only.
     // - _netdev: The filesystem resides on a device that requires network access (used to prevent
     //   the system from attempting to mount these filesystems until the network has been enabled


### PR DESCRIPTION
The erofs snapshotter mounts each image layer as its own erofs, then stacks them with overlay. Guest paths look like
`/run/kata-containers/virtual-volumes/<b64>/...` and are joined into one `lowerdir=a:b:c:...` string. A typical image with tens of layers pushes that string past `PAGE_SIZE` (~4K), so `mount(2)` fails.

**Before (fails)** — kata-agent rejects the overlay mount:
<img width="1064" height="381" alt="image" src="https://github.com/user-attachments/assets/8eba9bf7-bb05-4c6a-9538-4e17f62dd1db" />

**After (succeeds)** — same image: agent falls back to `fsopen`/`fsconfig`/`fsmount` and passes each layer via `lowerdir+`.Container reaches running.
<img width="1075" height="214" alt="image" src="https://github.com/user-attachments/assets/ef22ae46-852d-476f-ab27-dbedda052888" />