### PR TITLE
libs: Restore unsafe blocks around __cpuid() calls for older Rust

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -126,7 +126,8 @@ pub fn arch_guest_protection(
         // shouldn't hurt to double-check and have better logging if anything
         // goes wrong.
 
-        let fn0 = x86_64::__cpuid(0);
+        #[allow(unused_unsafe)]
+        let fn0 = unsafe { x86_64::__cpuid(0) };
         // The values in [ ebx, edx, ecx ] spell out "AuthenticAMD" when
         // interpreted byte-wise as ASCII.  No need to bother here with an
         // actual conversion to string though.
@@ -139,7 +140,8 @@ pub fn arch_guest_protection(
         }
 
         // AMD64 Architecture Prgrammer's Manual Fn8000_001f docs on pg. 640
-        let fn8000_001f = x86_64::__cpuid(0x8000_001f);
+        #[allow(unused_unsafe)]
+        let fn8000_001f = unsafe { x86_64::__cpuid(0x8000_001f) };
         if fn8000_001f.eax & 0x10 == 0 {
             return Err(ProtectionError::CheckFailed("SEV not supported".to_owned()));
         }


### PR DESCRIPTION
Commit a63a948b4afc ("libs: Remove unnecessary unsafe blocks in protection.rs") dropped the unsafe blocks around x86_64::__cpuid() calls because Rust 1.94 made that function safe. However, this breaks the build on older Rust versions where __cpuid() is still an unsafe function.

Restore the unsafe blocks and annotate them with pre-1.94 Rust (where unsafe is required) and Rust 1.94+ (where the block is redundant but now silenced).

This is to make the life of downstream consumers who can only use conservative toolchains less miserable.
