### PR TITLE
kata-deploy: install the nodes that join after the release

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -192,7 +192,7 @@ of any pod running there.
 
 | | runs where | privileged on the host | API rights |
 |---|---|---|---|
-| dispatcher (install, uninstall) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; Jobs in the release namespace; `nodes/proxy: get` only when guest pull or image conversion is configured |
+| dispatcher (install, uninstall, and each scheduled reconcile) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; Jobs in the release namespace; `nodes/proxy: get` only when guest pull or image conversion is configured; `pods: get` and `cronjobs: get, delete` only with [`job.reconcile`](#doing-it-on-a-schedule-instead) enabled |
 | per-node Jobs | every node Kata is installed on | yes | **none — no token is mounted** |
 | `post-delete` hook (uninstall only) | one pod, wherever it schedules | no | `delete` on ClusterRoles, ClusterRoleBindings, Roles, RoleBindings and ServiceAccounts |
 | verification Job (only if `verification.pod` is set) | one pod, wherever it schedules | no | pods and pod logs (`create`, `delete`, `get`, `list`, `watch`), `nodes`/`events`/`daemonsets`/`jobs`: `get`, `list` |
@@ -351,6 +351,52 @@ helm upgrade kata-deploy "${CHART}" --version "${VERSION}" --reuse-values
 
 Each per-node stage is idempotent (it skips when already applied), so the
 upgrade only does real work on the newly added nodes.
+
+#### Doing it on a schedule instead
+
+On a fleet that grows on its own — an autoscaler, or nodes joining faster than
+anybody notices — the upgrade above needs somebody to run it, and until they do the
+new node adds no Kata capacity. Nothing lands on it wrongly (every RuntimeClass
+selects `katacontainers.io/kata-runtime`, which is exactly what the install has not
+written there yet), so a pod asking for a Kata runtime class stays `Pending` while a
+node that could have run it takes non-Kata work instead — and if it was the pending
+pod that grew the fleet in the first place, the next node changes nothing either.
+`job.reconcile` turns that upgrade into a `CronJob` running the same dispatcher,
+against the same selectors and the same per-node templates:
+
+```yaml title="values.yaml"
+job:
+  reconcile:
+    enabled: true
+    schedule: "*/15 * * * *"
+```
+
+A tick installs the nodes that have nothing to show yet and leaves the rest of the
+fleet untouched, so a tick over a settled fleet lists nodes, finds nothing to do,
+and exits without creating a single pod. It also stands aside when a release
+rollout is in flight, rather than deleting the per-node Jobs that rollout is
+waiting on. Failures are visible where you would look for them: the CronJob keeps
+its last three failed Jobs, and a tick that failed on a node fails as a Job rather
+than being retried immediately — the next tick is the retry.
+
+!!! note "It only ever adds nodes"
+
+    A node that has dropped out of the selection is left alone, where `helm
+    upgrade` would run the cleanup pipeline on it. That asymmetry is deliberate: a
+    node falling out is usually a label gone wrong somewhere, and taking a host
+    apart on a timer with nobody watching is the worse of the two outcomes. Removals
+    stay with the upgrade you run yourself.
+
+!!! warning "Off by default"
+
+    Enabling this stands up a recurring, privileged rollout, so it is opt-in. It
+    also needs a `job.dispatcherImage` of `0.2.0` or newer; older dispatchers do
+    not understand the flags a scheduled run needs and every tick fails at startup.
+
+`helm uninstall` takes the schedule away before it starts reverting nodes (a
+`pre-delete` hook that runs ahead of the uninstall dispatcher and removes the
+CronJob together with anything it still has in flight), so a tick cannot reinstall
+a node the uninstall has just cleaned.
 
 ### Recovering from a failed or deleted dispatcher
 

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -236,7 +236,7 @@ rbac_doc() {
 	cleanup=$(render_job_mode kata-deploy-cleanup-job.yaml)
 
 	for rendered in "${install}" "${cleanup}"; do
-		echo "${rendered}" | grep -q 'image: ghcr.io/kata-containers/k8s-job-dispatcher:0.1.0'
+		echo "${rendered}" | grep -q 'image: ghcr.io/kata-containers/k8s-job-dispatcher:0.2.0'
 		echo "${rendered}" | grep -q -- '/usr/bin/k8s-job-dispatcher'
 		echo "${rendered}" | grep -q -- '--tracking-label-prefix=kata-deploy-job-dispatcher'
 		echo "${rendered}" | grep -q -- '--node-label-key=katacontainers.io/kata-runtime'

--- a/tests/functional/kata-deploy/kata-deploy-reconcile.bats
+++ b/tests/functional/kata-deploy/kata-deploy-reconcile.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for the scheduled reconcile (job.reconcile). No cluster
+# required.
+#
+# A tick has to install a node that joined after the release was applied, and do
+# nothing else: it must not fight the rollout of an upgrade, must not tear a node
+# down, and must reach the same nodes with the same labelling contract as the hook
+# that installed the fleet. Every one of those is a flag, and a flag that quietly
+# stops being rendered looks like nothing at all.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+# Render one template of the chart in job mode with the reconcile enabled.
+render_with_reconcile() {
+	local template="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set job.reconcile.enabled=true \
+		--show-only "templates/${template}" \
+		"$@"
+}
+
+render_reconcile() {
+	render_with_reconcile kata-deploy-reconcile.yaml "$@"
+}
+
+# The install hook, for the flags a tick has to agree with.
+render_install_hook() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only templates/kata-deploy-install-job.yaml \
+		"$@"
+}
+
+# Assert that rendered output does NOT contain a pattern. Not `! grep`, which
+# fails without saying what it found.
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
+# The dispatcher flags of a rendered manifest, one per line.
+dispatcher_flags() {
+	grep -o -- '--[a-z-]*[^"]*' | sed 's/[[:space:]]*$//' | sort -u
+}
+
+@test "Helm template: no reconcile unless it is asked for" {
+	# A recurring privileged rollout is opt-in, so job mode alone renders nothing.
+	local default_mode
+	default_mode=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job)
+	refute_match "${default_mode}" 'kind: CronJob'
+
+	# And asking for it in daemonset mode asks for something that does not exist
+	# there: that DaemonSet already installs a node the moment it appears.
+	local daemonset_mode
+	daemonset_mode=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--set job.reconcile.enabled=true)
+	refute_match "${daemonset_mode}" 'kind: CronJob'
+}
+
+@test "Helm template: a tick covers new nodes and takes none apart" {
+	local reconcile
+	reconcile=$(render_reconcile)
+
+	echo "${reconcile}" | grep -q 'kind: CronJob'
+	echo "${reconcile}" | grep -q -- '--job-template=/etc/kata-job/install-job.yaml'
+
+	# The install pipeline only. With a cleanup template the dispatcher would also
+	# dismantle nodes that fell out of the selection, on a timer, with nobody
+	# watching.
+	refute_match "${reconcile}" '--cleanup-job-template'
+
+	# Nodes that already show a finished install are left out, so a tick over a
+	# settled fleet creates no pods at all.
+	echo "${reconcile}" | grep -q -- '--skip-satisfied-nodes'
+
+	# An upgrade rolling out while a tick starts is the overlap
+	# concurrencyPolicy cannot see, and the tick is the one that gives way.
+	echo "${reconcile}" | grep -q -- '--yield-to-live-run'
+	echo "${reconcile}" | grep -q 'concurrencyPolicy: Forbid'
+
+	# The Job a CronJob creates is named after the schedule it fired on, so a tick
+	# cannot name its own Job to own the per-node Jobs with. It reads it off its pod.
+	echo "${reconcile}" | grep -q -- '--owner-job-from-pod=$(POD_NAME)'
+	echo "${reconcile}" | grep -q 'fieldPath: metadata.name'
+	refute_match "${reconcile}" '--owner-job-name'
+}
+
+@test "Helm template: a tick waits for nothing and fails on nothing" {
+	local reconcile
+	reconcile=$(render_reconcile --set job.waitForNodesSeconds=120 \
+		--set job.nodeSettleSeconds=30)
+
+	# The hook's waits declare that nodes are expected and make an empty selection
+	# an error. For something periodic that is a quiet no-op, so the wait is off -
+	# which also switches off settling, since a tick that catches the fleet
+	# mid-labelling can leave the rest to the next one.
+	echo "${reconcile}" | grep -q -- '--wait-for-nodes-secs=0'
+	refute_match "${reconcile}" '--wait-for-nodes-secs=120'
+	refute_match "${reconcile}" '--node-settle-secs'
+
+	# A tick that failed on a node is a failed Job to look at, not a retry loop:
+	# the next tick is the retry.
+	echo "${reconcile}" | grep -q 'backoffLimit: 0'
+	echo "${reconcile}" | grep -q 'failedJobsHistoryLimit: 3'
+}
+
+@test "Helm template: a tick installs like the hook it stands in for" {
+	local reconcile install
+	reconcile=$(render_reconcile --set 'startupTaints[0]=kata/installing:NoSchedule')
+	install=$(render_install_hook --set 'startupTaints[0]=kata/installing:NoSchedule')
+
+	# Same Jobs, same nodes, same labelling contract. Anything the hook passes to
+	# manage a node has to be passed here too, or a node this covers ends up
+	# installed but never advertised, or advertised without the checks. Only the
+	# four flags a tick differs by on purpose are left out, each covered by a test
+	# of its own above.
+	local flag
+	while read -r flag; do
+		case "${flag}" in
+			--wait-for-nodes-secs=*|--node-settle-secs=*) continue ;;
+			--cleanup-job-template=*|--owner-job-name=*) continue ;;
+		esac
+		echo "${reconcile}" | grep -q -- "${flag}"
+	done < <(echo "${install}" | dispatcher_flags)
+
+	# Including the name prefix, which is what makes the two runs one family: each
+	# recognises the other's per-node Jobs instead of reading them as an abandoned
+	# run's leftovers to clear away.
+	echo "${reconcile}" | grep -q -- '--name-prefix=kata-deploy-install'
+
+	# The pod that holds the token is still confined and unprivileged.
+	echo "${reconcile}" | grep -q 'runAsNonRoot: true'
+	echo "${reconcile}" | grep -q 'readOnlyRootFilesystem: true'
+	echo "${reconcile}" | grep -q 'privileged: false'
+}
+
+@test "Helm template: the reconcile follows the dispatcher's node selection" {
+	# nodeSelector, affinity terms and the NFD requirements the chart adds all
+	# compile into --node-selector flags, and a tick that resolved a different set
+	# than the hook would install a node the release never selected - or, worse,
+	# leave out one it did.
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+nodeSelector:
+  kata: allowed
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node.kubernetes.io/instance-type
+              operator: In
+              values: ["m5.large"]
+        - matchExpressions:
+            - key: kata.io/pool
+              operator: Exists
+EOF
+
+	local nfd reconcile install reconcile_selectors install_selectors
+	for nfd in false true; do
+		reconcile=$(render_reconcile -f "${values_file}" \
+			--set "node-feature-discovery.enabled=${nfd}")
+		install=$(render_install_hook -f "${values_file}" \
+			--set "node-feature-discovery.enabled=${nfd}")
+
+		reconcile_selectors=$(echo "${reconcile}" | grep -o -- '--node-selector=[^"]*' | sort -u)
+		install_selectors=$(echo "${install}" | grep -o -- '--node-selector=[^"]*' | sort -u)
+		[[ -n "${install_selectors}" ]]
+		[[ "${reconcile_selectors}" == "${install_selectors}" ]]
+	done
+	rm -f "${values_file}"
+
+	# Taints are the other half of the selection, and the dispatcher reads them off
+	# the per-node Job template it is given. Both are given the same one, and only
+	# uninstall is allowed to ignore a taint.
+	refute_match "${reconcile}" '--ignore-node-taints'
+
+	# An explicit node list is used verbatim in both, so naming nodes still means
+	# those nodes and no others.
+	local named
+	named=$(render_reconcile --set 'job.nodes={worker-1,worker-2}')
+	echo "${named}" | grep -q -- '--nodes=worker-1,worker-2'
+	refute_match "${named}" '--node-selector='
+}
+
+@test "Helm template: uninstall stops the schedule before it reverts nodes" {
+	local reconcile
+	reconcile=$(render_reconcile)
+
+	# Helm deletes the CronJob only once the pre-delete hooks are done, so a tick
+	# firing in between would reinstall a node the uninstall has just cleaned. This
+	# hook runs at a lower weight than the cleanup dispatcher's 5.
+	echo "${reconcile}" | grep -q 'helm.sh/hook": pre-delete'
+	echo "${reconcile}" | grep -q 'helm.sh/hook-weight": "0"'
+	echo "${reconcile}" | grep -q 'kubectl delete cronjob "kata-deploy-reconcile"'
+
+	# Only this release's per-node Jobs: with env.multiInstallSuffix a sibling
+	# release's installs carry the same stage label, and they are none of this
+	# uninstall's business.
+	echo "${reconcile}" | grep -q 'app.kubernetes.io/instance=kata-deploy'
+}
+
+@test "Helm template: the reconcile asks for its own rights and no others" {
+	local role
+	role=$(render_with_reconcile kata-rbac.yaml)
+
+	# Reading its own pod is what --owner-job-from-pod needs; deleting the CronJob
+	# is what the uninstall hook needs.
+	echo "${role}" | grep -q 'resources: \["pods"\]'
+	echo "${role}" | grep -q 'resources: \["cronjobs"\]'
+	echo "${role}" | grep -q 'verbs: \["get"\]'
+	echo "${role}" | grep -q 'verbs: \["get", "delete"\]'
+
+	# Neither is asked for by a release that does not run a schedule.
+	local plain
+	plain=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only templates/kata-rbac.yaml)
+	refute_match "${plain}" 'resources: \["pods"\]'
+	refute_match "${plain}" 'cronjobs'
+}
+
+@test "Helm template: a reconcile without a schedule is refused" {
+	# An empty schedule renders a CronJob the apiserver rejects, and Helm reports
+	# that as a validation error against the manifest rather than a missing value.
+	run helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--set job.reconcile.enabled=true \
+		--set job.reconcile.schedule=""
+	[ "${status}" -ne 0 ]
+	echo "${output}" | grep -q 'job.reconcile.schedule is empty'
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -35,6 +35,7 @@ else
 		"kata-deploy-distribution.bats" \
 		"kata-deploy-privileges.bats" \
 		"kata-deploy-multi-install.bats" \
+		"kata-deploy-reconcile.bats" \
 	)
 fi
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-reconcile.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-reconcile.yaml
@@ -1,0 +1,236 @@
+{{- /*
+Scheduled reconcile (deploymentMode: job, opt-in).
+
+The install dispatcher runs as a release hook, so it covers the nodes that exist
+while the release is applied. A node joining afterwards matches the same
+selectors, yet nothing installs Kata on it until somebody re-runs `helm upgrade`,
+which on a cluster with an autoscaler nobody reliably does. This CronJob is that
+re-run on a schedule, with the same templates, selectors and labelling flags as
+the hook.
+
+It only ever adds nodes: no --cleanup-job-template is passed, so a node that fell
+out of the selection is left for the next upgrade. Such a node is usually a label
+gone wrong somewhere, and dismantling a host on a timer with nobody watching is
+the worse outcome.
+*/ -}}
+{{- if eq (.Values.deploymentMode | default "daemonset") "job" }}
+{{- $reconcile := .Values.job.reconcile | default dict }}
+{{- if $reconcile.enabled }}
+{{- $root := . }}
+{{- $base := .Chart.Name }}
+{{- if .Values.env.multiInstallSuffix }}
+{{- $base = printf "%s-%s" .Chart.Name .Values.env.multiInstallSuffix }}
+{{- end }}
+{{- $sa := include "kata-deploy.dispatcherServiceAccountName" . }}
+{{- /* A CronJob names each Job it creates after itself plus a timestamp, so its
+       own name has to leave room for that suffix. */}}
+{{- $reconcileName := printf "%s-reconcile" $base | trunc 52 | trimSuffix "-" }}
+{{- $schedule := $reconcile.schedule | default "" | toString }}
+{{- if not $schedule }}
+{{- fail "job.reconcile.enabled is set but job.reconcile.schedule is empty. Give it a cron expression, e.g. \"*/15 * * * *\"." }}
+{{- end }}
+{{- $nodes := .Values.job.nodes | default list }}
+{{- $selectors := include "kata-deploy.installNodeSelectors" . | splitList "\n" | compact }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $reconcileName }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    kata-deploy/dispatcher: reconcile
+spec:
+  schedule: {{ $schedule | quote }}
+  # Two runs over the same fleet would fight over the same nodes, and a tick
+  # missed while the cluster was unavailable has nothing to catch up on - the next
+  # one covers whatever is still uncovered.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  # A failed tick is the thing worth looking at, so keep a few of those and only
+  # the last success.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # A tick that failed on a node should surface as a failed Job rather than be
+      # retried at once: the next tick is the retry.
+      backoffLimit: 0
+      # Nothing outside bounds a tick the way Helm's release timeout bounds the
+      # hook, and concurrencyPolicy means one that hangs holds up every tick after
+      # it. Ending it loses nothing: the per-node Jobs it created run on, and the
+      # next tick labels the nodes they finished.
+      activeDeadlineSeconds: {{ $root.Values.job.activeDeadlineSeconds | default 3600 }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
+            app.kubernetes.io/instance: {{ $root.Release.Name }}
+            kata-deploy/dispatcher: reconcile
+        spec:
+{{- with $root.Values.imagePullSecrets }}
+          imagePullSecrets:
+{{- toYaml . | nindent 12 }}
+{{- end }}
+          serviceAccountName: {{ $sa }}
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+{{- with include "kata-deploy.dispatcherPlacement" $root | trim }}
+{{- . | nindent 10 }}
+{{- end }}
+{{- with $root.Values.priorityClassName }}
+          priorityClassName: {{ . | quote }}
+{{- end }}
+          containers:
+            - name: dispatcher
+              image: {{ include "kata-deploy.dispatcherImage" $root }}
+              imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+              securityContext:
+                privileged: false
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              command:
+                - /usr/bin/k8s-job-dispatcher
+                - "--job-template=/etc/kata-job/install-job.yaml"
+{{- /* The same name prefix as the hook, so each sees the other's per-node Jobs
+       and neither treats them as an abandoned run's leftovers. */}}
+                - "--name-prefix={{ $base }}-install"
+{{- /* A CronJob's Jobs are named for it plus a timestamp, so a tick cannot name
+       its own Job to own what it creates; it reads it off its pod instead. */}}
+                - "--owner-job-from-pod=$(POD_NAME)"
+{{- /* An upgrade rolling out is the overlap concurrencyPolicy cannot see. */}}
+                - "--yield-to-live-run"
+{{- /* Leaving the fleet alone but for the nodes with nothing to show yet. */}}
+                - "--skip-satisfied-nodes"
+                - "--parallelism={{ $root.Values.job.parallelism }}"
+{{- if $nodes }}
+                - "--nodes={{ join "," $nodes }}"
+{{- else }}
+{{- /* One flag per nodeSelectorTerm; the dispatcher unions the matches (OR). */}}
+{{- range $selector := $selectors }}
+                - "--node-selector={{ $selector }}"
+{{- end }}
+{{- /*
+Deliberately not job.waitForNodesSeconds: a wait declares that nodes are
+expected and makes an empty selection an error, which for something periodic
+should be a quiet no-op. It also enables settling, and a tick that catches the
+fleet mid-labelling can leave the rest to the next one.
+*/}}
+                - "--wait-for-nodes-secs=0"
+{{- end }}
+{{- include "kata-deploy.dispatcherNodeWorkFlags" (dict "root" $root "stage" "install") | nindent 16 }}
+              env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              volumeMounts:
+                - name: job-templates
+                  mountPath: /etc/kata-job
+                  readOnly: true
+          volumes:
+            - name: job-templates
+              configMap:
+                name: {{ printf "%s-job-templates" $base | trunc 63 | trimSuffix "-" }}
+---
+{{- /*
+Helm deletes the CronJob above only after the pre-delete hooks are done, so a tick
+firing while the uninstall dispatcher works would reinstall the nodes it has just
+taken apart. This runs first (a lower hook weight) and takes the schedule away,
+along with any tick and per-node install Job still in flight.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-reconcile-stop" $base | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
+    app.kubernetes.io/instance: {{ $root.Release.Name }}
+    kata-deploy/dispatcher: reconcile-stop
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: {{ $root.Values.job.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kata-deploy.name" $root }}
+        app.kubernetes.io/instance: {{ $root.Release.Name }}
+        kata-deploy/dispatcher: reconcile-stop
+    spec:
+{{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ $sa }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+{{- with include "kata-deploy.dispatcherPlacement" $root | trim }}
+{{- . | nindent 6 }}
+{{- end }}
+      containers:
+        - name: stop-reconcile
+          image: {{ include "kata-deploy.kubectlImage" $root }}
+          imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - bash
+            - -c
+            - |
+              set -e
+
+              NS="{{ $root.Release.Namespace }}"
+
+              # A timeout of its own, so a Job that will not go away is reported as
+              # that rather than as Helm's release timeout.
+              kubectl delete cronjob "{{ $reconcileName }}" -n "${NS}" \
+                --ignore-not-found --cascade=foreground --wait=true --timeout=180s
+
+              # A tick's per-node Jobs outlive the tick that created them, and each
+              # one is a privileged pod writing to a node this uninstall is about
+              # to revert. Only this release's own: with env.multiInstallSuffix a
+              # sibling release's installs carry the same stage label.
+              kubectl delete jobs -n "${NS}" \
+                -l kata-deploy/stage=install,app.kubernetes.io/instance={{ $root.Release.Name }} \
+                --ignore-not-found --cascade=foreground --wait=true --timeout=180s
+          env:
+            # kubectl caches API discovery under $HOME, and the root filesystem is
+            # read-only.
+            - name: HOME
+              value: /tmp
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -123,6 +123,17 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["create", "get", "list", "delete"]
+{{- if (.Values.job.reconcile | default dict).enabled }}
+# A scheduled run cannot know the name of the Job the CronJob made for it, so it
+# reads its own pod to find it and own the per-node Jobs with it.
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+# And uninstall takes the schedule away before it starts reverting nodes.
+- apiGroups: ["batch"]
+  resources: ["cronjobs"]
+  verbs: ["get", "delete"]
+{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -23,6 +23,9 @@
 #   installed nodes are skipped). This is intentional: it avoids an always-on
 #   privileged component on every node.
 #
+#   On a fleet that grows on its own, `job.reconcile` does that re-run on a
+#   schedule instead.
+#
 # NOTE on host kernel modules in "job" mode:
 #   Each per-node install Job starts with one short-lived privileged, tokenless
 #   init container that loads the modules the enabled runtimes and snapshotters
@@ -45,7 +48,7 @@ job:
   # released independently of Kata Containers, so its version is pinned here.
   dispatcherImage:
     reference: ghcr.io/kata-containers/k8s-job-dispatcher
-    tag: "0.1.0"
+    tag: "0.2.0"
   # Where the dispatcher pods themselves may run (install and uninstall). Nothing
   # to do with which nodes get Kata - that is the top-level `nodeSelector` /
   # `affinity` / `tolerations`.
@@ -125,6 +128,27 @@ job:
   # NotReady for a moment. Waiting keeps the first Kata workload away until the
   # runtime is back. A node that never becomes Ready stays unlabeled.
   waitNodeReadySeconds: 300
+  # Scheduled reconcile: covers the nodes that join after the release was applied.
+  #
+  # The dispatcher runs as a release hook, so a node joining later is never
+  # dispatched to and stays without Kata until the next `helm upgrade`. Enable
+  # this and a CronJob does that upgrade's work on a schedule instead, running the
+  # same dispatcher against the same selectors and per-node templates.
+  #
+  # A tick stands aside while a release rollout is in flight, and leaves out the
+  # nodes that already show a finished install, so a tick over a settled fleet is
+  # a couple of API calls and no pods.
+  #
+  # Off by default, for two reasons. A recurring privileged rollout is something
+  # to ask for explicitly, and this only ever ADDS nodes: one that fell out of the
+  # selection is usually a label gone wrong somewhere, so it is left for the next
+  # upgrade rather than dismantled on a timer with nobody watching.
+  #
+  # Requires job.dispatcherImage 0.2.0 or newer.
+  reconcile:
+    enabled: false
+    # Cron expression, interpreted in the cluster's own timezone.
+    schedule: "*/15 * * * *"
   # Node selection for the UNINSTALL (pre-delete hook) dispatcher.
   #
   # Deliberately independent of the install selection: uninstall has to reach


### PR DESCRIPTION
In job mode the dispatcher runs as a release hook, so it reaches the nodes that
are present when the release is applied and no others. A node joining later
matches the same selectors, yet nothing installs Kata on it until somebody
re-runs `helm upgrade`, and on a cluster with an autoscaler nobody reliably does.
Until then that node adds no Kata capacity, so a pod asking for a Kata runtime
class waits while a node that could have run it takes other work instead.

So run the same dispatcher on a schedule, against the same templates and
selectors as the hook, and let it install whatever is missing. A tick stands
aside for a rollout already in flight and leaves out the nodes that already show
a finished install, which keeps a tick over a settled fleet down to a couple of
API calls and no pods at all.

It is off by default, because standing up a recurring privileged rollout is
something an operator ought to ask for explicitly. And it only ever adds nodes: a
node that dropped out of the selection is usually a label gone wrong somewhere,
so dismantling a host on a timer with nobody watching is worse than leaving it
for the next upgrade to clean up.

Uninstall takes the schedule away before it starts reverting nodes, since Helm
deletes the CronJob only once the pre-delete hooks are done and a tick firing in
between would reinstall what the cleanup has just removed.