### PR TITLE
kata-deploy: switch to external k8s-job-dispatcher

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -154,13 +154,14 @@ top-level `deploymentMode` value:
 - **`daemonset`** (default): the long-running `kata-deploy` DaemonSet installs
   Kata on every matching node and reverts it when the pod is terminated (i.e. on
   uninstall). This is the historical behavior and is unchanged.
-- **`job`**: there is **no always-on component**. A tiny *dispatcher* Job (the
-  dispatcher, `kata-deploy-job-dispatcher`) runs as a `post-install`/`post-upgrade` hook,
-  enumerates the selected nodes **live** via the Kubernetes API, and creates one
+- **`job`**: there is **no always-on component**. A tiny
+  [`k8s-job-dispatcher`](https://github.com/kata-containers/k8s-job-dispatcher)
+  Job runs as a `post-install`/`post-upgrade` hook, enumerates the selected nodes
+  **live** via the Kubernetes API, and creates one
   node-pinned install `Job` per node. Each per-node Job runs the staged install
   pipeline as ordered `initContainers` and then exits:
 
-  ```
+  ```text
   host-check -> artifacts   (initContainers)  ->  cri (main)
   ```
 

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -160,10 +160,20 @@ rbac_doc() {
 }
 
 @test "Helm template (job mode): the dispatcher does the node-level work" {
-	local install cleanup
+	local install cleanup rendered
 	install=$(render_job_mode kata-deploy-install-job.yaml \
 		--set 'startupTaints[0]=kata/installing:NoSchedule')
 	cleanup=$(render_job_mode kata-deploy-cleanup-job.yaml)
+
+	for rendered in "${install}" "${cleanup}"; do
+		echo "${rendered}" | grep -q 'image: ghcr.io/kata-containers/k8s-job-dispatcher:0.1.0'
+		echo "${rendered}" | grep -q -- '/usr/bin/k8s-job-dispatcher'
+		echo "${rendered}" | grep -q -- '--tracking-label-prefix=kata-deploy-job-dispatcher'
+		echo "${rendered}" | grep -q -- '--node-label-key=katacontainers.io/kata-runtime'
+		echo "${rendered}" | grep -q -- '--instance-label-prefix=kata-deploy.katacontainers.io'
+		echo "${rendered}" | grep -q -- '--require-node-runtime-version'
+		echo "${rendered}" | grep -q -- '--require-node-machine-id'
+	done
 
 	# Labelling last, and only once the node is Ready again: the install restarts
 	# the node's CRI runtime, and the label is what admits workloads.

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -65,23 +65,10 @@ generate_base_values() {
 	local output_file="$1"
 	local extra_values_file="${2:-}"
 
-	local kata_deploy_image="${DOCKER_REGISTRY}/${DOCKER_REPO}"
-	local dispatcher_image
-	if [[ "${kata_deploy_image}" == *-ci ]]; then
-		dispatcher_image="${kata_deploy_image%-ci}-job-dispatcher-ci"
-	else
-		dispatcher_image="${kata_deploy_image}-job-dispatcher"
-	fi
-
 	cat > "${output_file}" <<EOF
 image:
   reference: ${DOCKER_REGISTRY}/${DOCKER_REPO}
   tag: ${DOCKER_TAG}
-
-job:
-  dispatcherImage:
-    reference: ${dispatcher_image}
-    tag: ${DOCKER_TAG}
 
 k8sDistribution: "${KUBERNETES}"
 debug: true

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -696,19 +696,6 @@ function helm_helper() {
 	fi
 	yq -i ".image.tag = \"${HELM_IMAGE_TAG}\"" "${values_yaml}"
 
-	# Derive the dispatcher image name from the main kata-deploy image,
-	# mirroring the -ci/non-ci logic used by the build/release scripts: the
-	# dispatcher lives at "<base>-job-dispatcher", with the "-ci" suffix (if
-	# any) kept at the very end (e.g. kata-deploy-ci -> kata-deploy-job-dispatcher-ci).
-	local dispatcher_reference
-	if [[ "${HELM_IMAGE_REFERENCE}" == *-ci ]]; then
-		dispatcher_reference="${HELM_IMAGE_REFERENCE%-ci}-job-dispatcher-ci"
-	else
-		dispatcher_reference="${HELM_IMAGE_REFERENCE}-job-dispatcher"
-	fi
-	yq -i ".job.dispatcherImage.reference = \"${dispatcher_reference}\"" "${values_yaml}"
-	yq -i ".job.dispatcherImage.tag = \"${HELM_IMAGE_TAG}\"" "${values_yaml}"
-
 	# Resolve the deployment mode coming from the (base) values file so the
 	# post-install wait below knows whether to expect a DaemonSet or per-node Jobs.
 	local deployment_mode

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -345,7 +345,7 @@ async fn main() -> Result<()> {
 /// dispatcher passed down. An older chart passes none, and then there is nothing to
 /// compare against.
 fn verify_node_machine_id() -> Result<()> {
-    const EXPECTED_ENV: &str = "KATA_DEPLOY_NODE_MACHINE_ID";
+    const EXPECTED_ENV: &str = "NODE_MACHINE_ID";
     const HOST_MACHINE_ID: &str = "/host-machine-id";
 
     let Ok(expected) = std::env::var(EXPECTED_ENV) else {

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -463,15 +463,16 @@ reference:tag (tag defaults to Chart.AppVersion).
 {{- end -}}
 
 {{/*
-Dispatcher image reference for the job-mode dispatcher (kata-deploy-job-dispatcher).
-Supports tag (reference:tag) and digest (reference@sha256:...) formats; tag
-defaults to Chart.AppVersion.
+Image reference for k8s-job-dispatcher.
+Supports tag (reference:tag) and digest (reference@sha256:...) formats.
 */}}
 {{- define "kata-deploy.dispatcherImage" -}}
 {{- $ref := .Values.job.dispatcherImage.reference -}}
-{{- $tag := default .Chart.AppVersion .Values.job.dispatcherImage.tag | toString -}}
+{{- $tag := .Values.job.dispatcherImage.tag | toString -}}
 {{- if contains "@" $ref -}}
 {{- $ref -}}
+{{- else if eq $tag "" -}}
+{{- fail "job.dispatcherImage.tag is required when job.dispatcherImage.reference is not a digest" -}}
 {{- else -}}
 {{- printf "%s:%s" $ref $tag -}}
 {{- end -}}
@@ -719,7 +720,7 @@ e.g. `{{- include "kata-deploy.commonEnv" . | nindent 8 }}`.
 {{/*
 Build a Kubernetes label-selector STRING (the form accepted by the apiserver
 and `kubectl --selector`) from an equality map plus a list of match-expression
-requirements. This is handed to `kata-deploy-job-dispatcher --node-selector`, which
+requirements. This is handed to `k8s-job-dispatcher --node-selector`, which
 resolves the actual target nodes LIVE at run time (so node membership is never
 frozen into the Helm release).
 
@@ -786,6 +787,13 @@ kata-deploy.katacontainers.io/default
 
 {{- define "kata-deploy.dispatcherNodeWorkFlags" -}}
 {{- $root := .root -}}
+{{- /* Preserve the tracking and node-management contract of the dispatcher that
+       originally lived in this repository. */ -}}
+- "--tracking-label-prefix=kata-deploy-job-dispatcher"
+- "--node-label-key=katacontainers.io/kata-runtime"
+- "--instance-label-prefix=kata-deploy.katacontainers.io"
+- "--require-node-runtime-version"
+- "--require-node-machine-id"
 {{- /* Installs share katacontainers.io/kata-runtime, so each one also marks its
        own nodes and gives the shared label up only once no other mark is left.
        Both stages need to know which mark is ours. */}}
@@ -1084,7 +1092,7 @@ Same return contract as `kata-deploy.installNodeSelectors`.
 
 {{/*
 Per-node staged Job manifest (deploymentMode: job), embedded verbatim into the
-job-templates ConfigMap. The dispatcher (kata-deploy-job-dispatcher) clones this once per
+job-templates ConfigMap. k8s-job-dispatcher clones this once per
 target node, injecting metadata.name + spec.template.spec.nodeName, so the
 template itself carries NO node identity and NO Helm hook annotations.
 
@@ -1221,7 +1229,7 @@ kata-deploy.dispatcherServiceAccountName.
 {{- end -}}
 
 {{/*
-ServiceAccount name for the job-mode dispatcher (kata-deploy-job-dispatcher). Separate from
+ServiceAccount name for k8s-job-dispatcher. Separate from
 kata-deploy.serviceAccountName: the dispatcher is a pure API client (list nodes,
 manage Jobs) and must NOT carry the privileged kata-deploy host-mutation rights.
 */}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -2,7 +2,7 @@
 Cleanup dispatcher (deploymentMode: job, pre-delete hook).
 
 The mirror image of the install dispatcher: a single tiny pre-delete hook Job that
-runs the dispatcher (kata-deploy-job-dispatcher) to fan out one node-pinned cleanup Job
+runs k8s-job-dispatcher to fan out one node-pinned cleanup Job
 per selected node, paced to job.parallelism. Each per-node Job runs the install
 pipeline in reverse and exits:
 
@@ -87,7 +87,7 @@ spec:
               drop:
                 - ALL
           command:
-            - /usr/bin/kata-deploy-job-dispatcher
+            - /usr/bin/k8s-job-dispatcher
             - "--job-template=/etc/kata-job/cleanup-job.yaml"
             - "--name-prefix={{ $base }}-cleanup"
             - "--owner-job-name={{ $dispatcherName }}"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -1,8 +1,8 @@
 {{- /*
 Install dispatcher (deploymentMode: job).
 
-A single, tiny post-install/post-upgrade hook Job that runs the dispatcher
-(kata-deploy-job-dispatcher). The dispatcher enumerates the selected nodes LIVE, then
+A single, tiny post-install/post-upgrade hook Job that runs k8s-job-dispatcher.
+The dispatcher enumerates the selected nodes LIVE, then
 creates one node-pinned install Job per node from the job-templates ConfigMap,
 keeping at most job.parallelism in flight and refilling as they finish. This
 guarantees one install per node (coverage) with a paced rollout, while the Helm
@@ -93,7 +93,7 @@ spec:
               drop:
                 - ALL
           command:
-            - /usr/bin/kata-deploy-job-dispatcher
+            - /usr/bin/k8s-job-dispatcher
             - "--job-template=/etc/kata-job/install-job.yaml"
             - "--cleanup-job-template=/etc/kata-job/cleanup-job.yaml"
             - "--name-prefix={{ $base }}-install"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-job-templates.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-job-templates.yaml
@@ -2,8 +2,8 @@
 Per-node Job templates for deploymentMode: job.
 
 This ConfigMap holds the install and cleanup per-node Job manifests, rendered
-ONCE (constant size, independent of the number of nodes). The job-mode dispatcher
-(kata-deploy-job-dispatcher) mounts it, and for every selected node clones the relevant
+ONCE (constant size, independent of the number of nodes). k8s-job-dispatcher
+mounts it, and for every selected node clones the relevant
 template, injects metadata.name + spec.template.spec.nodeName, and creates the
 Job. Keeping the rich pod spec (env/volumes/shim config) here means the Helm
 chart stays the single source of truth; the dispatcher only does fan-out.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -1,8 +1,8 @@
 # Deployment model for installing/cleaning up Kata on nodes.
 #   daemonset: (default) the long-running kata-deploy DaemonSet installs Kata on
 #              every matching node and reverts it on pod termination (uninstall).
-#   job:       no always-on component. A tiny dispatcher Job (the dispatcher,
-#              kata-deploy-job-dispatcher) runs as a post-install/upgrade hook, enumerates
+#   job:       no always-on component. A tiny k8s-job-dispatcher Job runs as a
+#              post-install/upgrade hook, enumerates
 #              the selected nodes LIVE, and creates one node-pinned install Job
 #              per node - paced to job.parallelism and guaranteeing one install
 #              per node. Each per-node Job runs the staged pipeline as ordered
@@ -28,11 +28,11 @@ deploymentMode: daemonset  # daemonset | job
 job:
   # Dispatcher image: the dispatcher that fans out per-node Jobs. It only talks to
   # the Kubernetes API (lists nodes, creates/watches Jobs); it never touches the
-  # host. Supports reference:tag or reference@sha256:digest; tag defaults to the
-  # chart appVersion.
+  # host. Supports reference:tag or reference@sha256:digest. This component is
+  # released independently of Kata Containers, so its version is pinned here.
   dispatcherImage:
-    reference: quay.io/kata-containers/kata-deploy-job-dispatcher
-    tag: ""
+    reference: ghcr.io/kata-containers/k8s-job-dispatcher
+    tag: "0.1.0"
   # Where the dispatcher pods themselves may run (install and uninstall). Nothing
   # to do with which nodes get Kata - that is the top-level `nodeSelector` /
   # `affinity` / `tolerations`.

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
@@ -24,20 +24,8 @@ trap '[[ -n "${KEEP_TMPDIR}" ]] && echo "kept: ${tmp}" || rm -rf "${tmp}"' EXIT
 
 cp -r "${CHART_SRC}" "${tmp}/"
 
-# Job-mode dispatcher image. Its repo mirrors the kata-deploy repo with
-# "-job-dispatcher" inserted before any "-ci" suffix (so the "-ci" stays last):
-#   .../kata-deploy     -> .../kata-deploy-job-dispatcher
-#   .../kata-deploy-ci  -> .../kata-deploy-job-dispatcher-ci
-# It is built and pushed with the same tag by kata-deploy-build-and-upload-payload.sh.
-if [[ "${REGISTRY}" == *-ci ]]; then
-	JOB_DISPATCHER_IMAGE_REFERENCE="${JOB_DISPATCHER_IMAGE_REFERENCE:-"${REGISTRY%-ci}-job-dispatcher-ci"}"
-else
-	JOB_DISPATCHER_IMAGE_REFERENCE="${JOB_DISPATCHER_IMAGE_REFERENCE:-"${REGISTRY}-job-dispatcher"}"
-fi
-
 yq eval ".version = \"${CHART_VERSION}\" | .appVersion = \"${CHART_VERSION}\"" -i "${tmp}/kata-deploy/Chart.yaml"
 yq eval ".image.reference = \"${REGISTRY}\" | .image.tag = \"${TAG}\"" -i "${tmp}/kata-deploy/values.yaml"
-yq eval ".job.dispatcherImage.reference = \"${JOB_DISPATCHER_IMAGE_REFERENCE}\" | .job.dispatcherImage.tag = \"${TAG}\"" -i "${tmp}/kata-deploy/values.yaml"
 
 # Optional values overlay baked into the packaged chart's defaults, so a
 # plain `helm install` of the published chart gives the intended profile


### PR DESCRIPTION
Consume the independently released dispatcher while preserving Kata's existing tracking labels and node lifecycle behavior.

This commit is strictly focused on switching to the k8s-job-dispatcher. The kata-deploy-job-dispatcher removal will come in a new PR, since it requires testing from a ci-devel branch (due to the coming changes removing the kata-deploy-job-dispatcher build steps).

Assisted-by: Cursor <cursoragent@cursor.com>

k8s-job-dispatcher: https://github.com/kata-containers/k8s-job-dispatcher