### PR TITLE
agent: unmount nested bundle mounts before removing the bundle

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1363,6 +1363,13 @@ impl BaseContainer for LinuxContainer {
             warn!(self.logger, "rootfs not mounted");
             Ok(())
         })?;
+
+        // Storage handlers may place backing mounts inside the bundle, and the
+        // recursive delete below is mount-unaware: it would fail on a read-only
+        // filesystem such as EROFS, and silently wipe the contents of a
+        // writable one. Detach them first.
+        mount::umount_nested_mount_points(&self.root, &self.logger)?;
+
         fs::remove_dir_all(&self.root)?;
 
         Ok(())

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -650,6 +650,48 @@ pub fn parse_mount_table(mountinfo_path: &str) -> Result<Vec<Info>> {
     Ok(infos)
 }
 
+/// Collect the mount points nested under `root`, deepest first.
+///
+/// The ordering lets callers unmount children before their parents, and `root`
+/// itself is never included.
+fn get_nested_mount_points(mountinfo_path: &str, root: &str) -> Result<Vec<String>> {
+    let prefix = format!("{}/", root.trim_end_matches('/'));
+
+    let mut mount_points: Vec<String> = parse_mount_table(mountinfo_path)?
+        .into_iter()
+        .map(|info| info.mount_point)
+        .filter(|mount_point| mount_point.starts_with(&prefix))
+        .collect();
+
+    mount_points.sort_by_key(|mount_point| std::cmp::Reverse(mount_point.matches('/').count()));
+
+    Ok(mount_points)
+}
+
+/// Unmount everything still mounted under `root`.
+///
+/// Callers that are about to delete `root` recursively must do this first: a
+/// recursive delete is mount-unaware, so it would either fail on a read-only
+/// filesystem or descend into a writable one and destroy its contents.
+///
+/// A plain unmount is attempted before falling back to a lazy one, so that
+/// callers tearing down the backing devices afterwards do not race with a
+/// detach that has not completed yet.
+pub fn umount_nested_mount_points(root: &str, logger: &slog::Logger) -> Result<()> {
+    for mount_point in get_nested_mount_points(MOUNTINFO_PATH, root)? {
+        if let Err(e) = umount2(mount_point.as_str(), MntFlags::empty())
+            .or_else(|_| umount2(mount_point.as_str(), MntFlags::MNT_DETACH))
+        {
+            warn!(
+                logger,
+                "failed to umount {} nested under {}: {:?}", mount_point, root, e
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[inline(always)]
 #[cfg(not(test))]
 fn chroot<P: ?Sized + NixPath>(path: &P) -> Result<(), nix::Error> {
@@ -1716,6 +1758,53 @@ mod tests {
 
             assert_result!(d.result, result, msg);
         }
+    }
+
+    #[test]
+    fn test_get_nested_mount_points() {
+        let mountinfo_data = r#"22 933 0:20 / / rw,nodev - tmpfs tmpfs rw
+                               23 22 0:21 / /run/kata-containers/cid/rootfs rw shared:2 - overlay overlay rw
+                               24 22 0:22 / /run/kata-containers/cid/multi-layer/upper rw shared:3 - ext4 /dev/vda rw
+                               25 22 0:23 / /run/kata-containers/cid/multi-layer/lower-0 ro shared:4 - erofs /dev/vdb ro
+                               26 22 0:24 / /run/kata-containers/cid-other/rootfs rw shared:5 - overlay overlay rw
+                               27 22 0:25 / /run/kata-containers/cid rw shared:6 - tmpfs tmpfs rw"#;
+
+        let tempdir = tempdir().unwrap();
+        let mountinfo_path = tempdir.path().join("mountinfo");
+        std::fs::write(&mountinfo_path, mountinfo_data).unwrap();
+
+        let result =
+            get_nested_mount_points(mountinfo_path.to_str().unwrap(), "/run/kata-containers/cid")
+                .unwrap();
+
+        // A sibling bundle sharing the same prefix, and the bundle itself, are
+        // both excluded. The remaining mount points come back deepest first.
+        assert_eq!(
+            result,
+            vec![
+                "/run/kata-containers/cid/multi-layer/upper".to_string(),
+                "/run/kata-containers/cid/multi-layer/lower-0".to_string(),
+                "/run/kata-containers/cid/rootfs".to_string(),
+            ]
+        );
+
+        // A trailing separator on the root must not change the outcome.
+        assert_eq!(
+            get_nested_mount_points(
+                mountinfo_path.to_str().unwrap(),
+                "/run/kata-containers/cid/"
+            )
+            .unwrap(),
+            result
+        );
+
+        // A bundle with nothing mounted underneath it.
+        assert!(get_nested_mount_points(
+            mountinfo_path.to_str().unwrap(),
+            "/run/kata-containers/cid-other/rootfs"
+        )
+        .unwrap()
+        .is_empty());
     }
 
     #[test]

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -454,13 +454,13 @@ impl AgentService {
         if req.timeout == 0 {
             let mut sandbox = self.sandbox.lock().await;
             sandbox.bind_watcher.remove_container(&cid).await;
-            sandbox
+            let destroyed = sandbox
                 .get_container(&cid)
                 .ok_or_else(|| anyhow!("Invalid container id"))?
                 .destroy()
-                .await?;
-            remove_container_resources(&mut sandbox, &cid).await?;
-            return Ok(());
+                .await;
+            log_container_destroy_failure(&cid, &destroyed);
+            return remove_container_resources(&mut sandbox, &cid).await;
         }
 
         // timeout != 0
@@ -476,10 +476,13 @@ impl AgentService {
                 .await
         });
 
+        // A timeout leaves destroy() running and holding the sandbox lock, so
+        // there is no safe way to carry on reclaiming resources here.
         let to = Duration::from_secs(req.timeout.into());
-        tokio::time::timeout(to, handle)
+        let destroyed = tokio::time::timeout(to, handle)
             .await
-            .map_err(|_| anyhow!(nix::Error::ETIME))???;
+            .map_err(|_| anyhow!(nix::Error::ETIME))??;
+        log_container_destroy_failure(&cid, &destroyed);
 
         remove_container_resources(&mut *self.sandbox.lock().await, &cid).await
     }
@@ -2164,6 +2167,17 @@ fn update_container_namespaces(
     }
 
     Ok(())
+}
+
+// Tearing the bundle down and reclaiming the container's resources are
+// independent steps, and the resources are what the host waits on before it
+// cleans up its own volumes and rootfs. So a destroy() failure is reported but
+// never allowed to skip remove_container_resources(); whatever is left of the
+// bundle is reclaimed when the sandbox itself is destroyed.
+fn log_container_destroy_failure(cid: &str, result: &Result<()>) {
+    if let Err(e) = result {
+        error!(sl(), "failed to destroy container {}: {:?}", cid, e);
+    }
 }
 
 async fn remove_container_resources(sandbox: &mut Sandbox, cid: &str) -> Result<()> {


### PR DESCRIPTION
## What

Make container bundle teardown mount-aware, so a storage handler can mount things inside `/run/kata-containers/<cid>` without breaking `remove_container`.

Fixes #13757. Alternative to #13756, which fixes the same issue by relocating the multi-layer EROFS backing mounts to `/run/kata-erofs/<cid>`.

## Why

`LinuxContainer::destroy()` detaches exactly one mount, the bundle's `rootfs` bind, and then hands the whole bundle to `fs::remove_dir_all()`. That delete is mount-unaware, so anything still mounted underneath is walked into instead of unmounted.

The multi-layer EROFS handler mounts the overlay's lower layers at `<bundle>/multi-layer/lower-N` and, when the host provides one, an ext4 upper at `<bundle>/multi-layer/upper`. Both outcomes are bad, and only one of them is visible:

- The EROFS lowers are read-only, so the delete fails with `EROFS`, `destroy()` returns an error, and every `remove_container` RPC for a container using EROFS fails. This is the reported symptom.
- The ext4 upper is writable, so the delete quietly descends into the mounted filesystem and erases the contents of the container's rw layer on the backing block device. Nothing errors; the data is just gone.

Relocating the EROFS mounts addresses the first point for one handler. Fixing the teardown addresses both, and leaves the bundle usable as the single place a container's disposable state lives — `fs_handler` already puts the `overlay-rw` `upper`/`work` directories there, and `image_pull_handler` puts pulled bundles there.

## How

**1. Unmount nested bundle mounts before removing the bundle.**

`destroy()` now enumerates the mount points nested under the bundle from `/proc/self/mountinfo` and unmounts them, deepest first, before deleting it. A plain unmount is attempted before falling back to a lazy one, because `remove_container_resources()` destroys the layers' dm-verity devices immediately afterwards and must not race with a detach that has not completed.

Nothing else legitimately lives under the bundle in the agent's mount namespace: the container's own volume and `init_rootfs` mounts happen after `unshare(CLONE_NEWNS)` in the child, and the sandbox storages sit under `/run/kata-containers/shared/`.

**2. Do not let a failed container destroy leak its resources.**

`do_remove_container()` propagated a `destroy()` failure straight out of the RPC, skipping `remove_container_resources()` entirely, so a bundle that could not be deleted also leaked the container's storage mounts and dm-verity devices. It leaked host resources too: runtime-rs only calls `clean_volumes()` and `clean_rootfs()` after a successful `remove_container` unless the stop is forced.

The failure is now reported and resource reclamation carries on, the way the rollback path in `do_create_container()` already does. What is left behind is a directory in the guest's `/run`, reclaimed when the sandbox is destroyed, instead of mounts and devices on both sides of the VM.

This also makes the first commit safe to fail closed: if the mount table cannot be read, `destroy()` refuses to run the recursive delete rather than risk wiping a mounted filesystem, and that refusal no longer strands any resources.

## Test

- `cargo test -p rustjail` (63 passed) and `cargo test -p kata-agent` (386 passed), including the existing `test_linuxcontainer_destroy`.
- New unit test `test_get_nested_mount_points` covers the deepest-first ordering, exclusion of the root itself, exclusion of a sibling bundle sharing the same path prefix (`<cid>` vs `<cid>-other`), and a trailing separator on the root.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.

I have not been able to run this against a live multi-layer EROFS workload; @jind-oai, would you be able to confirm it clears the `Read-only file system (os error 30)` failure you hit in #13756?