### PR TITLE
build: Fix pcilibs-rs dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "pcilibs-rs"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/pcilibs-rs?rev=ce6486db#ce6486db79ade33028583a9e81245db5f4de2079"
+source = "git+https://github.com/kata-containers/pcilibs-rs?rev=d248714e#d248714ed4b34b5738dbafab510611f543802e27"
 dependencies = [
  "nix 0.31.3",
  "pci-ids",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "pcilibs-rs"
 version = "0.1.0"
-source = "git+https://github.com/zvonkok/pcilibs-rs?rev=ce6486db#ce6486db79ade33028583a9e81245db5f4de2079"
+source = "git+https://github.com/kata-containers/pcilibs-rs?rev=ce6486db#ce6486db79ade33028583a9e81245db5f4de2079"
 dependencies = [
  "nix 0.31.3",
  "pci-ids",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ wasm_container = { path = "src/runtime-rs/crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/lib`
 kata-sys-util = { path = "src/libs/kata-sys-util" }
-pcilibs-rs = { git = "https://github.com/kata-containers/pcilibs-rs", rev = "ce6486db" }
+pcilibs-rs = { git = "https://github.com/kata-containers/pcilibs-rs", rev = "d248714e" }
 pod-resources-rs = { path = "src/libs/pod-resources-rs" }
 kata-types = { path = "src/libs/kata-types", features = ["safe-path"] }
 logging = { path = "src/libs/logging" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ wasm_container = { path = "src/runtime-rs/crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/lib`
 kata-sys-util = { path = "src/libs/kata-sys-util" }
-pcilibs-rs = { git = "https://github.com/zvonkok/pcilibs-rs", rev = "ce6486db" }
+pcilibs-rs = { git = "https://github.com/kata-containers/pcilibs-rs", rev = "ce6486db" }
 pod-resources-rs = { path = "src/libs/pod-resources-rs" }
 kata-types = { path = "src/libs/kata-types", features = ["safe-path"] }
 logging = { path = "src/libs/logging" }


### PR DESCRIPTION
Fix a bogus URL that was mistakenly added by #13526.

While here, also bump `pcilibs-rs` to https://github.com/kata-containers/pcilibs-rs/commit/d248714ed4b34b5738dbafab510611f543802e27 because https://github.com/kata-containers/kata-device-plugin needs it.