### PR TITLE
agent: synchronize initrd clocks with KVM PTP

### DIFF
--- a/src/agent/src/clock_sync.rs
+++ b/src/agent/src/clock_sync.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use slog::{info, warn, Logger};
+use std::path::Path;
+use tokio::process::Command;
+
+const CHRONYD_PATH: &str = "/usr/sbin/chronyd";
+const CHRONY_CONFIG_PATH: &str = "/etc/chrony/chrony.conf";
+const KVM_PTP_DEVICE: &str = "/dev/ptp0";
+
+fn available(chronyd: &Path, config: &Path, ptp_device: &Path) -> bool {
+    chronyd.is_file() && config.is_file() && ptp_device.exists()
+}
+
+pub async fn start(logger: &Logger) {
+    if !available(
+        Path::new(CHRONYD_PATH),
+        Path::new(CHRONY_CONFIG_PATH),
+        Path::new(KVM_PTP_DEVICE),
+    ) {
+        warn!(logger, "guest clock synchronization unavailable");
+        return;
+    }
+
+    info!(logger, "starting guest clock synchronization"; "source" => KVM_PTP_DEVICE);
+    if let Err(err) = Command::new(CHRONYD_PATH).args(["-d", "-F", "2"]).spawn() {
+        warn!(logger, "failed to start guest clock synchronization"; "error" => format!("{err:#}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_available() {
+        let dir = tempdir().unwrap();
+        let chronyd = dir.path().join("chronyd");
+        let config = dir.path().join("chrony.conf");
+        let ptp_device = dir.path().join("ptp0");
+
+        fs::write(&chronyd, []).unwrap();
+        fs::write(&config, []).unwrap();
+        fs::write(&ptp_device, []).unwrap();
+
+        assert!(available(&chronyd, &config, &ptp_device));
+
+        fs::remove_file(&ptp_device).unwrap();
+        assert!(!available(&chronyd, &config, &ptp_device));
+    }
+}

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -38,6 +38,7 @@ use std::process::exit;
 use std::sync::Arc;
 use tracing::{instrument, span};
 
+mod clock_sync;
 mod confidential_data_hub;
 mod config;
 mod console;
@@ -403,6 +404,10 @@ async fn start_sandbox(
     ));
 
     tasks.push(signal_handler_task);
+
+    if init_mode {
+        clock_sync::start(logger).await;
+    }
 
     let uevents_handler_task = tokio::spawn(watch_uevents(sandbox.clone(), shutdown.clone()));
 

--- a/tools/osbuilder/rootfs-builder/alpine/config.sh
+++ b/tools/osbuilder/rootfs-builder/alpine/config.sh
@@ -17,7 +17,7 @@ BASE_PACKAGES="alpine-base"
 # shellcheck disable=SC2034
 MIRROR=http://dl-cdn.alpinelinux.org/alpine/
 
-PACKAGES="bash iptables ip6tables"
+PACKAGES="bash chrony iptables ip6tables"
 
 # Init process must be one of {systemd,kata-agent}
 # shellcheck disable=SC2034

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -742,6 +742,10 @@ EOF
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chrony.service"
 			;;
+		"alpine")
+			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
+			chrony_systemd_service=""
+			;;
 		*)
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/usr/lib/systemd/system/chronyd.service"
@@ -749,6 +753,7 @@ EOF
 	esac
 
 	info "Configure chrony file ${chrony_conf_file}"
+	mkdir -p "$(dirname "${chrony_conf_file}")"
 	cat >> "${chrony_conf_file}" <<EOF
 refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
 # Step the system clock instead of slewing it if the adjustment is larger than
@@ -758,7 +763,7 @@ EOF
 
 	# Comment out ntp sources for chrony to be extra careful
 	# Reference:  https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html
-	sed -i 's/^\(server \|pool \|peer \)/# &/g'  "${chrony_conf_file}"
+	sed -i 's/^\(server \|pool \|peer \|initstepslew \)/# &/g' "${chrony_conf_file}"
 
 	if [[ -f "${chrony_systemd_service}" ]]; then
 		# Remove user option, user could not exist in the rootfs


### PR DESCRIPTION
Alpine initrd guests run kata-agent as PID 1 and do not start the systemd Chrony service used by image guests. Their kvm-clock can therefore diverge from a host clock that is continuously adjusted.

Package Chrony in Alpine root filesystems and configure it to use /dev/ptp0 without external time sources. Start it as a foreground kata-agent child when KVM PTP is available. Treat startup as non-fatal and log unavailable prerequisites.