### PR TITLE
kata-deploy: discover NVIDIA GPUs through node-feature-discovery

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -1077,3 +1077,97 @@ are still rendered, and delete the chart's rule if it duplicates yours.
     `env.multiInstallSuffix` when that is set. A rule called `amd64-tee-keys`
     belongs to a release that has not been upgraded yet, and can be deleted once
     every release has been.
+
+`nodeFeatureRules.create` is one switch for every rule the chart ships, so it also
+governs the NVIDIA GPU rule below.
+
+## NVIDIA GPU discovery
+
+Kata's NVIDIA shims have to land on a node that actually has the GPU they are built
+for, so the chart ships a second `NodeFeatureRule`, `kata-nvidia-gpu`, asking
+node-feature-discovery for three labels:
+
+`nvidia.feature.node.kubernetes.io/gpu`
+:   `"true"` when the node has an NVIDIA display or 3D controller (PCI vendor
+    `10de`, class `0300` or `0302`). Matched by device *class*, so a GPU newer than
+    your chart still gets it.
+
+`nvidia.feature.node.kubernetes.io/gpu.family`
+:   The family the GPU's PCI device ID belongs to — `hopper` or `blackwell` out of
+    the box.
+
+`nvidia.feature.node.kubernetes.io/cc.capable`
+:   `"true"` when the node pairs a GPU family that can run confidentially with a CPU
+    reporting SEV-SNP or TDX.
+
+!!! info "Why the chart carries these at all"
+    NVIDIA's GPU Operator published equivalent labels under `nvidia.com` until
+    v25.10 and removed them in v26.3.0, so on a current GPU Operator nothing
+    provides GPU family or CC-capability labels any more.
+
+    The labels sit under `nvidia.feature.node.kubernetes.io` rather than
+    `nvidia.com` because NFD publishes subdomains of `feature.node.kubernetes.io`
+    without further configuration, while `nvidia.com` needs `-extra-label-ns` on
+    nfd-master — which the chart cannot set for an NFD installation it does not own.
+    The TEE rule uses `amd.`/`intel.` for the same reason.
+
+### Teaching it about a new GPU
+
+Family membership is a device-ID list in values, not something baked into the rule,
+so a GPU released after your chart is one override away:
+
+```yaml title="values.yaml"
+nodeFeatureRules:
+  nvidiaGpu:
+    families:
+      blackwell:
+        - "2901"   # B200
+        - "31c2"   # GB300
+        - "abcd"   # the one your chart has never heard of
+    ccCapableFamilies:
+      - hopper
+      - blackwell
+```
+
+Device IDs are hex, without the `0x`, as listed for vendor `10de` in the
+[PCI ID repository](https://pci-ids.ucw.cz/read/PC/10de). Overriding a family
+replaces its whole list. A family in `ccCapableFamilies` with no entry under
+`families` can never match, so keep the two in step; adding a family key is enough
+to have it labelled.
+
+!!! note "A node with two GPU families"
+    `gpu.family` is a single label, so a node holding both a Hopper and a Blackwell
+    card reports whichever rule matched last. Select on `gpu` or `cc.capable` for
+    such a node, not on `gpu.family`.
+
+### What the RuntimeClasses select
+
+The plain GPU shims select the chart's own presence label, so a GPU passthrough
+sandbox no longer waits on a label only the GPU Operator can write:
+
+```yaml title="values.yaml"
+shims:
+  qemu-nvidia-gpu:
+    runtimeClass:
+      nodeSelector:
+        nvidia.feature.node.kubernetes.io/gpu: "true"
+```
+
+The confidential GPU shims (`qemu-nvidia-gpu-snp`, `qemu-nvidia-gpu-tdx`, and their
+`-runtime-rs` variants) deliberately keep selecting the GPU Operator's
+`nvidia.com/cc.ready.state: "true"`.
+
+!!! warning "`cc.capable` is not a substitute for `cc.ready.state`"
+    `cc.capable` says the node *could* run a confidential GPU workload.
+    `cc.ready.state` says the GPU has actually been put into that mode, which only
+    whatever programs the GPU — the GPU Operator's CC manager — knows. Selecting on
+    capability alone would let a confidential sandbox land on a node whose GPU is
+    running in the clear.
+
+    So these shims still need a GPU Operator. If you drive GPU CC mode some other
+    way, point them at whatever label that produces via
+    `shims.<shim>.runtimeClass.nodeSelector`.
+
+Since the plain GPU classes now match any GPU node, a cluster that runs both plain
+and confidential GPU workloads should keep them apart explicitly — select
+`nvidia.com/cc.ready.state: "false"` on the plain classes, as the chart did before.

--- a/tests/functional/kata-deploy/kata-deploy-nvidia-gpu-nfd.bats
+++ b/tests/functional/kata-deploy/kata-deploy-nvidia-gpu-nfd.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 The Kata Containers Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for the NVIDIA GPU NodeFeatureRule: the labels it asks
+# node-feature-discovery to publish, and the RuntimeClasses that select on them.
+# No cluster required.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+RENDERED="/tmp/kata-deploy-nvidia-gpu-nfd-rendered.yaml"
+
+render_chart() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@" > "${RENDERED}"
+}
+
+# `! grep ...` would be exempt from set -e and could never fail a test.
+refute_rendered() {
+	if grep -q "$1" "${RENDERED}"; then
+		echo "unexpected in rendered chart: $1" >&2
+		return 1
+	fi
+}
+
+# The rendered YAML of the one object with this metadata.name, so a grep cannot
+# match a neighbouring object instead.
+document_of() {
+	awk -v name="$1" 'BEGIN { RS = "\n---\n" } index($0, "\n  name: " name "\n") { print }' \
+		"${RENDERED}"
+}
+
+# The node label keys a NodeFeatureRule document on stdin publishes, one per
+# line. Only the ones under spec: the object's own metadata.labels are chart
+# bookkeeping, not something NFD puts on a node.
+published_label_keys() {
+	awk '
+		!started && /^spec:/ { started = 1; next }
+		!started { next }
+		/^[[:space:]]*labels:[[:space:]]*$/ {
+			match($0, /^[[:space:]]*/)
+			indent = RLENGTH
+			inside = 1
+			next
+		}
+		inside {
+			match($0, /^[[:space:]]*/)
+			if (RLENGTH <= indent) { inside = 0; next }
+			key = $1
+			sub(/:$/, "", key)
+			gsub(/"/, "", key)
+			print key
+		}
+	'
+}
+
+# The nodeSelector of a RuntimeClass document on stdin, as key=value lines.
+node_selector_of() {
+	awk '
+		/^[[:space:]]*nodeSelector:[[:space:]]*$/ {
+			match($0, /^[[:space:]]*/)
+			indent = RLENGTH
+			inside = 1
+			next
+		}
+		inside {
+			match($0, /^[[:space:]]*/)
+			if (RLENGTH <= indent) { inside = 0; next }
+			key = $1
+			sub(/:$/, "", key)
+			gsub(/"/, "", key)
+			value = $2
+			gsub(/"/, "", value)
+			print key "=" value
+		}
+	'
+}
+
+@test "Helm template: the NVIDIA GPU rule publishes presence, family and CC capability" {
+	render_chart --set nodeFeatureRules.create=true
+
+	local rule
+	rule="$(document_of kata-nvidia-gpu)"
+	[[ -n "${rule}" ]]
+
+	echo "${rule}" | grep -q "kind: NodeFeatureRule"
+	echo "${rule}" | grep -q "nvidia.feature.node.kubernetes.io/gpu\": \"true\""
+	echo "${rule}" | grep -q "nvidia.feature.node.kubernetes.io/gpu.family"
+	echo "${rule}" | grep -q "nvidia.feature.node.kubernetes.io/cc.capable"
+
+	# Presence is matched by PCI class, not by an ever-growing device list, so
+	# a GPU newer than the chart still gets the label.
+	echo "${rule}" | grep -q 'class: { op: In, value: \["0300", "0302"\] }'
+}
+
+@test "Helm template: no NVIDIA GPU rule without NFD to act on it" {
+	local args
+	for args in "--set nodeFeatureRules.create=false" \
+		"--set node-feature-discovery.enabled=true --set nodeFeatureRules.create=false" \
+		""; do
+		# shellcheck disable=SC2086
+		render_chart ${args}
+
+		refute_rendered "name: kata-nvidia-gpu"
+		refute_rendered "nvidia.feature.node.kubernetes.io/gpu.family"
+	done
+}
+
+@test "Helm template: the GPU labels stay in a namespace NFD publishes by default" {
+	# NFD drops labels outside feature.node.kubernetes.io and its subdomains
+	# unless nfd-master runs with -extra-label-ns, which this chart cannot set
+	# for an NFD installation it does not own. A label in, say, nvidia.com would
+	# render fine here and then never reach a node.
+	render_chart --set nodeFeatureRules.create=true
+
+	local key
+	while read -r key; do
+		[[ "${key}" == */* ]]
+		[[ "${key%%/*}" == "feature.node.kubernetes.io" ||
+			"${key%%/*}" == *".feature.node.kubernetes.io" ]]
+	done < <(document_of kata-nvidia-gpu | published_label_keys)
+}
+
+@test "Helm template: the family device IDs come from values" {
+	# A GPU released after the chart should need a value override, not a new
+	# chart, so the device lists must be data rather than baked into the rule.
+	render_chart --set nodeFeatureRules.create=true \
+		--set nodeFeatureRules.nvidiaGpu.families.hopper=null \
+		--set nodeFeatureRules.nvidiaGpu.families.blackwell=null \
+		--set nodeFeatureRules.nvidiaGpu.families.imaginary[0]=beef \
+		--set nodeFeatureRules.nvidiaGpu.ccCapableFamilies={imaginary}
+
+	local rule
+	rule="$(document_of kata-nvidia-gpu)"
+
+	echo "${rule}" | grep -q 'nvidia.gpu.family.imaginary'
+	echo "${rule}" | grep -q '"beef"'
+	refute_rendered "nvidia.gpu.family.hopper"
+}
+
+@test "Helm template: every CC-capable family has device IDs to match on" {
+	# A family named in ccCapableFamilies but absent from families sets no var,
+	# leaving that branch of the CC rule dead: the label would quietly never
+	# appear on a node holding exactly that GPU.
+	render_chart --set nodeFeatureRules.create=true
+
+	local rule referenced family
+	rule="$(document_of kata-nvidia-gpu)"
+
+	while read -r referenced; do
+		family="${referenced#kata.nvidia.gpu.family.}"
+		echo "${rule}" | grep -q "name: \"nvidia.gpu.family.${family}\""
+	done < <(echo "${rule}" |
+		grep -o 'kata\.nvidia\.gpu\.family\.[a-z0-9-]*' | sort -u)
+}
+
+@test "Helm template: the plain GPU RuntimeClasses select the chart's own GPU label" {
+	# These used to select the GPU Operator's nvidia.com/cc.ready.state, which
+	# made a plain GPU sandbox wait for a CC manager it has no use for.
+	render_chart --set nodeFeatureRules.create=true
+
+	local shim selectors
+	for shim in kata-qemu-nvidia-gpu kata-qemu-nvidia-gpu-runtime-rs; do
+		selectors="$(document_of "${shim}" | node_selector_of)"
+
+		echo "${selectors}" | grep -q "^nvidia.feature.node.kubernetes.io/gpu=true$"
+		if echo "${selectors}" | grep -q "cc.ready.state"; then
+			echo "${shim} still waits on the GPU Operator: ${selectors}" >&2
+			return 1
+		fi
+	done
+}
+
+@test "Helm template: the confidential GPU RuntimeClasses still require a GPU in CC mode" {
+	# cc.capable says the GPU could run confidentially; only cc.ready.state says
+	# it has been put in that mode. Selecting on capability alone would place a
+	# confidential sandbox on a GPU running in the clear.
+	render_chart --set nodeFeatureRules.create=true
+
+	local shim selectors
+	for shim in kata-qemu-nvidia-gpu-snp kata-qemu-nvidia-gpu-tdx; do
+		selectors="$(document_of "${shim}" | node_selector_of)"
+
+		echo "${selectors}" | grep -q "^nvidia.com/cc.ready.state=true$"
+	done
+}
+
+@test "Helm template: a second install gets its own NVIDIA GPU rule" {
+	# NodeFeatureRules are cluster scoped, so two installs sharing one name
+	# would fight over the object.
+	render_chart --set nodeFeatureRules.create=true \
+		--set env.multiInstallSuffix=second
+
+	grep -q "name: kata-nvidia-gpu-second" "${RENDERED}"
+	refute_rendered "name: kata-nvidia-gpu$"
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -24,6 +24,7 @@ else
 		"kata-deploy-lifecycle.bats" \
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \
+		"kata-deploy-nvidia-gpu-nfd.bats" \
 		"kata-deploy-distribution.bats" \
 		"kata-deploy-privileges.bats" \
 		"kata-deploy-multi-install.bats" \

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/node-feature-rules-nvidia-gpu.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/node-feature-rules-nvidia-gpu.yaml
@@ -1,0 +1,114 @@
+{{- /*
+NodeFeatureRule teaching node-feature-discovery about a node's NVIDIA GPU: that
+one is there at all, which family it belongs to, and whether that family on this
+host can back a confidential VM. Kata's NVIDIA shims select their nodes on these
+labels.
+
+NVIDIA's GPU Operator published equivalent labels under `nvidia.com` until v25.10
+and removed them in v26.3.0, so a cluster on a current GPU Operator gets no GPU
+family or CC-capability label from anywhere.
+
+The labels sit under `nvidia.feature.node.kubernetes.io` because NFD publishes
+subdomains of `feature.node.kubernetes.io` without further configuration, while
+`nvidia.com` needs `-extra-label-ns` on nfd-master, which we cannot set for an NFD
+we do not own. The TEE rules use `amd.`/`intel.` for the same reason.
+
+One object rather than one per concern: a rule reading `rule.matched` only sees
+rules processed before it, and between objects that order is just alphabetical by
+name.
+
+Everything matches on PCI devices and CPU features, so the rules are inert on a
+node without an NVIDIA GPU; no architecture gating is needed.
+*/ -}}
+{{- if eq (include "kata-deploy.nfdRulesActive" . | trim) "true" }}
+{{- $nvidiaGpu := (.Values.nodeFeatureRules | default dict).nvidiaGpu | default dict }}
+{{- $families := $nvidiaGpu.families | default dict }}
+{{- $ccFamilies := $nvidiaGpu.ccCapableFamilies | default list }}
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: kata-nvidia-gpu-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
+  name: kata-nvidia-gpu
+{{- end }}
+  labels:
+    app.kubernetes.io/managed-by: kata-deploy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    kata-deploy/instance: {{ .Values.env.multiInstallSuffix | default "default" | quote }}
+spec:
+  rules:
+    - name: "nvidia.gpu"
+      labels:
+        "nvidia.feature.node.kubernetes.io/gpu": "true"
+      matchFeatures:
+        - feature: pci.device
+{{- /* 0300 is a VGA-compatible controller and 0302 a 3D controller; a datacenter
+       GPU reports the latter. Matching the class keeps NVIDIA's non-GPU PCI
+       devices - NVSwitch, the DPU side of a converged card - out of it.
+
+       The classes NFD's own pci source is configured to label (its
+       deviceClassWhitelist, source of `feature.node.kubernetes.io/pci-10de.present`)
+       do not constrain this: rules match the discovered pci.device feature, which
+       holds every PCI device on the node. */}}
+          matchExpressions:
+            vendor: { op: In, value: ["10de"] }
+            class: { op: In, value: ["0300", "0302"] }
+{{- range $family, $devices := $families }}
+{{- if $devices }}
+    - name: "nvidia.gpu.family.{{ $family }}"
+      labels:
+        "nvidia.feature.node.kubernetes.io/gpu.family": {{ $family | quote }}
+{{- /* Also a var, so the CC rules below can backreference the family without
+       depending on how NFD keys a namespaced label in rule.matched. */}}
+      vars:
+        "kata.nvidia.gpu.family.{{ $family }}": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: { op: In, value: ["10de"] }
+            device:
+              op: In
+              value:
+{{- range $devices }}
+                - {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $ccFamilies }}
+{{- /* Collapsing the CC-capable families into one var first keeps the rule below
+       at two branches - one per host TEE - instead of one per family per TEE. */}}
+    - name: "nvidia.gpu.cc-capable-family"
+      vars:
+        "kata.nvidia.gpu.cc-capable-family": "true"
+      matchAny:
+{{- range $ccFamilies }}
+        - matchFeatures:
+            - feature: rule.matched
+              matchExpressions:
+                "kata.nvidia.gpu.family.{{ . }}": { op: IsTrue }
+{{- end }}
+{{- /* Both ends are needed: a GPU that can run in CC mode, and a host CPU TEE to
+       hold the guest it gets passed into. The label says the node could do it,
+       not that the GPU is in that mode - only whoever programs the GPU (the GPU
+       Operator's CC manager, through nvidia.com/cc.ready.state) knows that. */}}
+    - name: "nvidia.cc.capable"
+      labels:
+        "nvidia.feature.node.kubernetes.io/cc.capable": "true"
+      matchAny:
+        - matchFeatures:
+            - feature: rule.matched
+              matchExpressions:
+                "kata.nvidia.gpu.cc-capable-family": { op: IsTrue }
+            - feature: cpu.security
+              matchExpressions:
+                sev.snp.enabled: { op: IsTrue }
+        - matchFeatures:
+            - feature: rule.matched
+              matchExpressions:
+                "kata.nvidia.gpu.cc-capable-family": { op: IsTrue }
+            - feature: cpu.security
+              matchExpressions:
+                tdx.enabled: { op: IsTrue }
+{{- end }}
+{{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -55,10 +55,12 @@ shims:
     containerd:
       snapshotter: ""
     runtimeClass:
-      # This label is automatically added by gpu-operator. Override it
-      # if you want to use a different label.
+      # Published by this chart's NVIDIA GPU NodeFeatureRule, so no GPU Operator
+      # is needed to find a GPU node. Select on the GPU Operator's
+      # `nvidia.com/cc.ready.state: "false"` instead to keep this class off the
+      # nodes your confidential workloads use.
       nodeSelector:
-        nvidia.com/cc.ready.state: "false"
+        nvidia.feature.node.kubernetes.io/gpu: "true"
 
   qemu-nvidia-gpu-runtime-rs:
     enabled: true
@@ -68,10 +70,9 @@ shims:
     containerd:
       snapshotter: "erofs"
     runtimeClass:
-      # This label is automatically added by gpu-operator. Override it
-      # if you want to use a different label.
+      # See qemu-nvidia-gpu above.
       nodeSelector:
-        nvidia.com/cc.ready.state: "false"
+        nvidia.feature.node.kubernetes.io/gpu: "true"
 
   qemu-nvidia-gpu-snp:
     enabled: true

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -644,10 +644,14 @@ shims:
     containerd:
       snapshotter: ""
     runtimeClass:
-      # This label is automatically added by gpu-operator. Override it
-      # if you want to use a different label.
+      # Published by this chart's NVIDIA GPU NodeFeatureRule (see
+      # nodeFeatureRules.nvidiaGpu), so the class finds a GPU node without the
+      # GPU Operator having to label it. It says nothing about the GPU's
+      # confidential computing mode: to keep this class off the nodes your
+      # confidential workloads use, select on the GPU Operator's
+      # `nvidia.com/cc.ready.state: "false"` instead.
       nodeSelector:
-        nvidia.com/cc.ready.state: "false"
+        nvidia.feature.node.kubernetes.io/gpu: "true"
 
   qemu-nvidia-gpu-runtime-rs:
     enabled: ~
@@ -658,10 +662,9 @@ shims:
     containerd:
       snapshotter: ""
     runtimeClass:
-      # This label is automatically added by gpu-operator. Override it
-      # if you want to use a different label.
+      # See qemu-nvidia-gpu above.
       nodeSelector:
-        nvidia.com/cc.ready.state: "false"
+        nvidia.feature.node.kubernetes.io/gpu: "true"
 
   qemu-nvidia-gpu-snp:
     enabled: ~
@@ -677,10 +680,14 @@ shims:
       httpsProxy: ""
       noProxy: ""
     runtimeClass:
-      # These labels are automatically added by gpu-operator and NFD
-      # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the snp label by other
-      # means to your SNP nodes.
+      # cc.ready.state is added by the GPU Operator's CC manager, the snp label by
+      # NFD. Override if you want to use different labels; without NFD, the snp
+      # label has to reach your SNP nodes some other way.
+      #
+      # Deliberately not this chart's nvidia.feature.node.kubernetes.io/cc.capable:
+      # that one says the node's GPU *could* run confidentially, while
+      # cc.ready.state says it has actually been put in that mode, which is what a
+      # confidential workload needs.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         amd.feature.node.kubernetes.io/snp: "true"
@@ -717,10 +724,14 @@ shims:
       httpsProxy: ""
       noProxy: ""
     runtimeClass:
-      # These labels are automatically added by gpu-operator and NFD
-      # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the tdx label by other
-      # means to your TDX nodes.
+      # cc.ready.state is added by the GPU Operator's CC manager, the tdx label by
+      # NFD. Override if you want to use different labels; without NFD, the tdx
+      # label has to reach your TDX nodes some other way.
+      #
+      # Deliberately not this chart's nvidia.feature.node.kubernetes.io/cc.capable:
+      # that one says the node's GPU *could* run confidentially, while
+      # cc.ready.state says it has actually been put in that mode, which is what a
+      # confidential workload needs.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         intel.feature.node.kubernetes.io/tdx: "true"
@@ -931,10 +942,16 @@ env:
 node-feature-discovery:
   enabled: false
 
-# The NodeFeatureRule that makes node-feature-discovery advertise each node's TEE
-# key counts (AMD SEV-SNP encrypted-state IDs, Intel TDX key slots), together with
-# the matching `overhead.podFixed` request on Kata's confidential RuntimeClasses so
-# a sandbox consumes one key and the scheduler cannot oversubscribe them.
+# The NodeFeatureRules this chart hands to node-feature-discovery, and the
+# RuntimeClass fields that go with them:
+#
+#   - TEE keys: each node's TEE key count (AMD SEV-SNP encrypted-state IDs, Intel
+#     TDX key slots) as an extended resource, together with the matching
+#     `overhead.podFixed` request on Kata's confidential RuntimeClasses so a
+#     sandbox consumes one key and the scheduler cannot oversubscribe them.
+#   - NVIDIA GPUs: whether a node has one, which family it belongs to, and whether
+#     that family together with the host CPU TEE can back a confidential VM. See
+#     `nvidiaGpu` below.
 #
 #   auto (default) - create them when NFD is around: installed by this release,
 #                    found already running, or its CRD registered in the cluster.
@@ -942,11 +959,75 @@ node-feature-discovery:
 #                    renders nothing under `auto`.
 #   true / false   - decide explicitly.
 #
-# The rule and the key requests are gated together on purpose: an extended-resource
-# request that nothing advertises makes every pod on that RuntimeClass unschedulable,
-# so the keys must never be requested without the rule that produces them.
+# The TEE rule and the key requests are gated together on purpose: an
+# extended-resource request that nothing advertises makes every pod on that
+# RuntimeClass unschedulable, so the keys must never be requested without the rule
+# that produces them.
 nodeFeatureRules:
   create: auto
+
+  # NVIDIA GPU discovery. The labels published are, all under
+  # `nvidia.feature.node.kubernetes.io`:
+  #
+  #   gpu: "true"              an NVIDIA display or 3D controller is present
+  #   gpu.family: <family>     the key from `families` its device ID belongs to
+  #   cc.capable: "true"       a family from `ccCapableFamilies` on a host whose
+  #                            CPU reports SEV-SNP or TDX
+  #
+  # NVIDIA's GPU Operator published equivalent labels under `nvidia.com` until
+  # v25.10 and dropped them in v26.3.0, so on a current GPU Operator nothing
+  # provides them. `nvidia.feature.node.kubernetes.io` rather than `nvidia.com`
+  # because NFD publishes subdomains of `feature.node.kubernetes.io` out of the
+  # box, while `nvidia.com` needs `-extra-label-ns` on nfd-master, which we cannot
+  # set for an NFD installation we do not own.
+  #
+  # `families` maps a family name to the PCI device IDs (hex, vendor 10de) that
+  # belong to it, so a GPU newer than your chart is one value override away rather
+  # than a chart release. Device IDs are the datacenter parts named in the PCI ID
+  # repository (https://pci-ids.ucw.cz/read/PC/10de); the comments are those names.
+  # A node holding two families gets the label of whichever rule matched last, so
+  # `gpu.family` describes a mixed node only loosely.
+  nvidiaGpu:
+    families:
+      hopper:
+        - "230c"  # H20 NVL16
+        - "230e"  # H20 NVL16
+        - "2313"  # H100 CNX
+        - "2321"  # H100L 94GB
+        - "2322"  # H800 PCIe
+        - "2324"  # H800
+        - "2328"  # H20B
+        - "2329"  # H20
+        - "232c"  # H20 HBM3e
+        - "2330"  # H100 SXM5 80GB
+        - "2331"  # H100 PCIe
+        - "2335"  # H200 SXM 141GB
+        - "2336"  # H100
+        - "2337"  # H100 SXM5 64GB
+        - "2338"  # H100 SXM5 96GB
+        - "2339"  # H100 SXM5 94GB
+        - "233a"  # H800L 94GB
+        - "233b"  # H200 NVL
+        - "233d"  # H100 96GB
+        - "2342"  # GH200 120GB / 480GB
+        - "2348"  # GH200 144G HBM3e
+        - "237e"  # H100 GH3
+      blackwell:
+        - "2901"  # B200
+        - "2909"  # HGX B200 168GB
+        - "2920"  # TS4 / B100
+        - "2941"  # HGX GB200
+        - "29bc"  # B100
+        - "3182"  # B300 SXM6 AC
+        - "31a1"  # GB300 MaxQ
+        - "31c2"  # GB300
+        - "31c3"  # GB300
+
+    # Families whose GPUs can be put into a confidential computing mode, and so
+    # can serve a confidential VM once the host CPU offers a TEE to run it in.
+    ccCapableFamilies:
+      - hopper
+      - blackwell
 
 # Verification
 # Post-install verification to validate Kata Containers is working correctly.


### PR DESCRIPTION
## Summary

Kata's NVIDIA shims need to land on a node that holds the GPU they were built for, and the only labels saying so came from NVIDIA's GPU Operator. It published them under `nvidia.com` up to v25.10 and [removed the GPU family and CC-capability rules in v26.3.0](https://github.com/NVIDIA/gpu-operator/commit/bd954f7ce25707d33519862f3a22b7d15b942078), so on a current GPU Operator nothing provides them any more.

This adds a `NodeFeatureRule` of our own, `kata-nvidia-gpu`, on the same `nodeFeatureRules.create` switch as the existing TEE key rule:

| Label | Meaning |
| --- | --- |
| `nvidia.feature.node.kubernetes.io/gpu` | node has an NVIDIA display or 3D controller (vendor `10de`, class `0300`/`0302`) |
| `nvidia.feature.node.kubernetes.io/gpu.family` | `hopper` or `blackwell`, from the GPU's PCI device ID |
| `nvidia.feature.node.kubernetes.io/cc.capable` | a CC-capable GPU family on a CPU reporting SEV-SNP or TDX |

A few things worth a reviewer's attention:

- **Label namespace.** `nvidia.feature.node.kubernetes.io`, not `nvidia.com`: NFD publishes subdomains of `feature.node.kubernetes.io` without further configuration, while `nvidia.com` needs `-extra-label-ns` on nfd-master, which the chart cannot set for an NFD installation it does not own. Same reason the TEE rule uses `amd.`/`intel.`.
- **Device IDs are values, not template.** `nodeFeatureRules.nvidiaGpu.families` maps a family to its PCI device IDs, so a GPU newer than the chart is an override away rather than a release. Presence is matched by PCI *class*, which needs no list at all. The shipped IDs are the datacenter parts named for vendor `10de` in the PCI ID repository.
- **The plain GPU RuntimeClasses now select the presence label** instead of the GPU Operator's `nvidia.com/cc.ready.state: "false"`, which used to leave a sandbox wanting nothing to do with confidential computing waiting for a CC manager to label the node.
- **The confidential GPU RuntimeClasses deliberately keep `cc.ready.state: "true"`.** `cc.capable` says the GPU *could* run confidentially; only `cc.ready.state` says it has been put in that mode. Selecting on capability alone would let a confidential sandbox land on a node whose GPU is running in the clear, so those shims still need a GPU Operator.
- One `NodeFeatureRule` object rather than one per concern, because a rule reading `rule.matched` only sees rules processed before it and between objects that order is merely alphabetical by name.

## Test plan

- [x] `bats tests/functional/kata-deploy/kata-deploy-nvidia-gpu-nfd.bats` — 8 new render-time tests
- [x] `bats tests/functional/kata-deploy/kata-deploy-tee-keys.bats` — the rule it shares a switch with
- [x] `kata-deploy-scheduling.bats`, `kata-deploy-privileges.bats`, `kata-deploy-multi-install.bats` still green
- [x] `helm lint` clean; rendered rule checked field by field against the `NodeFeatureRule` CRD in the vendored NFD 0.19.0 subchart
- [x] `make docs-lint`
- [ ] Labels confirmed on a real Hopper node with NFD running