### PR TITLE
runtime(-rs): resolve symlinked mount paths

### DIFF
--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -66,6 +66,7 @@ const PROC_FIELDS_PER_LINE: usize = 6;
 const PROC_DEVICE_INDEX: usize = 0;
 const PROC_PATH_INDEX: usize = 1;
 const PROC_TYPE_INDEX: usize = 2;
+const PROC_OPTIONS_INDEX: usize = 3;
 
 lazy_static! {
     static ref MAX_MOUNT_PARAM_SIZE: usize =
@@ -129,10 +130,21 @@ pub struct LinuxMountInfo {
     pub path: String,
     /// Filesystem type of mount, third field of records from `/proc/mounts`.
     pub fs_type: String,
+    /// Mount options, fourth field of records from `/proc/mounts`.
+    pub options: Vec<String>,
 }
 
-/// Get the device and file system type of a mount point by parsing `/proc/mounts`.
+/// Get mount information for a mount point by parsing `/proc/mounts`.
 pub fn get_linux_mount_info(mount_point: &str) -> Result<LinuxMountInfo> {
+    // Mounting resolves symlinks in the target path, so `/proc/mounts` records
+    // the resolved path. In case `mount_point` contains a symlink, resolve it
+    // before comparing, or fall back to the original path if resolution fails.
+    // If resolution fails, compare the original path and let the scan determine
+    // whether a matching mount exists.
+    let requested_path = Path::new(mount_point);
+    let resolved_path =
+        fs::canonicalize(requested_path).unwrap_or_else(|_| requested_path.to_path_buf());
+
     let mount_file = fs::File::open(PROC_MOUNTS_FILE)?;
     let reader = io::BufReader::new(mount_file);
 
@@ -148,11 +160,15 @@ pub fn get_linux_mount_info(mount_point: &str) -> Result<LinuxMountInfo> {
             ));
         }
 
-        if mount_point == fields[PROC_PATH_INDEX] {
+        if resolved_path == Path::new(fields[PROC_PATH_INDEX]) {
             return Ok(LinuxMountInfo {
                 device: fields[PROC_DEVICE_INDEX].to_string(),
                 path: fields[PROC_PATH_INDEX].to_string(),
                 fs_type: fields[PROC_TYPE_INDEX].to_string(),
+                options: fields[PROC_OPTIONS_INDEX]
+                    .split(',')
+                    .map(str::to_string)
+                    .collect(),
             });
         }
     }
@@ -834,6 +850,7 @@ pub fn get_mount_type(m: &oci::Mount) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
     use std::path::PathBuf;
 
     #[test]
@@ -843,6 +860,7 @@ mod tests {
         assert_eq!(&info.device, "tmpfs");
         assert_eq!(&info.fs_type, "tmpfs");
         assert_eq!(&info.path, "/dev/shm");
+        assert!(!info.options.is_empty());
 
         assert!(matches!(
             get_linux_mount_info(""),
@@ -852,6 +870,21 @@ mod tests {
             get_linux_mount_info("/sys/fs/cgroup/do_not_exist/____hi"),
             Err(Error::NoMountEntry(_))
         ));
+    }
+
+    #[test]
+    fn test_get_linux_mount_info_through_symlinked_parent() {
+        let direct_options = get_linux_mount_info("/dev/shm").unwrap().options;
+        let tmpdir = tempfile::tempdir().unwrap();
+        let symlinked_dev = tmpdir.path().join("dev");
+        symlink("/dev", &symlinked_dev).unwrap();
+
+        let info = get_linux_mount_info(symlinked_dev.join("shm").to_str().unwrap()).unwrap();
+
+        assert_eq!(&info.device, "tmpfs");
+        assert_eq!(&info.fs_type, "tmpfs");
+        assert_eq!(&info.path, "/dev/shm");
+        assert_eq!(info.options, direct_options);
     }
 
     #[test]

--- a/src/runtime-rs/crates/resource/src/volume/hugepage.rs
+++ b/src/runtime-rs/crates/resource/src/volume/hugepage.rs
@@ -4,11 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    fs::File,
-    io::{BufRead, BufReader},
-};
+use std::collections::HashMap;
 
 use super::{Volume, BIND};
 use crate::share_fs::ephemeral_path;
@@ -19,7 +15,7 @@ use byte_unit::{Byte, Unit};
 use hypervisor::{device::device_manager::DeviceManager, HUGETLBFS};
 use kata_sys_util::{
     fs::get_base_name,
-    mount::{get_mount_path, PROC_MOUNTS_FILE},
+    mount::{get_linux_mount_info, get_mount_path, Error as MountError},
 };
 use kata_types::mount::KATA_EPHEMERAL_VOLUME_TYPE;
 use oci_spec::runtime as oci;
@@ -113,21 +109,13 @@ pub(crate) fn get_huge_page_option(m: &oci::Mount) -> Result<Option<Vec<String>>
     if m.source().is_none() {
         return Err(anyhow!("empty mount source"));
     }
-    let file = File::open(PROC_MOUNTS_FILE).context("failed open file")?;
-    let reader = BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok) {
-        let items: Vec<&str> = line.split(' ').collect();
-        if get_mount_path(m.source()).as_str() == items[1] && items[2] == HUGETLBFS {
-            let fs_options: Vec<&str> = items[3].split(',').collect();
-            return Ok(Some(
-                fs_options
-                    .iter()
-                    .map(|&s| s.to_string())
-                    .collect::<Vec<String>>(),
-            ));
-        }
+
+    let mount_path = get_mount_path(m.source());
+    match get_linux_mount_info(&mount_path) {
+        Ok(info) if info.fs_type == HUGETLBFS => Ok(Some(info.options)),
+        Ok(_) | Err(MountError::NoMountEntry(_)) => Ok(None),
+        Err(err) => Err(err.into()),
     }
-    Ok(None)
 }
 
 // TODO add hugepage limit to sandbox memory once memory hotplug is enabled

--- a/src/runtime/virtcontainers/utils/utils_linux.go
+++ b/src/runtime/virtcontainers/utils/utils_linux.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,6 +114,14 @@ func GetDevicePathAndFsTypeOptions(mountPoint string) (devicePath, fsType string
 		return
 	}
 
+	// Mounting resolves symlinks in the target path, so /proc/mounts records
+	// the resolved path. Resolve the requested path before comparing, or fall
+	// back to the original path if resolution fails.
+	resolvedMountPoint, resolveErr := filepath.EvalSymlinks(mountPoint)
+	if resolveErr != nil {
+		resolvedMountPoint = mountPoint
+	}
+
 	var file *os.File
 
 	file, err = os.Open(procMountsFile)
@@ -138,7 +147,7 @@ func GetDevicePathAndFsTypeOptions(mountPoint string) (devicePath, fsType string
 			return
 		}
 
-		if mountPoint == fields[procPathIndex] {
+		if resolvedMountPoint == fields[procPathIndex] {
 			devicePath = fields[procDeviceIndex]
 			fsType = fields[procTypeIndex]
 			fsOptions = strings.Split(fields[procOptionIndex], ",")

--- a/src/runtime/virtcontainers/utils/utils_linux_test.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_test.go
@@ -8,7 +8,9 @@ package utils
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -62,4 +64,20 @@ func TestGetDevicePathAndFsTypeOptionsSuccessful(t *testing.T) {
 	assert.Equal(fstype, "proc")
 	assert.Equal(fstype, fstypeOut)
 	assert.Equal(fsOptions, optsOut)
+}
+
+func TestGetDevicePathAndFsTypeOptionsThroughSymlinkedParent(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedPath, expectedFSType, expectedOptions, err := GetDevicePathAndFsTypeOptions("/proc")
+	assert.NoError(err)
+
+	rootLink := filepath.Join(t.TempDir(), "root")
+	assert.NoError(os.Symlink("/", rootLink))
+
+	path, fsType, fsOptions, err := GetDevicePathAndFsTypeOptions(filepath.Join(rootLink, "proc"))
+	assert.NoError(err)
+	assert.Equal(expectedPath, path)
+	assert.Equal(expectedFSType, fsType)
+	assert.Equal(expectedOptions, fsOptions)
 }


### PR DESCRIPTION
On some machines /var may be backed by a symlink, e.g., pointing to an NVMe storage medium.

When using emptyDir, the kubelet passes paths under /var/lib/kubelet to the shim. Looking up /proc/mounts finds their resolved NVMe paths, thus resulting in Error::NoMountEntry in get_linux_mount_info() in case that folder under /var is backed by a symlink.
With the literal path comparison then failing, memory-backed emptyDir mounts are misclassified as disk-backed mounts. Meaning: 'medium: Memory' is being ignored, and we silently fall back to, e.g., block-plain emptydir_mode.

This change canonicalizes the requested mount point before comparing it with /proc/mounts, and falls back to the original path if resolution fails. In case of a failure, we let our existing detection logic be the final judge to decide whether a matching mount exists or not.