### PR TITLE
ci: tests: Get the vanilla k8s deployment working with kubeadm 1.37

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -164,6 +164,28 @@ function kubectl_retry() {
 	echo "'kubectl $*' failed after ${max_tries} tries" 1>&2 && return 1
 }
 
+# A wrapper around `apt-get update` with retry logic.
+#
+# The GitHub runner images come with third-party apt repositories configured
+# (packages.microsoft.com, dl.google.com, ...) that we don't use but that apt
+# still refreshes, and a single one of them answering 403 or timing out is
+# enough to make the whole update fail.  Retrying keeps a hiccup on a
+# repository we don't even need from taking the job down.
+function apt_get_update() {
+	local -r max_tries=5
+	local -r interval=15
+	local i
+
+	for ((i = 1; i <= max_tries; i++)); do
+		sudo apt-get update && return 0
+		[[ "${i}" -eq "${max_tries}" ]] && break
+		warn "'apt-get update' failed, retrying in ${interval} seconds"
+		sleep "${interval}"
+	done
+
+	die "'apt-get update' failed after ${max_tries} tries"
+}
+
 function waitForProcess() {
 	wait_time="$1"
 	sleep_time="$2"
@@ -907,7 +929,7 @@ function install_erofs_utils() {
 		Pin: release n=questing
 		Pin-Priority: 100
 		APTPIN
-		sudo apt-get update
+		apt_get_update
 		sudo apt-get -y install --no-install-recommends -t questing erofs-utils
 		sudo rm -f /etc/apt/preferences.d/questing-pin
 		sudo add-apt-repository -y --remove 'deb https://archive.ubuntu.com/ubuntu/ questing universe'
@@ -1383,7 +1405,7 @@ function install_crio() {
 	echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://pkgs.k8s.io/addons:/cri-o:/stable:/v${version}/deb/ /" | \
 		sudo tee /etc/apt/sources.list.d/cri-o.list
 
-	sudo apt update
+	apt_get_update
 	sudo apt install -y cri-o
 
 	# We need to set the default capabilities to ensure our tests will pass
@@ -1414,7 +1436,7 @@ EOF
 
 function install_docker() {
 	# Add Docker's official GPG key
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install ca-certificates curl gnupg
 	sudo install -m 0755 -d /etc/apt/keyrings
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -1425,7 +1447,7 @@ function install_docker() {
 		"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
 		$(. /etc/os-release && echo "${VERSION_CODENAME}") stable" | \
 		sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-	sudo apt-get update
+	apt_get_update
 
 	sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 }

--- a/tests/functional/kata-agent-apis/gha-run.sh
+++ b/tests/functional/kata-agent-apis/gha-run.sh
@@ -29,7 +29,7 @@ function install_dependencies() {
 		umoci
 	)
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${deps[@]}"
 
 	info "Installing bats"

--- a/tests/functional/kata-monitor/gha-run.sh
+++ b/tests/functional/kata-monitor/gha-run.sh
@@ -28,7 +28,7 @@ function install_dependencies() {
 		jq
 	)
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -475,12 +475,12 @@ function do_deploy_k8s() {
 	local kubeadm_config
 	kubeadm_config="$(mktemp --tmpdir kubeadm-config.XXXXXX.yaml)"
 	cat <<EOF | tee "${kubeadm_config}"
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
-  criSocket: "/run/containerd/containerd.sock"
+  criSocket: "unix:///run/containerd/containerd.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: "10.244.0.0/16"

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -395,7 +395,7 @@ function deploy_microk8s() {
 function install_system_dependencies() {
 	dependencies="${1}"
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${dependencies}"
 }
 
@@ -452,7 +452,7 @@ function do_deploy_k8s() {
 		Pin-Priority: 1000
 		EOF
 
-		sudo apt-get update
+		apt_get_update
 		if sudo apt-get -y install --dry-run kubeadm kubelet kubectl cri-tools \
 			--allow-downgrades >/dev/null 2>&1; then
 			version="${candidate}"

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -44,7 +44,7 @@ function install_dependencies() {
 		podman-docker
 	)
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${system_deps[@]}"
 
 	# Dependency list of projects that we can install them

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -267,7 +267,7 @@ kbs_install_cli() {
 		debian|ubuntu)
 			local pkgs="build-essential pkg-config libssl-dev"
 
-			sudo apt-get update -y
+			apt_get_update
 			# shellcheck disable=2086
 			sudo apt-get install -y ${pkgs}
 			;;

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -29,7 +29,7 @@ function install_dependencies() {
 		pip
 	)
 
-	sudo apt update
+	apt_get_update
 	sudo apt -y install "${system_deps[@]}"
 
 	# Install lastversion from pip

--- a/tests/integration/nydus/gha-run.sh
+++ b/tests/integration/nydus/gha-run.sh
@@ -24,7 +24,7 @@ function install_dependencies() {
 		jq
 	)
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq

--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -28,7 +28,7 @@ function install_dependencies() {
 		gnupg
 	)
 
-	sudo apt-get update
+	apt_get_update
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq


### PR DESCRIPTION
kubeadm 1.37 dropped the `kubeadm.k8s.io/v1beta3` API, and the config we hand `kubeadm init` still used it, so the vanilla k8s deployment now fails outright:
```
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use kubeadm v1.36 instead and run 'kubeadm config migrate ...'
```

The same job also hit a second, unrelated problem: the runner images come with third-party apt repositories that we never install anything from, and apt refreshes them all the same, so packages.microsoft.com answering 403 was enough to fail the whole `apt-get update`. Let's retry the apt cache refresh, everywhere the CI does it, since every one of those call sites is exposed to the same hiccup.