### PR TITLE
tools: Take the toolchains into account for the tools builder image

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -245,7 +245,7 @@ get_tools_image_name() {
 	libs_dir="${repo_root_dir}/src/libs"
 	agent_dir="${repo_root_dir}/src/agent"
 
-	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification "${tools_dir}")-$(get_last_modification "${libs_dir}")-$(get_last_modification "${agent_dir}")-$(get_last_modification "${tools_script_dir}")-$(uname -m)"
+	echo "${BUILDER_REGISTRY}:tools-go-$(get_from_kata_deps ".languages.golang.meta.newest-version")-rust-$(get_from_kata_deps ".languages.rust.meta.newest-version")-$(get_last_modification "${tools_dir}")-$(get_last_modification "${libs_dir}")-$(get_last_modification "${agent_dir}")-$(get_last_modification "${tools_script_dir}")-$(uname -m)"
 }
 
 get_agent_image_name() {

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -239,19 +239,23 @@ get_virtiofsd_image_name() {
 	echo "${BUILDER_REGISTRY}:virtiofsd-$(get_from_kata_deps ".externals.virtiofsd.toolchain")-${libc}-$(get_last_modification "${virtiofsd_script_dir}")-$(uname -m)"
 }
 
+get_libseccomp_hash() {
+	merge_two_hashes \
+		"$(get_last_modification "${repo_root_dir}/ci/install_libseccomp.sh")" \
+		"$(get_last_modification "${repo_root_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh")"
+}
+
 get_tools_image_name() {
 	tools_script_dir="${repo_root_dir}/tools/packaging/static-build/tools"
 	tools_dir="${repo_root_dir}/src/tools"
 	libs_dir="${repo_root_dir}/src/libs"
 	agent_dir="${repo_root_dir}/src/agent"
 
-	echo "${BUILDER_REGISTRY}:tools-go-$(get_from_kata_deps ".languages.golang.meta.newest-version")-rust-$(get_from_kata_deps ".languages.rust.meta.newest-version")-$(get_last_modification "${tools_dir}")-$(get_last_modification "${libs_dir}")-$(get_last_modification "${agent_dir}")-$(get_last_modification "${tools_script_dir}")-$(uname -m)"
+	echo "${BUILDER_REGISTRY}:tools-go-$(get_from_kata_deps ".languages.golang.meta.newest-version")-rust-$(get_from_kata_deps ".languages.rust.meta.newest-version")-$(get_libseccomp_hash)-$(get_last_modification "${tools_dir}")-$(get_last_modification "${libs_dir}")-$(get_last_modification "${agent_dir}")-$(get_last_modification "${tools_script_dir}")-$(uname -m)"
 }
 
 get_agent_image_name() {
-	libseccomp_hash=$(merge_two_hashes \
-		"$(get_last_modification "${repo_root_dir}/ci/install_libseccomp.sh")" \
-		"$(get_last_modification "${repo_root_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh")")
+	libseccomp_hash="$(get_libseccomp_hash)"
 	agent_dir="${repo_root_dir}/tools/packaging/static-build/agent"
 	rust_toolchain="$(get_from_kata_deps ".languages.rust.meta.newest-version")"
 


### PR DESCRIPTION
The tools builder image installs both the Go and the Rust toolchains pinned by versions.yaml, but its tag only tracked the modification time of src/tools, src/libs, src/agent and static-build/tools.

A toolchain bump touches none of those, so the cached image was reused with the previous toolchains.  After the bump to Rust 1.96 that meant the pulled image still had 1.95 as its default toolchain, and since rust-toolchain.toml pins 1.96 rustup silently installed 1.96 with the default profile at build time - without the musl target the image had only added for 1.95:
```
  error[E0463]: can't find crate for `core`
    = note: the `x86_64-unknown-linux-musl` target may not be installed
```

Fold both toolchain versions into the tag, as already done for the shim-v2 builder image, so that a bump invalidates the image.

Assisted-by: Cursor <cursoragent@cursor.com>