### PR TITLE
kata-monitor: downgrade scrape errors after sandbox teardown

### DIFF
--- a/src/runtime/pkg/kata-monitor/metrics.go
+++ b/src/runtime/pkg/kata-monitor/metrics.go
@@ -10,6 +10,8 @@ import (
 	"compress/gzip"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -191,7 +193,7 @@ func (km *KataMonitor) aggregateSandboxMetrics(encoder expfmt.Encoder, filterFam
 		go func(sandboxID string, sandboxMetadata sandboxCRIMetadata, results chan<- []*dto.MetricFamily) {
 			sandboxMetrics, err := getParsedMetrics(sandboxID, sandboxMetadata)
 			if err != nil {
-				monitorLog.WithError(err).WithField("sandbox_id", sandboxID).Errorf("failed to get metrics for sandbox")
+				logSandboxMetricsError(sandboxID, err, getSandboxFSPaths())
 			}
 
 			results <- sandboxMetrics
@@ -256,6 +258,33 @@ func (km *KataMonitor) aggregateSandboxMetrics(encoder expfmt.Encoder, filterFam
 	}
 	return nil
 
+}
+
+func logSandboxMetricsError(sandboxID string, metricsErr error, sandboxPaths []string) {
+	exists, stateErr := sandboxExistsInPaths(sandboxID, sandboxPaths)
+	entry := monitorLog.WithError(metricsErr).WithField("sandbox_id", sandboxID)
+
+	if stateErr == nil && !exists {
+		entry.Debug("sandbox removed while collecting metrics")
+		return
+	}
+	if stateErr != nil {
+		entry = entry.WithField("sandbox_state_error", stateErr.Error())
+	}
+	entry.Error("failed to get metrics for sandbox")
+}
+
+func sandboxExistsInPaths(sandboxID string, sandboxPaths []string) (bool, error) {
+	for _, sandboxPath := range sandboxPaths {
+		_, err := os.Stat(filepath.Join(sandboxPath, sandboxID))
+		if err == nil {
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 func getParsedMetrics(sandboxID string, sandboxMetadata sandboxCRIMetadata) ([]*dto.MetricFamily, error) {

--- a/src/runtime/pkg/kata-monitor/metrics_test.go
+++ b/src/runtime/pkg/kata-monitor/metrics_test.go
@@ -7,12 +7,18 @@ package katamonitor
 
 import (
 	"bytes"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -36,6 +42,60 @@ go_gc_duration_seconds_count 6491
 ttt 999
 `
 )
+
+func withMonitorLogHook(t *testing.T) *logrustest.Hook {
+	t.Helper()
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	previousMonitorLog := monitorLog
+	monitorLog = logger.WithField("source", "kata-monitor")
+	t.Cleanup(func() { monitorLog = previousMonitorLog })
+	return hook
+}
+
+func TestMetricsErrorKeepsErrorWhileSandboxExists(t *testing.T) {
+	hook := withMonitorLogHook(t)
+	sandboxID := "sandbox-live"
+	goPath, rustPath := t.TempDir(), t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(rustPath, sandboxID), 0o755))
+
+	logSandboxMetricsError(sandboxID, io.ErrUnexpectedEOF, []string{goPath, rustPath})
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	assert.Equal(t, logrus.ErrorLevel, entry.Level)
+	assert.Equal(t, "failed to get metrics for sandbox", entry.Message)
+}
+
+func TestMetricsErrorDowngradesAfterSandboxRemoval(t *testing.T) {
+	hook := withMonitorLogHook(t)
+	sandboxID := "sandbox-removed"
+	goPath, rustPath := t.TempDir(), t.TempDir()
+	sandboxPath := filepath.Join(goPath, sandboxID)
+	require.NoError(t, os.Mkdir(sandboxPath, 0o755))
+	require.NoError(t, os.RemoveAll(sandboxPath))
+
+	logSandboxMetricsError(sandboxID, io.ErrUnexpectedEOF, []string{goPath, rustPath})
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	assert.Equal(t, logrus.DebugLevel, entry.Level)
+	assert.Equal(t, "sandbox removed while collecting metrics", entry.Message)
+}
+
+func TestSandboxExistsInAnyWatchedPath(t *testing.T) {
+	sandboxID := "sandbox-dual-path"
+	goPath, rustPath := t.TempDir(), t.TempDir()
+
+	exists, err := sandboxExistsInPaths(sandboxID, []string{goPath, rustPath})
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	require.NoError(t, os.Mkdir(filepath.Join(rustPath, sandboxID), 0o755))
+	exists, err = sandboxExistsInPaths(sandboxID, []string{goPath, rustPath})
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
 
 func TestParsePrometheusMetrics(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
## Motivation

`kata-monitor` can start scraping a sandbox before teardown removes its metrics socket and storage directory. The failed request then produces an error-level log even though the sandbox no longer exists. This expected race makes transport failures for live sandboxes harder to identify.

## Resolution

Recheck `/run/vc/sbs` and `/run/kata` after a scrape fails. Log at debug level only when both paths confirm that the sandbox is gone. Keep error-level logs when either path still contains the sandbox or when a path check fails.

Fixes #13735