### PR TITLE
runtime-rs: avoid panics on unsupported hypervisor metrics

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
@@ -222,6 +222,22 @@ impl FcInner {
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
         warn!(sl(), "Get Hypervisor Metrics: Not implemented");
-        todo!()
+        Ok(String::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn test_unsupported_hypervisor_metrics_are_empty() {
+        let (exit_notify, _exit_waiter) = mpsc::channel(1);
+        let firecracker = FcInner::new(exit_notify);
+
+        for _ in 0..3 {
+            assert_eq!(firecracker.get_hypervisor_metrics().await.unwrap(), "");
+        }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -836,7 +836,8 @@ impl QemuInner {
     }
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
-        todo!()
+        warn!(sl!(), "Get Hypervisor Metrics: Not implemented");
+        Ok(String::new())
     }
 
     pub(crate) fn set_capabilities(&mut self, flag: CapabilityBits) {
@@ -1494,6 +1495,16 @@ mod tests {
     fn test_memlock_limit_adds_headroom() {
         assert_eq!(memlock_limit_with_headroom(10 * 1024), 11 * 1024);
         assert_eq!(memlock_limit_with_headroom(u64::MAX), u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_hypervisor_metrics_are_empty() {
+        let (exit_notify, _exit_waiter) = mpsc::channel(1);
+        let qemu = QemuInner::new(exit_notify);
+
+        for _ in 0..3 {
+            assert_eq!(qemu.get_hypervisor_metrics().await.unwrap(), "");
+        }
     }
 
     #[rstest]


### PR DESCRIPTION
## Motivation

The shim management server answers `/metrics` by concatenating the agent, hypervisor, and shim metric
sections. In `runtime-rs`, QEMU and Firecracker still leave `get_hypervisor_metrics()` as `todo!()`, so a
single scrape of that endpoint panics the shim and takes the sandbox down with it.

I see metrics as optional data. A hypervisor that does not report them must not be able to kill a running
workload, and anyone monitoring a Kata node has no way to know which hypervisor is safe to scrape.

## Resolution

Both hypervisors now return an empty metrics payload. `metrics_url_handler` folds the hypervisor section
in through `unwrap_or_default()`, so an empty string leaves a valid response that still carries the agent
and shim metrics.

Each hypervisor also gains a unit test that calls `get_hypervisor_metrics()` repeatedly, so a future
reintroduction of `todo!()` or other panicking code on this path fails the build instead of production.

Fixes #13708