### PR TITLE
ci: retry AKS cluster deletion on failure 

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -166,4 +166,9 @@ jobs:
 
       - name: Delete AKS cluster
         if: always()
-        run: bash tests/integration/kubernetes/gha-run.sh delete-cluster
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 300
+          command: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -207,8 +207,7 @@ function delete_cluster() {
 	rg="$(_print_rg_name "${test_type}")"
 
 	if [[ "$(az group exists -g "${rg}")" == "true" ]]; then
-		az group delete -g "${rg}" --yes || \
-			warn "Failed to delete the resource group ${rg}"
+		az group delete -g "${rg}" --yes
 	fi
 }
 


### PR DESCRIPTION
```
ci: retry AKS cluster deletion on failure 

In #13741 folks rightfully pointed out that we have the following job to
clean up dangling Azure resources:

https://github.com/kata-containers/kata-containers/actions/workflows/cleanup-resources.yaml

But I'd prefer minimizing as much as possible how much we rely on that job
as I have not found a way to reliably get notified when it fails:

https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs

And if this cleanup job begins failing consistently, we risk burning
through the Azure sponsorship very quickly, like has happened in the past,
affecting the Kata and CoCo CIs.

So instead I'd like to trial retrying on deletion failure and see if this
works well enough.
```

@fidencio @stevenhorsman Any thoughts on this? I'd like to trial this for a bit, and OK to revert it if maintainers feel it doesn't help.