### PR TITLE
versions: Rust 1.96 bump

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep in sync with versions.yaml
-channel = "1.95"
+channel = "1.96"

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/muxer_killq.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/muxer_killq.rs
@@ -122,12 +122,9 @@ impl MuxerKillQ {
     /// This will succeed and return a connection key, only if the connection at
     /// the front of the queue has expired. Otherwise, `None` is returned.
     pub fn pop(&mut self) -> Option<ConnMapKey> {
-        if let Some(item) = self.q.front() {
-            if Instant::now() > item.kill_time {
-                return Some(self.q.pop_front().unwrap().key);
-            }
-        }
-        None
+        self.q
+            .pop_front_if(|item| Instant::now() > item.kill_time)
+            .map(|item| item.key)
     }
 
     /// Check if the kill queue is synchronized with the connection pool.

--- a/tools/packaging/kata-deploy/Dockerfile.components
+++ b/tools/packaging/kata-deploy/Dockerfile.components
@@ -41,8 +41,8 @@ RUN \
 #### Build binary package
 FROM ubuntu:22.04 AS rust-builder
 
-# Default to Rust 1.95
-ARG RUST_TOOLCHAIN=1.95
+# Default to Rust 1.96
+ARG RUST_TOOLCHAIN=1.96
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"

--- a/versions.yaml
+++ b/versions.yaml
@@ -426,12 +426,12 @@ languages:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
     # Keep in sync with rust-toolchain.toml
-    version: "1.95"
+    version: "1.96"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.95"
+      newest-version: "1.96"
 
   golangci-lint:
     description: "golangci-lint"


### PR DESCRIPTION
Rust 1.98 has released, so in compliance with our toolchain guidance we bump to rust 1.96
