### PR TITLE
kata-deploy: Fix installation_prefix drop-in

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy-installation-prefix.bats
+++ b/tests/functional/kata-deploy/kata-deploy-installation-prefix.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kata Deploy Installation Prefix Tests
+#
+# Installing anywhere other than /opt/kata makes kata-deploy write a drop-in
+# that moves the paths of every shim it configures, so a shim the drop-in gets
+# wrong is handed an artifact it never asked for. The confidential shims are the
+# ones with something to lose, since they run a different kernel and image from
+# the rest, and qemu-coco-dev is the one that carries such a configuration
+# without asking for TEE hardware. (Regression test for #13697)
+#
+# Required environment variables:
+#   DOCKER_REGISTRY - Container registry for kata-deploy image
+#   DOCKER_REPO     - Repository name for kata-deploy image
+#   DOCKER_TAG      - Image tag to test
+#   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
+#   KUBERNETES      - K8s distribution (microk8s, k3s, rke2, etc.)
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+DEFAULT_INSTALL_DIR="/opt/kata"
+INSTALLATION_PREFIX="/opt/kata-prefix-test"
+INSTALL_DIR="${INSTALLATION_PREFIX}${DEFAULT_INSTALL_DIR}"
+
+CONFIDENTIAL_SHIM="qemu-coco-dev"
+PREFIX_POD_NAME="kata-prefix-test"
+
+DROP_IN="10-installation-prefix.toml"
+DUMP_SEPARATOR="===DROP-IN==="
+DUMP_DIR="${BATS_FILE_TMPDIR:-/tmp}/configs"
+
+# The keys naming an artifact the runtime resolves before it can boot a VM.
+ARTIFACT_KEYS=( \
+	"kernel" \
+	"image" \
+	"initrd" \
+	"firmware" \
+	"firmware_volume" \
+	"virtio_fs_daemon" \
+)
+
+setup_file() {
+	ensure_helm
+
+	echo "# Image: ${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" >&3
+	echo "# Hypervisor: ${KATA_HYPERVISOR}" >&3
+	echo "# K8s distribution: ${KUBERNETES}" >&3
+	echo "# Deploying kata-deploy into ${INSTALL_DIR}..." >&3
+
+	local values
+	values=$(mktemp)
+	cat > "${values}" <<EOF
+env:
+  installationPrefix: "${INSTALLATION_PREFIX}"
+
+shims:
+  ${CONFIDENTIAL_SHIM}:
+    enabled: true
+EOF
+
+	deploy_kata "${values}"
+	rm -f "${values}"
+	echo "# kata-deploy deployed successfully" >&3
+
+	# Reading the host costs a pod per file, so collect the configurations once
+	# and let the tests work off the copies.
+	mkdir -p "${DUMP_DIR}"
+
+	local dir
+	for dir in $(runtime_config_dirs); do
+		echo "# Collecting the configuration of ${dir##*/}..." >&3
+		runtime_configs "${dir}" > "${DUMP_DIR}/${dir##*/}"
+	done
+}
+
+# The runtime configuration directories the install left on the host, one per
+# line: one per shim, plus one per custom runtime handler derived from a shim.
+runtime_config_dirs() {
+	run_on_host "find /host${INSTALL_DIR}/share/defaults/kata-containers -maxdepth 4 -type d -name config.d" \
+		| sed -e 's|/config.d$||' -e 's|^/host||'
+}
+
+# A runtime directory's base configuration followed by its installation prefix
+# drop-in, the two separated by ${DUMP_SEPARATOR}. Chained on success so that a
+# file that is not there fails the collection rather than handing the tests an
+# empty configuration they would find nothing to complain about in.
+runtime_configs() {
+	local dir="${1}"
+
+	run_on_host "cat /host${dir}/configuration-*.toml && echo ${DUMP_SEPARATOR} && cat /host${dir}/config.d/${DROP_IN}"
+}
+
+# The value a configuration gives to a key, empty when it gives none.
+toml_value() {
+	local content="${1}" key="${2}"
+
+	echo "${content}" | sed -n "s/^${key} = \"\(.*\)\"\$/\1/p" | head -1
+}
+
+# Every absolute path a configuration sets, one per line.
+toml_paths() {
+	echo "${1}" | sed -n 's|^[a-z_]\+ = "\(/[^"]*\)"$|\1|p'
+}
+
+@test "Artifacts are installed under the prefix" {
+	run run_on_host "test -f /host${INSTALL_DIR}/bin/containerd-shim-kata-v2 && echo FOUND || (test -f /host${INSTALL_DIR}/runtime-rs/bin/containerd-shim-kata-v2 && echo FOUND || echo MISSING)"
+	echo "# ${INSTALL_DIR}/bin/containerd-shim-kata-v2: ${output}" >&3
+	[[ "${output}" == *"FOUND"* ]]
+}
+
+@test "The prefix drop-in moves the artifacts each configuration asks for" {
+	local names
+	names=$(ls "${DUMP_DIR}")
+	[[ -n "${names}" ]]
+
+	local saw_confidential="no"
+	local name
+	for name in ${names}; do
+		if [[ "${name}" == "${CONFIDENTIAL_SHIM}" ]]; then
+			saw_confidential="yes"
+		fi
+
+		local configs base drop_in
+		configs=$(cat "${DUMP_DIR}/${name}")
+		base="${configs%%"${DUMP_SEPARATOR}"*}"
+		drop_in="${configs##*"${DUMP_SEPARATOR}"}"
+
+		# Every shipped configuration puts its hypervisor under the install
+		# directory, so failing to read that is how this notices it is
+		# comparing against a configuration it never got.
+		[[ "$(toml_value "${base}" "path")" == "${DEFAULT_INSTALL_DIR}/"* ]]
+
+		local key
+		for key in "${ARTIFACT_KEYS[@]}"; do
+			local base_value drop_in_value
+			base_value=$(toml_value "${base}" "${key}")
+			drop_in_value=$(toml_value "${drop_in}" "${key}")
+
+			if [[ "${base_value}" == "${DEFAULT_INSTALL_DIR}/"* ]]; then
+				echo "# ${name}: ${key} = ${drop_in_value}" >&3
+				[[ "${drop_in_value}" == "${INSTALL_DIR}${base_value#"${DEFAULT_INSTALL_DIR}"}" ]]
+			else
+				# There is nothing of ours to move, so the drop-in has no
+				# business naming the key: an initrd handed to an image-only
+				# guest is refused outright, and an artifact the install never
+				# laid down is a path that cannot resolve.
+				[[ -z "${drop_in_value}" ]]
+			fi
+		done
+	done
+
+	# A deploy that quietly left the confidential shim out would satisfy every
+	# assertion above without testing what this suite is here for.
+	echo "# ${CONFIDENTIAL_SHIM} configured: ${saw_confidential}" >&3
+	[[ "${saw_confidential}" == "yes" ]]
+}
+
+@test "Every path the prefix drop-in sets is on the host" {
+	# The runtime resolves each of them before it can start a VM, so a path
+	# that is not there is a boot failure whatever the drop-in says.
+	local checks=""
+	local name
+	for name in $(ls "${DUMP_DIR}"); do
+		local configs drop_in path
+		configs=$(cat "${DUMP_DIR}/${name}")
+		drop_in="${configs##*"${DUMP_SEPARATOR}"}"
+
+		for path in $(toml_paths "${drop_in}"); do
+			echo "# ${name}: ${path}" >&3
+			checks+="test -e /host${path} || echo MISSING ${path}; "
+		done
+	done
+
+	[[ -n "${checks}" ]]
+
+	run run_on_host "${checks}true"
+	echo "# ${output}" >&3
+	[[ "${output}" != *"MISSING"* ]]
+}
+
+@test "A pod runs on a relocated installation" {
+	cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${PREFIX_POD_NAME}
+spec:
+  runtimeClassName: kata-${KATA_HYPERVISOR}
+  restartPolicy: Never
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: test
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: IfNotPresent
+      command: ["sleep", "infinity"]
+EOF
+
+	echo "# Waiting for the pod to be running..." >&3
+	if ! kubectl wait --for=condition=Ready "pod/${PREFIX_POD_NAME}" --timeout=180s; then
+		echo "::group::${PREFIX_POD_NAME}"
+		kubectl describe "pod/${PREFIX_POD_NAME}" || true
+		echo "::endgroup::"
+		return 1
+	fi
+}
+
+teardown_file() {
+	kubectl delete pod "${PREFIX_POD_NAME}" --ignore-not-found=true --wait=false 2>/dev/null || true
+	uninstall_kata 2>/dev/null || true
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -37,6 +37,7 @@ else
 		"kata-deploy-multi-install.bats" \
 		"kata-deploy-reconcile.bats" \
 		"kata-deploy-node-binaries.bats" \
+		"kata-deploy-installation-prefix.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
-use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table, Value};
 #[cfg(test)]
 use walkdir::WalkDir;
 
@@ -245,9 +245,15 @@ fn write_common_drop_ins(
     info!("Generating drop-in configuration files for shim: {}", shim);
 
     // 1. Installation prefix adjustments (if not default)
-    if config.dest_dir != DEFAULT_KATA_INSTALL_DIR {
+    let prefix_content = if config.dest_dir != DEFAULT_KATA_INSTALL_DIR {
         info!("  - Installation prefix: {} (non-default)", config.dest_dir);
-        let prefix_content = generate_installation_prefix_drop_in(config, shim)?;
+        generate_installation_prefix_drop_in(config, shim)?
+    } else {
+        String::new()
+    };
+    if prefix_content.is_empty() {
+        reconcile_stale_drop_in(config_d_dir, "10-installation-prefix.toml")?;
+    } else {
         write_drop_in_file(config_d_dir, "10-installation-prefix.toml", &prefix_content)?;
     }
 
@@ -1432,27 +1438,6 @@ fn write_drop_in_file(config_d_dir: &str, filename: &str, content: &str) -> Resu
     Ok(())
 }
 
-/// Get the name of the QEMU artifact a given shim is installed from.
-/// Every artifact other than "qemu" is a suffixed build, so the name is also
-/// the suffix of both its share directory and its qemu-system-* binary.
-fn get_qemu_artifact_name(shim: &str) -> Option<String> {
-    if !is_qemu_shim(shim) {
-        return None;
-    }
-
-    let artifact_name = match shim {
-        "qemu-nvidia-cpu-runtime-rs" => "qemu-no-shared-fs",
-        "qemu-nvidia-gpu-runtime-rs" => "qemu-no-shared-fs",
-        "qemu-nvidia-gpu-snp" => "qemu-snp-experimental",
-        "qemu-nvidia-gpu-snp-runtime-rs" => "qemu-snp-experimental",
-        "qemu-nvidia-gpu-tdx" => "qemu-tdx-experimental",
-        "qemu-nvidia-gpu-tdx-runtime-rs" => "qemu-tdx-experimental",
-        _ => "qemu",
-    };
-
-    Some(artifact_name.to_string())
-}
-
 /// Name of the QEMU system emulator for a given architecture.  QEMU calls its
 /// ppc64le target "ppc64"; every other one matches the architecture.
 fn qemu_system_binary_for(arch: &str) -> String {
@@ -1464,131 +1449,171 @@ fn qemu_system_binary_for(arch: &str) -> String {
     format!("qemu-system-{target}")
 }
 
-/// Create a QEMU wrapper script that adds the -L flag for firmware paths.
-/// This is needed when using a non-default installation prefix.
-fn create_qemu_wrapper_script(config: &Config, shim: &str) -> Result<Option<String>> {
-    let qemu_artifact = match get_qemu_artifact_name(shim) {
-        Some(artifact) => artifact,
-        None => return Ok(None), // Not a QEMU shim, no wrapper needed
-    };
+/// Each QEMU flavour is built with its own `--datadir`, named after its binary.
+fn qemu_data_dir(qemu_binary: &str, dest_dir: &str) -> Option<String> {
+    let system_binary = qemu_system_binary_for(current_arch());
+    let flavour_suffix = Path::new(qemu_binary)
+        .file_name()?
+        .to_str()?
+        .strip_prefix(system_binary.as_str())?;
 
-    let binary_suffix = qemu_artifact.trim_start_matches("qemu");
-    let qemu_binary = format!(
-        "{}/bin/{}{}",
-        config.dest_dir,
-        qemu_system_binary_for(current_arch()),
-        binary_suffix
-    );
+    Some(format!("{dest_dir}/share/kata-qemu{flavour_suffix}/qemu/"))
+}
+
+/// QEMU has its data directory compiled in, so a relocated one needs `-L`.
+fn create_qemu_wrapper_script(qemu_binary: &str, qemu_data_dir: &str) -> Result<String> {
     let wrapper_script_path = format!("{}-installation-prefix", qemu_binary);
-    let host_wrapper_path = wrapper_script_path.clone();
 
-    // Create wrapper script if it doesn't exist
-    if !Path::new(&host_wrapper_path).exists() {
-        // Ensure parent directory exists
-        if let Some(parent) = Path::new(&host_wrapper_path).parent() {
+    if !Path::new(&wrapper_script_path).exists() {
+        if let Some(parent) = Path::new(&wrapper_script_path).parent() {
             fs::create_dir_all(parent)?;
         }
 
         let script_content = format!(
             r#"#!/usr/bin/env bash
 
-exec {} "$@" -L {}/share/kata-{}/qemu/
+exec {} "$@" -L {}
 "#,
-            qemu_binary, config.dest_dir, qemu_artifact
+            qemu_binary, qemu_data_dir
         );
 
-        fs::write(&host_wrapper_path, &script_content)?;
-        let mut perms = fs::metadata(&host_wrapper_path)?.permissions();
+        fs::write(&wrapper_script_path, &script_content)?;
+        let mut perms = fs::metadata(&wrapper_script_path)?.permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(&host_wrapper_path, perms)?;
+        fs::set_permissions(&wrapper_script_path, perms)?;
 
-        log::debug!("Created QEMU wrapper script: {}", host_wrapper_path);
+        log::debug!("Created QEMU wrapper script: {}", wrapper_script_path);
     }
 
-    Ok(Some(wrapper_script_path))
+    Ok(wrapper_script_path)
 }
 
-/// Get the hypervisor binary path for a given shim.
-/// Returns the path to the hypervisor binary based on the shim type.
-fn get_hypervisor_path(config: &Config, shim: &str) -> Result<String> {
-    if is_qemu_shim(shim) {
-        // For QEMU shims, use the wrapper script that adds firmware paths
-        // create_qemu_wrapper_script always returns Some for QEMU shims
-        create_qemu_wrapper_script(config, shim)?.ok_or_else(|| {
-            anyhow::anyhow!("QEMU wrapper script should always be created for QEMU shims")
-        })
-    } else {
-        // For non-QEMU shims, use the appropriate hypervisor binary
-        let binary = match shim {
-            "clh" | "clh-azure" | "clh-runtime-rs" | "clh-azure-runtime-rs" => "cloud-hypervisor",
-            "openvmm-azure-runtime-rs" => "openvmm",
-            "fc" | "firecracker" => "firecracker",
-            "dragonball" => "dragonball",
-            "stratovirt" => "stratovirt",
-            // Remote and other shims don't have a local hypervisor binary
-            _ => return Ok(String::new()),
-        };
-        Ok(format!("{}/bin/{}", config.dest_dir, binary))
+/// `None` outside the prefix: not part of the installation, so it does not move.
+fn reprefix_installed_path(path: &str, dest_dir: &str) -> Option<String> {
+    let relative = path.strip_prefix(DEFAULT_KATA_INSTALL_DIR)?;
+    if !relative.is_empty() && !relative.starts_with('/') {
+        return None;
+    }
+
+    Some(format!("{dest_dir}{relative}"))
+}
+
+/// Arrays are re-emitted whole, since the drop-in merge replaces them.
+fn reprefixed_value(value: &Value, dest_dir: &str) -> Option<Value> {
+    match value {
+        Value::String(path) => reprefix_installed_path(path.value(), dest_dir).map(Value::from),
+        Value::Array(paths) => {
+            let mut reprefixed = Array::new();
+            let mut relocated = false;
+            for path in paths.iter() {
+                let path = path.as_str()?;
+                match reprefix_installed_path(path, dest_dir) {
+                    Some(path) => {
+                        reprefixed.push(path);
+                        relocated = true;
+                    }
+                    None => reprefixed.push(path),
+                }
+            }
+            relocated.then_some(Value::Array(reprefixed))
+        }
+        _ => None,
     }
 }
 
-/// Generate drop-in content for installation prefix adjustments.
-/// This replaces /opt/kata with the custom dest_dir in all relevant paths.
-/// For QEMU shims, this also creates a wrapper script for firmware paths.
+fn reprefixed_table(table: &Table, dest_dir: &str) -> Table {
+    let mut reprefixed = Table::new();
+    // Implicit: no header for a table left with only sub-tables.
+    reprefixed.set_implicit(true);
+
+    for (key, item) in table.iter() {
+        if let Some(item) = reprefixed_item(item, dest_dir) {
+            reprefixed.insert(key, item);
+        }
+    }
+
+    reprefixed
+}
+
+fn reprefixed_item(item: &Item, dest_dir: &str) -> Option<Item> {
+    match item {
+        Item::Value(value) => reprefixed_value(value, dest_dir).map(Item::Value),
+        Item::Table(table) => {
+            let reprefixed = reprefixed_table(table, dest_dir);
+            (!reprefixed.is_empty()).then_some(Item::Table(reprefixed))
+        }
+        _ => None,
+    }
+}
+
+/// `None` for a QEMU from outside the installation: it finds its own data dir.
+fn relocated_qemu_binary(
+    drop_in: &DocumentMut,
+    shim: &str,
+    hypervisor_name: &str,
+) -> Option<String> {
+    if !is_qemu_shim(shim) {
+        return None;
+    }
+
+    drop_in
+        .get("hypervisor")?
+        .get(hypervisor_name)?
+        .get("path")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Re-prefixes what the base config already sets, so each shim keeps the
+/// artifacts it was configured with rather than a hardcoded guess.
 fn generate_installation_prefix_drop_in(config: &Config, shim: &str) -> Result<String> {
     let hypervisor_name = get_hypervisor_name(shim)?;
+    let base_config = base_config_file(config, shim);
+    let base_config_path = Path::new(&base_config);
 
-    // Build the drop-in content with adjusted paths
+    if !base_config_path.exists() {
+        warn!(
+            "{}: base config {} is missing; no installation prefix drop-in will be generated",
+            shim, base_config
+        );
+        return Ok(String::new());
+    }
+
+    let base = fs::read_to_string(base_config_path)
+        .with_context(|| format!("Failed to read base config: {base_config}"))?
+        .parse::<DocumentMut>()
+        .with_context(|| format!("Failed to parse base config as TOML: {base_config}"))?;
+
+    let mut drop_in = DocumentMut::new();
+    *drop_in.as_table_mut() = reprefixed_table(base.as_table(), &config.dest_dir);
+
+    if let Some(qemu_binary) = relocated_qemu_binary(&drop_in, shim, hypervisor_name) {
+        match qemu_data_dir(&qemu_binary, &config.dest_dir) {
+            Some(data_dir) => {
+                let wrapper = create_qemu_wrapper_script(&qemu_binary, &data_dir)?;
+                drop_in["hypervisor"][hypervisor_name]["path"] = value(wrapper);
+            }
+            None => warn!(
+                "{}: cannot tell which data directory {} belongs to, so it is run unwrapped \
+                 and may fail to find its firmware",
+                shim, qemu_binary
+            ),
+        }
+    }
+
+    if drop_in.as_table().is_empty() {
+        return Ok(String::new());
+    }
+
     let mut content = String::new();
     content.push_str("# Installation prefix adjustments\n");
-    content.push_str("# Generated by kata-deploy\n\n");
-
-    // Hypervisor section
-    content.push_str(&format!("[hypervisor.{}]\n", hypervisor_name));
-
-    // Only set hypervisor path if applicable for this shim type
-    let hypervisor_path = get_hypervisor_path(config, shim)?;
-    if !hypervisor_path.is_empty() {
-        content.push_str(&format!("path = \"{}\"\n", hypervisor_path));
-    }
-
-    // Common paths for all hypervisors
+    content.push_str("# Generated by kata-deploy\n");
+    content.push_str("#\n");
     content.push_str(&format!(
-        "kernel = \"{}/share/kata-containers/vmlinux.container\"\n",
-        config.dest_dir
+        "# The paths the base configuration sets under {}, moved to {}.\n\n",
+        DEFAULT_KATA_INSTALL_DIR, config.dest_dir
     ));
-    content.push_str(&format!(
-        "image = \"{}/share/kata-containers/kata-containers.img\"\n",
-        config.dest_dir
-    ));
-    content.push_str(&format!(
-        "initrd = \"{}/share/kata-containers/kata-containers-initrd.img\"\n",
-        config.dest_dir
-    ));
-
-    // QEMU-specific paths (firmware is only relevant for QEMU)
-    if is_qemu_shim(shim) {
-        content.push_str(&format!(
-            "firmware = \"{}/share/kata-containers/firmware/\"\n",
-            config.dest_dir
-        ));
-        content.push_str(&format!(
-            "firmware_volume = \"{}/share/kata-containers/firmware/\"\n",
-            config.dest_dir
-        ));
-    }
-
-    // Firecracker-specific paths (jailer is only for Firecracker)
-    if shim == "fc" || shim == "firecracker" {
-        content.push_str(&format!(
-            "jailer_path = \"{}/bin/jailer\"\n",
-            config.dest_dir
-        ));
-        content.push_str(&format!(
-            "valid_jailer_paths = [\"{}/bin/jailer\"]\n",
-            config.dest_dir
-        ));
-    }
+    content.push_str(&drop_in.to_string());
 
     Ok(content)
 }
@@ -1841,12 +1866,18 @@ fn get_proxy_value_for_shim(proxy_var: &Option<String>, shim: &str) -> Option<St
     }
 }
 
+/// The shim's installed configuration, the one config.d is layered on top of.
+fn base_config_file(config: &Config, shim: &str) -> String {
+    let original_config_dir =
+        utils::get_kata_containers_original_config_path(shim, &config.dest_dir);
+
+    format!("{}/configuration-{}.toml", original_config_dir, shim)
+}
+
 /// Read base kernel_params from the original configuration file.
 fn read_base_kernel_params(config: &Config, shim: &str) -> Result<String> {
     let hypervisor_name = get_hypervisor_name(shim)?;
-    let original_config_dir =
-        utils::get_kata_containers_original_config_path(shim, &config.dest_dir);
-    let original_config_file = format!("{}/configuration-{}.toml", original_config_dir, shim);
+    let original_config_file = base_config_file(config, shim);
     let config_path = Path::new(&original_config_file);
 
     if !config_path.exists() {
@@ -2027,25 +2058,47 @@ mod tests {
     }
 
     #[rstest]
-    #[case("qemu", "qemu")]
-    #[case("qemu-runtime-rs", "qemu")]
-    #[case("qemu-nvidia-cpu", "qemu")]
-    #[case("qemu-nvidia-cpu-runtime-rs", "qemu-no-shared-fs")]
-    #[case("qemu-nvidia-gpu-runtime-rs", "qemu-no-shared-fs")]
-    #[case("qemu-nvidia-gpu-snp", "qemu-snp-experimental")]
-    #[case("qemu-nvidia-gpu-snp-runtime-rs", "qemu-snp-experimental")]
-    #[case("qemu-nvidia-gpu-tdx", "qemu-tdx-experimental")]
-    #[case("qemu-nvidia-gpu-tdx-runtime-rs", "qemu-tdx-experimental")]
-    fn test_get_qemu_artifact_name(#[case] shim: &str, #[case] expected: &str) {
-        assert_eq!(get_qemu_artifact_name(shim).unwrap(), expected);
+    #[case("", "kata-qemu")]
+    #[case("-no-shared-fs", "kata-qemu-no-shared-fs")]
+    #[case("-snp-experimental", "kata-qemu-snp-experimental")]
+    #[case("-tdx-experimental", "kata-qemu-tdx-experimental")]
+    fn test_qemu_data_dir_follows_the_flavour(
+        #[case] flavour_suffix: &str,
+        #[case] expected_share_dir: &str,
+    ) {
+        let qemu_binary = format!(
+            "/opt/kata-coco/bin/{}{}",
+            qemu_system_binary_for(current_arch()),
+            flavour_suffix
+        );
+
+        assert_eq!(
+            qemu_data_dir(&qemu_binary, "/opt/kata-coco").unwrap(),
+            format!("/opt/kata-coco/share/{}/qemu/", expected_share_dir)
+        );
+    }
+
+    #[test]
+    fn test_qemu_data_dir_unknown_binary() {
+        assert!(qemu_data_dir("/usr/bin/some-other-vmm", "/opt/kata-coco").is_none());
     }
 
     #[rstest]
-    #[case("clh")]
-    #[case("dragonball")]
-    #[case("fc")]
-    fn test_get_qemu_artifact_name_non_qemu(#[case] shim: &str) {
-        assert!(get_qemu_artifact_name(shim).is_none());
+    #[case(
+        "/opt/kata/share/kata-containers/vmlinuz.container",
+        Some("/prefix/opt/kata/share/kata-containers/vmlinuz.container")
+    )]
+    #[case("/opt/kata", Some("/prefix/opt/kata"))]
+    // Host-provided artifact.
+    #[case("/usr/share/cloud-hypervisor/vmlinux.bin", None)]
+    // Another multi-install, not ours.
+    #[case("/opt/kata-other/bin/qemu-system-x86_64", None)]
+    #[case("", None)]
+    fn test_reprefix_installed_path(#[case] path: &str, #[case] expected: Option<&str>) {
+        assert_eq!(
+            reprefix_installed_path(path, "/prefix/opt/kata").as_deref(),
+            expected
+        );
     }
 
     #[rstest]
@@ -2517,15 +2570,13 @@ mod tests {
         assert!(content.contains("debug_console_enabled = true"));
     }
 
-    /// A Config with no source of kernel params of its own, so each test can
-    /// switch on just the one it is about. dest_dir points at a path with no
-    /// installed configuration, which makes the base params come out empty.
-    fn kernel_params_config() -> crate::config::Config {
+    /// A Config carrying just enough to exercise the drop-in generators.
+    fn test_config(shim: &str, dest_dir: &str) -> crate::config::Config {
         crate::config::Config {
             node_name: "test".to_string(),
             debug: true,
-            shims_for_arch: vec!["qemu".to_string()],
-            default_shim_for_arch: "qemu".to_string(),
+            shims_for_arch: vec![shim.to_string()],
+            default_shim_for_arch: shim.to_string(),
             allowed_hypervisor_annotations_for_arch: vec![],
             snapshotter_handler_mapping_for_arch: None,
             agent_https_proxy: None,
@@ -2539,8 +2590,8 @@ mod tests {
             experimental_setup_snapshotter: None,
             erofs_merge_mode: None,
             experimental_force_guest_pull_for_arch: vec![],
-            dest_dir: "/opt/kata".to_string(),
-            host_install_dir: "/opt/kata".to_string(),
+            dest_dir: dest_dir.to_string(),
+            host_install_dir: dest_dir.to_string(),
             crio_drop_in_conf_dir: String::new(),
             crio_drop_in_conf_file: String::new(),
             crio_drop_in_conf_file_debug: String::new(),
@@ -2558,6 +2609,13 @@ mod tests {
             k8s_distribution: None,
             containerd_config_dir: None,
         }
+    }
+
+    /// A Config with no source of kernel params of its own, so each test can
+    /// switch on just the one it is about. dest_dir points at a path with no
+    /// installed configuration, which makes the base params come out empty.
+    fn kernel_params_config() -> crate::config::Config {
+        test_config("qemu", DEFAULT_KATA_INSTALL_DIR)
     }
 
     #[test]
@@ -2590,7 +2648,169 @@ mod tests {
         assert!(other.is_empty());
     }
 
+    /// Lay down `content` where the payload ships the shim's base config.
+    fn install_base_config(config: &crate::config::Config, shim: &str, content: &str) -> String {
+        let base_config = base_config_file(config, shim);
+        fs::create_dir_all(Path::new(&base_config).parent().unwrap()).unwrap();
+        fs::write(&base_config, content).unwrap();
+        base_config
+    }
+
+    /// The qemu-snp base config, trimmed to the paths that matter.
+    fn confidential_base_config() -> String {
+        format!(
+            r#"[hypervisor.qemu]
+path = "/opt/kata/bin/{qemu}-snp-experimental"
+valid_hypervisor_paths = ["/opt/kata/bin/{qemu}-snp-experimental"]
+kernel = "/opt/kata/share/kata-containers/vmlinuz.container"
+image = "/opt/kata/share/kata-containers/kata-containers-confidential.img"
+firmware = "/opt/kata/share/ovmf/AMDSEV.fd"
+firmware_volume = ""
+virtio_fs_daemon = "/opt/kata/libexec/virtiofsd"
+shared_fs = "virtio-fs"
+kernel_params = ""
+
+[runtime]
+enable_debug = false
+"#,
+            qemu = qemu_system_binary_for(current_arch())
+        )
+    }
+
+    #[test]
+    fn test_installation_prefix_drop_in_keeps_confidential_artifacts() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dest_dir = tmpdir.path().to_str().unwrap();
+        let config = test_config("qemu-snp", dest_dir);
+        install_base_config(&config, "qemu-snp", &confidential_base_config());
+
+        let content = generate_installation_prefix_drop_in(&config, "qemu-snp").unwrap();
+        let drop_in = content.parse::<DocumentMut>().unwrap();
+        let hypervisor = &drop_in["hypervisor"]["qemu"];
+
+        assert_eq!(
+            hypervisor["kernel"].as_str().unwrap(),
+            format!("{dest_dir}/share/kata-containers/vmlinuz.container")
+        );
+        assert_eq!(
+            hypervisor["image"].as_str().unwrap(),
+            format!("{dest_dir}/share/kata-containers/kata-containers-confidential.img")
+        );
+        assert_eq!(
+            hypervisor["firmware"].as_str().unwrap(),
+            format!("{dest_dir}/share/ovmf/AMDSEV.fd")
+        );
+
+        // An image-only guest must not be given an initrd.
+        assert!(hypervisor.get("initrd").is_none());
+        assert!(hypervisor.get("firmware_volume").is_none());
+    }
+
+    #[test]
+    fn test_installation_prefix_drop_in_wraps_the_qemu_flavour_the_shim_runs() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dest_dir = tmpdir.path().to_str().unwrap();
+        let config = test_config("qemu-snp", dest_dir);
+        install_base_config(&config, "qemu-snp", &confidential_base_config());
+
+        let content = generate_installation_prefix_drop_in(&config, "qemu-snp").unwrap();
+        let drop_in = content.parse::<DocumentMut>().unwrap();
+
+        let qemu_binary = format!(
+            "{dest_dir}/bin/{}-snp-experimental",
+            qemu_system_binary_for(current_arch())
+        );
+        let wrapper = format!("{qemu_binary}-installation-prefix");
+        assert_eq!(
+            drop_in["hypervisor"]["qemu"]["path"].as_str().unwrap(),
+            wrapper
+        );
+
+        // Its own flavour's firmware, not the plain build's.
+        let script = fs::read_to_string(&wrapper).unwrap();
+        assert!(
+            script.contains(&format!(
+                "exec {qemu_binary} \"$@\" -L {dest_dir}/share/kata-qemu-snp-experimental/qemu/"
+            )),
+            "unexpected wrapper script: {script}"
+        );
+    }
+
+    #[test]
+    fn test_installation_prefix_drop_in_only_carries_installed_paths() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dest_dir = tmpdir.path().to_str().unwrap();
+        let config = test_config("qemu-snp", dest_dir);
+        install_base_config(&config, "qemu-snp", &confidential_base_config());
+
+        let content = generate_installation_prefix_drop_in(&config, "qemu-snp").unwrap();
+        let drop_in = content.parse::<DocumentMut>().unwrap();
+        let hypervisor = &drop_in["hypervisor"]["qemu"];
+
+        assert_eq!(
+            hypervisor["valid_hypervisor_paths"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|path| path.as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![format!(
+                "{dest_dir}/bin/{}-snp-experimental",
+                qemu_system_binary_for(current_arch())
+            )]
+        );
+        assert_eq!(
+            hypervisor["virtio_fs_daemon"].as_str().unwrap(),
+            format!("{dest_dir}/libexec/virtiofsd")
+        );
+
+        // Anything that is not a path stays with the base config.
+        assert!(hypervisor.get("shared_fs").is_none());
+        assert!(hypervisor.get("kernel_params").is_none());
+        assert!(
+            !content.contains("[runtime]"),
+            "a section with nothing to relocate should not be emitted: {content}"
+        );
+    }
+
+    #[test]
+    fn test_installation_prefix_drop_in_keeps_host_provided_artifacts() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dest_dir = tmpdir.path().to_str().unwrap();
+        let config = test_config("clh-azure", dest_dir);
+        install_base_config(
+            &config,
+            "clh-azure",
+            r#"[hypervisor.clh]
+path = "/opt/kata/bin/cloud-hypervisor"
+kernel = "/usr/share/cloud-hypervisor/vmlinux.bin"
+image = "/opt/kata/share/kata-containers/kata-containers-mariner.img"
+"#,
+        );
+
+        let content = generate_installation_prefix_drop_in(&config, "clh-azure").unwrap();
+        let drop_in = content.parse::<DocumentMut>().unwrap();
+        let hypervisor = &drop_in["hypervisor"]["clh"];
+
+        assert_eq!(
+            hypervisor["path"].as_str().unwrap(),
+            format!("{dest_dir}/bin/cloud-hypervisor")
+        );
+        assert!(hypervisor.get("kernel").is_none());
+    }
+
+    #[test]
+    fn test_installation_prefix_drop_in_is_empty_without_a_base_config() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = test_config("qemu", tmpdir.path().to_str().unwrap());
+
+        assert!(generate_installation_prefix_drop_in(&config, "qemu")
+            .unwrap()
+            .is_empty());
+    }
+
     #[rstest]
+    #[case("10-installation-prefix.toml")]
     #[case("20-debug.toml")]
     #[case("30-kernel-params.toml")]
     fn test_reconcile_stale_drop_in_removes_file(#[case] filename: &str) {


### PR DESCRIPTION
Prefixed installs are broken, and we never ever had a test for it.

Fixes: #13697 