### PR TITLE
kata-deploy: load required host modules in job mode

### DIFF
--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -30,18 +30,17 @@ permissions: {}
 
 jobs:
   run-kata-deploy-tests:
-    name: run-kata-deploy-tests
+    name: run-kata-deploy-tests (${{ matrix.environment.vmm }}, ${{ matrix.environment.k8s }})
     strategy:
       fail-fast: false
       matrix:
-        vmm:
-          - qemu
-        k8s:
-          - k0s
-          - k3s
-          - rke2
-          - microk8s
-          - kubeadm
+        environment: [
+          { vmm: qemu-runtime-rs, k8s: k0s },
+          { vmm: qemu-runtime-rs, k8s: k3s },
+          { vmm: qemu-runtime-rs, k8s: rke2 },
+          { vmm: qemu-runtime-rs, k8s: microk8s },
+          { vmm: qemu-nvidia-cpu-runtime-rs, k8s: kubeadm, snapshotter: erofs, erofs_snapshotter_mode: disk, erofs_dmverity: dmverity, manages_host_modules: "yes" },
+        ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
@@ -51,11 +50,17 @@ jobs:
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
       GH_PR_NUMBER: ${{ inputs.pr-number }}
-      KATA_HYPERVISOR: ${{ matrix.vmm }}
-      KUBERNETES: ${{ matrix.k8s }}
+      KATA_HYPERVISOR: ${{ matrix.environment.vmm }}
+      KUBERNETES: ${{ matrix.environment.k8s }}
       # Only used when deploying the kubeadm flavour
       CONTAINER_ENGINE: containerd
       CONTAINER_ENGINE_VERSION: latest
+      # Only the kubeadm path prepares EROFS on the runner, so that is where the
+      # host module coverage lives.
+      SNAPSHOTTER: ${{ matrix.environment.snapshotter }}
+      EROFS_SNAPSHOTTER_MODE: ${{ matrix.environment.erofs_snapshotter_mode }}
+      EROFS_DMVERITY: ${{ matrix.environment.erofs_dmverity }}
+      KATA_DEPLOY_MANAGES_HOST_MODULES: ${{ matrix.environment.manages_host_modules }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -87,7 +92,7 @@ jobs:
           sudo rm -rf /opt/google
           sudo rm -rf /usr/lib/firefox
 
-      - name: Deploy ${{ matrix.k8s }}
+      - name: Deploy ${{ matrix.environment.k8s }}
         run:  bash tests/functional/kata-deploy/gha-run.sh deploy-k8s
 
       - name: Install `bats`

--- a/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
+++ b/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
@@ -26,6 +26,15 @@ CUSTOM_RUNTIME_HANDLER="kata-my-custom-handler"
 TEST_POD_NAME="kata-deploy-custom-verify"
 CHART_PATH="$(get_chart_path)"
 
+# The two runtimes spell the agent dial timeout differently, and runtime-rs
+# refuses a config carrying a field it does not know, so a drop-in meant to be
+# applied for real has to match the base config it extends.
+if [[ "${KATA_HYPERVISOR:-qemu-runtime-rs}" == *-runtime-rs ]]; then
+	DROP_IN_SETTING="dial_timeout_ms = 999"
+else
+	DROP_IN_SETTING="dial_timeout = 999"
+fi
+
 # =============================================================================
 # Template Rendering Tests (no cluster required)
 # =============================================================================
@@ -62,7 +71,7 @@ CHART_PATH="$(get_chart_path)"
 		> /tmp/rendered.yaml
 
 	grep -q "dropin-${CUSTOM_RUNTIME_HANDLER}.toml" /tmp/rendered.yaml
-	grep -q "dial_timeout = 999" /tmp/rendered.yaml
+	grep -q "${DROP_IN_SETTING}" /tmp/rendered.yaml
 }
 
 @test "Helm template: CUSTOM_RUNTIMES_ENABLED env var is set" {
@@ -306,7 +315,7 @@ customRuntimes:
       baseConfig: "${KATA_HYPERVISOR}"
       dropIn: |
         [agent.kata]
-        dial_timeout = 999
+        ${DROP_IN_SETTING}
       runtimeClass: |
         kind: RuntimeClass
         apiVersion: node.k8s.io/v1
@@ -344,7 +353,7 @@ customRuntimes:
       baseConfig: "${KATA_HYPERVISOR:-qemu-runtime-rs}"
       dropIn: |
         [agent.kata]
-        dial_timeout = 999
+        ${DROP_IN_SETTING}
       runtimeClass: |
         kind: RuntimeClass
         apiVersion: node.k8s.io/v1

--- a/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
+++ b/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
@@ -35,6 +35,15 @@ else
 	DROP_IN_SETTING="dial_timeout = 999"
 fi
 
+# A custom runtime inherits the rootfs type of the base config it extends, so it
+# needs the very snapshotter that base config was built around -- an EROFS
+# configuration cannot make sense of the overlayfs rootfs containerd hands out
+# by default.
+CUSTOM_RUNTIME_SNAPSHOTTER=""
+if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
+	CUSTOM_RUNTIME_SNAPSHOTTER="erofs"
+fi
+
 # =============================================================================
 # Template Rendering Tests (no cluster required)
 # =============================================================================
@@ -332,7 +341,7 @@ customRuntimes:
           nodeSelector:
             katacontainers.io/kata-runtime: "true"
       containerd:
-        snapshotter: ""
+        snapshotter: "${CUSTOM_RUNTIME_SNAPSHOTTER}"
       crio:
         pullType: ""
 EOF
@@ -370,7 +379,7 @@ customRuntimes:
           nodeSelector:
             katacontainers.io/kata-runtime: "true"
       containerd:
-        snapshotter: ""
+        snapshotter: "${CUSTOM_RUNTIME_SNAPSHOTTER}"
       crio:
         pullType: ""
 EOF

--- a/tests/functional/kata-deploy/kata-deploy-host-modules.bats
+++ b/tests/functional/kata-deploy/kata-deploy-host-modules.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Host kernel module loading in "job" mode, on a real node.
+#
+# The template tests pin down which stage is privileged and what it mounts, but
+# the stage runs the host's modprobe under a chroot, so only a real node shows
+# whether it loaded the right modules.
+#
+# Required environment variables:
+#   DOCKER_REGISTRY - Container registry for kata-deploy image
+#   DOCKER_REPO     - Repository name for kata-deploy image
+#   DOCKER_TAG      - Image tag to test
+#   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
+#   KUBERNETES      - Must be kubeadm
+#   SNAPSHOTTER     - Must be erofs
+#   EROFS_DMVERITY  - Must be dmverity
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+MODULES_LOAD_FILE="/host/etc/modules-load.d/kata-containers-default.conf"
+KATA_POD_NAME="kata-deploy-host-modules-verify"
+
+# The module names the install recorded on the node, space separated.
+persisted_modules() {
+	run_on_host "grep -v '^#' ${MODULES_LOAD_FILE} | tr '\n' ' '"
+}
+
+# Reports each module as "<name>=loaded" or "<name>=missing", checking
+# /sys/module as well because a built-in module never reaches /proc/modules.
+module_states() {
+	local modules="${1}"
+	run_on_host "for m in ${modules}; do if [ -d /host/sys/module/\$m ] || cut -d' ' -f1 /host/proc/modules | grep -qx \$m; then echo \$m=loaded; else echo \$m=missing; fi; done"
+}
+
+setup_file() {
+	if [[ "${KUBERNETES}" != "kubeadm" ]]; then
+		skip "host-module integration coverage is kubeadm-only"
+	fi
+
+	if [[ "${KATA_HYPERVISOR}" == "remote" ]]; then
+		skip "a remote hypervisor needs no host virtualization modules"
+	fi
+
+	if [[ "${SNAPSHOTTER:-}" != "erofs" || "${EROFS_DMVERITY:-}" != "dmverity" ]]; then
+		skip "host-module integration coverage requires EROFS with dm-verity"
+	fi
+
+	ensure_helm
+	echo "# Deploying kata-deploy in job mode with EROFS and dm-verity..." >&3
+	deploy_kata "" --set deploymentMode=job
+}
+
+@test "Job mode loads and persists the host modules the install needs" {
+	run persisted_modules
+	echo "# Persisted modules: ${output}" >&3
+	[ "${status}" -eq 0 ]
+
+	# This job runs QEMU, which does reach the agent through the host's VSOCK.
+	[[ "${output}" == *"vhost_vsock"* ]]
+
+	# It also runs EROFS with dm-verity, so their modules are persisted too.
+	[[ "${output}" == *"erofs"* ]]
+	[[ "${output}" == *"loop"* ]]
+	[[ "${output}" == *"dm_mod"* ]]
+	[[ "${output}" == *"dm_verity"* ]]
+
+	local modules="${output}"
+	run module_states "${modules}"
+	echo "# Module states: ${output}" >&3
+	[ "${status}" -eq 0 ]
+	[[ "${output}" != *"=missing"* ]]
+}
+
+@test "A Kata pod starts with EROFS after the modules are loaded" {
+	kubectl delete pod "${KATA_POD_NAME}" --ignore-not-found --wait=true
+
+	cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${KATA_POD_NAME}
+spec:
+  runtimeClassName: kata-${KATA_HYPERVISOR}
+  restartPolicy: Never
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: test
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: Always
+      command: ["sleep", "300"]
+EOF
+
+	kubectl wait --for=condition=Ready "pod/${KATA_POD_NAME}" --timeout=180s
+
+	run kubectl exec "${KATA_POD_NAME}" -- uname -r
+	echo "# Kata guest kernel: ${output}" >&3
+	[ "${status}" -eq 0 ]
+	[[ -n "${output}" ]]
+
+	kubectl delete pod "${KATA_POD_NAME}" --wait=true
+}
+
+@test "Uninstall forgets the modules without unloading them" {
+	local modules
+	run persisted_modules
+	[ "${status}" -eq 0 ]
+	modules="${output}"
+
+	uninstall_kata
+	kubectl wait nodes --timeout=300s --all --for condition=Ready=True
+
+	run run_on_host "test -e ${MODULES_LOAD_FILE} && echo PRESENT || echo GONE"
+	echo "# Persistence file after uninstall: ${output}" >&3
+	[[ "${output}" == *"GONE"* ]]
+
+	# Module state is host-global and may be in use by something else, so
+	# uninstall leaves the modules loaded.
+	run module_states "${modules}"
+	echo "# Module states after uninstall: ${output}" >&3
+	[[ "${output}" != *"=missing"* ]]
+}
+
+teardown_file() {
+	kubectl delete pod "${KATA_POD_NAME}" --ignore-not-found --wait=false 2>/dev/null || true
+	uninstall_kata 2>/dev/null || true
+}

--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -32,53 +32,6 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 
 LIFECYCLE_POD_NAME="kata-lifecycle-test"
 
-# Run a command on the host node's filesystem using a short-lived privileged pod.
-# The host root is mounted at /host inside the pod.
-# Usage: run_on_host "test -d /host/opt/kata && echo YES || echo NO"
-#
-# We avoid `kubectl run --rm -i` because rke2 injects session-recording banners
-# into interactive pods, polluting stdout. Instead: create, wait, fetch logs, delete.
-run_on_host() {
-	local cmd="$1"
-	local node_name
-	node_name=$(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name | head -1)
-	local pod_name="host-exec-${RANDOM}"
-
-	kubectl run "${pod_name}" \
-		--image=quay.io/kata-containers/alpine-bash-curl:latest \
-		--restart=Never \
-		--overrides="{
-			\"spec\": {
-				\"nodeName\": \"${node_name}\",
-				\"activeDeadlineSeconds\": 300,
-				\"tolerations\": [{\"operator\": \"Exists\"}],
-				\"containers\": [{
-					\"name\": \"exec\",
-					\"image\": \"quay.io/kata-containers/alpine-bash-curl:latest\",
-					\"imagePullPolicy\": \"IfNotPresent\",
-					\"command\": [\"sh\", \"-c\", \"${cmd}\"],
-					\"securityContext\": {\"privileged\": true},
-					\"volumeMounts\": [{\"name\": \"host\", \"mountPath\": \"/host\", \"readOnly\": true}]
-				}],
-				\"volumes\": [{\"name\": \"host\", \"hostPath\": {\"path\": \"/\"}}]
-			}
-		}" > /dev/null 2>&1
-
-	local deadline=$((SECONDS + 60))
-	while (( SECONDS < deadline )); do
-		local phase
-		phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null) || true
-		case "${phase}" in
-			Succeeded|Failed) break ;;
-		esac
-		sleep 1
-	done
-
-	kubectl logs "${pod_name}" 2>/dev/null
-	kubectl delete pod "${pod_name}" --ignore-not-found=true > /dev/null 2>&1
-	[[ "${phase}" == "Succeeded" ]]
-}
-
 setup_file() {
 	ensure_helm
 

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -63,6 +63,18 @@ per_node_pod_spec() {
 	'
 }
 
+# One named container out of a staged per-node Job. Its env entries are indented
+# deeper than the container itself, so the next peer `- name:` ends it.
+stage_container() {
+	local stage="${1}" name="${2}"
+	shift 2
+	per_node_pod_spec "${stage}" "$@" | awk -v want="            - name: ${name}" '
+		$0 == want { inside = 1 }
+		inside && $0 != want && $0 ~ /^            - name: / { exit }
+		inside { print }
+	'
+}
+
 # One YAML document out of a rendered multi-document template, picked by name, so
 # that a test can assert what a single ClusterRole grants rather than counting
 # substrings across every document at once.
@@ -122,11 +134,69 @@ rbac_doc() {
 
 	# The stages that are left, in order. Install ends with the CRI restart, which
 	# is why it is the main container rather than an init container.
+	echo "${jobs}" | grep -q 'install-stage-load-kernel-modules'
 	echo "${jobs}" | grep -q 'install-stage-host-check'
 	echo "${jobs}" | grep -q 'install-stage-artifacts'
 	echo "${jobs}" | grep -q 'install-stage-cri'
 	echo "${jobs}" | grep -q 'cleanup-stage-revert-cri'
 	echo "${jobs}" | grep -q 'cleanup-stage-remove-artifacts'
+}
+
+@test "Helm template (job mode): module loading is the only privileged stage" {
+	local loader host_check artifacts cri cleanup revert_cri remove_artifacts
+	loader=$(stage_container install load-kernel-modules)
+	host_check=$(stage_container install host-check)
+	artifacts=$(stage_container install artifacts)
+	cri=$(stage_container install cri)
+	cleanup=$(per_node_pod_spec cleanup)
+	revert_cri=$(stage_container cleanup revert-cri)
+	remove_artifacts=$(stage_container cleanup remove-artifacts)
+
+	[[ -n "${loader}" ]]
+	echo "${loader}" | grep -q 'install-stage-load-kernel-modules'
+	echo "${loader}" | grep -qE '^                privileged: true$'
+	echo "${loader}" | grep -qE '^                  mountPath: /host$'
+	echo "${loader}" | grep -qE '^                  readOnly: true$'
+	echo "${loader}" | grep -qE '^                  mountPath: /host-modules-load.d$'
+
+	for container in "${host_check}" "${artifacts}" "${cri}"; do
+		[[ -n "${container}" ]]
+		echo "${container}" | grep -qE '^                privileged: false$'
+		refute_match "${container}" 'mountPath: /host$'
+		refute_match "${container}" 'mountPath: /host-modules-load.d$'
+	done
+
+	# Cleanup never touches host-global module state, so it needs the persistence
+	# file but not the host root.
+	refute_match "${cleanup}" 'install-stage-load-kernel-modules'
+	refute_match "${cleanup}" 'name: host-root'
+	refute_match "${revert_cri}" 'mountPath: /host-modules-load.d$'
+	echo "${remove_artifacts}" | grep -qE '^                  mountPath: /host-modules-load.d$'
+	echo "${remove_artifacts}" | grep -qE '^                privileged: false$'
+
+	# Module loading is job-mode only, so the DaemonSet path stays unprivileged.
+	local daemonset
+	daemonset=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--show-only templates/kata-deploy.yaml)
+	refute_match "${daemonset}" 'install-stage-load-kernel-modules'
+	refute_match "${daemonset}" 'name: host-root'
+	refute_match "${daemonset}" 'name: modules-load-d'
+	refute_match "${daemonset}" 'privileged: true'
+}
+
+@test "Helm template (job mode): module loading runs before host validation" {
+	# The host check rejects a node whose kernel lacks EROFS or device-mapper,
+	# and that is only true after the modules are in.
+	local actions
+	actions=$(per_node_jobs |
+		grep -o 'install-stage-[a-z-]*' |
+		awk '!seen[$0]++')
+	[[ "${actions}" == "$(printf '%s\n' \
+		install-stage-load-kernel-modules \
+		install-stage-host-check \
+		install-stage-artifacts \
+		install-stage-cri)" ]]
 }
 
 @test "Helm template (job mode): a per-node Job can tell which host it woke up on" {

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -11,9 +11,61 @@
 #   DOCKER_TAG      - Image tag to test
 #   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
 #   KUBERNETES      - K8s distribution (microk8s, k3s, rke2, etc.)
+# Optional EROFS settings:
+#   SNAPSHOTTER                 - Set to "erofs" to configure the EROFS snapshotter
+#   EROFS_SNAPSHOTTER_MODE      - "disk" or "memory"
+#   EROFS_DMVERITY              - Set to "dmverity" to enable dm-verity
+#   EROFS_MERGE_MODE            - "merged" or "unmerged"
 
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-kata-deploy}"
 HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
+
+# Run a command against the host node's filesystem, mounted at /host inside a
+# short-lived privileged pod.
+# Usage: run_on_host "test -d /host/opt/kata && echo YES || echo NO"
+#
+# We avoid `kubectl run --rm -i` because rke2 injects session-recording banners
+# into interactive pods, polluting stdout. Instead: create, wait, fetch logs, delete.
+run_on_host() {
+	local cmd="$1"
+	local node_name
+	node_name=$(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name | head -1)
+	local pod_name="host-exec-${RANDOM}"
+
+	kubectl run "${pod_name}" \
+		--image=quay.io/kata-containers/alpine-bash-curl:latest \
+		--restart=Never \
+		--overrides="{
+			\"spec\": {
+				\"nodeName\": \"${node_name}\",
+				\"activeDeadlineSeconds\": 300,
+				\"tolerations\": [{\"operator\": \"Exists\"}],
+				\"containers\": [{
+					\"name\": \"exec\",
+					\"image\": \"quay.io/kata-containers/alpine-bash-curl:latest\",
+					\"imagePullPolicy\": \"IfNotPresent\",
+					\"command\": [\"sh\", \"-c\", \"${cmd}\"],
+					\"securityContext\": {\"privileged\": true},
+					\"volumeMounts\": [{\"name\": \"host\", \"mountPath\": \"/host\", \"readOnly\": true}]
+				}],
+				\"volumes\": [{\"name\": \"host\", \"hostPath\": {\"path\": \"/\"}}]
+			}
+		}" > /dev/null 2>&1
+
+	local deadline=$((SECONDS + 60))
+	while (( SECONDS < deadline )); do
+		local phase
+		phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null) || true
+		case "${phase}" in
+			Succeeded|Failed) break ;;
+		esac
+		sleep 1
+	done
+
+	kubectl logs "${pod_name}" 2>/dev/null
+	kubectl delete pod "${pod_name}" --ignore-not-found=true > /dev/null 2>&1
+	[[ "${phase}" == "Succeeded" ]]
+}
 
 # The tolerations of a rendered pod spec, one entry per line, its fields joined
 # by "; " in the order they were rendered.
@@ -70,6 +122,30 @@ generate_base_values() {
 		k8s_distribution="k8s"
 	fi
 
+	local shim_snapshotter_values=""
+	local snapshotter_values=""
+	if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
+		local erofs_dmverity="false"
+		if [[ "${EROFS_DMVERITY:-}" == "dmverity" ]]; then
+			erofs_dmverity="true"
+		fi
+
+		shim_snapshotter_values="    containerd:
+      snapshotter: erofs"
+		snapshotter_values="snapshotter:
+  setup: [\"erofs\"]
+  erofsSnapshotterMode: \"${EROFS_SNAPSHOTTER_MODE:-}\"
+  erofsDmverity: ${erofs_dmverity}
+  erofsMergeMode: \"${EROFS_MERGE_MODE:-}\"
+
+# fs-verity would also need the backing filesystem prepared for it, and these
+# tests only care about dm-verity.
+containerd:
+  userDropIn: |
+    [plugins.'io.containerd.snapshotter.v1.erofs']
+      enable_fsverity = false"
+	fi
+
 	cat > "${output_file}" <<EOF
 image:
   reference: ${DOCKER_REGISTRY}/${DOCKER_REPO}
@@ -83,6 +159,7 @@ shims:
   disableAll: true
   ${KATA_HYPERVISOR}:
     enabled: true
+${shim_snapshotter_values}
 
 defaultShim:
   amd64: ${KATA_HYPERVISOR}
@@ -91,6 +168,8 @@ defaultShim:
 runtimeClasses:
   enabled: true
   createDefault: true
+
+${snapshotter_values}
 EOF
 }
 

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -18,7 +18,15 @@ export BATS_TEST_FAIL_FAST="${BATS_TEST_FAIL_FAST:-no}"
 if [[ -n "${KATA_DEPLOY_TEST_UNION:-}" ]]; then
 	KATA_DEPLOY_TEST_UNION=("${KATA_DEPLOY_TEST_UNION}")
 else
-	KATA_DEPLOY_TEST_UNION=( \
+	KATA_DEPLOY_TEST_UNION=()
+
+	# Only the kubeadm setup prepares EROFS, and this has to run before any
+	# other suite loads the modules it is meant to exercise.
+	if [[ "${KUBERNETES:-}" == "kubeadm" ]]; then
+		KATA_DEPLOY_TEST_UNION+=("kata-deploy-host-modules.bats")
+	fi
+
+	KATA_DEPLOY_TEST_UNION+=( \
 		"kata-deploy.bats" \
 		"kata-deploy-custom-runtimes.bats" \
 		"kata-deploy-lifecycle.bats" \

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -578,8 +578,10 @@ function deploy_k8s() {
 				# fs-verity on the layer blobs.
 				sudo apt-get -y install --no-install-recommends fsverity
 
-				# Load device-mapper and dm-verity kernel modules.
-				if [[ "${EROFS_DMVERITY:-}" == "dmverity" ]]; then
+				# The kata-deploy host module job leaves these unloaded, so that
+				# its own privileged stage is what has to load them.
+				if [[ "${EROFS_DMVERITY:-}" == "dmverity" ]] &&
+					[[ "${KATA_DEPLOY_MANAGES_HOST_MODULES:-no}" != "yes" ]]; then
 					load_dm_verity_modules
 				fi
 

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -14,8 +14,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use flate2::read::GzDecoder;
 use log::{error, info};
-use std::collections::BTreeMap;
-use std::io::BufRead;
+use std::collections::{BTreeMap, HashSet};
+use std::io::{BufRead, Write};
 
 /// Env var name used to thread the detected container runtime through the
 /// post-install re-exec. Avoids re-querying the apiserver after we've already
@@ -59,17 +59,22 @@ enum Action {
     Install,
     Cleanup,
     Reset,
-    /// Stage 0 of a staged (JobSet) install: validate host/node prerequisites
+    /// Stage 0 of a staged (JobSet) install: load the host kernel modules the
+    /// enabled runtimes and snapshotters need. The only privileged stage, and
+    /// the only one the DaemonSet path does not share.
+    #[clap(name = "install-stage-load-kernel-modules")]
+    InstallStageLoadKernelModules,
+    /// Stage 1 of a staged (JobSet) install: validate host/node prerequisites
     /// without mutating the host. Fails fast with actionable diagnostics when
     /// the node cannot support installation.
     #[clap(name = "install-stage-host-check")]
     InstallStageHostCheck,
-    /// Stage 1 of a staged (JobSet) install: install kata artifacts/config on
+    /// Stage 2 of a staged (JobSet) install: install kata artifacts/config on
     /// the host and set up configured snapshotters. Does not touch CRI
     /// configuration.
     #[clap(name = "install-stage-artifacts")]
     InstallStageArtifacts,
-    /// Stage 2 of a staged (JobSet) install: write CRI drop-ins, restart the
+    /// Stage 3 of a staged (JobSet) install: write CRI drop-ins, restart the
     /// runtime, and wait for node readiness.
     #[clap(name = "install-stage-cri")]
     InstallStageCri,
@@ -152,7 +157,8 @@ async fn main() -> Result<()> {
     let config = config::Config::from_env()?;
     if matches!(
         args.action,
-        Action::InstallStageHostCheck
+        Action::InstallStageLoadKernelModules
+            | Action::InstallStageHostCheck
             | Action::InstallStageArtifacts
             | Action::InstallStageCri
             | Action::CleanupStageRevertCri
@@ -164,6 +170,7 @@ async fn main() -> Result<()> {
         Action::Install => "install",
         Action::Cleanup => "cleanup",
         Action::Reset => "reset",
+        Action::InstallStageLoadKernelModules => "install-stage-load-kernel-modules",
         Action::InstallStageHostCheck => "install-stage-host-check",
         Action::InstallStageArtifacts => "install-stage-artifacts",
         Action::InstallStageCri => "install-stage-cri",
@@ -311,6 +318,10 @@ async fn main() -> Result<()> {
         // pipeline as a short-lived Job/initContainer and exits. The DaemonSet
         // path does not use these directly; it goes through `install` above,
         // which composes the same stage functions.
+        Action::InstallStageLoadKernelModules => {
+            install_stage_load_kernel_modules(&config)?;
+            info!("Install kernel-module stage completed, exiting");
+        }
         Action::InstallStageHostCheck => {
             install_stage_host_check(&config, &runtime, true).await?;
             info!("Install host-check stage completed, exiting");
@@ -436,10 +447,382 @@ const SUPPORTED_RUNTIMES: &[&str] = &[
     "microk8s",
 ];
 
-/// Install stage 0 (host-check): validate that this node can support a Kata
-/// installation before any host mutation happens. This is read-only and safe
-/// to run repeatedly; it fails fast with actionable diagnostics so a staged
-/// JobSet can abort the per-node pipeline before the privileged stages run.
+const HOST_ROOT: &str = "/host";
+const HOST_MODULES_LOAD_DIR: &str = "/host-modules-load.d";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HostModule {
+    name: &'static str,
+    required: bool,
+}
+
+impl HostModule {
+    const fn required(name: &'static str) -> Self {
+        Self {
+            name,
+            required: true,
+        }
+    }
+
+    const fn optional(name: &'static str) -> Self {
+        Self {
+            name,
+            required: false,
+        }
+    }
+}
+
+/// The modules the stage can load itself, kept apart from the x86 backend
+/// requirement because no module can satisfy the latter on its own.
+#[derive(Debug, Default)]
+struct HostModulePlan {
+    modules: Vec<HostModule>,
+    needs_x86_virtualization: bool,
+}
+
+/// Not composed into [`install`], so the DaemonSet path stays unprivileged.
+fn install_stage_load_kernel_modules(config: &config::Config) -> Result<()> {
+    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo")
+        .context("failed to read /proc/cpuinfo while selecting host kernel modules")?;
+    let custom_bases = config
+        .custom_runtimes
+        .iter()
+        .map(|runtime| runtime.base_config.as_str())
+        .collect::<Vec<_>>();
+    let erofs_enabled = config
+        .experimental_setup_snapshotter
+        .as_ref()
+        .is_some_and(|snapshotters| snapshotters.iter().any(|s| s == "erofs"));
+    let plan = host_modules_for_install(
+        std::env::consts::ARCH,
+        &cpuinfo,
+        &config
+            .shims_for_arch
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        &custom_bases,
+        erofs_enabled,
+        config.erofs_dmverity,
+    )?;
+
+    if plan.modules.is_empty() && !plan.needs_x86_virtualization {
+        info!("install (kernel-modules): no host modules are needed");
+        return Ok(());
+    }
+
+    let modprobe = find_host_modprobe()?;
+    let _node_lock = acquire_node_mutation_lock()?;
+    let mut loaded = Vec::new();
+    for module in &plan.modules {
+        if host_module_visible(module.name) {
+            info!(
+                "install (kernel-modules): host module {} is already loaded",
+                module.name
+            );
+            loaded.push(module.name);
+            continue;
+        }
+
+        info!(
+            "install (kernel-modules): loading host module {}",
+            module.name
+        );
+        match run_host_modprobe(&modprobe, module.name) {
+            Ok(()) => loaded.push(module.name),
+            Err(error) => handle_module_load_failure(*module, error)?,
+        }
+    }
+
+    if plan.needs_x86_virtualization {
+        ensure_x86_virtualization_backend()?;
+    }
+
+    // Persisting what loaded, rather than what was asked for, keeps a module
+    // that does not apply to this node from being retried at every boot.
+    persist_modules_load_config(config, &loaded)?;
+    Ok(())
+}
+
+/// Follows the per-architecture `kata-runtime check` maps.
+fn host_modules_for_install(
+    arch: &str,
+    cpuinfo: &str,
+    shims: &[&str],
+    custom_bases: &[&str],
+    erofs_enabled: bool,
+    erofs_dmverity: bool,
+) -> Result<HostModulePlan> {
+    let has_local_runtime = shims.iter().any(|shim| *shim != "remote")
+        || custom_bases.iter().any(|base| *base != "remote");
+    let mut plan = HostModulePlan::default();
+    let modules = &mut plan.modules;
+
+    if has_local_runtime {
+        let vhost_vsock = if wants_host_vsock_device(shims, custom_bases) {
+            HostModule::required("vhost_vsock")
+        } else {
+            HostModule::optional("vhost_vsock")
+        };
+
+        match arch {
+            "x86_64" => {
+                // Every x86 VMM we ship runs on either KVM or MSHV, picking at
+                // run time, so KVM is worth trying but never the requirement:
+                // a Hyper-V root partition cannot load it and does not need to.
+                plan.needs_x86_virtualization = true;
+                modules.push(HostModule::optional("kvm"));
+                if cpuinfo.contains("GenuineIntel") {
+                    modules.push(HostModule::optional("kvm_intel"));
+                } else if cpuinfo.contains("AuthenticAMD") {
+                    modules.push(HostModule::optional("kvm_amd"));
+                }
+                modules.extend([
+                    HostModule::required("vhost"),
+                    HostModule::required("vhost_net"),
+                    vhost_vsock,
+                ]);
+            }
+            "aarch64" | "riscv64" => modules.extend([
+                HostModule::required("kvm"),
+                HostModule::required("vhost"),
+                HostModule::required("vhost_net"),
+                vhost_vsock,
+            ]),
+            "powerpc64" | "powerpc64le" => modules.extend([
+                HostModule::required("kvm"),
+                HostModule::required("kvm_hv"),
+                vhost_vsock,
+            ]),
+            "s390x" => modules.extend([HostModule::required("kvm"), vhost_vsock]),
+            unsupported => anyhow::bail!(
+                "cannot select Kata host kernel modules for unsupported architecture {unsupported}"
+            ),
+        }
+    }
+
+    if erofs_enabled {
+        // fs-verity is deliberately absent: CONFIG_FS_VERITY is a bool, so it is
+        // either built in or unavailable, and the host check already says which.
+        modules.extend([HostModule::required("erofs"), HostModule::required("loop")]);
+        if erofs_dmverity {
+            modules.extend([
+                HostModule::required("dm_mod"),
+                HostModule::required("dm_verity"),
+            ]);
+        }
+    }
+
+    let mut seen = HashSet::new();
+    modules.retain(|module| seen.insert(module.name));
+    Ok(plan)
+}
+
+/// QEMU is the only shim that talks to the guest through the host's
+/// /dev/vhost-vsock; the rest tunnel VSOCK over a UNIX socket and do not care
+/// whether the module is there.
+fn wants_host_vsock_device(shims: &[&str], custom_bases: &[&str]) -> bool {
+    shims
+        .iter()
+        .chain(custom_bases.iter())
+        .any(|runtime| runtime.starts_with("qemu"))
+}
+
+/// The device nodes are the honest test. `kvm` alone loads happily on a machine
+/// with virtualization switched off in firmware and creates no /dev/kvm, and
+/// MSHV cannot be loaded at all: mshv_root only binds when the kernel booted as
+/// the Hyper-V root partition.
+fn ensure_x86_virtualization_backend() -> Result<()> {
+    if host_device_exists("kvm") {
+        info!("install (kernel-modules): the host provides KVM");
+        return Ok(());
+    }
+
+    if host_device_exists("mshv") {
+        info!("install (kernel-modules): the host provides MSHV instead of KVM");
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "this node has no usable virtualization backend: neither /dev/kvm nor /dev/mshv is \
+         present. Check the warnings above for why the KVM modules would not load, and that \
+         virtualization is enabled in firmware or exposed to this VM."
+    )
+}
+
+fn host_device_exists(device: &str) -> bool {
+    std::path::Path::new(HOST_ROOT)
+        .join("dev")
+        .join(device)
+        .exists()
+        || std::path::Path::new("/dev").join(device).exists()
+}
+
+fn modules_load_config_path(
+    base: &std::path::Path,
+    multi_install_suffix: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    let suffix = multi_install_suffix.unwrap_or("default");
+    anyhow::ensure!(
+        suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')),
+        "MULTI_INSTALL_SUFFIX {suffix:?} cannot be used in a modules-load.d filename"
+    );
+    Ok(base.join(format!("kata-containers-{suffix}.conf")))
+}
+
+fn persist_modules_load_config(config: &config::Config, modules: &[&str]) -> Result<()> {
+    let path = modules_load_config_path(
+        std::path::Path::new(HOST_MODULES_LOAD_DIR),
+        config.multi_install_suffix.as_deref(),
+    )?;
+    let content = modules_load_config_content(modules);
+    let temp_path = path.with_extension(format!("conf.{}.tmp", std::process::id()));
+    let write_result = (|| -> Result<()> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut temp = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o644)
+            .open(&temp_path)
+            .with_context(|| {
+                format!(
+                    "failed to create temporary modules-load.d file {}",
+                    temp_path.display()
+                )
+            })?;
+        temp.write_all(content.as_bytes())
+            .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        temp.sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))?;
+        std::fs::rename(&temp_path, &path).with_context(|| {
+            format!(
+                "failed to atomically install modules-load.d file {}",
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    write_result?;
+
+    info!(
+        "install (kernel-modules): persisted the loaded modules in {}",
+        path.display()
+    );
+    Ok(())
+}
+
+fn modules_load_config_content(modules: &[&str]) -> String {
+    format!(
+        "# Managed by kata-deploy; removed when this installation is uninstalled.\n{}\n",
+        modules.join("\n")
+    )
+}
+
+fn remove_modules_load_config(config: &config::Config) -> Result<()> {
+    let path = modules_load_config_path(
+        std::path::Path::new(HOST_MODULES_LOAD_DIR),
+        config.multi_install_suffix.as_deref(),
+    )?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => info!(
+            "cleanup (remove-artifacts): removed modules-load.d file {}",
+            path.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to remove modules-load.d file {}", path.display())
+            })
+        }
+    }
+    Ok(())
+}
+
+fn handle_module_load_failure(module: HostModule, error: anyhow::Error) -> Result<()> {
+    if module.required {
+        return Err(error);
+    }
+
+    log::warn!(
+        "install (kernel-modules): optional host module {} could not be loaded: {error}",
+        module.name
+    );
+    Ok(())
+}
+
+/// The path is returned as it looks after the chroot, not as mounted here.
+fn find_host_modprobe() -> Result<String> {
+    const CANDIDATES: &[&str] = &[
+        "/usr/sbin/modprobe",
+        "/sbin/modprobe",
+        "/usr/bin/modprobe",
+        "/bin/modprobe",
+    ];
+
+    CANDIDATES
+        .iter()
+        .find(|path| {
+            std::path::Path::new(HOST_ROOT)
+                .join(path.trim_start_matches('/'))
+                .is_file()
+        })
+        .map(|path| (*path).to_string())
+        .with_context(|| {
+            format!(
+                "host modprobe was not found under {HOST_ROOT}; install kmod on the node before \
+                 deploying Kata"
+            )
+        })
+}
+
+fn run_host_modprobe(modprobe: &str, module: &str) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let host_root = std::ffi::CString::new(HOST_ROOT).expect("HOST_ROOT contains no NUL");
+    let root_dir = std::ffi::CString::new("/").expect("root path contains no NUL");
+    let mut command = std::process::Command::new(modprobe);
+    command.arg(module);
+
+    // This image ships no kmod, and only the host's own modprobe matches the
+    // running kernel's modules and compression.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::chroot(host_root.as_ptr()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::chdir(root_dir.as_ptr()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let output = command
+        .output()
+        .with_context(|| format!("failed to execute host {modprobe} for module {module}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    anyhow::bail!(
+        "host modprobe failed for module {module} (status {}): stdout={stdout:?}, stderr={stderr:?}",
+        output.status
+    )
+}
+
+/// Install stage 1 (host-check): validate that this node can support a Kata
+/// installation before artifacts or CRI configuration are changed. This is
+/// read-only and safe to run repeatedly; it fails fast with actionable
+/// diagnostics so a staged Job can abort before persistent host changes.
 ///
 /// `staged` marks the job-mode pipeline, whose containers hold no Kubernetes
 /// credentials: the one check that needs the apiserver (reading the kubelet's
@@ -1449,6 +1832,8 @@ async fn cleanup_stage_revert_cri(
 async fn cleanup_stage_remove_artifacts(config: &config::Config) -> Result<()> {
     info!("cleanup (remove-artifacts): removing kata artifacts from host");
     let _node_lock = acquire_node_mutation_lock()?;
+    // A partial install may have loaded modules but extracted nothing.
+    remove_modules_load_config(config)?;
 
     // The install dir is bind mounted into this pod, so it always exists and
     // outlives the artifacts it holds: an empty one means there is nothing
@@ -1542,6 +1927,10 @@ mod tests {
     #[case("install", Action::Install)]
     #[case("cleanup", Action::Cleanup)]
     #[case("reset", Action::Reset)]
+    #[case(
+        "install-stage-load-kernel-modules",
+        Action::InstallStageLoadKernelModules
+    )]
     #[case("install-stage-host-check", Action::InstallStageHostCheck)]
     #[case("install-stage-artifacts", Action::InstallStageArtifacts)]
     #[case("install-stage-cri", Action::InstallStageCri)]
@@ -1691,6 +2080,7 @@ mod tests {
     /// can discover and run individual stages.
     #[rstest]
     #[case(Action::InstallStageHostCheck)]
+    #[case(Action::InstallStageLoadKernelModules)]
     #[case(Action::InstallStageArtifacts)]
     #[case(Action::InstallStageCri)]
     #[case(Action::CleanupStageRevertCri)]
@@ -1704,5 +2094,187 @@ mod tests {
             "staged action {:?} should be visible in --help",
             value.get_name(),
         );
+    }
+
+    fn module_names(modules: &[HostModule]) -> Vec<&str> {
+        modules.iter().map(|module| module.name).collect()
+    }
+
+    fn test_module_plan(
+        arch: &str,
+        cpuinfo: &str,
+        shims: &[&str],
+        custom_bases: &[&str],
+        erofs_enabled: bool,
+        erofs_dmverity: bool,
+    ) -> Result<HostModulePlan> {
+        host_modules_for_install(
+            arch,
+            cpuinfo,
+            shims,
+            custom_bases,
+            erofs_enabled,
+            erofs_dmverity,
+        )
+    }
+
+    fn test_host_modules(
+        arch: &str,
+        cpuinfo: &str,
+        shims: &[&str],
+        custom_bases: &[&str],
+        erofs_enabled: bool,
+        erofs_dmverity: bool,
+    ) -> Result<Vec<HostModule>> {
+        test_module_plan(
+            arch,
+            cpuinfo,
+            shims,
+            custom_bases,
+            erofs_enabled,
+            erofs_dmverity,
+        )
+        .map(|plan| plan.modules)
+    }
+
+    #[rstest]
+    #[case("GenuineIntel", "kvm_intel")]
+    #[case("AuthenticAMD", "kvm_amd")]
+    fn x86_module_selection_follows_cpu_vendor(#[case] vendor: &str, #[case] vendor_module: &str) {
+        let modules = test_host_modules("x86_64", vendor, &["qemu"], &[], false, false).unwrap();
+        assert_eq!(
+            module_names(&modules),
+            vec!["kvm", vendor_module, "vhost", "vhost_net", "vhost_vsock"]
+        );
+    }
+
+    #[test]
+    fn x86_asks_for_a_backend_and_treats_the_kvm_modules_as_optional() {
+        let plan =
+            test_module_plan("x86_64", "GenuineIntel", &["qemu"], &[], false, false).unwrap();
+        assert!(plan.needs_x86_virtualization);
+        for name in ["kvm", "kvm_intel"] {
+            let module = plan
+                .modules
+                .iter()
+                .find(|module| module.name == name)
+                .expect("the KVM modules are still attempted");
+            assert!(!module.required);
+        }
+    }
+
+    /// An unnameable vendor may just mean a Hyper-V root partition, where no KVM
+    /// module would have loaded anyway.
+    #[test]
+    fn unknown_x86_vendor_leaves_the_backend_check_to_decide() {
+        let plan =
+            test_module_plan("x86_64", "UnknownVendor", &["qemu"], &[], false, false).unwrap();
+        assert!(plan.needs_x86_virtualization);
+        assert_eq!(
+            module_names(&plan.modules),
+            vec!["kvm", "vhost", "vhost_net", "vhost_vsock"]
+        );
+    }
+
+    #[rstest]
+    #[case(
+        "aarch64",
+        vec!["kvm", "vhost", "vhost_net", "vhost_vsock"]
+    )]
+    #[case("riscv64", vec!["kvm", "vhost", "vhost_net", "vhost_vsock"])]
+    #[case("powerpc64", vec!["kvm", "kvm_hv", "vhost_vsock"])]
+    #[case("s390x", vec!["kvm", "vhost_vsock"])]
+    fn non_x86_module_selection_matches_kata_check(
+        #[case] arch: &str,
+        #[case] expected: Vec<&str>,
+    ) {
+        let modules = test_host_modules(arch, "", &["qemu"], &[], false, false).unwrap();
+        assert_eq!(module_names(&modules), expected);
+    }
+
+    #[test]
+    fn remote_only_install_needs_no_virtualization_at_all() {
+        for plan in [
+            test_module_plan("x86_64", "", &["remote"], &[], false, false).unwrap(),
+            test_module_plan("x86_64", "", &[], &["remote"], false, false).unwrap(),
+        ] {
+            assert!(plan.modules.is_empty());
+            assert!(!plan.needs_x86_virtualization);
+        }
+    }
+
+    #[test]
+    fn local_custom_runtime_requests_virtualization_modules() {
+        let modules = test_host_modules(
+            "x86_64",
+            "GenuineIntel",
+            &["remote"],
+            &["qemu"],
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(module_names(&modules).contains(&"kvm_intel"));
+    }
+
+    #[rstest]
+    #[case(&["qemu-runtime-rs"], true)]
+    #[case(&["clh-azure-runtime-rs"], false)]
+    #[case(&["clh", "qemu"], true)]
+    fn vhost_vsock_is_only_required_where_the_host_device_is_used(
+        #[case] shims: &[&str],
+        #[case] expected_required: bool,
+    ) {
+        let modules =
+            test_host_modules("x86_64", "GenuineIntel", shims, &[], false, false).unwrap();
+        let vsock = modules
+            .iter()
+            .find(|module| module.name == "vhost_vsock")
+            .expect("vhost_vsock is always considered");
+        assert_eq!(vsock.required, expected_required);
+    }
+
+    #[test]
+    fn erofs_features_are_selected_and_deduplicated() {
+        let modules = test_host_modules("aarch64", "", &["qemu"], &[], true, true).unwrap();
+        let names = module_names(&modules);
+        assert!(names.ends_with(&["erofs", "loop", "dm_mod", "dm_verity"]));
+        assert_eq!(
+            names.iter().copied().collect::<HashSet<_>>().len(),
+            names.len()
+        );
+        assert!(modules.iter().all(|module| module.required));
+    }
+
+    #[test]
+    fn modules_load_config_is_per_install() {
+        let base = std::path::Path::new("/etc/modules-load.d");
+        assert_eq!(
+            modules_load_config_path(base, None).unwrap(),
+            base.join("kata-containers-default.conf")
+        );
+        assert_eq!(
+            modules_load_config_path(base, Some("dev")).unwrap(),
+            base.join("kata-containers-dev.conf")
+        );
+        assert!(modules_load_config_path(base, Some("../escape")).is_err());
+
+        let content = modules_load_config_content(&["kvm", "vhost_vsock"]);
+        assert!(content.starts_with("# Managed by kata-deploy"));
+        assert!(content.contains("\nkvm\nvhost_vsock\n"));
+    }
+
+    #[test]
+    fn required_module_failures_abort_but_optional_failures_do_not() {
+        assert!(handle_module_load_failure(
+            HostModule::required("vhost_vsock"),
+            anyhow::anyhow!("no vhost_vsock")
+        )
+        .is_err());
+        assert!(handle_module_load_failure(
+            HostModule::optional("fsverity"),
+            anyhow::anyhow!("no fsverity")
+        )
+        .is_ok());
     }
 }

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1100,7 +1100,7 @@ Arguments (dict):
   root  - top-level context (.)
   stage - "install" | "cleanup"
 
-install pipeline:  host-check -> artifacts (initContainers) ; cri (main)
+install pipeline:  load-kernel-modules -> host-check -> artifacts (initContainers) ; cri (main)
 cleanup pipeline:  revert-cri              (initContainer)  ; remove-artifacts (main)
 
 The node label is not a stage here: the dispatcher sets it once the Job as a whole
@@ -1200,6 +1200,8 @@ spec:
 {{- end }}
 {{- if eq $stage "install" }}
       initContainers:
+{{- /* Privileged, and holding the host root, because it runs the host's own modprobe. */}}
+{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "load-kernel-modules" "action" "install-stage-load-kernel-modules" "privileged" true "mountHost" true "mountHostRoot" true "mountModulesLoad" true) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "host-check" "action" "install-stage-host-check" "privileged" false "mountHost" true) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "artifacts" "action" "install-stage-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
@@ -1208,10 +1210,20 @@ spec:
       initContainers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "revert-cri" "action" "cleanup-stage-revert-cri" "privileged" false "mountHost" true) | nindent 8 }}
       containers:
-{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "remove-artifacts" "action" "cleanup-stage-remove-artifacts" "privileged" false "mountHost" true) | nindent 8 }}
+{{- include "kata-deploy.stageContainer" (dict "root" $root "name" "remove-artifacts" "action" "cleanup-stage-remove-artifacts" "privileged" false "mountHost" true "mountModulesLoad" true) | nindent 8 }}
 {{- end }}
       volumes:
 {{- include "kata-deploy.commonVolumes" $root | nindent 8 }}
+        - name: modules-load-d
+          hostPath:
+            path: /etc/modules-load.d
+            type: DirectoryOrCreate
+{{- if eq $stage "install" }}
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -1264,6 +1276,8 @@ Arguments (dict):
   action      - kata-deploy subcommand (e.g. install-stage-cri)
   privileged  - bool, whether the container runs privileged
   mountHost   - bool, whether to mount the host paths (crio/containerd/install/...)
+  mountHostRoot - bool, whether to mount the host root read-only at /host
+  mountModulesLoad - bool, whether to mount the host modules-load.d directory writable
 
 Emitted at column 0; indent with `nindent` at the call site.
 */}}
@@ -1282,6 +1296,15 @@ Emitted at column 0; indent with `nindent` at the call site.
 {{- include "kata-deploy.commonVolumeMounts" .root | nindent 4 }}
 {{- else }}
 {{- include "kata-deploy.tmpVolumeMount" . | nindent 4 }}
+{{- end }}
+{{- if .mountHostRoot }}
+    - name: host-root
+      mountPath: /host
+      readOnly: true
+{{- end }}
+{{- if .mountModulesLoad }}
+    - name: modules-load-d
+      mountPath: /host-modules-load.d
 {{- end }}
 {{- end -}}
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -22,6 +22,19 @@
 #   and installs the new nodes (the staged actions are idempotent, so already-
 #   installed nodes are skipped). This is intentional: it avoids an always-on
 #   privileged component on every node.
+#
+# NOTE on host kernel modules in "job" mode:
+#   Each per-node install Job starts with one short-lived privileged, tokenless
+#   init container that loads the modules the enabled runtimes and snapshotters
+#   need. It mounts the host root read-only because only the host's own modprobe
+#   matches the running kernel, and it fails the node before anything on it is
+#   changed if a required module cannot be loaded, or if x86 ends up with
+#   neither /dev/kvm nor /dev/mshv.
+#
+#   Those modules are also recorded under the host's /etc/modules-load.d so they
+#   come back after a reboot. Uninstall drops that file but never unloads a
+#   module, because module state is host-global and may be in use by something
+#   else.
 deploymentMode: daemonset  # daemonset | job
 
 # Settings specific to deploymentMode: job


### PR DESCRIPTION
A node with no kvm, vhost or erofs module loaded cannot run Kata, and today
noticing that is left to whoever deployed it. Job mode can fix it cheaply:
each per-node install Job now starts with a short-lived, tokenless
privileged init container that runs the host's own modprobe, and fails the
node before anything on it is changed if a required module will not load.
Whatever did load is recorded under /etc/modules-load.d so it survives a
reboot, and uninstall drops that file without unloading anything, since
module state is host-global and may be in use by something else.

On x86 the KVM modules are attempted rather than demanded, because our VMMs
run on either KVM or MSHV and choose at run time: a Hyper-V root partition
cannot load KVM and needs no help, as /dev/mshv comes from mshv_root, which
binds nowhere else. So the stage requires only that one of /dev/kvm or
/dev/mshv ends up present, which is anyway the honest test, given that kvm
loads happily on a machine with virtualization disabled in firmware and
creates no device. For the same reason vhost_vsock is required only for
QEMU, the one shim that reaches the guest through the host's VSOCK device.

Daemonset mode is deliberately untouched: it has no privileged container
today, and loading modules from a pod that lives forever is precisely the
always-on privileged agent that job mode set out to avoid.

The kubeadm CI job exercises this for real, being the only one that can
prepare EROFS on the runner: it leaves the dm-verity modules unloaded so
kata-deploy has to load them, starts a Kata pod on top, and checks that
uninstall forgets the modules without unloading them. Since the matrix had
to be reshaped anyway to carry those per-entry settings, it now names the
environment it provisions and runs the runtime-rs shims instead of the Go
qemu one, matching what the chart already treats as the default.

**Notes:**
* **DO NOT ADD the `ok-to-test` label**
* ci-devel: https://github.com/kata-containers/kata-containers/actions/runs/32766198115