### PR TITLE
tests: wait for the kata-monitor pods to exist before checking them

### DIFF
--- a/tests/functional/kata-monitor/kata-monitor.bats
+++ b/tests/functional/kata-monitor/kata-monitor.bats
@@ -98,6 +98,22 @@ predicate_has_shim_metric() {
 	grep -E '^kata_shim_[a-z_]+\{[^}]*sandbox_id="[0-9a-f-]+' >/dev/null
 }
 
+wait_for_pods_to_exist() {
+	local selector="$1"
+	local deadline=$((SECONDS + 120))
+
+	while (( SECONDS < deadline )); do
+		if [[ -n "$(kubectl -n "${HELM_NAMESPACE}" get pods -l "${selector}" \
+			-o name 2>/dev/null)" ]]; then
+			return 0
+		fi
+		sleep 2
+	done
+
+	echo "Timed out waiting for pods matching '${selector}' to be created" >&2
+	return 1
+}
+
 @test "kata-monitor helm chart rolls out and exposes per-sandbox metrics" {
 	pushd "${repo_root_dir}"
 
@@ -112,8 +128,16 @@ predicate_has_shim_metric() {
 		--set "monitor.image.reference=${KATA_MONITOR_IMAGE_REFERENCE}" \
 		--set "monitor.image.tag=${KATA_MONITOR_IMAGE_TAG}"
 
+	# deploy_kata's readiness wait is best-effort, so make sure kata-deploy has
+	# really finished here: everything below is written around containerd having
+	# already been bounced by the install.
+	wait_for_pods_to_exist "name=kata-deploy"
+	kubectl -n "${HELM_NAMESPACE}" wait pod -l name=kata-deploy \
+		--for=condition=Ready --timeout="${helm_timeout}"
+
 	echo ""
 	echo "::group::kata-monitor DaemonSet rollout"
+	wait_for_pods_to_exist "app.kubernetes.io/name=kata-monitor"
 	kubectl -n "${HELM_NAMESPACE}" rollout status ds/kata-monitor \
 		--timeout="${rollout_timeout}"
 	echo "::endgroup::"


### PR DESCRIPTION
On a cluster only seconds old the controllers are still catching up, so helm returns with both DaemonSets created but nothing scheduled yet, and the checks that follow read that emptiness as success: an unscheduled DaemonSet counts as rolled out, and `kubectl wait` gives up rather than waits when its selector matches nothing, failing the test outright.

Wait for the pods to be created before asking anything about them, and for kata-deploy to actually be ready, which is what the rest of the test is written around -- it expects the install to have bounced containerd already, and reads a restart afterwards as a crash loop.

Generated-by: Cursor <cursoragent@cursor.com>