### PR TITLE
genpolicy: enforce image_guest_pull storage cardinality

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1233,6 +1233,10 @@ mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
 ######################################################################
 # Create container Storages
 
+expected_image_guest_pull_count := 1 if {
+    policy_data.cluster_config.guest_pull
+} else := 0
+
 allow_storages(p_storages, i_storages, bundle_id, sandbox_id) if {
     print("allow_storages: p_storages =", p_storages)
     print("allow_storages: i_storages =", i_storages)
@@ -1242,6 +1246,7 @@ allow_storages(p_storages, i_storages, bundle_id, sandbox_id) if {
     img_pull_count := count([s | s := i_storages[_]; s.driver == "image_guest_pull"])
     print("allow_storages: p_count =", p_count, "i_count =", i_count, "img_pull_count =", img_pull_count)
 
+    img_pull_count == expected_image_guest_pull_count
     p_count == i_count - img_pull_count
 
     every i_storage in i_storages {

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -276,6 +276,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_container_image_guest_pull_count() {
+        runtests("createcontainer/image_guest_pull_count").await;
+    }
+
+    #[tokio::test]
     async fn test_create_container_sysctls() {
         runtests("createcontainer/sysctls").await;
     }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/testcases.json
@@ -132,7 +132,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummysfx_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummysfx\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -268,7 +281,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_xyzdummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"xyzdummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
@@ -101,7 +101,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfio2\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -207,7 +219,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfio3\":\"nvidia.com/gpu=2\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -311,7 +335,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -417,7 +453,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfioABC\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -523,7 +571,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"invalid-format\",\"cdi.k8s.io/vfio2\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -628,7 +688,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -734,7 +806,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfio3\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -840,7 +924,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfio2\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -931,7 +1027,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"cdi.k8s.io/vfio2\":\"nvidia.com/gpu=1\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -1021,7 +1129,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"cdi.k8s.io/vfio1\":\"nvidia.com/gpu=0\",\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   },
@@ -1110,7 +1230,19 @@
       "stderr_port": 0,
       "stdin_port": 0,
       "stdout_port": 0,
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gpu-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab\",\"io.kubernetes.cri.sandbox-name\":\"gpu-test-pod\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"12345678-1234-1234-1234-123456789012\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ],
       "string_user": null
     }
   }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_guest_pull_count/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_guest_pull_count/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_guest_pull_count/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_guest_pull_count/testcases.json
@@ -1,0 +1,299 @@
+[
+  {
+    "allowed": false,
+    "description": "guest pull storage is missing",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": ""
+        },
+        "Process": {
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "SelinuxLabel": "",
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "Readonly": true
+        },
+        "Version": "1.1.0"
+      },
+      "storages": []
+    }
+  },
+  {
+    "allowed": false,
+    "description": "guest pull storage is duplicated",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": ""
+        },
+        "Process": {
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "SelinuxLabel": "",
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "Readonly": true
+        },
+        "Version": "1.1.0"
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        },
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
+    }
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/testcases.json
@@ -132,7 +132,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -268,7 +281,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -400,7 +426,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -536,7 +575,20 @@
           "Readonly": true
         },
         "Version": "1.1.0"
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/runas/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/runas/testcases.json
@@ -244,7 +244,20 @@
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"2\",\"io.kubernetes.cri.sandbox-id\":\"a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/kata-containers-k8s-tests_dummy_fd055c20-d44c-4fc5-aa90-283f629201af\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"fd055c20-d44c-4fc5-aa90-283f629201af\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-50720768-bd65-bf4b-6185-5d5a2adf5305\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -577,7 +590,20 @@
         "Version": "1.1.0",
         "Windows": null
       },
-      "container_id": "dummy"
+      "container_id": "dummy",
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48\",\"io.kubernetes.cri.sandbox-id\":\"5cd5b1a9a4ccc5c9fcf9fcc66fb72bf01e0920a1f34ef505f744119db6679c41\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"3cfbfd7a-3065-4862-805e-3f5e4142bcbd\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48"
+        }
+      ]
     }
   },
   {
@@ -825,7 +851,20 @@
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"2\",\"io.kubernetes.cri.sandbox-id\":\"a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/kata-containers-k8s-tests_dummy_fd055c20-d44c-4fc5-aa90-283f629201af\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"fd055c20-d44c-4fc5-aa90-283f629201af\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-50720768-bd65-bf4b-6185-5d5a2adf5305\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   },
   {
@@ -1073,7 +1112,20 @@
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"2\",\"io.kubernetes.cri.sandbox-id\":\"a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/kata-containers-k8s-tests_dummy_fd055c20-d44c-4fc5-aa90-283f629201af\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"fd055c20-d44c-4fc5-aa90-283f629201af\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-50720768-bd65-bf4b-6185-5d5a2adf5305\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/a10abe57d2a2e47c30d5bd2427170e019fddc587a59d173544d87842f1905da4/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/supplemental_groups/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/supplemental_groups/testcases.json
@@ -330,7 +330,20 @@
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48\",\"io.kubernetes.cri.sandbox-id\":\"5cd5b1a9a4ccc5c9fcf9fcc66fb72bf01e0920a1f34ef505f744119db6679c41\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"3cfbfd7a-3065-4862-805e-3f5e4142bcbd\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48"
+        }
+      ]
     }
   },
   {
@@ -665,7 +678,20 @@
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
-      }
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48\",\"io.kubernetes.cri.sandbox-id\":\"5cd5b1a9a4ccc5c9fcf9fcc66fb72bf01e0920a1f34ef505f744119db6679c41\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"kata-containers-k8s-tests\",\"io.kubernetes.cri.sandbox-uid\":\"3cfbfd7a-3065-4862-805e-3f5e4142bcbd\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
@@ -12,7 +12,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -131,7 +132,19 @@
         },
         "Version": "1.1.0"
       },
-      "storages": []
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
@@ -12,7 +12,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "redis",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "quay.io/opstree/redis"
         },
         "Linux": {
           "GIDMappings": [],
@@ -121,7 +122,19 @@
         },
         "Version": "1.1.0"
       },
-      "storages": []
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"redis\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/opstree/redis\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"redis\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "quay.io/opstree/redis"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
@@ -12,7 +12,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -217,7 +218,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -233,7 +245,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -418,7 +431,18 @@
           "source": "invalid-source",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -434,7 +458,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -629,7 +654,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -645,7 +681,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -825,7 +862,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -841,7 +889,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -1036,7 +1085,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -1052,7 +1112,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -1247,7 +1308,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -1263,7 +1335,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -1488,7 +1561,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -1504,7 +1588,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -1697,7 +1782,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -1713,7 +1809,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -1898,7 +1995,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   },
   {
@@ -1914,7 +2022,8 @@
           "io.kubernetes.cri.container-type": "container",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
           "io.kubernetes.cri.sandbox-name": "dummy",
-          "io.kubernetes.cri.sandbox-namespace": "default"
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
         },
         "Linux": {
           "GIDMappings": [],
@@ -2099,7 +2208,18 @@
           "source": "03/03",
           "shared": true
         }
-      ]
+      ,
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        }]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
@@ -17,7 +17,8 @@
           "io.kubernetes.cri.sandbox-memory": "0",
           "io.kubernetes.cri.sandbox-name": "busybox",
           "io.kubernetes.cri.sandbox-namespace": "default",
-          "io.kubernetes.cri.sandbox-uid": "eb1495ed-331a-44ff-ad6d-fce1a69280cd"
+          "io.kubernetes.cri.sandbox-uid": "eb1495ed-331a-44ff-ad6d-fce1a69280cd",
+          "io.kubernetes.cri.image-name": "quay.io/prometheus/busybox:latest"
         },
         "Hooks": null,
         "Hostname": "busybox",
@@ -299,7 +300,19 @@
       "exec_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
       "sandbox_pidns": false,
       "shared_mounts": [],
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"first-test-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/prometheus/busybox:latest\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"2\",\"io.kubernetes.cri.sandbox-id\":\"257a671dd451a8bf7ea4950d722106db358ef5ded2997c60f7dc1101b31b727a\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"busybox\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"eb1495ed-331a-44ff-ad6d-fce1a69280cd\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9/rootfs",
+          "options": [],
+          "source": "quay.io/prometheus/busybox:latest"
+        }
+      ],
       "string_user": null
     }
   },
@@ -321,7 +334,8 @@
           "io.kubernetes.cri.sandbox-memory": "0",
           "io.kubernetes.cri.sandbox-name": "busybox",
           "io.kubernetes.cri.sandbox-namespace": "default",
-          "io.kubernetes.cri.sandbox-uid": "eb1495ed-331a-44ff-ad6d-fce1a69280cd"
+          "io.kubernetes.cri.sandbox-uid": "eb1495ed-331a-44ff-ad6d-fce1a69280cd",
+          "io.kubernetes.cri.image-name": "quay.io/prometheus/busybox:latest"
         },
         "Hooks": null,
         "Hostname": "busybox",
@@ -603,7 +617,19 @@
       "exec_id": "22941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
       "sandbox_pidns": false,
       "shared_mounts": [],
-      "storages": [],
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/22941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"second-test-container\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"quay.io/prometheus/busybox:latest\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"2\",\"io.kubernetes.cri.sandbox-id\":\"257a671dd451a8bf7ea4950d722106db358ef5ded2997c60f7dc1101b31b727a\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"busybox\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"eb1495ed-331a-44ff-ad6d-fce1a69280cd\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/22941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9/rootfs",
+          "options": [],
+          "source": "quay.io/prometheus/busybox:latest"
+        }
+      ],
       "string_user": null
     }
   },


### PR DESCRIPTION
In guest-pull mode we expect exactly one `image_guest_pull` storage and none in host-pull mode. This change to `rules.rego` reflects that fact, preventing requests with a missing or duplicated `image_guest_pull` storage in guest-pull mode and assuring no such storages are accepted in host-pull mode.

As of today, our policy test suite runs all manifests in guest-pull mode - adding the change to `rules.rego` exposes various fixtures lacking the `image_guest_pull` storage the runtime supplies. This PR adjusts these incorrect fixtures and adds fixtures for "guest pull storage is duplicated" and "guest pull storage is missing".

Also - as a consequence of our prior work to always derive proper IDs under guest-pull mode, I believe we can remove this adaptation of the config for force-guest pull mode: `20-experimental-force-guest-pull-drop-in.json`

Notably, we are not testing host-pull mode in these tests - I am thinking of creating another pull request for this, but this would require us to introduce new fixtures without `image_guest_pull` storage entries.
