### PR TITLE
tests: don't fail the CI if an AKS cluster deletion fails

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -207,7 +207,8 @@ function delete_cluster() {
 	rg="$(_print_rg_name "${test_type}")"
 
 	if [[ "$(az group exists -g "${rg}")" == "true" ]]; then
-		az group delete -g "${rg}" --yes
+		az group delete -g "${rg}" --yes || \
+			warn "Failed to delete the resource group ${rg}"
 	fi
 }
 


### PR DESCRIPTION
Deleting the resource group of an AKS cluster fails from time to time for reasons that have nothing to do with the changes being tested, and that's enough to fail an otherwise green job, and with no benefit at all, as it leads to a maintainer re-running the job. :-/