### PR TITLE
tests: run the kata-deploy tests on a kubeadm deployed cluster

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -27,6 +27,9 @@ self-hosted-runner:
     - s390x-large
     - tdx
     - ubuntu-24.04-arm
+    # GitHub hosted, but missing from the hard coded list of the actionlint
+    # release we pin. Drop once rhysd/actionlint#683 reaches a release.
+    - ubuntu-26.04
 
 paths:
   .github/workflows/**/*.{yml,yaml}:

--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -41,10 +41,11 @@ jobs:
           - k3s
           - rke2
           - microk8s
+          - kubeadm
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
@@ -52,6 +53,9 @@ jobs:
       GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: ${{ matrix.k8s }}
+      # Only used when deploying the kubeadm flavour
+      CONTAINER_ENGINE: containerd
+      CONTAINER_ENGINE_VERSION: latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -65,12 +65,17 @@ generate_base_values() {
 	local output_file="$1"
 	local extra_values_file="${2:-}"
 
+	local k8s_distribution="${KUBERNETES}"
+	if [[ "${k8s_distribution}" == "kubeadm" ]]; then
+		k8s_distribution="k8s"
+	fi
+
 	cat > "${output_file}" <<EOF
 image:
   reference: ${DOCKER_REGISTRY}/${DOCKER_REPO}
   tag: ${DOCKER_TAG}
 
-k8sDistribution: "${KUBERNETES}"
+k8sDistribution: "${k8s_distribution}"
 debug: true
 
 # Disable all shims at once, then enable only the one we need

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -171,11 +171,19 @@ function install_bats() {
 	source /etc/os-release
 	case "${ID}" in
 		ubuntu)
-			# Installing bats from the noble repo.
-			sudo apt install -y software-properties-common
-			sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
-			sudo apt install -y bats
-			sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+			# Only jammy and older need bats fetched from somewhere else:
+			# their own universe carries one too old for these suites,
+			# while noble onwards already ships a new enough bats. Pulling
+			# noble's repo into a later release would be reaching backwards.
+			if dpkg --compare-versions "${VERSION_ID:-}" lt 24.04; then
+				# Installing bats from the noble repo.
+				sudo apt install -y software-properties-common
+				sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+				sudo apt install -y bats
+				sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+			else
+				sudo apt install -y bats
+			fi
 			;;
 		*)
 			echo "${ID} is not a supported distro, install bats manually"
@@ -561,7 +569,7 @@ function deploy_k8s() {
 		k3s) deploy_k3s ;;
 		rke2) deploy_rke2 ;;
 		microk8s) deploy_microk8s ;;
-		vanilla)
+		kubeadm|vanilla)
 			if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
 				install_erofs_utils
 


### PR DESCRIPTION
The kata-deploy tests currently only run against k8s distros, such as k0s, k3s, rke2, and microk8s, and so far this has been okay as the rest of the CI exercises the kubeadm flow.

With kata-deploy growing on responsibilities, we are safer if we also test things with kubeadm as part of the kata-deploy tests, and that also opens us a door to easily test things out with newer versions of containerd, which we control in the kubeadm case, as the k8s distros have containerd baked into what they ship.

While here, let's also bump the runner from ubuntu-22.04 to ubuntu-26.04.

Please, **DO NOT ADD THE `ok-to-test` LABEL**, as it'll be tested through a ci-devel branch.

ci-devel run: https://github.com/kata-containers/kata-containers/actions/runs/32479310234