### PR TITLE
tests: remove workarounds for k8s-policy-pod.yaml

### DIFF
--- a/src/tools/genpolicy/drop-in-examples/20-experimental-force-guest-pull-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/20-experimental-force-guest-pull-drop-in.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "replace",
-    "path": "/cluster_config/guest_pull",
-    "value": false
-  }
-]

--- a/src/tools/genpolicy/drop-in-examples/README.md
+++ b/src/tools/genpolicy/drop-in-examples/README.md
@@ -26,6 +26,5 @@ Drop-ins are layered: `10-*` files set the platform base, `20-*` files overlay O
 | `20-oci-1.2.0-drop-in.json` | OCI bundle version 1.2.0 |
 | `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU) |
 | `20-oci-1.3.0-drop-in.json` | OCI bundle version 1.3.0 (e.g. containerd 2.2.x, CBL-Mariner) |
-| `20-experimental-force-guest-pull-drop-in.json` | Disable guest pull |
 
 Request/exec overrides (e.g. allowing `kubectl exec` or specific ttRPC requests) are not shipped as drop-in examples; build your own drop-in or merge the needed `request_defaults` into a local file in `genpolicy-settings.d/`.

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -9,8 +9,6 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
-issue="https://github.com/kata-containers/kata-containers/issues/10297"
-
 setup() {
 	auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
     setup_common || die "setup_common failed"
@@ -43,9 +41,6 @@ setup() {
 
     # Save some time by executing genpolicy a single time.
     if [ "${BATS_TEST_NUMBER}" == "1" ]; then
-		# Work around #10297 if needed.
-		prometheus_image_supported || replace_prometheus_image
-
 		# Save pre-generated yaml files
 		cp "${correct_configmap_yaml}" "${pre_generate_configmap_yaml}"
 		cp "${correct_pod_yaml}" "${pre_generate_pod_yaml}"
@@ -64,23 +59,6 @@ setup() {
 
 	set_node "${testcase_pre_generate_pod_yaml}" "${node}"
 	set_node "${correct_pod_yaml}" "${node}"
-}
-
-prometheus_image_supported() {
-	[[ "${SNAPSHOTTER:-}" == "nydus" ]] && return 1
-	return 0
-}
-
-replace_prometheus_image() {
-	info "Replacing prometheus image with busybox to work around ${issue}"
-
-	yq -i \
-		'.spec.containers[0].name = "busybox"' \
-		"${correct_pod_yaml}"
-	yq -i \
-		'.spec.containers[0].image = "quay.io/prometheus/busybox:latest"' \
-		"${correct_pod_yaml}"
-	set_pod_spec_security_context "${correct_pod_yaml}" ".spec" "" "" "10"
 }
 
 wait_for_pod_ready() {
@@ -245,23 +223,7 @@ test_pod_policy_error() {
 	pod_exec_blocked_command "${pod_name}" "echo" "hello"
 }
 
-@test "Successful pod: runAsUser having the same value as the UID from the container image" {
-	prometheus_image_supported || skip "Test case not supported due to ${issue}"
-
-	# This container image specifies user = "nobody" that corresponds to UID = 65534. Setting
-	# the same value for runAsUser in the YAML file doesn't change the auto-generated Policy.
-	yq -i \
-		'.spec.containers[0].securityContext.runAsUser = 65534' \
-		"${incorrect_pod_yaml}"
-
-	kubectl create -f "${correct_configmap_yaml}"
-	kubectl create -f "${incorrect_pod_yaml}"
-	wait_for_pod_ready
-}
-
 @test "Policy failure: unexpected UID = 0" {
-	prometheus_image_supported || skip "Test case not supported due to ${issue}"
-
 	# Change the container UID to 0 after the policy has been generated, and verify that the
 	# change gets rejected by the policy. UID = 0 is the default value from genpolicy, but
 	# this container image specifies user = "nobody" that corresponds to UID = 65534.

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -38,6 +38,8 @@ spec:
               apiVersion: v1
               fieldPath: metadata.labels['some-test-label']
       securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       livenessProbe:
@@ -90,8 +92,8 @@ spec:
               - not-a-real-hostname
   resources:
     limits:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "500m"
     requests:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "500m"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -381,12 +381,6 @@ install_genpolicy_drop_ins() {
 	elif is_k3s_or_rke2 || is_nvidia_gpu_platform || is_snp_hypervisor "${KATA_HYPERVISOR}" || is_tdx_hypervisor "${KATA_HYPERVISOR}" || [[ -n "${CONTAINER_ENGINE_VERSION:-}" ]] || is_arm64_host; then
 		cp "${examples_dir}/20-oci-1.3.0-drop-in.json" "${settings_d}/"
 	fi
-
-	# 20-* experimental force guest pull overlay
-	if [[ "${PULL_TYPE:-}" == "experimental-force-guest-pull" ]]; then
-		cp "${examples_dir}/20-experimental-force-guest-pull-drop-in.json" "${settings_d}/"
-	fi
-
 }
 
 # If auto-generated policy testing is enabled, make a copy of the genpolicy settings


### PR DESCRIPTION
As I authored #13105, I was unaware of the two workarounds for `tests/integration/kubernetes/k8s-policy-pod.bats`:
- under experimental force-guest pull, disable the guest-pull genpolicy configuration setting
- under nydus guest pull, change the underlying container image as the image ('s config) under test would include the `nobody` user which Kubernetes/containerd cannot resolve at runtime under nydus guest-pull.

One of the two commits in this PR adds the `securityContext` information mandated by genpolicy for `k8s-policy-pod.yaml`, hence deployment will succeed at runtime as well. Thus, we no longer require the nydus workaround. Further, at the time #13105 was merged, making the experimental-force-guest-pull workaround already became obsolete - the other commit now removes that workaround. 

Noteworthy: we didn't update the securityContext for this YAML file back then because none of the guest-pull configurations (experimental or nydus) was *actually* exercising that YAML under guest-pull, so genpolicy would never complain about this.