### PR TITLE
genpolicy: add host-pull policy tests

### DIFF
--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -76,6 +76,8 @@ mod tests {
     /// should be exactly one entry with a PodSpec. The test case file must contain
     /// a JSON list of [TestCase] instances. Each instance will be of type enum TestRequest,
     /// with the tag `type` listing the exact type of request.
+    /// An optional `settings-patch.json` file in the test case directory customizes
+    /// the genpolicy settings used by that test.
     async fn runtests(test_case_dir: &str) {
         // Check if config_map.yaml exists.
         // If it does, we need to copy it to the workdir.
@@ -93,6 +95,8 @@ mod tests {
 
         // Prepare temp dir for running genpolicy.
         let (workdir, testdata_dir) = prepare_workdir(test_case_dir, &files_to_copy);
+
+        let settings = prepare_settings(&workdir, &testdata_dir);
 
         let config_files = if is_config_map_file_present {
             Some(vec![workdir
@@ -113,9 +117,7 @@ mod tests {
             raw_out: false,
             rego_rules_path: workdir.join("rules.rego").to_str().unwrap().to_string(),
             runtime_class_names: Vec::new(),
-            settings: genpolicy::settings::Settings::new(
-                workdir.join("genpolicy-settings.json").to_str().unwrap(),
-            ),
+            settings,
             silent_unsupported_fields: false,
             use_cache: false,
             version: false,
@@ -201,6 +203,26 @@ mod tests {
             .to_string()
     }
 
+    fn prepare_settings(
+        workdir: &path::Path,
+        testdata_dir: &path::Path,
+    ) -> genpolicy::settings::Settings {
+        let settings_patch = testdata_dir.join("settings-patch.json");
+        if settings_patch.exists() {
+            let drop_in_dir = workdir.join("genpolicy-settings.d");
+            fs::create_dir(&drop_in_dir).expect("settings drop-in directory should be created");
+            fs::copy(&settings_patch, drop_in_dir.join("settings-patch.json"))
+                .context(format!(
+                    "{:?} --> {:?}",
+                    settings_patch,
+                    drop_in_dir.join("settings-patch.json")
+                ))
+                .expect("copying the settings patch should not fail");
+        }
+
+        genpolicy::settings::Settings::new(workdir.to_str().unwrap())
+    }
+
     fn prepare_workdir(
         test_case_dir: &str,
         files_to_copy: &[&str],
@@ -217,7 +239,15 @@ mod tests {
         // Make sure that workdir is empty.
         for entry in fs::read_dir(&workdir).expect("should be able to read directories") {
             let entry = entry.expect("should be able to read directory entries");
-            fs::remove_file(entry.path()).expect("should be able to remove files");
+            if entry
+                .file_type()
+                .expect("workdir entry should have a file type")
+                .is_dir()
+            {
+                fs::remove_dir_all(entry.path()).expect("should be able to remove directories");
+            } else {
+                fs::remove_file(entry.path()).expect("should be able to remove files");
+            }
         }
 
         for file in files_to_copy {
@@ -278,6 +308,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_container_image_guest_pull_count() {
         runtests("createcontainer/image_guest_pull_count").await;
+    }
+
+    #[tokio::test]
+    async fn test_create_container_image_host_pull() {
+        runtests("createcontainer/image_host_pull").await;
     }
 
     #[tokio::test]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/settings-patch.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/settings-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/guest_pull",
+    "value": false
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/image_host_pull/testcases.json
@@ -1,0 +1,288 @@
+[
+  {
+    "allowed": true,
+    "description": "valid host-pull request",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": ""
+        },
+        "Process": {
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "SelinuxLabel": "",
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "Readonly": true
+        },
+        "Version": "1.1.0"
+      },
+      "storages": []
+    }
+  },
+  {
+    "allowed": false,
+    "description": "host-pull request with forbidden image_guest_pull storage",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": ""
+        },
+        "Process": {
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "SelinuxLabel": "",
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "Readonly": true
+        },
+        "Version": "1.1.0"
+      },
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.sandbox-id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_dummy_00000000-0000-0000-0000-000000000000\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-00000000-0000-0000-0000-000000000000\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This PR allows policy tests to select guest- or host-pull mode explicitly. All existing test cases which were exercised in guest pull mode so far, are kept in guest-pull mode. Add a host-pull fixture that allows a valid request (without `image_guest_pull` storage) and that rejects one that contains `image_guest_pull`.

I see two alternatives to this which would allow to run the **full suite** in  both guest and host pull mode:
- add explicit host- and guest-pull testcase files for every fixture (lots of duplication of json files)
- derive host-pull requests in the test logic based on existing json files by filtering the image_guest_pull storages (in this case we can't test host-pull mode with an injected image_pull_request storage, but this may be forgiveable, or if not, we can add a special case for this).

This PR depends on #13689 (until then, its negative host-pull test case would allow the create container request and hence fail).

