### PR TITLE
nvidia: ship dcgm-exporter in the GPU images

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -55,6 +55,43 @@ default (non-custom) runtime. kata-deploy writes it as
 
 It's best to reference the default `values.yaml` file above for more details.
 
+### NVIDIA guest settings
+
+The NVIDIA GPU images boot [NVRC](https://github.com/NVIDIA/nvrc) as their init
+process, which brings the NVIDIA stack up before the Kata agent starts. The
+`shims.<shim>.nvrc` block configures it. Every key becomes an `nvrc.*` guest
+kernel parameter, so it applies to all sandboxes on that shim and takes effect
+when a sandbox boots:
+
+```yaml title="values.yaml"
+shims:
+  qemu-nvidia-gpu:
+    nvrc:
+      enableDCGM: true
+```
+
+`enableDCGM` runs `nv-hostengine` and `dcgm-exporter` inside the guest. The
+exporter serves GPU metrics on port 9400 of the sandbox, which is the pod IP, so
+anything that can reach the pod can scrape `/metrics` without a sidecar:
+
+```sh
+curl "http://$(kubectl get pod my-gpu-pod -o jsonpath='{.status.podIP}'):9400/metrics"
+```
+
+It is off by default because it costs guest memory and an extra process in every
+sandbox on the shim. Enable it per shim, on the shims whose workloads you want to
+observe.
+
+!!! note
+    The block is only meaningful on the `qemu-nvidia-gpu*` shims, and kata-deploy
+    refuses to install if it finds it on any other shim. DCGM itself ships in the
+    NVIDIA GPU guest images — with composable images it arrives in the GPU
+    extension — so a shim using a guest image without it will not serve metrics.
+
+Under the hood kata-deploy appends `nvrc.dcgm=on` to the shim's kernel command
+line, in the same `config.d/30-kernel-params.toml` drop-in that carries the proxy
+and debug settings.
+
 ### defaultShim
 
 `defaultShim` selects, per architecture, which shim the auto-created default

--- a/tests/integration/kubernetes/k8s-nvidia-dcgm.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-dcgm.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu-nvidia-gpu-runtime-rs}"
+
+export POD_NAME_DCGM="nvidia-dcgm-exporter"
+
+# dcgm-exporter's built-in listen address. NVRC passes it only -k and -f, so the
+# default stands, and the guest shares the pod's network namespace: whatever the
+# exporter binds inside the VM answers on the pod IP.
+DCGM_EXPORTER_PORT="${DCGM_EXPORTER_PORT:-9400}"
+
+POD_WAIT_TIMEOUT="${POD_WAIT_TIMEOUT:-300s}"
+
+# The exporter starts with the sandbox, so it is normally listening well before
+# the pod reports ready. The budget covers nv-hostengine still enumerating GPUs.
+METRICS_TIMEOUT="${METRICS_TIMEOUT:-60}"
+
+# NVRC keeps nv-hostengine and dcgm-exporter switched off until the guest is
+# asked for them, and the request travels on the kernel command line.
+#
+# It has to arrive through a config.d/ drop-in rather than the pod annotation
+# the CoCo tests use: the NVIDIA GPU shims ship an empty enable_annotations
+# allowlist (DEFENABLEANNOTATIONS_NVIDIA), so a hypervisor annotation is
+# refused before it can reach the guest.
+#
+# The runtime merges drop-ins in alphabetical order and a string value replaces
+# rather than extends the one below it, so this fragment has to carry the whole
+# kernel_params line. Read back whichever drop-in currently owns it -- the
+# suite's own 90-nvrc-trace.toml, usually -- and fall back to the base config.
+enable_dcgm_via_dropin() {
+    local config_dir params local_dropin
+
+    config_dir="$(get_kata_runtime_config_dir "${node}")" ||
+        die "no Kata runtime config dir for ${KATA_HYPERVISOR}"
+
+    params="$(exec_host "${node}" "
+        params=
+        for f in ${config_dir}/config.d/*.toml; do
+            [ -f \"\${f}\" ] || continue
+            v=\$(sed -n 's/^[[:space:]]*kernel_params[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p' \"\${f}\" | tail -1)
+            [ -n \"\${v}\" ] && params=\${v}
+        done
+        [ -n \"\${params}\" ] || params=\$(sed -n 's/^[[:space:]]*kernel_params[[:space:]]*=[[:space:]]*\"\(.*\)\"[[:space:]]*\$/\1/p' \\
+            ${config_dir}/configuration-${KATA_HYPERVISOR}.toml | tail -1)
+        printf '%s' \"\${params}\"
+    ")"
+
+    # Every shim this suite supports is QEMU-backed, which is the same
+    # assumption run_kubernetes_nv_tests.sh makes when it enables NVRC tracing.
+    local_dropin="${BATS_FILE_TMPDIR}/95-dcgm-test.toml"
+    {
+        echo "[hypervisor.qemu]"
+        echo "kernel_params = \"${params} nvrc.dcgm=on\""
+    } > "${local_dropin}"
+
+    runtime_config_dropin="$(set_kata_runtime_config_dropin_file "${node}" "${local_dropin}")" ||
+        die "failed to write the dcgm drop-in for ${KATA_HYPERVISOR}"
+    export runtime_config_dropin
+
+    echo "# Wrote drop-in ${runtime_config_dropin}:" >&3
+    sed 's/^/# /' "${local_dropin}" >&3
+}
+
+# Scrape the exporter, retrying until it answers, and print the payload.
+#
+# A successful scrape is already evidence that the counter CSV shipped in the
+# image: dcgm-exporter refuses to start when the file named by -f is missing.
+scrape_dcgm_metrics() {
+    local pod_ip
+    pod_ip="$(kubectl get pod "${POD_NAME_DCGM}" -o jsonpath='{.status.podIP}')"
+    [[ -n "${pod_ip}" ]] || die "${POD_NAME_DCGM}: no pod IP"
+
+    local url="http://${pod_ip}:${DCGM_EXPORTER_PORT}/metrics"
+    local deadline=$((SECONDS + METRICS_TIMEOUT))
+    local body=""
+
+    while ((SECONDS < deadline)); do
+        if body="$(curl -sf --max-time 10 "${url}")"; then
+            echo "${body}"
+            return 0
+        fi
+        sleep 5
+    done
+
+    die "${POD_NAME_DCGM}: no metrics from ${url} within ${METRICS_TIMEOUT}s"
+}
+
+setup_file() {
+    setup_common || die "setup_common failed"
+
+    export POD_YAML_IN="${pod_config_dir}/${POD_NAME_DCGM}.yaml.in"
+    export POD_YAML="${pod_config_dir}/${POD_NAME_DCGM}.yaml"
+    envsubst < "${POD_YAML_IN}" > "${POD_YAML}"
+
+    export policy_settings_dir
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+    auto_generate_policy "${policy_settings_dir}" "${POD_YAML}"
+
+    # Must precede the pod: the sandbox reads the drop-in when it boots.
+    enable_dcgm_via_dropin
+
+    kubectl apply -f "${POD_YAML}"
+    kubectl wait --for=condition=Ready --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_DCGM}"
+
+    # BATS_TEST_COMPLETED is per-test and remains empty in teardown_file.
+    # Persist file-level state so success does not trigger journal dumps.
+    touch "${BATS_FILE_TMPDIR}/setup-file-completed"
+}
+
+teardown() {
+    if [[ "${BATS_TEST_COMPLETED:-}" != "1" && -z "${BATS_TEST_SKIPPED:-}" ]]; then
+        touch "${BATS_FILE_TMPDIR}/test-failed"
+    fi
+}
+
+@test "dcgm-exporter serves GPU metrics" {
+    run scrape_dcgm_metrics
+    [[ "${status}" -eq 0 ]]
+
+    # Count series lines rather than matching the name anywhere in the body: an
+    # exporter that enumerated nothing still emits the HELP and TYPE comments.
+    local series
+    series="$(grep -c '^DCGM_FI_' <<<"${output}" || true)"
+    [[ "${series}" -gt 0 ]]
+
+    echo "# DCGM_FI_ series: ${series}" >&3
+}
+
+@test "dcgm-exporter metrics carry GPU identity" {
+    run scrape_dcgm_metrics
+    [[ "${status}" -eq 0 ]]
+
+    # Labels come from DCGM's device enumeration, so their presence means the
+    # exporter reached the passthrough GPU rather than publishing an empty
+    # scrape with no devices behind it.
+    [[ "${output}" =~ gpu=\" ]]
+    [[ "${output}" =~ UUID=\" ]]
+
+    echo "# $(grep -m1 '^DCGM_FI_' <<<"${output}")" >&3
+}
+
+teardown_file() {
+    kubectl describe pod "${POD_NAME_DCGM}" || true
+
+    # Before anything that might fail: a leaked drop-in would leave DCGM on for
+    # every pod that lands on this node afterwards.
+    remove_kata_runtime_config_dropin_file "${node}" "${runtime_config_dropin:-}" || true
+
+    delete_tmp_policy_settings_dir "${policy_settings_dir}"
+
+    [[ -f "${POD_YAML}" ]] && kubectl delete -f "${POD_YAML}" --ignore-not-found=true
+
+    # The exporter logs to the guest console, not to the container, so NVRC's
+    # output on the node journal is where a failed scrape gets explained.
+    local bats_test_completed=1
+    if [[ ! -f "${BATS_FILE_TMPDIR}/setup-file-completed" || -f "${BATS_FILE_TMPDIR}/test-failed" ]]; then
+        bats_test_completed=
+    fi
+    print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${bats_test_completed}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -90,6 +90,7 @@ delete_nvidia_gpu_test_pods_if_any_exist() {
 	local pods=(
 		"aa-test-cc"
 		"nvidia-cuda-vectoradd"
+		"nvidia-dcgm-exporter"
 		"nvidia-nim-llama-3-2-1b-instruct"
 		"nvidia-nim-llama-3-2-1b-instruct-tee"
 		"nvidia-nim-llama-3-2-nv-embedqa-1b-v2"
@@ -159,6 +160,7 @@ else
 	K8S_TEST_NV=("k8s-confidential-attestation.bats" \
 		"k8s-nvidia-numa.bats" \
 		"k8s-nvidia-cuda.bats" \
+		"k8s-nvidia-dcgm.bats" \
 		"k8s-nvidia-vllm.bats" \
 		"k8s-qemu-rootless-sandbox.bats")
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-dcgm-exporter.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-dcgm-exporter.yaml.in
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME_DCGM}
+  labels:
+    app: ${POD_NAME_DCGM}
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+  - name: dcgm-exporter-probe
+    # The container only has to hold the sandbox open: the exporter runs in the
+    # guest next to NVRC, not in here. Reuse the CUDA sample the other GPU tests
+    # already pull so this costs no extra image on the runner.
+    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04"
+    command: ["sleep", "infinity"]
+    resources:
+      limits:
+        nvidia.com/pgpu: "1"
+        memory: 16Gi

--- a/tests/spellcheck/kata-dictionary.txt
+++ b/tests/spellcheck/kata-dictionary.txt
@@ -52,6 +52,7 @@ VPMU
 
 # GPU & NVIDIA
 CUDA
+DCGM
 DGX
 Gramine
 Mellanox

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -686,14 +686,6 @@ assemble_nvidia_gpu_extension() {
 			"${fm_cfg}"
 	fi
 
-	# The topology files are only available under the GPU extension mount.
-	# Point Fabric Manager there so it can find them.
-	local fm_cfg="${extension}/usr/share/nvidia/nvswitch/fabricmanager.cfg"
-	if [[ -f "${fm_cfg}" ]]; then
-		sed -i 's|^TOPOLOGY_FILE_PATH=.*|TOPOLOGY_FILE_PATH=/run/kata-extensions/gpu/usr/share/nvidia/nvswitch|' \
-			"${fm_cfg}"
-	fi
-
 	# GPU firmware (GSP, ...); NVRC binds this onto /lib/firmware/nvidia.
 	[[ -d "${source}/lib/firmware/nvidia" ]] \
 		&& cp -a "${source}/lib/firmware/nvidia" "${extension}/lib/firmware/"

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -280,6 +280,14 @@ chisseled_dcgm() {
 	cp -a "${stage_one}"/usr/"${libdir}"/libdcgm.*     "${libdir}"/.
 	cp -a "${stage_one}"/"${libdir}"/libgcc_s.so.1*    "${libdir}"/.
 	cp -a "${stage_one}"/usr/bin/nv-hostengine   bin/.
+	# dcgm-exporter dlopen()s libdcgm.so.4, so it needs no extra NEEDED entry
+	# beyond the libc/libdl/libpthread/libresolv set chisseled_compute copies.
+	cp -a "${stage_one}"/usr/bin/dcgm-exporter   bin/.
+
+	# NVRC passes the counter set as -f gpu_extension::path(<csv>), which is the
+	# identity mapping in the monolith, so the CSVs belong at the canonical path
+	# here. partition_base() drops them and the extension ships its own copy.
+	cp -a "${stage_one}"/etc/dcgm-exporter/*.csv etc/dcgm-exporter/.
 }
 
 # copute always includes utility per default
@@ -567,6 +575,7 @@ readonly nvidia_gpu_extension_bins=(
 	bin/nvidia-cdi-hook
 	bin/nvidia-persistenced
 	bin/nv-hostengine
+	bin/dcgm-exporter
 	bin/nv-fabricmanager
 	sbin/nvlsm
 )
@@ -643,7 +652,12 @@ assemble_nvidia_gpu_extension() {
 
 	if nvidia_stack_has dcgm; then
 		install -D -m0755 "${source}/usr/bin/nv-hostengine" "${extension}/bin/nv-hostengine"
+		install -D -m0755 "${source}/usr/bin/dcgm-exporter" "${extension}/bin/dcgm-exporter"
 		cp -a "${source}/${source_lib}"/libdcgm.* "${extension}/${extlib}/"
+		# The counter CSVs travel with the exporter: NVRC resolves them through
+		# gpu_extension::path(), so they resolve under the extension mount.
+		mkdir -p "${extension}/etc/dcgm-exporter"
+		cp -a "${source}/etc/dcgm-exporter/"*.csv "${extension}/etc/dcgm-exporter/"
 	fi
 
 	if nvidia_stack_has nvswitch; then
@@ -749,6 +763,10 @@ partition_base() {
 	# GPU configs live in the extension; keep usr/share/nvidia as an empty stub.
 	rm -rf usr/share/nvidia
 	mkdir -p usr/share/nvidia
+
+	# The exporter and its counter CSVs both live in the extension, and NVRC
+	# resolves the -f path there, so the base needs no stub for them.
+	rm -rf etc/dcgm-exporter
 
 	# Keep /lib/firmware/nvidia as an empty mountpoint for NVRC's firmware bind.
 	rm -rf lib/firmware/nvidia

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -1806,6 +1806,12 @@ fn generate_kernel_params_drop_in(
         additional_params.push(format!("agent.no_proxy={}", no_proxy));
     }
 
+    // NVRC keeps nv-hostengine and dcgm-exporter switched off until the guest is
+    // asked for them, and the request travels on the kernel command line.
+    if config.nvrc_enable_dcgm.iter().any(|s| s == shim) {
+        additional_params.push("nvrc.dcgm=on".to_string());
+    }
+
     // Guest debug kernel cmdline params (debug variant runtimes only)
     if include_debug_params {
         additional_params.push("agent.log=debug".to_string());
@@ -2436,9 +2442,11 @@ mod tests {
         assert!(content.contains("debug_console_enabled = true"));
     }
 
-    #[test]
-    fn test_generate_kernel_params_drop_in_guest_debug_only_when_requested() {
-        let config = crate::config::Config {
+    /// A Config with no source of kernel params of its own, so each test can
+    /// switch on just the one it is about. dest_dir points at a path with no
+    /// installed configuration, which makes the base params come out empty.
+    fn kernel_params_config() -> crate::config::Config {
+        crate::config::Config {
             node_name: "test".to_string(),
             debug: true,
             shims_for_arch: vec!["qemu".to_string()],
@@ -2447,6 +2455,7 @@ mod tests {
             snapshotter_handler_mapping_for_arch: None,
             agent_https_proxy: None,
             agent_no_proxy: None,
+            nvrc_enable_dcgm: vec![],
             pull_type_mapping_for_arch: None,
             installation_prefix: None,
             multi_install_suffix: None,
@@ -2472,7 +2481,12 @@ mod tests {
             startup_taints: vec![],
             container_runtime_version: None,
             k8s_distribution: None,
-        };
+        }
+    }
+
+    #[test]
+    fn test_generate_kernel_params_drop_in_guest_debug_only_when_requested() {
+        let config = kernel_params_config();
 
         let without_debug = generate_kernel_params_drop_in(&config, "qemu", false).unwrap();
         assert!(without_debug.is_empty());
@@ -2480,6 +2494,24 @@ mod tests {
         let with_debug = generate_kernel_params_drop_in(&config, "qemu", true).unwrap();
         assert!(with_debug.contains("agent.log=debug"));
         assert!(with_debug.contains("initcall_debug"));
+    }
+
+    #[test]
+    fn test_generate_kernel_params_drop_in_dcgm_only_for_listed_shims() {
+        let mut config = kernel_params_config();
+        config.shims_for_arch = vec![
+            "qemu-nvidia-gpu".to_string(),
+            "qemu-nvidia-gpu-tdx".to_string(),
+        ];
+        config.nvrc_enable_dcgm = vec!["qemu-nvidia-gpu".to_string()];
+
+        let enabled = generate_kernel_params_drop_in(&config, "qemu-nvidia-gpu", false).unwrap();
+        assert!(enabled.contains("nvrc.dcgm=on"));
+
+        // A GPU shim left out of the set is a GPU shim without DCGM, and with
+        // nothing else to say it writes no drop-in at all.
+        let other = generate_kernel_params_drop_in(&config, "qemu-nvidia-gpu-tdx", false).unwrap();
+        assert!(other.is_empty());
     }
 
     #[rstest]

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -180,6 +180,10 @@ pub struct Config {
     pub snapshotter_handler_mapping_for_arch: Option<String>,
     pub agent_https_proxy: Option<String>,
     pub agent_no_proxy: Option<String>,
+    /// Shims whose guests run the NVIDIA DCGM stack (nv-hostengine and
+    /// dcgm-exporter). A set rather than a per-shim mapping: the setting is a
+    /// boolean, so naming a shim here means it is on.
+    pub nvrc_enable_dcgm: Vec<String>,
     pub pull_type_mapping_for_arch: Option<String>,
     pub installation_prefix: Option<String>,
     pub multi_install_suffix: Option<String>,
@@ -287,6 +291,13 @@ impl Config {
         // Normalize empty strings to None at the boundary
         let agent_https_proxy = env::var("AGENT_HTTPS_PROXY").ok().filter(|s| !s.is_empty());
         let agent_no_proxy = env::var("AGENT_NO_PROXY").ok().filter(|s| !s.is_empty());
+
+        let nvrc_enable_dcgm = env::var("NVRC_ENABLE_DCGM")
+            .unwrap_or_default()
+            .split(';')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
 
         let pull_type_mapping_for_arch = get_arch_var_or_base("PULL_TYPE_MAPPING", &arch);
 
@@ -456,6 +467,7 @@ impl Config {
             snapshotter_handler_mapping_for_arch,
             agent_https_proxy,
             agent_no_proxy,
+            nvrc_enable_dcgm,
             pull_type_mapping_for_arch,
             installation_prefix,
             multi_install_suffix,
@@ -605,6 +617,25 @@ impl Config {
             _ => {}
         }
 
+        // Validate NVRC_ENABLE_DCGM
+        // Format: "shim1;shim2", naming the shims whose guests run DCGM.
+        //
+        // Only the NVIDIA GPU images carry DCGM and an NVRC to start it, so
+        // nvrc.dcgm=on anywhere else is a setting that would silently do
+        // nothing. Membership in shims_for_arch is deliberately not required:
+        // the chart builds this list from every enabled shim, and the same
+        // value reaches nodes of every architecture, so a GPU shim missing here
+        // means "not on this node" rather than a mistake.
+        for shim in &self.nvrc_enable_dcgm {
+            if !shim.contains("nvidia-gpu") {
+                return Err(anyhow::anyhow!(
+                    "NVRC_ENABLE_DCGM references '{}', which is not an NVIDIA GPU shim. \
+                     DCGM only runs in the NVIDIA GPU guest images.",
+                    shim
+                ));
+            }
+        }
+
         // Validate SNAPSHOTTER_HANDLER_MAPPING_FOR_ARCH
         // Format: "shim1:snapshotter1,shim2:snapshotter2"
         match self.snapshotter_handler_mapping_for_arch.as_ref() {
@@ -708,6 +739,7 @@ impl Config {
         );
         info!("* AGENT_HTTPS_PROXY: {:?}", self.agent_https_proxy);
         info!("* AGENT_NO_PROXY: {:?}", self.agent_no_proxy);
+        info!("* NVRC_ENABLE_DCGM: {:?}", self.nvrc_enable_dcgm);
         info!("* PULL_TYPE_MAPPING: {:?}", self.pull_type_mapping_for_arch);
         info!("* INSTALLATION_PREFIX: {:?}", self.installation_prefix);
         info!("* MULTI_INSTALL_SUFFIX: {:?}", self.multi_install_suffix);
@@ -1195,6 +1227,7 @@ mod tests {
             "ALLOWED_HYPERVISOR_ANNOTATIONS_PPC64LE",
             "AGENT_HTTPS_PROXY",
             "AGENT_NO_PROXY",
+            "NVRC_ENABLE_DCGM",
             "SNAPSHOTTER_HANDLER_MAPPING",
             "SNAPSHOTTER_HANDLER_MAPPING_X86_64",
             "SNAPSHOTTER_HANDLER_MAPPING_AARCH64",
@@ -1642,6 +1675,44 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("AGENT_HTTPS_PROXY references unknown shim"));
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_nvrc_enable_dcgm_parses_shim_set() {
+        setup_minimal_env();
+        set_arch_var("SHIMS", "qemu qemu-nvidia-gpu");
+        std::env::set_var(
+            "NVRC_ENABLE_DCGM",
+            "qemu-nvidia-gpu;qemu-nvidia-gpu-snp-runtime-rs",
+        );
+
+        let config = Config::from_env().unwrap();
+        // The chart lists every enabled shim regardless of architecture, so a
+        // name absent from SHIMS is carried rather than rejected.
+        assert_eq!(
+            config.nvrc_enable_dcgm,
+            vec!["qemu-nvidia-gpu", "qemu-nvidia-gpu-snp-runtime-rs"]
+        );
+
+        cleanup_env_vars();
+    }
+
+    #[serial]
+    #[test]
+    fn test_validate_nvrc_enable_dcgm_rejects_non_gpu_shim() {
+        setup_minimal_env();
+        set_arch_var("SHIMS", "qemu qemu-nvidia-gpu");
+        std::env::set_var("NVRC_ENABLE_DCGM", "qemu");
+
+        let result = Config::from_env();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not an NVIDIA GPU shim"));
 
         cleanup_env_vars();
     }

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -417,6 +417,39 @@ Builds per-shim semicolon-separated list: "shim1=value1;shim2=value2"
 {{- end -}}
 
 {{/*
+Get the shims that run DCGM in the guest from structured config
+Builds a semicolon-separated list of shim names: "shim1;shim2"
+
+The value is a set rather than the "shim=value" mapping the proxies use,
+because the setting is a boolean: naming a shim here means it is on.
+
+A shim with no nvrc block at all reads as off, so a values file written before
+this setting existed - or one defining a shim the chart does not - keeps
+upgrading cleanly instead of failing to render.
+*/}}
+{{- define "kata-deploy.getNvrcEnableDcgm" -}}
+{{- $disableAll := .Values.shims.disableAll | default false -}}
+{{- $shims := list -}}
+{{- range $shimName, $shimConfig := .Values.shims -}}
+{{- if ne $shimName "disableAll" -}}
+{{- $shimEnabled := false -}}
+{{- if eq $shimConfig.enabled true -}}
+{{- $shimEnabled = true -}}
+{{- else if eq $shimConfig.enabled false -}}
+{{- $shimEnabled = false -}}
+{{- else if not $disableAll -}}
+{{- $shimEnabled = true -}}
+{{- end -}}
+{{- $nvrc := $shimConfig.nvrc | default dict -}}
+{{- if and $shimEnabled ($nvrc.enableDCGM | default false) -}}
+{{- $shims = append $shims $shimName -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- join ";" $shims -}}
+{{- end -}}
+
+{{/*
 Main kata-deploy image reference for the DaemonSet.
 Supports tag (reference:tag) and digest (reference@sha256:...) formats.
 When reference contains "@" (digest), use reference as-is; otherwise use reference:tag (tag defaults to Chart.AppVersion).
@@ -618,6 +651,11 @@ e.g. `{{- include "kata-deploy.commonEnv" . | nindent 8 }}`.
 {{- if $agentNoProxy }}
 - name: AGENT_NO_PROXY
   value: {{ $agentNoProxy | quote }}
+{{- end }}
+{{- $nvrcEnableDcgm := include "kata-deploy.getNvrcEnableDcgm" . | trim -}}
+{{- if $nvrcEnableDcgm }}
+- name: NVRC_ENABLE_DCGM
+  value: {{ $nvrcEnableDcgm | quote }}
 {{- end }}
 {{- $pullTypeMappingAmd64 := include "kata-deploy.getPullTypeMappingForArch" (dict "root" . "arch" "amd64") | trim -}}
 {{- if $pullTypeMappingAmd64 }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -680,6 +680,11 @@ shims:
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
+    # Settings for NVRC, the init process of the NVIDIA guest images. Each key
+    # becomes an nvrc.* guest kernel parameter; see docs/helm-configuration.md.
+    nvrc:
+      # Run nv-hostengine and dcgm-exporter in the guest (nvrc.dcgm=on).
+      enableDCGM: false
     runtimeClass:
       # This label is automatically added by gpu-operator. Override it
       # if you want to use a different label.
@@ -694,6 +699,8 @@ shims:
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
+    nvrc:
+      enableDCGM: false
     runtimeClass:
       # This label is automatically added by gpu-operator. Override it
       # if you want to use a different label.
@@ -713,6 +720,8 @@ shims:
     agent:
       httpsProxy: ""
       noProxy: ""
+    nvrc:
+      enableDCGM: false
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
@@ -735,6 +744,8 @@ shims:
     agent:
       httpsProxy: ""
       noProxy: ""
+    nvrc:
+      enableDCGM: false
     runtimeClass:
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
@@ -753,6 +764,8 @@ shims:
     agent:
       httpsProxy: ""
       noProxy: ""
+    nvrc:
+      enableDCGM: false
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
@@ -775,6 +788,8 @@ shims:
     agent:
       httpsProxy: ""
       noProxy: ""
+    nvrc:
+      enableDCGM: false
     runtimeClass:
       nodeSelector:
         nvidia.com/cc.ready.state: "true"

--- a/versions.yaml
+++ b/versions.yaml
@@ -221,7 +221,7 @@ externals:
   nvrc:
     # yamllint disable-line rule:line-length
     desc: "The NVRC project provides a Rust binary that implements a simple init system for microVMs"
-    version: "v0.1.5"
+    version: "v0.1.6"
     url: "https://github.com/NVIDIA/nvrc/releases/download/"
 
   nvidia:


### PR DESCRIPTION
The exporter has been installed into the build's stage one and then thrown away
ever since we started taking it from the CUDA repository: the commit that
dropped the hand-built tarball took the untar in chisseled_dcgm() with it and
never put a copy in its place. Every default NVIDIA build therefore carries
nv-hostengine but no /bin/dcgm-exporter, and because dcgm sits in the default
stack NVRC panics as PID 1 the moment it tries to start it.

Copy the binary out of stage one for the monolith, and install it into the gpu
extension as well, which had a gap of its own. The binary is driver-coupled, so
the base partition hands it to the extension the way it already does for
nv-hostengine. It needs no new libraries: it links only the libc set the
compute chisel already carries and reaches DCGM by dlopen'ing libdcgm.

The counter CSVs follow the binary. NVRC resolves the exporter's -f argument
through gpu_extension::path(), so they ship in the extension for the composable
images and stay at the canonical path in the monolith, where that mapping is
the identity.

The NVRC update is needed as we want to bring in https://github.com/NVIDIA/nvrc/pull/214,
which fixes properly spawning DCGM from the GPU guest extension.