### PR TITLE
qemu: prevent lock the shared Kata rootfs image

### DIFF
--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -104,3 +104,48 @@ jobs:
       - name: Report tests
         if: always()
         run: bash tests/functional/kata-deploy/gha-run.sh report-tests
+
+  run-kata-deploy-mixed-shims:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-26.04
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_DEPLOY_TEST_UNION: kata-deploy-mixed-shims.bats
+      KATA_HYPERVISOR: qemu
+      KUBERNETES: k3s
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Deploy k3s
+        run: bash tests/functional/kata-deploy/gha-run.sh deploy-k8s
+
+      - name: Install `bats`
+        run: bash tests/functional/kata-deploy/gha-run.sh install-bats
+
+      - name: Run mixed-shim test
+        run: bash tests/functional/kata-deploy/gha-run.sh run-tests
+
+      - name: Report tests
+        if: always()
+        run: bash tests/functional/kata-deploy/gha-run.sh report-tests
+
+      - name: Clean up mixed-shim deployment
+        if: always()
+        run: |
+          kubectl delete pods -l test=kata-deploy-mixed-shims --ignore-not-found=true --wait=true --timeout=180s || true
+          helm uninstall kata-deploy -n kube-system --ignore-not-found --wait --timeout 10m || true

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1019,6 +1019,7 @@ struct BlockBackend {
     cache_direct: bool,
     cache_no_flush: bool,
     read_only: bool,
+    locking: bool,
     discard_unmap: bool,
 }
 
@@ -1060,6 +1061,7 @@ impl BlockBackend {
             cache_direct,
             cache_no_flush: false,
             read_only: true,
+            locking: true,
             discard_unmap: false,
         }
     }
@@ -1094,6 +1096,11 @@ impl BlockBackend {
         self
     }
 
+    fn set_locking(&mut self, locking: bool) -> &mut Self {
+        self.locking = locking;
+        self
+    }
+
     #[allow(dead_code)]
     fn set_discard_unmap(&mut self, discard_unmap: bool) -> &mut Self {
         self.discard_unmap = discard_unmap;
@@ -1119,6 +1126,9 @@ impl BlockBackend {
             "{prefix}read-only={}",
             if self.read_only { "on" } else { "off" }
         ));
+        if !self.locking {
+            params.push(format!("{prefix}locking=off"));
+        }
         if self.discard_unmap {
             params.push(format!("{prefix}discard=unmap"));
         }
@@ -1170,10 +1180,14 @@ fn block_backend_node(
     is_direct: bool,
     is_readonly: bool,
     discard_unmap: bool,
+    disable_locking: bool,
 ) -> Box<dyn ToQemuParams> {
     let mut backend = BlockBackend::new(device_id, path, is_direct);
     backend.set_read_only(is_readonly);
     backend.set_discard_unmap(discard_unmap);
+    if disable_locking {
+        backend.set_locking(false);
+    }
 
     if vmdk.is_some() {
         Box::new(VmdkFormatNode::new(device_id, backend))
@@ -3329,6 +3343,7 @@ impl<'a> QemuCmdLine<'a> {
         is_scsi: bool,
         discard_unmap: bool,
         serial_override: Option<&str>,
+        disable_locking: bool,
     ) -> Result<()> {
         if self.block_fdsets.contains_key(device_id) {
             return Err(anyhow!("duplicate QEMU block device ID {device_id}"));
@@ -3350,6 +3365,7 @@ impl<'a> QemuCmdLine<'a> {
             is_direct,
             is_readonly,
             discard_unmap,
+            disable_locking,
         );
         self.devices.push(backend);
         let devno = get_devno_ccw(&mut self.ccw_subchannel, device_id);
@@ -4222,6 +4238,7 @@ mod tests {
             false,
             false,
             None,
+            false,
         );
         result.unwrap();
 
@@ -4249,8 +4266,15 @@ mod tests {
     #[actix_rt::test]
     async fn test_cold_plug_vmdk_uses_format_node() {
         let vmdk = crate::VmdkConfig::default();
-        let format_node =
-            block_backend_node("rootfs", "/dev/fdset/2", Some(&vmdk), false, true, false);
+        let format_node = block_backend_node(
+            "rootfs",
+            "/dev/fdset/2",
+            Some(&vmdk),
+            false,
+            true,
+            false,
+            false,
+        );
 
         let format_params = format_node.qemu_params().await.unwrap();
         assert_eq!(format_params[0], "-blockdev");
@@ -4277,12 +4301,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case::read_only(true, "read-only=on")]
-    #[case::writable(false, "read-only=off")]
+    #[case::shared_read_only(true, true, "read-only=on")]
+    #[case::read_only_with_locking(true, false, "read-only=on")]
+    #[case::writable(false, false, "read-only=off")]
     #[actix_rt::test]
     #[serial]
     async fn test_qemu_block_backend_read_only_params(
         #[case] is_readonly: bool,
+        #[case] disable_locking: bool,
         #[case] expected_param: &str,
     ) {
         let dir = tempdir().unwrap();
@@ -4301,6 +4327,7 @@ mod tests {
                 false,
                 false,
                 None,
+                disable_locking,
             )
             .unwrap();
 
@@ -4310,6 +4337,10 @@ mod tests {
                 && args[1].contains("node-name=image-blk0")
                 && contains_param(&args[1..2], expected_param)
         }));
+        assert_eq!(
+            params.iter().any(|arg| arg.contains("locking=off")),
+            disable_locking
+        );
         assert!(!params.iter().any(|arg| arg.contains("auto-read-only=")));
 
         drop(cmdline);

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -176,6 +176,12 @@ impl QemuInner {
                         // command line.
                         continue;
                     }
+                    // Cloud Hypervisor locks the image's full byte range, which
+                    // overlaps QEMU's permission lock bytes despite both VMMs
+                    // opening this shared Kata rootfs read-only. Kata owns this
+                    // immutable file, so QEMU locking is redundant.
+                    let disable_locking =
+                        is_readonly && path_on_host == self.config.boot_info.image;
                     match driver_option.as_str() {
                         KATA_NVDIMM_DEV_TYPE => cmdline.add_nvdimm(&path_on_host, is_readonly)?,
                         KATA_CCW_DEV_TYPE | KATA_BLK_DEV_TYPE | KATA_SCSI_DEV_TYPE => {
@@ -193,6 +199,7 @@ impl QemuInner {
                                 driver_option.as_str() == KATA_SCSI_DEV_TYPE,
                                 discard_unmap,
                                 serial,
+                                disable_locking,
                             )?
                         }
                         unsupported => {

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -341,6 +341,9 @@ type BlockDrive struct {
 	// ReadOnly sets the device file readonly
 	ReadOnly bool
 
+	// DisableLocking disables VMM advisory locking for immutable shared files.
+	DisableLocking bool
+
 	// DiscardUnmap enables discard/unmap support for this block device.
 	DiscardUnmap bool
 

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1378,6 +1378,9 @@ type BlockDevice struct {
 	// ReadOnly sets the block device in readonly mode
 	ReadOnly bool
 
+	// DisableLocking disables QEMU advisory locking for the file backend.
+	DisableLocking bool
+
 	// DiscardUnmap enables discard/unmap support for this block device.
 	DiscardUnmap bool
 
@@ -1435,7 +1438,12 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	deviceParams = append(deviceParams, fmt.Sprintf("serial=%s", blkdev.ID))
 
 	blkParams = append(blkParams, fmt.Sprintf("id=%s", blkdev.ID))
-	blkParams = append(blkParams, fmt.Sprintf("file=%s", blkdev.File))
+	if blkdev.DisableLocking {
+		blkParams = append(blkParams, fmt.Sprintf("file.filename=%s", blkdev.File))
+		blkParams = append(blkParams, "file.locking=off")
+	} else {
+		blkParams = append(blkParams, fmt.Sprintf("file=%s", blkdev.File))
+	}
 	blkParams = append(blkParams, fmt.Sprintf("aio=%s", blkdev.AIO))
 	blkParams = append(blkParams, fmt.Sprintf("format=%s", blkdev.Format))
 	blkParams = append(blkParams, fmt.Sprintf("if=%s", blkdev.Interface))

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -7,7 +7,10 @@
 
 package qemu
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 var (
 	deviceFSString                 = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs,romfile=efi-virtio.rom -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
@@ -64,6 +67,40 @@ func TestAppendDeviceVhostUser(t *testing.T) {
 		ROMFile:       romfile,
 	}
 	testAppendQ35(vhostuserNetDevice, deviceVhostUserNetString, t)
+}
+
+func TestBlockDeviceDisablesFileLocking(t *testing.T) {
+	blockDevice := BlockDevice{
+		Driver:         VirtioBlock,
+		ID:             "rootfs",
+		File:           "/var/lib/rootfs.img",
+		Interface:      NoInterface,
+		AIO:            Threads,
+		Format:         "raw",
+		ShareRW:        true,
+		ReadOnly:       true,
+		DisableLocking: true,
+	}
+
+	params := strings.Join(blockDevice.QemuParams(&Config{}), " ")
+	if !strings.Contains(params, "file.filename=/var/lib/rootfs.img") {
+		t.Fatalf("missing structured file backend: %s", params)
+	}
+	if !strings.Contains(params, "file.locking=off") {
+		t.Fatalf("file locking was not disabled: %s", params)
+	}
+	if strings.Contains(params, "file=/var/lib/rootfs.img") {
+		t.Fatalf("legacy file option conflicts with structured backend: %s", params)
+	}
+
+	blockDevice.DisableLocking = false
+	params = strings.Join(blockDevice.QemuParams(&Config{}), " ")
+	if !strings.Contains(params, "file=/var/lib/rootfs.img") {
+		t.Fatalf("default file backend was not preserved: %s", params)
+	}
+	if strings.Contains(params, "file.locking=off") {
+		t.Fatalf("file locking was disabled without an explicit request: %s", params)
+	}
 }
 
 func TestAppendVirtioBalloon(t *testing.T) {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -443,11 +443,12 @@ func genericImage(path string) (config.BlockDrive, error) {
 	id := utils.MakeNameID("image", hex.EncodeToString(randBytes), maxDevIDSize)
 
 	drive := config.BlockDrive{
-		File:     path,
-		Format:   "raw",
-		ID:       id,
-		ShareRW:  true,
-		ReadOnly: true,
+		File:           path,
+		Format:         "raw",
+		ID:             id,
+		ShareRW:        true,
+		ReadOnly:       true,
+		DisableLocking: true,
 	}
 
 	return drive, nil
@@ -683,16 +684,17 @@ func genericBlockDevice(drive config.BlockDrive, nestedRun bool) (govmmQemu.Bloc
 	}
 
 	return govmmQemu.BlockDevice{
-		Driver:        govmmQemu.VirtioBlock,
-		ID:            drive.ID,
-		File:          drive.File,
-		AIO:           govmmQemu.Threads,
-		Format:        govmmQemu.BlockDeviceFormat(drive.Format),
-		Interface:     "none",
-		DisableModern: nestedRun,
-		ShareRW:       drive.ShareRW,
-		ReadOnly:      drive.ReadOnly,
-		DiscardUnmap:  drive.DiscardUnmap,
+		Driver:         govmmQemu.VirtioBlock,
+		ID:             drive.ID,
+		File:           drive.File,
+		AIO:            govmmQemu.Threads,
+		Format:         govmmQemu.BlockDeviceFormat(drive.Format),
+		Interface:      "none",
+		DisableModern:  nestedRun,
+		ShareRW:        drive.ShareRW,
+		ReadOnly:       drive.ReadOnly,
+		DisableLocking: drive.DisableLocking,
+		DiscardUnmap:   drive.DiscardUnmap,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -375,14 +375,15 @@ func TestQemuArchBaseAppendImage(t *testing.T) {
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.BlockDevice{
-			Driver:    govmmQemu.VirtioBlock,
-			ID:        drive.ID,
-			File:      image.Name(),
-			AIO:       govmmQemu.Threads,
-			Format:    "raw",
-			Interface: "none",
-			ShareRW:   true,
-			ReadOnly:  true,
+			Driver:         govmmQemu.VirtioBlock,
+			ID:             drive.ID,
+			File:           image.Name(),
+			AIO:            govmmQemu.Threads,
+			Format:         "raw",
+			Interface:      "none",
+			ShareRW:        true,
+			ReadOnly:       true,
+			DisableLocking: true,
 		},
 	}
 

--- a/tests/functional/kata-deploy/kata-deploy-mixed-shims.bats
+++ b/tests/functional/kata-deploy/kata-deploy-mixed-shims.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 Kata Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that mixed Kata hypervisors can use the shared immutable rootfs image
+# concurrently, independent of sandbox startup order.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+MIXED_POD_LABEL="kata-deploy-mixed-shims"
+
+run_on_host() {
+	local cmd="$1"
+	local node_name
+	node_name=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+	local pod_name="mixed-host-exec-${RANDOM}"
+	local phase=""
+
+	kubectl run "${pod_name}" \
+		--image=quay.io/kata-containers/alpine-bash-curl:latest \
+		--restart=Never \
+		--overrides="{
+			\"spec\": {
+				\"nodeName\": \"${node_name}\",
+				\"hostPID\": true,
+				\"activeDeadlineSeconds\": 300,
+				\"tolerations\": [{\"operator\": \"Exists\"}],
+				\"containers\": [{
+					\"name\": \"exec\",
+					\"image\": \"quay.io/kata-containers/alpine-bash-curl:latest\",
+					\"imagePullPolicy\": \"IfNotPresent\",
+					\"command\": [\"sh\", \"-c\", \"${cmd}\"],
+					\"securityContext\": {\"privileged\": true}
+				}]
+			}
+		}" > /dev/null
+
+	local deadline=$((SECONDS + 60))
+	while (( SECONDS < deadline )); do
+		phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null) || true
+		case "${phase}" in
+			Succeeded|Failed) break ;;
+		esac
+		sleep 1
+	done
+
+	kubectl logs "${pod_name}" 2>/dev/null || true
+	kubectl delete pod "${pod_name}" --ignore-not-found=true > /dev/null 2>&1
+	[[ "${phase}" == "Succeeded" ]]
+}
+
+cleanup_mixed_pods() {
+	kubectl delete pods -l "test=${MIXED_POD_LABEL}" \
+		--ignore-not-found=true --wait=true --timeout=180s
+}
+
+assert_kata_processes_stopped() {
+	run run_on_host "kata_processes() { found=1; for proc in /proc/[0-9]*; do exe=\$(readlink \${proc}/exe 2>/dev/null || true); case \${exe} in *qemu-system*|*cloud-hypervisor*|*containerd-shim-kata-v2*) echo \${proc##*/} \${exe}; found=0;; esac; state=\$(awk '{print \$3}' \${proc}/stat 2>/dev/null || true); comm=\$(awk '{print \$2}' \${proc}/stat 2>/dev/null || true); if [ x\${state} = xZ ]; then case \${comm} in *qemu-system*|*cloud-hypervis*|*containerd-shim*) echo \${proc##*/} zombie \${comm}; found=0;; esac; fi; done; return \${found}; }; for attempt in \$(seq 1 30); do if ! kata_processes >/dev/null; then exit 0; fi; sleep 1; done; kata_processes; exit 1"
+	if [[ "${status}" -ne 0 ]]; then
+		echo "${output}" >&3
+	fi
+	[[ "${status}" -eq 0 ]]
+}
+
+create_mixed_pod() {
+	local scenario="$1"
+	local shim="$2"
+	local node_name="$3"
+	local pod_name="mixed-${scenario}-${shim}"
+
+	cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod_name}
+  labels:
+    test: ${MIXED_POD_LABEL}
+spec:
+  nodeName: ${node_name}
+  runtimeClassName: kata-${shim}
+  restartPolicy: Never
+  containers:
+    - name: hold
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: IfNotPresent
+      command: ["sleep", "infinity"]
+EOF
+
+	if ! kubectl wait --for=condition=Ready "pod/${pod_name}" --timeout=180s; then
+		kubectl describe pod "${pod_name}" >&3 || true
+		kubectl get events --sort-by=.lastTimestamp >&3 || true
+		return 1
+	fi
+}
+
+exercise_startup_order() {
+	local scenario="$1"
+	shift
+	local node_name
+	node_name=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+	local shim
+
+	for shim in "$@"; do
+		create_mixed_pod "${scenario}" "${shim}" "${node_name}"
+	done
+
+	for shim in "$@"; do
+		kubectl exec "mixed-${scenario}-${shim}" -- true
+	done
+
+	cleanup_mixed_pods
+	assert_kata_processes_stopped
+}
+
+setup_file() {
+	ensure_helm
+
+	local mixed_values
+	mixed_values=$(mktemp)
+	cat > "${mixed_values}" <<EOF
+shims:
+  disableAll: true
+  qemu:
+    enabled: true
+  qemu-runtime-rs:
+    enabled: true
+  clh:
+    enabled: true
+defaultShim:
+  amd64: qemu
+EOF
+
+	deploy_kata "${mixed_values}"
+	rm -f "${mixed_values}"
+}
+
+@test "Mixed shims share the Kata rootfs in either startup order" {
+	exercise_startup_order forward clh qemu qemu-runtime-rs
+	exercise_startup_order reverse qemu qemu-runtime-rs clh
+}
+
+teardown_file() {
+	cleanup_mixed_pods || true
+	uninstall_kata
+}

--- a/tests/functional/kata-deploy/kata-deploy-mixed-shims.bats
+++ b/tests/functional/kata-deploy/kata-deploy-mixed-shims.bats
@@ -15,57 +15,9 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 
 MIXED_POD_LABEL="kata-deploy-mixed-shims"
 
-run_on_host() {
-	local cmd="$1"
-	local node_name
-	node_name=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
-	local pod_name="mixed-host-exec-${RANDOM}"
-	local phase=""
-
-	kubectl run "${pod_name}" \
-		--image=quay.io/kata-containers/alpine-bash-curl:latest \
-		--restart=Never \
-		--overrides="{
-			\"spec\": {
-				\"nodeName\": \"${node_name}\",
-				\"hostPID\": true,
-				\"activeDeadlineSeconds\": 300,
-				\"tolerations\": [{\"operator\": \"Exists\"}],
-				\"containers\": [{
-					\"name\": \"exec\",
-					\"image\": \"quay.io/kata-containers/alpine-bash-curl:latest\",
-					\"imagePullPolicy\": \"IfNotPresent\",
-					\"command\": [\"sh\", \"-c\", \"${cmd}\"],
-					\"securityContext\": {\"privileged\": true}
-				}]
-			}
-		}" > /dev/null
-
-	local deadline=$((SECONDS + 60))
-	while (( SECONDS < deadline )); do
-		phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null) || true
-		case "${phase}" in
-			Succeeded|Failed) break ;;
-		esac
-		sleep 1
-	done
-
-	kubectl logs "${pod_name}" 2>/dev/null || true
-	kubectl delete pod "${pod_name}" --ignore-not-found=true > /dev/null 2>&1
-	[[ "${phase}" == "Succeeded" ]]
-}
-
 cleanup_mixed_pods() {
 	kubectl delete pods -l "test=${MIXED_POD_LABEL}" \
 		--ignore-not-found=true --wait=true --timeout=180s
-}
-
-assert_kata_processes_stopped() {
-	run run_on_host "kata_processes() { found=1; for proc in /proc/[0-9]*; do exe=\$(readlink \${proc}/exe 2>/dev/null || true); case \${exe} in *qemu-system*|*cloud-hypervisor*|*containerd-shim-kata-v2*) echo \${proc##*/} \${exe}; found=0;; esac; state=\$(awk '{print \$3}' \${proc}/stat 2>/dev/null || true); comm=\$(awk '{print \$2}' \${proc}/stat 2>/dev/null || true); if [ x\${state} = xZ ]; then case \${comm} in *qemu-system*|*cloud-hypervis*|*containerd-shim*) echo \${proc##*/} zombie \${comm}; found=0;; esac; fi; done; return \${found}; }; for attempt in \$(seq 1 30); do if ! kata_processes >/dev/null; then exit 0; fi; sleep 1; done; kata_processes; exit 1"
-	if [[ "${status}" -ne 0 ]]; then
-		echo "${output}" >&3
-	fi
-	[[ "${status}" -eq 0 ]]
 }
 
 create_mixed_pod() {
@@ -115,7 +67,6 @@ exercise_startup_order() {
 	done
 
 	cleanup_mixed_pods
-	assert_kata_processes_stopped
 }
 
 setup_file() {


### PR DESCRIPTION
## Motivation

`kata-deploy` installs one rootfs image that every enabled shim boots from
read-only. Cloud Hypervisor locks the whole file. QEMU takes permission locks on
the same bytes even when it opens the image read-only.

On a node that offers both runtime classes, whichever VMM starts first stops the
other from opening the rootfs. The losing shim keeps failing while that image is
in use. Mixed hypervisors on one node is a configuration `kata-deploy`
supports, so the second runtime class is unusable.

This is a concurrency bug in how QEMU locks a shared immutable file. It is not a
new feature. Both the Go `kata-qemu` default shim and runtime-rs QEMU are affected.

## Resolution

Add a `DisableLocking` option to the Go `govmm` block device backend and emit
`file.locking=off` through the structured `file.filename` parameter. Locking
stays on by default.

Apply that option in the Go and runtime-rs QEMU paths when they open the Kata
rootfs read-only. Kata owns this immutable file, so the lock protects no writes.
Workload block devices keep normal locking.

Add a kata-deploy regression that enables Cloud Hypervisor, Go QEMU, and
runtime-rs QEMU on one k3s node, starts a sandbox on each shim in both orders,
and verifies that every sandbox reaches Ready while all three share the same
read-only rootfs.

Fixes: #13731