### PR TITLE
Revert "packaging: update OVMF for Intel TDX"

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -366,7 +366,7 @@ externals:
       package_output_dir: "AmdSev"
     tdx:
       description: "UEFI for Intel TDX virtual machines."
-      version: "edk2-stable202605"
+      version: "edk2-stable202511"
       package: "OvmfPkg/IntelTdx/IntelTdxX64.dsc"
       package_output_dir: "IntelTdx"
     arm64:


### PR DESCRIPTION
This reverts commit 747eff991b5a82a0036df90c1589eb4c44504a89.

There are strong signals that edk2-202605 makes some Nightly CI tests to fail on TDX. These failing tests are not run part of baremetal-small-tee suite so we missed them in the PR checks:

Go runtime / qemu-tdx: k8s-limit-range, k8s-number-cpus, k8s-qos-pods, k8s-sandbox-vcpus-allocation. The failures are consistent: VMs time out connecting to the agent over vsock.