### PR TITLE
runtime: keep the pause container free of cold-plug VFIO devices

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1199,32 +1199,22 @@ func (c *Container) createDevices(ctx context.Context, contConfig *ContainerConf
 		hotPlugDevices = append(hotPlugDevices, deviceInfos[i])
 	}
 
-	// If modeVFIO is enabled we need 1st to attach the VFIO control group
-	// device /dev/vfio/vfio an 2nd the actuall device(s) afterwards.
-	// Sort the devices starting with device #1 being the VFIO control group
-	// device and the next the actuall device(s) /dev/vfio/<group>
+	// Cold-plugged devices are already attached to the VM, but workload
+	// containers keep them in their device list because the agent needs
+	// the entries: to create the in-guest /dev/vfio nodes (vfio_mode =
+	// "vfio") and to build the host->guest PCI mapping that
+	// PCIDEVICE_<RES> env var translation relies on (vfio_mode =
+	// "guest-kernel"). FindDevice matches the sandbox-level device, so
+	// nothing double-attaches.
 	//
-	// Cold-plug VFIO devices must also reach the agent in
-	// `VfioMode == GuestKernel`. The agent's `vfio-pci-gk` handler
-	// returns `dev: None` (so /dev/vfio/<group> is *not* materialised in
-	// the container spec — `constrainGRPCSpec(stripVfio=true)` will have
-	// already removed it from `grpcSpec.Linux.Devices`), but it still
-	// records the host->guest PCI mapping into `sandbox.pcimap[cid]`.
-	// Without that mapping, `update_env_pci` cannot translate the
-	// `PCIDEVICE_<RES>=<host-BDF>` env vars set by the SR-IOV device
-	// plugin and aborts the container creation with
-	// "No PCI mapping found for container <id>".
-	//
-	// `devManager.NewDevice` calls `FindDevice` first, which matches the
-	// already-cold-plugged sandbox-level device by HostPath/major/minor,
-	// so this does not double-attach.
-	if coldPlugVFIO {
-		// DeviceInfo should still be added to the sandbox's device manager
-		// if vfio_mode is VFIO and coldPlugVFIO is true (e.g. vfio-ap-cold).
-		// This ensures that ociSpec.Linux.Devices is updated with
-		// this information before the container is created on the guest.
+	// The CRI sandbox (pause) container never owns any VFIO device, and
+	// the guest rejects a pause CreateContainer that carries one.
+	isCriSandbox := ContainerType(c.config.Annotations[vcAnnotations.ContainerTypeKey]).IsCriSandbox()
+	if coldPlugVFIO && !isCriSandbox {
 		sortedVFIODevices := sortContainerVFIODevices(vfioColdPlugDevices)
-		// Combine sorted VFIO devices with hot-plug devices
+		// The container needs the cold-plug VFIO devices AND the hot-plug
+		// devices (e.g. disks, network) for proper functioning, see
+		// https://github.com/kata-containers/kata-containers/issues/11288
 		deviceInfos = append(sortedVFIODevices, hotPlugDevices...)
 	} else {
 		deviceInfos = sortContainerVFIODevices(hotPlugDevices)

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -1298,6 +1298,7 @@ func TestKataAgentCreateContainerVFIODevices(t *testing.T) {
 		hotPlugVFIO   config.PCIePort
 		coldPlugVFIO  config.PCIePort
 		vfioMode      config.VFIOModeType
+		containerType ContainerType
 		expectVFIODev bool
 	}{
 		{
@@ -1321,6 +1322,25 @@ func TestKataAgentCreateContainerVFIODevices(t *testing.T) {
 			vfioMode:      config.VFIOModeGuestKernel,
 			expectVFIODev: true,
 		},
+		{
+			// The pause container never owns VFIO devices: cold-plugged
+			// devices are sandbox-level and consumed only by workload
+			// containers.
+			name:          "VFIO device with cold plug enabled skipped for CRI sandbox container",
+			hotPlugVFIO:   config.NoPort,
+			coldPlugVFIO:  config.BridgePort,
+			vfioMode:      config.VFIOModeGuestKernel,
+			containerType: PodSandbox,
+			expectVFIODev: false,
+		},
+		{
+			name:          "VFIO device with cold plug enabled kept for CRI workload container",
+			hotPlugVFIO:   config.NoPort,
+			coldPlugVFIO:  config.BridgePort,
+			vfioMode:      config.VFIOModeGuestKernel,
+			containerType: PodContainer,
+			expectVFIODev: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1341,6 +1361,10 @@ func TestKataAgentCreateContainerVFIODevices(t *testing.T) {
 			// Setup container config with the VFIO device
 			contConfig := &ContainerConfig{
 				DeviceInfos: []config.DeviceInfo{vfioDevice},
+				Annotations: map[string]string{},
+			}
+			if tt.containerType != "" {
+				contConfig.Annotations[vcAnnotations.ContainerTypeKey] = string(tt.containerType)
 			}
 
 			// Create mock URL for kata agent


### PR DESCRIPTION
The CRI sandbox (pause) container must never own VFIO devices. Since e6777f086 the cold-plug merge in createDevices applies to every container, so the pause CreateContainer request carries vfio-pci-gk entries for the pod cold-plugged devices and the guest rejects it, failing sandbox creation.

Gate the merge on the container type: workload containers keep the entries (in-guest /dev/vfio nodes for vfio_mode = "vfio", host to guest PCI mapping for PCIDEVICE_<RES> translation for "guest-kernel"), the pause container gets none. This also applies to vfio-ap-cold sandboxes on s390x.

TestKataAgentCreateContainerVFIODevices covers both directions; the pod_sandbox case fails without the fix.
