### PR TITLE
Runtime-rs: add loongarch64 support

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -233,6 +233,13 @@ pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> 
     Ok(GuestProtection::NoProtection)
 }
 
+#[cfg(target_arch = "loongarch64")]
+#[allow(dead_code)]
+// Guest protection is not supported on LoongArch.
+pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> {
+    Ok(GuestProtection::NoProtection)
+}
+
 #[cfg(target_arch = "x86_64")]
 #[cfg(test)]
 mod tests {

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -1065,6 +1065,10 @@ static-checks-build: $(GENERATED_FILES)
 
 $(TARGET): $(GENERATED_FILES) $(TARGET_PATH)
 
+ifeq ($(TRIPLE),loongarch64-unknown-linux-musl)
+        EXTRA_RUSTFLAGS += -C target-feature=+crt-static
+endif
+
 $(TARGET_PATH): $(SOURCES) | show-summary
 	@$(RELEASE_CARGO_PROFILE_ENV) RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build -p runtime-rs --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
 

--- a/src/runtime-rs/arch/loongarch64-options.mk
+++ b/src/runtime-rs/arch/loongarch64-options.mk
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Loongson Technology Corporation Limited.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# LoongArch 64 settings
+
+MACHINETYPE := virt
+KERNELPARAMS :=  cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1
+MACHINEACCELERATORS :=
+CPUFEATURES :=
+
+QEMUCMD := qemu-system-loongarch64


### PR DESCRIPTION
**Summary**

- Add loongarch64 as a target architecture for the runtime-rs, I also ported the tools/osbuilder and agent modules, and I will submit PRs for each of them.

**Validation**

* [x]   cargo fmt -- --check
* [x]  make

Fixes: https://github.com/kata-containers/kata-containers/issues/7423