### PR TITLE
ci: stop govulncheck from sharing its caller's concurrency group

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -3,10 +3,6 @@ on:
 
 name: Govulncheck
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 permissions: {}
 
 jobs:
@@ -23,6 +19,9 @@ jobs:
           - binary: "kata-monitor"
             make_target: "monitor"
       fail-fast: false
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}-golvulncheck
+      cancel-in-progress: true
 
     steps:
       - name: Checkout the code


### PR DESCRIPTION
govulncheck.yaml is only ever reached through workflow_call, and inside a reusable workflow github.workflow resolves to the caller's name. Its workflow-level concurrency group therefore evaluated to "Static checks-<pr>", byte-identical to the group static-checks.yaml already holds, and both sides set cancel-in-progress. The nested request collided with the caller's own run, so no govulncheck job was ever created and the calling job failed. Every "Static checks" run that did real work has been red since, even though all 36 of its jobs passed, and govulncheck itself has not scanned a binary in four months.

The regression was introduced by af4ced32f4.

Assisted-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability-check workflow concurrency handling.
  * In-progress duplicate vulnerability-check runs are now canceled to reduce redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->