### PR TITLE
dragonball: Optimize snapshot restore and remove boot-source dependency

### DIFF
--- a/src/dragonball/src/address_space_manager.rs
+++ b/src/dragonball/src/address_space_manager.rs
@@ -170,6 +170,15 @@ pub enum AddressManagerError {
     #[error("memory snapshot layout mismatch for guest address 0x{0:x}")]
     SnapshotLayoutMismatch(u64),
 
+    /// The memory snapshot has a different number of regions than the current address space.
+    #[error("memory snapshot region count mismatch: expected {expected}, found {actual}")]
+    SnapshotRegionCountMismatch {
+        /// Number of regions in the current guest address space.
+        expected: usize,
+        /// Number of regions recorded in the snapshot state.
+        actual: usize,
+    },
+
     /// The memory snapshot file is smaller than the mapped regions require.
     #[error(
         "memory snapshot file too small: region at guest address 0x{guest_addr:x} \
@@ -880,41 +889,53 @@ impl<'a> dbs_snapshot::Persist<'a> for AddressSpaceMgr {
             .ok_or(AddressManagerError::GuestMemoryNotInitialized)?;
         let guard = vm_as.memory();
 
-        // Validate the snapshot file is large enough for every region *before*
-        // installing any mapping. mmap(MAP_PRIVATE) happily maps past the end
-        // of a truncated file; the shortfall only surfaces later as a SIGBUS
-        // in the VMM when the guest first touches a page beyond EOF. Refuse a
-        // too-small file up front with a clear error instead.
+        let expected_region_count = guard.num_regions();
+        if state.regions.len() != expected_region_count {
+            return Err(AddressManagerError::SnapshotRegionCountMismatch {
+                expected: expected_region_count,
+                actual: state.regions.len(),
+            });
+        }
+
+        // Validate the complete layout *before* installing any mapping. The
+        // fresh address space describes every region expected from the current
+        // VM configuration; walking both lists in guest-address order catches
+        // omitted, extra, reordered and malformed snapshot regions.
         let file_len = file
             .metadata()
             .map_err(AddressManagerError::SnapshotFile)?
             .len();
-        for region_state in &state.regions {
-            let needed = region_state
-                .file_offset
-                .checked_add(region_state.size)
-                .ok_or(AddressManagerError::SnapshotLayoutMismatch(
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page_size <= 0 {
+            return Err(AddressManagerError::InvalidOperation);
+        }
+        let page_size = page_size as u64;
+        let mut expected_file_offset = 0u64;
+        for (region, region_state) in guard.iter().zip(&state.regions) {
+            let guest_addr = region.start_addr().raw_value();
+            if region_state.guest_addr != guest_addr
+                || region_state.size != region.len()
+                || region_state.file_offset != expected_file_offset
+                || region_state.file_offset % page_size != 0
+            {
+                return Err(AddressManagerError::SnapshotLayoutMismatch(
                     region_state.guest_addr,
-                ))?;
-            if needed > file_len {
+                ));
+            }
+
+            expected_file_offset = expected_file_offset.checked_add(region.len()).ok_or(
+                AddressManagerError::SnapshotLayoutMismatch(region_state.guest_addr),
+            )?;
+            if expected_file_offset > file_len {
                 return Err(AddressManagerError::SnapshotFileTooSmall {
                     guest_addr: region_state.guest_addr,
-                    needed,
+                    needed: expected_file_offset,
                     file_len,
                 });
             }
         }
 
-        for region_state in &state.regions {
-            let guest_addr = GuestAddress(region_state.guest_addr);
-            let region = guard.find_region(guest_addr).ok_or(
-                AddressManagerError::SnapshotLayoutMismatch(region_state.guest_addr),
-            )?;
-            if region.start_addr() != guest_addr || region.len() != region_state.size {
-                return Err(AddressManagerError::SnapshotLayoutMismatch(
-                    region_state.guest_addr,
-                ));
-            }
+        for (region, region_state) in guard.iter().zip(&state.regions) {
             // Back this region with a copy-on-write mapping of the template
             // file instead of copying it in: pages fault in lazily from the
             // template, guest writes stay private (MAP_PRIVATE), and the
@@ -924,16 +945,6 @@ impl<'a> dbs_snapshot::Persist<'a> for AddressSpaceMgr {
             let host_addr = region
                 .get_host_address(MemoryRegionAddress(0))
                 .map_err(|e| AddressManagerError::AccessGuestMemory(region_state.guest_addr, e))?;
-            // mmap requires a page-aligned file offset. Regions are written
-            // back-to-back at page-aligned sizes, so this holds by
-            // construction; validate it anyway and refuse a malformed snapshot
-            // with a clear error rather than letting mmap fail with EINVAL.
-            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
-            if page_size == 0 || region_state.file_offset % page_size != 0 {
-                return Err(AddressManagerError::SnapshotLayoutMismatch(
-                    region_state.guest_addr,
-                ));
-            }
             // SAFETY: `host_addr .. host_addr + size` is exactly this region's
             // own existing mapping; we atomically replace it with a private,
             // file-backed mapping of the same length and protection. The
@@ -988,12 +999,20 @@ mod tests {
 
     #[test]
     fn test_memory_save_restore_roundtrip() {
-        let numa_region_infos = vec![NumaRegionInfo {
-            size: 16,
-            host_numa_node_id: None,
-            guest_numa_node_id: Some(0),
-            vcpu_ids: vec![0],
-        }];
+        let numa_region_infos = vec![
+            NumaRegionInfo {
+                size: 8,
+                host_numa_node_id: None,
+                guest_numa_node_id: Some(0),
+                vcpu_ids: vec![0],
+            },
+            NumaRegionInfo {
+                size: 8,
+                host_numa_node_id: None,
+                guest_numa_node_id: Some(1),
+                vcpu_ids: vec![1],
+            },
+        ];
         let create_mgr = || {
             let res_mgr = ResourceManager::new(None);
             AddressSpaceMgrBuilder::new("shmem", "")
@@ -1017,10 +1036,13 @@ mod tests {
 
         let mut file = TempFile::new().unwrap().into_file();
         let state = dbs_snapshot::Persist::save_state(&mut src_mgr, &mut file).unwrap();
-        assert_eq!(state.regions.len(), 1);
+        assert_eq!(state.regions.len(), 2);
         assert_eq!(state.regions[0].guest_addr, GUEST_MEM_START);
-        assert_eq!(state.regions[0].size, 16 << 20);
+        assert_eq!(state.regions[0].size, 8 << 20);
         assert_eq!(state.regions[0].file_offset, 0);
+        assert_eq!(state.regions[1].guest_addr, GUEST_MEM_START + (8 << 20));
+        assert_eq!(state.regions[1].size, 8 << 20);
+        assert_eq!(state.regions[1].file_offset, 8 << 20);
 
         // The state must survive a JSON round-trip.
         let json = serde_json::to_string(&state).unwrap();
@@ -1038,13 +1060,71 @@ mod tests {
             .unwrap();
         assert_eq!(val, 0xa5);
 
+        // Missing or additional regions must be rejected even when every
+        // region listed in the snapshot individually matches the fresh guest
+        // address space.
+        let mut incomplete_state = state.clone();
+        incomplete_state.regions.pop();
+        let mut incomplete_mgr = create_mgr();
+        assert!(matches!(
+            dbs_snapshot::Persist::restore_state(&mut incomplete_mgr, &incomplete_state, &mut file),
+            Err(AddressManagerError::SnapshotRegionCountMismatch {
+                expected: 2,
+                actual: 1
+            })
+        ));
+
+        let mut extra_state = state.clone();
+        extra_state.regions.push(state.regions[1].clone());
+        let mut extra_mgr = create_mgr();
+        assert!(matches!(
+            dbs_snapshot::Persist::restore_state(&mut extra_mgr, &extra_state, &mut file),
+            Err(AddressManagerError::SnapshotRegionCountMismatch {
+                expected: 2,
+                actual: 3
+            })
+        ));
+
+        // Validate the whole layout before replacing any anonymous mappings.
+        // A mismatch in the second region must leave the first one untouched.
+        let mut malformed_state = state.clone();
+        malformed_state.regions[1].file_offset = 0;
+        let mut untouched_mgr = create_mgr();
+        {
+            let vm_as = untouched_mgr.get_vm_as().unwrap();
+            vm_as
+                .memory()
+                .write_obj(0x11223344u32, GuestAddress(GUEST_MEM_START))
+                .unwrap();
+        }
+        assert!(matches!(
+            dbs_snapshot::Persist::restore_state(&mut untouched_mgr, &malformed_state, &mut file),
+            Err(AddressManagerError::SnapshotLayoutMismatch(_))
+        ));
+        let vm_as = untouched_mgr.get_vm_as().unwrap();
+        assert_eq!(
+            vm_as
+                .memory()
+                .read_obj::<u32>(GuestAddress(GUEST_MEM_START))
+                .unwrap(),
+            0x11223344
+        );
+
         // A layout mismatch must be refused.
-        let small_infos = vec![NumaRegionInfo {
-            size: 8,
-            host_numa_node_id: None,
-            guest_numa_node_id: Some(0),
-            vcpu_ids: vec![0],
-        }];
+        let small_infos = vec![
+            NumaRegionInfo {
+                size: 4,
+                host_numa_node_id: None,
+                guest_numa_node_id: Some(0),
+                vcpu_ids: vec![0],
+            },
+            NumaRegionInfo {
+                size: 4,
+                host_numa_node_id: None,
+                guest_numa_node_id: Some(1),
+                vcpu_ids: vec![1],
+            },
+        ];
         let res_mgr = ResourceManager::new(None);
         let mut small_mgr = AddressSpaceMgrBuilder::new("shmem", "")
             .unwrap()

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -201,9 +201,9 @@ pub enum VmmAction {
     },
 
     /// Launch the microVM by restoring it from a snapshot instead of cold
-    /// booting. The microVM must have been configured with the same
-    /// configuration the snapshot was taken with. This action can only be
-    /// called before the microVM has booted.
+    /// booting. The microVM must have been configured with the same machine
+    /// and devices the snapshot was taken with; no boot source is required.
+    /// This action can only be called before the microVM has booted.
     #[cfg(target_arch = "x86_64")]
     StartMicroVmFromSnapshot {
         /// Path of the snapshot state file to read.

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -894,6 +894,43 @@ impl DeviceManager {
         address_space: Option<&AddressSpace>,
         vm_config: &VmConfigInfo,
     ) -> std::result::Result<(), StartMicroVmError> {
+        self.create_devices_with_boot_args(
+            vm_as,
+            epoll_mgr,
+            Some(kernel_config),
+            dmesg_fifo,
+            address_space,
+            vm_config,
+        )
+    }
+
+    pub(crate) fn create_devices_from_snapshot(
+        &mut self,
+        vm_as: GuestAddressSpaceImpl,
+        epoll_mgr: EpollManager,
+        dmesg_fifo: Option<Box<dyn io::Write + Send>>,
+        address_space: Option<&AddressSpace>,
+        vm_config: &VmConfigInfo,
+    ) -> std::result::Result<(), StartMicroVmError> {
+        self.create_devices_with_boot_args(
+            vm_as,
+            epoll_mgr,
+            None,
+            dmesg_fifo,
+            address_space,
+            vm_config,
+        )
+    }
+
+    fn create_devices_with_boot_args(
+        &mut self,
+        vm_as: GuestAddressSpaceImpl,
+        epoll_mgr: EpollManager,
+        kernel_config: Option<&mut KernelConfigInfo>,
+        dmesg_fifo: Option<Box<dyn io::Write + Send>>,
+        address_space: Option<&AddressSpace>,
+        vm_config: &VmConfigInfo,
+    ) -> std::result::Result<(), StartMicroVmError> {
         let mut ctx = DeviceOpContext::new(
             Some(epoll_mgr),
             self,
@@ -935,9 +972,15 @@ impl DeviceManager {
         self.vsock_manager.attach_devices(&mut ctx)?;
 
         #[cfg(any(feature = "virtio-blk", feature = "vhost-user-blk"))]
-        self.block_manager
-            .generate_kernel_boot_args(kernel_config)
-            .map_err(StartMicroVmError::DeviceManager)?;
+        let kernel_config = {
+            let mut kernel_config = kernel_config;
+            if let Some(kernel_config) = kernel_config.as_deref_mut() {
+                self.block_manager
+                    .generate_kernel_boot_args(kernel_config)
+                    .map_err(StartMicroVmError::DeviceManager)?;
+            }
+            kernel_config
+        };
 
         #[cfg(feature = "host-device")]
         {
@@ -947,10 +990,13 @@ impl DeviceManager {
             ctx.set_vfio_manager(self.vfio_manager.clone())
         }
 
-        // Ensure that all devices are attached before kernel boot args are
-        // generated.
-        ctx.generate_kernel_boot_args(kernel_config)
-            .map_err(StartMicroVmError::DeviceManager)?;
+        if let Some(kernel_config) = kernel_config {
+            // Ensure that all devices are attached before kernel boot args are
+            // generated for a cold boot. Restored memory already contains the
+            // finalized command line from the source VM.
+            ctx.generate_kernel_boot_args(kernel_config)
+                .map_err(StartMicroVmError::DeviceManager)?;
+        }
 
         #[cfg(target_arch = "aarch64")]
         {

--- a/src/dragonball/src/snapshot/mod.rs
+++ b/src/dragonball/src/snapshot/mod.rs
@@ -84,6 +84,10 @@ pub enum SnapshotError {
     #[error("invalid VM state for snapshot: {0}")]
     InvalidState(String),
 
+    /// Snapshot contents are incomplete or inconsistent with the target VM.
+    #[error("invalid VM snapshot: {0}")]
+    InvalidSnapshot(String),
+
     /// vCPU manager failure while saving/restoring vCPU state.
     #[error("vcpu manager error: {0}")]
     Vcpu(#[from] crate::vcpu::VcpuManagerError),
@@ -182,9 +186,9 @@ pub struct VmKvmState {
 
 /// Aggregated state of a microVM.
 ///
-/// Components are added progressively: a component whose `Persist` support is
-/// not implemented yet simply keeps its `Default` value in the snapshot and
-/// is ignored on restore.
+/// Core VM, vCPU and guest-memory state is required for restore. Device
+/// components are added progressively: a device class whose `Persist` support
+/// is not implemented yet keeps its `Default` value and is ignored on restore.
 #[derive(Default, Deserialize, Serialize)]
 pub struct MicrovmState {
     /// Snapshot header.
@@ -233,6 +237,53 @@ impl MicrovmState {
         check_epoch(found, FORMAT_EPOCH)?;
         Ok(serde_json::from_value(value)?)
     }
+
+    /// Validate the state that must be present before a restored VM can run.
+    #[cfg(target_arch = "x86_64")]
+    pub fn validate_for_restore(
+        &self,
+        expected_vcpu_count: u8,
+    ) -> std::result::Result<(), SnapshotError> {
+        if self.vm_kvm_state.is_none() {
+            return Err(SnapshotError::InvalidSnapshot(
+                "missing VM-scoped KVM state".to_string(),
+            ));
+        }
+
+        let memory_state = self.memory_state.as_ref().ok_or_else(|| {
+            SnapshotError::InvalidSnapshot("missing guest-memory state".to_string())
+        })?;
+        if memory_state.regions.is_empty() {
+            return Err(SnapshotError::InvalidSnapshot(
+                "guest-memory state has no regions".to_string(),
+            ));
+        }
+
+        let expected = usize::from(expected_vcpu_count);
+        if self.vcpu_states.len() != expected {
+            return Err(SnapshotError::InvalidSnapshot(format!(
+                "expected {expected} vCPU states, found {}",
+                self.vcpu_states.len()
+            )));
+        }
+
+        let mut seen = vec![false; expected];
+        for state in &self.vcpu_states {
+            let id = usize::from(state.id);
+            if id >= expected {
+                return Err(SnapshotError::InvalidSnapshot(format!(
+                    "vCPU state id {id} is outside configured count {expected}"
+                )));
+            }
+            if std::mem::replace(&mut seen[id], true) {
+                return Err(SnapshotError::InvalidSnapshot(format!(
+                    "duplicate vCPU state id {id}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -251,6 +302,16 @@ mod tests {
         assert_eq!(loaded.header.format_epoch, FORMAT_EPOCH);
         assert_eq!(loaded.header.producer_version, env!("CARGO_PKG_VERSION"));
         assert!(loaded.vcpu_states.is_empty());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_default_microvm_state_is_not_restorable() {
+        assert!(matches!(
+            MicrovmState::default().validate_for_restore(1),
+            Err(SnapshotError::InvalidSnapshot(message))
+                if message == "missing VM-scoped KVM state"
+        ));
     }
 
     #[test]

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -564,11 +564,12 @@ impl Vm {
                 .ok_or(StartMicroVmError::AddressManagerError(
                     AddressManagerError::GuestMemoryNotInitialized,
                 ))?;
+        let dmesg_fifo = self.dmesg_fifo.take();
         self.device_manager.create_devices(
             vm_as.clone(),
             epoll_manager,
             kernel_config,
-            self.dmesg_fifo.take(),
+            dmesg_fifo,
             self.address_space.address_space(),
             &self.vm_config,
         )?;
@@ -577,6 +578,41 @@ impl Vm {
         self.device_manager.start_devices(vm_as)?;
 
         info!(self.logger, "VM: initializing devices done");
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn init_devices_from_snapshot(
+        &mut self,
+        epoll_manager: EpollManager,
+    ) -> std::result::Result<(), StartMicroVmError> {
+        info!(self.logger, "VM: initializing devices from snapshot ...");
+
+        info!(self.logger, "VM: create interrupt manager");
+        self.device_manager
+            .create_interrupt_manager()
+            .map_err(StartMicroVmError::DeviceManager)?;
+
+        info!(self.logger, "VM: create devices");
+        let vm_as =
+            self.address_space
+                .get_vm_as()
+                .ok_or(StartMicroVmError::AddressManagerError(
+                    AddressManagerError::GuestMemoryNotInitialized,
+                ))?;
+        let dmesg_fifo = self.dmesg_fifo.take();
+        self.device_manager.create_devices_from_snapshot(
+            vm_as.clone(),
+            epoll_manager,
+            dmesg_fifo,
+            self.address_space.address_space(),
+            &self.vm_config,
+        )?;
+
+        info!(self.logger, "VM: start devices");
+        self.device_manager.start_devices(vm_as)?;
+
+        info!(self.logger, "VM: initializing devices from snapshot done");
         Ok(())
     }
 
@@ -872,12 +908,12 @@ impl Vm {
     /// Start a microVM by restoring it from a snapshot (see
     /// [`Vm::save_microvm`]) instead of cold booting.
     ///
-    /// The VM must have been configured with the *same configuration*
-    /// (machine config, boot source, devices) the snapshot was taken with.
-    /// This mirrors [`Vm::start_microvm`] but skips the boot-time system
-    /// configuration and applies the snapshot before the vCPUs start:
-    /// guest memory contents, device runtime state (replaying virtio
-    /// activation) and vCPU register state.
+    /// The VM must have been configured with the same machine and devices the
+    /// snapshot was taken with. A boot source is not required: this mirrors
+    /// [`Vm::start_microvm`] but skips kernel loading and boot-time system
+    /// configuration, then applies the snapshot before the vCPUs start. The
+    /// snapshot restores guest memory contents, device runtime state
+    /// (replaying virtio activation) and vCPU register state.
     #[cfg(target_arch = "x86_64")]
     pub fn start_microvm_from_snapshot(
         &mut self,
@@ -909,7 +945,6 @@ impl Vm {
         self.start_instance_request_cpu_ts = request_ts.cputime_us;
 
         self.init_dmesg_logger();
-        self.check_health()?;
 
         // Use expect() to crash if the other thread poisoned this lock.
         self.shared_info
@@ -933,11 +968,10 @@ impl Vm {
                 .unwrap_or_default(),
         )
         .map_err(StartMicroVmError::Vcpu)?;
-        // Creates devices and boot vCPUs. The boot-time vCPU register setup
-        // performed here is overwritten by the snapshot state below; the
-        // boot-time system configuration (`init_configure_system`) is
-        // skipped entirely since guest memory is reloaded from the snapshot.
-        self.init_microvm(event_mgr.epoll_manager(), vm_as.clone(), request_ts)?;
+        // Recreate host-side devices and fresh vCPU objects without requiring
+        // a boot source. The snapshot supplies guest memory, the finalized
+        // kernel command line and all vCPU state before execution resumes.
+        self.init_microvm_from_snapshot(event_mgr.epoll_manager(), vm_as.clone(), request_ts)?;
         #[cfg(feature = "dbs-upcall")]
         self.init_upcall()?;
 
@@ -1256,6 +1290,7 @@ impl Vm {
         use dbs_snapshot::Persist;
 
         let state = MicrovmState::load_from_file(state_path)?;
+        state.validate_for_restore(self.vm_config.vcpu_count)?;
 
         // Restore the VM-scoped KVM state first: interrupt delivery for
         // everything below depends on the IOAPIC/PIC redirection tables the
@@ -1337,6 +1372,8 @@ pub mod tests {
     use kvm_ioctls::VcpuExit;
     use linux_loader::cmdline::Cmdline;
     use test_utils::skip_if_kvm_unaccessable;
+    #[cfg(target_arch = "x86_64")]
+    use vm_memory::Address;
     use vm_memory::GuestMemory;
     use vmm_sys_util::tempfile::TempFile;
 
@@ -1370,6 +1407,237 @@ pub mod tests {
         assert!(!vm.is_vm_initialized());
         assert!(!vm.is_vm_running());
         assert!(vm.reset_console().is_ok());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_restore_initialization_without_kernel_config() {
+        skip_if_kvm_unaccessable!();
+
+        let vm_config = VmConfigInfo {
+            vcpu_count: 1,
+            max_vcpu_count: 1,
+            cpu_pm: "off".to_string(),
+            mem_type: "shmem".to_string(),
+            mem_file_path: "".to_string(),
+            mem_size_mib: 16,
+            serial_path: None,
+            cpu_topology: CpuTopology {
+                threads_per_core: 1,
+                cores_per_die: 1,
+                dies_per_socket: 1,
+                sockets: 1,
+            },
+            vpmu_feature: 0,
+            pci_hotplug_enabled: false,
+        };
+
+        let restore_epoll = EpollManager::default();
+        let mut restore_vm = create_vm_instance();
+        restore_vm.set_vm_config(vm_config.clone());
+        restore_vm.init_guest_memory().unwrap();
+        let restore_vm_as = restore_vm.vm_as().cloned().unwrap();
+        restore_vm
+            .init_vcpu_manager(restore_vm_as.clone(), Default::default())
+            .unwrap();
+
+        restore_vm
+            .init_microvm_from_snapshot(restore_epoll, restore_vm_as, TimestampUs::default())
+            .unwrap();
+
+        assert!(restore_vm.kernel_config.is_none());
+        assert_eq!(restore_vm.vcpu_manager().unwrap().vcpus().len(), 1);
+
+        let cold_epoll = EpollManager::default();
+        let mut cold_vm = create_vm_instance();
+        cold_vm.set_vm_config(vm_config);
+        cold_vm.init_guest_memory().unwrap();
+        let cold_vm_as = cold_vm.vm_as().cloned().unwrap();
+        cold_vm
+            .init_vcpu_manager(cold_vm_as.clone(), Default::default())
+            .unwrap();
+
+        let err = cold_vm
+            .init_microvm(cold_epoll, cold_vm_as, TimestampUs::default())
+            .unwrap_err();
+        assert!(matches!(err, StartMicroVmError::MissingKernelConfig));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_restore_valid_snapshot_without_kernel_config() {
+        use crate::snapshot::{MicrovmState, SnapshotError};
+        use dbs_snapshot::Persist;
+
+        skip_if_kvm_unaccessable!();
+
+        const CODE_ADDRESS: GuestAddress = GuestAddress(0x1000);
+        const MARKER_ADDRESS: GuestAddress = GuestAddress(0x2000);
+        const MEMORY_MARKER: u64 = 0xdbdb_1375_2db0_0bad;
+
+        let vm_config = VmConfigInfo {
+            vcpu_count: 1,
+            max_vcpu_count: 1,
+            cpu_pm: "off".to_string(),
+            mem_type: "shmem".to_string(),
+            mem_file_path: "".to_string(),
+            mem_size_mib: 16,
+            serial_path: None,
+            cpu_topology: CpuTopology {
+                threads_per_core: 1,
+                cores_per_die: 1,
+                dies_per_socket: 1,
+                sockets: 1,
+            },
+            vpmu_feature: 0,
+            pci_hotplug_enabled: false,
+        };
+        let state_file = TempFile::new().unwrap();
+        let memory_file = TempFile::new().unwrap();
+
+        // Build a complete snapshot without configuring a boot source. The
+        // two-byte loop gives the restored vCPU safe code to execute until the
+        // test shuts it down, while the marker verifies guest-memory restore.
+        let source_epoll = EpollManager::default();
+        let mut source = create_vm_instance();
+        source.set_vm_config(vm_config.clone());
+        source.init_guest_memory().unwrap();
+        let source_vm_as = source.vm_as().cloned().unwrap();
+        source
+            .init_vcpu_manager(source_vm_as.clone(), Default::default())
+            .unwrap();
+        source
+            .init_microvm_from_snapshot(source_epoll, source_vm_as, TimestampUs::default())
+            .unwrap();
+
+        let source_memory = source.address_space.vm_memory().unwrap();
+        source_memory
+            .write_slice(&[0xeb, 0xfe], CODE_ADDRESS)
+            .unwrap();
+        source_memory
+            .write_obj(MEMORY_MARKER, MARKER_ADDRESS)
+            .unwrap();
+
+        let msr_list = source.kvm.supported_msrs(0).unwrap();
+        let mut vcpu_states = {
+            let mut manager = source.vcpu_manager().unwrap();
+            manager
+                .vcpus_mut()
+                .into_iter()
+                .map(|vcpu| Persist::save_state(vcpu, msr_list.as_slice()).unwrap())
+                .collect::<Vec<_>>()
+        };
+        vcpu_states[0].regs.rip = CODE_ADDRESS.raw_value();
+        vcpu_states[0].regs.rflags = 2;
+        vcpu_states[0].regs.rbx = MEMORY_MARKER;
+        vcpu_states[0].sregs.cs.base = 0;
+        vcpu_states[0].sregs.cs.selector = 0;
+
+        {
+            let mut manager = source.vcpu_manager().unwrap();
+            Persist::restore_state(&mut *manager, &vcpu_states, ()).unwrap();
+            manager
+                .start_vcpus(vm_config.vcpu_count, Default::default(), false)
+                .unwrap();
+        }
+        source.set_instance_state(InstanceState::Paused);
+        source
+            .save_microvm(state_file.as_path(), memory_file.as_path())
+            .unwrap();
+
+        let snapshot = MicrovmState::load_from_file(state_file.as_path()).unwrap();
+        snapshot.validate_for_restore(vm_config.vcpu_count).unwrap();
+
+        let mut incomplete: MicrovmState =
+            serde_json::from_value(serde_json::to_value(&snapshot).unwrap()).unwrap();
+        incomplete.vcpu_states.clear();
+        assert!(matches!(
+            incomplete.validate_for_restore(vm_config.vcpu_count),
+            Err(SnapshotError::InvalidSnapshot(message))
+                if message == "expected 1 vCPU states, found 0"
+        ));
+
+        let mut duplicate_json = serde_json::to_value(&snapshot).unwrap();
+        let states = duplicate_json["vcpu_states"].as_array_mut().unwrap();
+        states.push(states[0].clone());
+        let duplicate: MicrovmState = serde_json::from_value(duplicate_json).unwrap();
+        assert!(matches!(
+            duplicate.validate_for_restore(2),
+            Err(SnapshotError::InvalidSnapshot(message))
+                if message == "duplicate vCPU state id 0"
+        ));
+
+        source.vcpu_manager().unwrap().exit_all_vcpus().unwrap();
+        drop(source);
+
+        // Inspect a fresh target before vCPU launch so both memory and register
+        // markers can be checked deterministically.
+        let inspect_epoll = EpollManager::default();
+        let mut inspected = create_vm_instance();
+        inspected.set_vm_config(vm_config.clone());
+        inspected.init_guest_memory().unwrap();
+        let inspected_vm_as = inspected.vm_as().cloned().unwrap();
+        inspected
+            .init_vcpu_manager(inspected_vm_as.clone(), Default::default())
+            .unwrap();
+        inspected
+            .init_microvm_from_snapshot(inspect_epoll, inspected_vm_as, TimestampUs::default())
+            .unwrap();
+        inspected
+            .restore_microvm(state_file.as_path(), memory_file.as_path())
+            .unwrap();
+        assert_eq!(
+            inspected
+                .address_space
+                .vm_memory()
+                .unwrap()
+                .read_obj::<u64>(MARKER_ADDRESS)
+                .unwrap(),
+            MEMORY_MARKER
+        );
+        let inspected_msrs = inspected.kvm.supported_msrs(0).unwrap();
+        let inspected_vcpu_states = {
+            let mut manager = inspected.vcpu_manager().unwrap();
+            manager
+                .vcpus_mut()
+                .into_iter()
+                .map(|vcpu| Persist::save_state(vcpu, inspected_msrs.as_slice()).unwrap())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(inspected_vcpu_states[0].regs.rbx, MEMORY_MARKER);
+        drop(inspected);
+
+        let target_epoll = EpollManager::default();
+        let vmm = Arc::new(Mutex::new(crate::vmm::tests::create_vmm_instance(
+            target_epoll.clone(),
+        )));
+        let mut event_manager = EventManager::new(&vmm, target_epoll).unwrap();
+        let mut vmm = vmm.lock().unwrap();
+        let target = vmm.get_vm_mut().unwrap();
+        target.set_vm_config(vm_config);
+
+        target
+            .start_microvm_from_snapshot(
+                &mut event_manager,
+                Default::default(),
+                state_file.as_path(),
+                memory_file.as_path(),
+            )
+            .unwrap();
+
+        assert!(target.kernel_config.is_none());
+        assert_eq!(target.instance_state(), InstanceState::Running);
+        assert_eq!(
+            target
+                .address_space
+                .vm_memory()
+                .unwrap()
+                .read_obj::<u64>(MARKER_ADDRESS)
+                .unwrap(),
+            MEMORY_MARKER
+        );
+
+        target.vcpu_manager().unwrap().exit_all_vcpus().unwrap();
     }
 
     #[test]

--- a/src/dragonball/src/vm/x86_64.rs
+++ b/src/dragonball/src/vm/x86_64.rs
@@ -183,6 +183,32 @@ impl Vm {
         vm_as: GuestAddressSpaceImpl,
         request_ts: TimestampUs,
     ) -> std::result::Result<(), StartMicroVmError> {
+        self.init_microvm_with_boot_mode(epoll_mgr, vm_as, request_ts, false)
+    }
+
+    /// Initialize a microVM that will resume from a snapshot.
+    ///
+    /// Unlike a cold boot, a snapshot restore does not need to load the guest
+    /// kernel or construct its initial boot register state: guest memory and
+    /// every vCPU register are replaced by the saved state before the vCPUs
+    /// start. Avoiding that throwaway work keeps the restore path focused on
+    /// rebuilding host-side devices and applying the snapshot.
+    pub fn init_microvm_from_snapshot(
+        &mut self,
+        epoll_mgr: EpollManager,
+        vm_as: GuestAddressSpaceImpl,
+        request_ts: TimestampUs,
+    ) -> std::result::Result<(), StartMicroVmError> {
+        self.init_microvm_with_boot_mode(epoll_mgr, vm_as, request_ts, true)
+    }
+
+    fn init_microvm_with_boot_mode(
+        &mut self,
+        epoll_mgr: EpollManager,
+        vm_as: GuestAddressSpaceImpl,
+        request_ts: TimestampUs,
+        restore_from_snapshot: bool,
+    ) -> std::result::Result<(), StartMicroVmError> {
         info!(self.logger, "VM: start initializing microvm ...");
 
         self.init_tss()?;
@@ -190,7 +216,11 @@ impl Vm {
         // while on aarch64 we need to do it the other way around.
         self.setup_interrupt_controller()?;
         self.create_pit()?;
-        self.init_devices(epoll_mgr)?;
+        if restore_from_snapshot {
+            self.init_devices_from_snapshot(epoll_mgr)?;
+        } else {
+            self.init_devices(epoll_mgr)?;
+        }
 
         let reset_event_fd = self.device_manager.get_reset_eventfd().unwrap();
         self.vcpu_manager()
@@ -201,6 +231,18 @@ impl Vm {
         if self.vm_config.cpu_pm == "on" {
             // TODO: add cpu_pm support. issue #4590.
             info!(self.logger, "VM: enable CPU disable_idle_exits capability");
+        }
+
+        // On a standard cold start, vCPU creation is deferred to
+        // `create_boot_vcpus()` until after the kernel has been loaded.
+        if restore_from_snapshot {
+            let boot_vcpu_count = self.vm_config.vcpu_count;
+            self.vcpu_manager()
+                .map_err(StartMicroVmError::Vcpu)?
+                .create_vcpus(boot_vcpu_count, Some(request_ts), None, None)
+                .map_err(StartMicroVmError::Vcpu)?;
+
+            return Ok(());
         }
 
         let vm_memory = vm_as.memory();

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -140,8 +140,25 @@ impl DragonballInner {
         info!(sl!(), "start sandbox cold");
 
         self.set_vm_base_config().context("set vm base config")?;
+        self.configure_boot_source()?;
 
-        // get kernel params
+        // add pending devices
+        while let Some(dev) = self.pending_devices.pop() {
+            self.add_device(dev).await.context("add_device")?;
+        }
+
+        // start vmm and wait ready
+        self.start_vmm_instance().context("start vmm instance")?;
+        self.wait_vmm_ready(timeout).context("wait vmm")?;
+
+        Ok(())
+    }
+
+    fn configure_boot_source(&mut self) -> Result<()> {
+        if self.config.vm_template.boot_from_template {
+            return Ok(());
+        }
+
         let mut kernel_params = KernelParams::new(self.config.debug_info.enable_debug);
 
         if self.config.boot_info.initrd.is_empty() {
@@ -171,18 +188,7 @@ impl DragonballInner {
                 .to_string()
                 .context("kernel params to string")?,
         )
-        .context("set_boot_source")?;
-
-        // add pending devices
-        while let Some(dev) = self.pending_devices.pop() {
-            self.add_device(dev).await.context("add_device")?;
-        }
-
-        // start vmm and wait ready
-        self.start_vmm_instance().context("start vmm instance")?;
-        self.wait_vmm_ready(timeout).context("wait vmm")?;
-
-        Ok(())
+        .context("set_boot_source")
     }
 
     pub(crate) fn run_vmm_server(&mut self) -> Result<()> {
@@ -590,5 +596,20 @@ impl Persist for DragonballInner {
             balloon_size: 0,
             passfd_listener_port: hypervisor_state.passfd_listener_port,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_template_restore_skips_boot_source_configuration() {
+        let (tx, _) = mpsc::channel(1);
+        let mut inner = DragonballInner::new(tx);
+        inner.config.vm_template.boot_from_template = true;
+        inner.config.boot_info.kernel = "/kernel-must-not-be-opened".to_string();
+
+        inner.configure_boot_source().unwrap();
     }
 }


### PR DESCRIPTION
Snapshot state already supplies guest memory, the finalized kernel command
line, and every vCPU register. Rebuilding cold-boot state during restore adds
work that is immediately overwritten.

This PR adds a restore-specific initialization path that:

- rebuilds the required host-side devices and KVM vCPU objects;
- skips opening and loading the kernel;
- skips throwaway cold-boot register, FPU, page-table, and special-register
  initialization;
- restores devices without generating kernel boot arguments;
- rejects incomplete or inconsistent snapshot state before starting vCPUs;
- leaves the normal cold-boot path and public device-manager API unchanged.

The runtime also skips boot-source configuration when starting from a template,
so restore no longer requires a configured or readable kernel file. The tests
cover a complete save/restore KVM round trip, restored memory and registers,
invalid vCPU state, the kernel-free restore path, and the unchanged cold-boot
requirement.

This supersedes #13752 by folding its restore initialization optimization into
the complete boot-source-independent restore path.

## Performance

A controlled A/B benchmark used the same one-vCPU, 2-GiB, image-backed
Dragonball template with no shared filesystem. The optimized change was
cherry-picked onto the baseline revision so the restore patch was the only
source difference. Each build ran in three fresh processes, with one warmup
and ten measured restores per process.

| Build | Run 1 | Run 2 | Run 3 | Combined mean |
| --- | ---: | ---: | ---: | ---: |
| Pre-optimization | 28.042 ms | 23.282 ms | 28.092 ms | 26.472 ms |
| Optimized restore | 11.371 ms | 11.408 ms | 11.569 ms | 11.449 ms |

Restore-to-agent-ready latency fell by **15.023 ms**, a **56.8% reduction** and
a **2.31x speedup** across 30 measured restores per build.

A matching five-iteration phase trace showed where the saving occurred:

| Phase | Baseline | Optimized | Saved |
| --- | ---: | ---: | ---: |
| Dragonball `microvm_init` | 17.129 ms | 1.017 ms | 16.112 ms |
| Dragonball internal restore | 20.895 ms | 4.267 ms | 16.628 ms |

Host-side Dragonball seccomp was disabled for both benchmark builds. With it
enabled, the optimized `kata-ctl` benchmark received `SIGSYS` while creating a
second VM in the same process; a single restore succeeded. This repeated-VM
harness behavior needs separate investigation and is outside the production
lifecycle where one shim serves one sandbox.

## Validation

- `make -C src/dragonball check`
- `cargo fmt -p hypervisor -- --check`
- `cargo clippy -p hypervisor --all-targets --all-features -- -D warnings`
- `cargo test -p hypervisor --all-features dragonball -- --test-threads=1`
