### PR TITLE
gha: Give every job a timeout-minutes

### DIFF
--- a/.github/workflows/PR-wip-checks.yaml
+++ b/.github/workflows/PR-wip-checks.yaml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   pr_wip_check:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     name: WIP Check
     steps:
     - name: WIP Check

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -14,6 +14,7 @@ jobs:
   run-actionlint:
     name: run-actionlint
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -34,6 +34,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-sandboxapi-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
@@ -93,6 +94,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-run-containerd-stability-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
+    timeout-minutes: 35
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
@@ -151,6 +153,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-run-nydus-amd64-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
@@ -211,6 +214,7 @@ jobs:
           - qemu-nvidia-gpu
           - qemu-nvidia-gpu-runtime-rs
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
@@ -266,6 +270,7 @@ jobs:
     # 24.04 is what the erofs snapshotter legs need: the erofs-utils backport
     # they install comes from Ubuntu 25.10 and does not install on 22.04.
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:

--- a/.github/workflows/basic-ci-s390x.yaml
+++ b/.github/workflows/basic-ci-s390x.yaml
@@ -36,6 +36,7 @@ jobs:
     # TODO: enable me when https://github.com/containerd/containerd/issues/11640 is fixed
     if: false
     runs-on: s390x-large
+    timeout-minutes: 40
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
@@ -100,6 +101,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-s390x-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: s390x-large
+    timeout-minutes: 25
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
@@ -146,6 +148,7 @@ jobs:
           - qemu
           - qemu-runtime-rs
     runs-on: s390x-large
+    timeout-minutes: 15
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:

--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -23,6 +23,7 @@ jobs:
   check:
     name: check
     runs-on: ${{ inputs.instance }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -36,6 +36,7 @@ jobs:
   build-asset:
     name: build-asset
     runs-on: ubuntu-22.04
+    timeout-minutes: 40
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
@@ -163,6 +164,7 @@ jobs:
   build-kata-deploy-components:
     name: build-kata-deploy-components
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     strategy:
       matrix:
         component:
@@ -203,6 +205,7 @@ jobs:
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-22.04
+    timeout-minutes: 25
     needs: build-asset
     permissions:
       contents: read
@@ -286,6 +289,7 @@ jobs:
   remove-rootfs-binary-artifacts:
     name: remove-rootfs-binary-artifacts
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -306,6 +310,7 @@ jobs:
   remove-rootfs-binary-artifacts-for-release:
     name: remove-rootfs-binary-artifacts-for-release
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -323,6 +328,7 @@ jobs:
   build-asset-shim-v2:
     name: build-asset-shim-v2
     runs-on: ubuntu-22.04
+    timeout-minutes: 35
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts, remove-rootfs-binary-artifacts-for-release]
     permissions:
       contents: read
@@ -451,6 +457,7 @@ jobs:
   build-tools-asset:
     name: build-tools-asset
     runs-on: ubuntu-22.04
+    timeout-minutes: 35
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
@@ -516,6 +523,7 @@ jobs:
   create-kata-tools-tarball:
     name: create-kata-tools-tarball
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: [build-tools-asset]
     permissions:
       contents: read

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -36,6 +36,7 @@ jobs:
   build-asset:
     name: build-asset
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 35
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
@@ -156,6 +157,7 @@ jobs:
   build-kata-deploy-components:
     name: build-kata-deploy-components
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
     strategy:
       matrix:
         component:
@@ -196,6 +198,7 @@ jobs:
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 35
     needs: build-asset
     permissions:
       contents: read
@@ -274,6 +277,7 @@ jobs:
   remove-rootfs-binary-artifacts:
     name: remove-rootfs-binary-artifacts
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -294,6 +298,7 @@ jobs:
   remove-rootfs-binary-artifacts-for-release:
     name: remove-rootfs-binary-artifacts-for-release
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -308,6 +313,7 @@ jobs:
   build-asset-shim-v2:
     name: build-asset-shim-v2
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 40
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts, remove-rootfs-binary-artifacts-for-release]
     permissions:
       contents: read
@@ -377,6 +383,7 @@ jobs:
   build-tools-asset:
     name: build-tools-asset
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
@@ -436,6 +443,7 @@ jobs:
   create-kata-tools-tarball:
     name: create-kata-tools-tarball
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     needs: [build-tools-asset]
     permissions:
       contents: read

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -37,6 +37,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-ppc64le
+    timeout-minutes: 55
     strategy:
       matrix:
         asset:
@@ -97,6 +98,7 @@ jobs:
   build-kata-deploy-components:
     name: build-kata-deploy-components
     runs-on: ubuntu-24.04-ppc64le
+    timeout-minutes: 50
     strategy:
       matrix:
         component:
@@ -137,6 +139,7 @@ jobs:
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-24.04-ppc64le
+    timeout-minutes: 30
     needs: build-asset
     permissions:
       contents: read
@@ -207,6 +210,7 @@ jobs:
   remove-rootfs-binary-artifacts:
     name: remove-rootfs-binary-artifacts
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -224,6 +228,7 @@ jobs:
   build-asset-shim-v2:
     name: build-asset-shim-v2
     runs-on: ubuntu-24.04-ppc64le
+    timeout-minutes: 55
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read

--- a/.github/workflows/build-kata-static-tarball-riscv64.yaml
+++ b/.github/workflows/build-kata-static-tarball-riscv64.yaml
@@ -31,6 +31,7 @@ jobs:
   build-asset:
     name: build-asset
     runs-on: riscv-builder
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -35,6 +35,7 @@ jobs:
   build-asset:
     name: build-asset
     runs-on: ubuntu-24.04-s390x
+    timeout-minutes: 40
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
@@ -141,6 +142,7 @@ jobs:
   build-kata-deploy-components:
     name: build-kata-deploy-components
     runs-on: ubuntu-24.04-s390x
+    timeout-minutes: 40
     strategy:
       matrix:
         component:
@@ -181,6 +183,7 @@ jobs:
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: s390x
+    timeout-minutes: 35
     needs: build-asset
     permissions:
       contents: read
@@ -255,6 +258,7 @@ jobs:
   remove-rootfs-binary-artifacts:
     name: remove-rootfs-binary-artifacts
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: build-asset-rootfs
     strategy:
       matrix:
@@ -274,6 +278,7 @@ jobs:
   build-asset-shim-v2:
     name: build-asset-shim-v2
     runs-on: ubuntu-24.04-s390x
+    timeout-minutes: 50
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read

--- a/.github/workflows/build-kubectl-image.yaml
+++ b/.github/workflows/build-kubectl-image.yaml
@@ -27,6 +27,7 @@ jobs:
   build-and-push:
     name: Build and push multi-arch image
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # needed to push the kubectl image to ghcr.io

--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -19,6 +19,7 @@ jobs:
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-nightly-s390x.yaml
+++ b/.github/workflows/ci-nightly-s390x.yaml
@@ -14,6 +14,7 @@ jobs:
   check-internal-test-result:
     name: check-internal-test-result
     runs-on: s390x
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -14,6 +14,7 @@ jobs:
   cleanup-resources:
     name: cleanup-resources
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       id-token: write # Used for OIDC access to log into Azure
     environment:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       security-events: write # required to upload SARIF results to code-scanning dashboard
       packages: read # required to fetch internal or private CodeQL packs

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -21,6 +21,7 @@ env:
 jobs:
   commit-message-check:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     name: Commit Message Check

--- a/.github/workflows/create-auth-registry-image.yaml
+++ b/.github/workflows/create-auth-registry-image.yaml
@@ -17,6 +17,7 @@ jobs:
   build-and-push:
     name: Build and push multi-arch authenticated test image
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: test
     runs-on: macos-latest
+    timeout-minutes: 35
     steps:
     - name: Install Protoc
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     name: Build docs
     permissions:
       contents: read
@@ -40,6 +41,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     name: Deploy docs
     permissions:
       pages: write # needed to deploy to GitHub Pages

--- a/.github/workflows/editorconfig-checker.yaml
+++ b/.github/workflows/editorconfig-checker.yaml
@@ -13,6 +13,7 @@ jobs:
   editorconfig-checker:
     name: editorconfig-checker
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gatekeeper-skipper.yaml
+++ b/.github/workflows/gatekeeper-skipper.yaml
@@ -41,6 +41,7 @@ jobs:
   skipper:
     name: skipper
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     outputs:
       skip_build: ${{ steps.skipper.outputs.skip_build }}
       skip_test: ${{ steps.skipper.outputs.skip_test }}

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -24,6 +24,7 @@ jobs:
   gatekeeper:
     name: gatekeeper
     runs-on: ubuntu-22.04
+    timeout-minutes: 240
     permissions:
       actions: read # needed to check workflow run status
       contents: read

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -13,6 +13,7 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     strategy:
       matrix:
         include:

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -19,6 +19,7 @@ jobs:
   scan:
     name: Scan PR changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       actions: read  # Required to upload SARIF file to CodeQL
       contents: read  # Read commit contents

--- a/.github/workflows/osv-scanner-scheduled.yaml
+++ b/.github/workflows/osv-scanner-scheduled.yaml
@@ -22,6 +22,7 @@ jobs:
   scan:
     name: Scan whole repository
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       actions: read # Required to upload SARIF file to CodeQL
       contents: read  # Read commit contents

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -214,6 +214,7 @@ jobs:
   publish-manifest:
     name: publish-manifest
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write # needed to push manifest images to ghcr.io
@@ -241,6 +242,7 @@ jobs:
   publish-kata-monitor-manifest:
     name: publish-kata-monitor-manifest
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write # needed to push manifest images to ghcr.io
@@ -276,6 +278,7 @@ jobs:
     name: upload-helm-chart-tarball
     needs: publish-manifest
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       packages: write # needed to push the helm chart to ghcr.io
     steps:

--- a/.github/workflows/publish-kata-images.yaml
+++ b/.github/workflows/publish-kata-images.yaml
@@ -77,6 +77,7 @@ jobs:
       contents: read
       packages: write # needed to push kata images to ghcr.io
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 25
     strategy:
       matrix:
         image-kind: ${{ fromJson(inputs.image-kinds-json != '' && inputs.image-kinds-json || format('["{0}"]', inputs.image-kind)) }}

--- a/.github/workflows/push-oras-tarball-cache.yaml
+++ b/.github/workflows/push-oras-tarball-cache.yaml
@@ -20,6 +20,7 @@ jobs:
   push-oras-cache:
     name: push-oras-cache
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write # needed to push the ORAS tarball cache to ghcr.io

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -39,6 +39,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -39,6 +39,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     steps:
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-kata-images.yaml
+++ b/.github/workflows/release-kata-images.yaml
@@ -21,6 +21,7 @@ jobs:
   resolve-tags:
     name: Resolve image tags
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     outputs:
       tags: ${{ steps.tags.outputs.tags }}
     steps:
@@ -78,6 +79,7 @@ jobs:
     name: Publish multi-arch manifest
     needs: [resolve-tags, publish-monitor]
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -36,6 +36,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-ppc64le
+    timeout-minutes: 30
     steps:
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -37,6 +37,7 @@ jobs:
       contents: read
       packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-s390x
+    timeout-minutes: 30
     steps:
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release create` command
     steps:
@@ -94,6 +95,7 @@ jobs:
   publish-multi-arch-images:
     name: publish-multi-arch-images
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
     permissions:
       contents: write # needed for the `gh release` commands
@@ -135,6 +137,7 @@ jobs:
     permissions:
       contents: write # needed for the `gh release` commands
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -268,6 +271,7 @@ jobs:
     name: upload-versions-yaml
     needs: release
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release` commands
     steps:
@@ -286,6 +290,7 @@ jobs:
     name: upload-cargo-vendored-tarball
     needs: release
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release` commands
     steps:
@@ -304,6 +309,7 @@ jobs:
     name: upload-libseccomp-tarball
     needs: release
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release` commands
     steps:
@@ -322,6 +328,7 @@ jobs:
     name: upload-helm-chart-tarball
     needs: release
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release` commands
       packages: write # needed to push the helm chart to ghcr.io
@@ -360,6 +367,7 @@ jobs:
     name: publish-release
     needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, publish-kata-monitor-image, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     permissions:
       contents: write # needed for the `gh release` commands
     steps:

--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -40,6 +40,7 @@ jobs:
   run-cri-containerd:
     name: run-cri-containerd-${{ inputs.arch }} (${{ inputs.containerd_version }}, ${{ inputs.vmm }})
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 25
     env:
       CONTAINERD_VERSION: ${{ inputs.containerd_version }}
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -73,6 +73,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-run-k8s-tests-aks-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write # Used for OIDC access to log into Azure

--- a/.github/workflows/run-k8s-tests-on-arm64.yaml
+++ b/.github/workflows/run-k8s-tests-on-arm64.yaml
@@ -43,6 +43,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm64-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: arm64-k8s
+    timeout-minutes: 60
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-k8s-tests-on-free-runner.yaml
+++ b/.github/workflows/run-k8s-tests-on-free-runner.yaml
@@ -61,6 +61,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-free-runner-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 70
     permissions:
       contents: read
     env:

--- a/.github/workflows/run-k8s-tests-on-nvidia-cpu-arm64.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-cpu-arm64.yaml
@@ -45,6 +45,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ${{ matrix.environment.runner }}
+    timeout-minutes: 70
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -54,6 +54,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ${{ matrix.environment.runner }}
+    timeout-minutes: 70
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -43,6 +43,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-ppc64le-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ppc64le-k8s
+    timeout-minutes: 50
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -70,6 +70,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-zvsi-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: s390x-large
+    timeout-minutes: 90
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-kata-coco-tests-arm64-k8s.yaml
+++ b/.github/workflows/run-kata-coco-tests-arm64-k8s.yaml
@@ -48,6 +48,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm64-coco-k8s-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: arm64-k8s
+    timeout-minutes: 100
     environment:
       name: ci
       deployment: false

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -67,6 +67,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-k8s-tee-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 130
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
@@ -167,6 +168,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     permissions:
       contents: read
     environment:
@@ -294,6 +296,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     environment:
       name: ci
       deployment: false

--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -45,6 +45,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-26.04
+    timeout-minutes: 30
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-kata-monitor-k8s-tests.yaml
+++ b/.github/workflows/run-kata-monitor-k8s-tests.yaml
@@ -53,6 +53,7 @@ jobs:
       group: ${{ github.workflow }}-run-kata-monitor-k8s-tests-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -43,6 +43,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       CONTAINER_ENGINE: ${{ matrix.container_engine }}
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -21,6 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/shellcheck_required.yaml
+++ b/.github/workflows/shellcheck_required.yaml
@@ -21,6 +21,7 @@ jobs:
   shellcheck-required:
     name: shellcheck-required
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -12,6 +12,7 @@ jobs:
   check-spelling:
     name: check-spelling
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,6 +14,7 @@ jobs:
   stale:
     name: stale
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       actions: write # Needed to manage caches for state persistence across runs
       pull-requests: write # Needed to add/remove labels, post comments, or close PRs

--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -23,6 +23,7 @@ jobs:
   stale:
     name: stale
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       actions: write # Needed to manage caches for state persistence across runs
       issues: write # Needed to add/remove labels, post comments, or close issues

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -26,6 +26,7 @@ jobs:
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,6 +58,7 @@ jobs:
   build-checks-depending-on-kvm:
     name: build-checks-depending-on-kvm
     runs-on: ubuntu-22.04
+    timeout-minutes: 130
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     strategy:
@@ -101,6 +103,7 @@ jobs:
   kata-deploy-binary-build-check:
     name: kata-deploy-binary-build-check
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     permissions:
@@ -125,6 +128,7 @@ jobs:
   static-checks:
     name: static-checks
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     strategy:
@@ -189,6 +193,7 @@ jobs:
   codegen:
     name: codegen
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     permissions:
@@ -223,6 +228,7 @@ jobs:
   go-mod-tidy:
     name: go-mod-tidy
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     permissions:
@@ -299,6 +305,7 @@ jobs:
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -313,6 +320,7 @@ jobs:
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -13,6 +13,7 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Of the 171 jobs across .github/workflows, only six declared a timeout-minutes, leaving the other 103 on GitHub's six hour default. A hung job therefore burns a runner for the rest of the day before anyone notices, and on the self-hosted fleet that is a runner nobody else can use. The remaining 62 jobs are reusable workflow calls, where GitHub does not accept timeout-minutes at all, so the bound has to live on the leaf jobs inside the reusable workflow, which is what this does.

The values are not guesses. Three throwaway scripts produced them:

  - inv_jobs.py parsed every workflow with PyYAML and listed each job, whether it was a reusable-workflow call, and whether it already carried a timeout-minutes.

  - collect_runs.py walked the REST API via gh api, taking /actions/workflows/<file>/runs?status=completed for the last 20 runs of each of the 61 workflows created in the preceding 10 days, then /actions/runs/<id>/jobs for each of those 475 runs, recording started_at and completed_at per job. Sampling completed rather than successful runs matters here: static-checks.yaml had 348 runs in the window and not one was fully green, so filtering on run conclusion would have left all eight of its jobs without data. Only jobs whose own conclusion was success were kept.

  - recommend.py mapped the observed job names back to the definitions they come from by walking the reusable-call graph, so that "kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-on-tee (tdx, qemu-tdx)" resolves to run-kata-coco-tests.yaml::run-k8s-tests-on-tee. All 103 resolved.

Each timeout is the longest successful run observed for that job times a safety factor that tapers as jobs get longer (3x below five minutes, 2.5x below fifteen, 2x below thirty, 1.6x below an hour, 1.4x above), floored at ten minutes and rounded up to a multiple of five. A matrix job shares a single timeout, so the maximum is taken across all its entries. Nothing that succeeded in the sample would be killed by the value picked for it.

Six jobs initially came out below their own longest step-level timeout, which is self-contradictory: run-k8s-tests-coco-nontee-with-erofs-snapshotter landed on 50 minutes while its "Run tests" step is explicitly allowed
80. Those were raised to the longest step plus ten minutes.

Three values are reasoned rather than measured. gatekeeper polls until every required check finishes, so its runtime tracks the whole of CI; a 200 run sample showed successful executions reaching 184 minutes, hence
240. The riscv64 jobs have not executed once in 120 days, sitting queued for the full 24 hour limit and then being cancelled because no riscv-builder runner is available, so they get a generous 120. build-checks-depending-on-kvm is bimodal, with a median of five minutes but real test execution reaching 91 minutes twice and 190 minutes once in the last week; 130 is a large improvement on six hours but weak protection for a job that normally takes five, and that variance is worth chasing separately.

Four jobs had no successful sample to draw on and take a sibling's value: basic-ci-s390x's sandboxapi job and govulncheck are always skipped, osv-scanner-scheduled only ever fails and does so in under three minutes, and create-auth-registry-image has never run. run-k8s-tests-on-arm64 is no longer called from ci.yaml, so its 120 day history was used instead.

actionlint is clean, and the workflows still parse to the same structure apart from the added keys.

Generated-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added execution time limits across continuous integration, testing, security scanning, build, documentation, publishing, and release automation.
  - Configured timeouts ranging from 10 to 240 minutes, tailored to each workflow’s expected runtime.
  - Prevents stalled or unexpectedly long-running automation jobs from consuming resources indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->