### PR TITLE
runtime-rs: unblock stdio on destructive teardown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8124,6 +8124,7 @@ dependencies = [
  "bytes 1.11.1",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 slog = { workspace = true }
 slog-scope = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 url = { workspace = true }
 tracing = { workspace = true }
 oci-spec = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -30,6 +30,7 @@ use resource::{
     cdi_devices::container_device::annotate_container_devices, ResourceManager, ResourceUpdateOp,
 };
 use tokio::sync::RwLock;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use super::{
     process::{Process, ProcessWatcher},
@@ -42,6 +43,11 @@ pub struct Exec {
     pub(crate) oci_process: OCIProcess,
 }
 
+pub struct IoLifecycle {
+    pub(super) cancel: CancellationToken,
+    pub(super) tasks: TaskTracker,
+}
+
 pub struct Container {
     pid: u32,
     pub container_id: ContainerID,
@@ -52,6 +58,7 @@ pub struct Container {
     resource_manager: Arc<ResourceManager>,
     logger: slog::Logger,
     pub(crate) passfd_listener_addr: Option<(String, u32)>,
+    io: IoLifecycle,
 }
 
 fn process_uses_passfd_io(inner: &ContainerInner, process: &ContainerProcess) -> Result<bool> {
@@ -75,11 +82,12 @@ impl Container {
         agent: Arc<dyn Agent>,
         resource_manager: Arc<ResourceManager>,
         passfd_listener_addr: Option<(String, u32)>,
+        io: IoLifecycle,
     ) -> Result<Self> {
         let container_id = ContainerID::new(&config.container_id).context("new container id")?;
         let logger = sl!().new(o!("container_id" => config.container_id.clone()));
         let process = ContainerProcess::new(&config.container_id, "")?;
-        let init_process = Process::new(
+        let mut init_process = Process::new(
             &process,
             pid,
             &config.bundle,
@@ -88,6 +96,8 @@ impl Container {
             config.stderr.clone(),
             config.terminal,
         );
+        init_process.io_cancel = io.cancel.child_token();
+        init_process.io_tasks = io.tasks.clone();
         let linux_resources = spec
             .linux()
             .as_ref()
@@ -108,6 +118,7 @@ impl Container {
             resource_manager,
             logger,
             passfd_listener_addr,
+            io,
         })
     }
 
@@ -475,6 +486,7 @@ impl Container {
         container_process: &ContainerProcess,
         signal: u32,
         all: bool,
+        io_cancel: &mut Option<CancellationToken>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
 
@@ -502,6 +514,19 @@ impl Container {
             return Ok(());
         }
 
+        // Capture only after the stopped-process no-op check, even for all=true.
+        // Keep the exact instance: the exec ID can be reused after this guard.
+        if signal == libc::SIGKILL as u32 {
+            *io_cancel = if all || container_process.exec_id.is_empty() {
+                Some(inner.init_process.io_cancel.clone())
+            } else {
+                inner
+                    .exec_processes
+                    .get(&container_process.exec_id)
+                    .map(|exec| exec.process.io_cancel.clone())
+            };
+        }
+
         match inner.signal_process(container_process, signal, all).await {
             Ok(()) => Ok(()),
             Err(e) if is_term_signal && is_no_such_process_error(&e) => {
@@ -515,6 +540,17 @@ impl Container {
                 Ok(())
             }
             Err(e) => Err(e),
+        }
+    }
+
+    pub(crate) fn cancel_io(&self) {
+        self.io.cancel.cancel();
+    }
+
+    pub(crate) async fn cancel_exec_io(&self, exec_id: &str) {
+        let inner = self.inner.read().await;
+        if let Some(exec) = inner.exec_processes.get(exec_id) {
+            exec.process.io_cancel.cancel();
         }
     }
 
@@ -532,7 +568,7 @@ impl Container {
             oci_process.set_selinux_label(None);
         }
 
-        let process = Process::new(
+        let mut process = Process::new(
             container_process,
             self.pid,
             &self.config.bundle,
@@ -541,6 +577,8 @@ impl Container {
             stderr,
             terminal,
         );
+        process.io_cancel = self.io.cancel.child_token();
+        process.io_tasks = self.io.tasks.clone();
         let exec = Exec {
             process,
             oci_process,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/binary_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/binary_io.rs
@@ -23,6 +23,7 @@ use tokio::{
     net::unix::pipe::Sender,
     process::{Child, Command},
 };
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 const BINARY_IO_PROC_DRAIN_TIMEOUT: Duration = Duration::from_secs(12);
@@ -39,7 +40,30 @@ pub(crate) struct BinaryLogger {
 }
 
 impl BinaryLogger {
-    pub(crate) async fn shutdown(mut self) {
+    pub(crate) async fn shutdown(mut self, cancel: &CancellationToken) {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {},
+            _ = self.wait_for_exit() => return,
+        }
+
+        // A destructive operation must not wait for a stalled logger to drain.
+        // Keep ownership until it has actually been killed and reaped.
+        if let Err(err) = self.child.kill().await {
+            warn!(
+                sl!(),
+                "failed to kill binary logger during teardown: {}", err
+            );
+        }
+        if let Err(err) = self.child.wait().await {
+            warn!(
+                sl!(),
+                "failed to reap binary logger during teardown: {}", err
+            );
+        }
+    }
+
+    async fn wait_for_exit(&mut self) {
         match tokio::time::timeout(BINARY_IO_PROC_DRAIN_TIMEOUT, self.child.wait()).await {
             Ok(Ok(status)) => {
                 info!(sl!(), "binary logger exited with {}", status);
@@ -215,6 +239,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn destructive_cancellation_kills_and_reaps_logger() {
+        for cancel_before_wait in [false, true] {
+            let dir =
+                std::env::temp_dir().join(format!("kata-logger-cancel-{}", uuid::Uuid::new_v4()));
+            fs::create_dir(&dir).unwrap();
+            let helper = dir.join("logger");
+            // exec retains the PID and creates no child that could outlive the logger.
+            fs::write(
+                &helper,
+                "#!/bin/sh\ntrap '' TERM\nprintf x >&5\nexec /bin/sleep 300\n",
+            )
+            .unwrap();
+            fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
+            let io = open(
+                &Url::parse(&format!("binary://{}", helper.display())).unwrap(),
+                "test",
+                "test",
+            )
+            .await
+            .unwrap();
+            let pid = io.logger.child.id().unwrap() as i32;
+            let cancel = CancellationToken::new();
+            if cancel_before_wait {
+                cancel.cancel();
+            }
+            let shutdown = io.logger.shutdown(&cancel);
+            tokio::pin!(shutdown);
+            if !cancel_before_wait {
+                tokio::select! {
+                    biased;
+                    _ = &mut shutdown => panic!("logger exited before cancellation"),
+                    _ = tokio::task::yield_now() => {},
+                }
+                cancel.cancel();
+            }
+            tokio::time::timeout(Duration::from_secs(2), shutdown)
+                .await
+                .unwrap();
+            assert_eq!(
+                kill(Pid::from_raw(pid), None),
+                Err(nix::errno::Errno::ESRCH)
+            );
+            assert_eq!(
+                nix::sys::wait::waitpid(
+                    Pid::from_raw(pid),
+                    Some(nix::sys::wait::WaitPidFlag::WNOHANG)
+                ),
+                Err(nix::errno::Errno::ECHILD)
+            );
+            drop(io.stdout);
+            drop(io.stderr);
+            fs::remove_dir_all(dir).unwrap();
+        }
+    }
+
+    #[tokio::test]
     async fn streams_to_binary_logger_and_passes_metadata() {
         let dir = std::env::temp_dir().join(format!(
             "kata-binary-logger-test-{}",
@@ -249,7 +329,7 @@ printf '%s\n%s\n%s\n%s\n' "$CONTAINER_ID" "$CONTAINER_NAMESPACE" "$1" "$2" > "$2
         io.stderr.write_all(b"stderr data\n").await.unwrap();
         drop(io.stdout);
         drop(io.stderr);
-        io.logger.shutdown().await;
+        io.logger.shutdown(&CancellationToken::new()).await;
 
         assert_eq!(
             fs::read(output.with_extension("stdout")).unwrap(),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
@@ -4,21 +4,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    io,
-    os::unix::{
-        fs::{FileTypeExt, OpenOptionsExt},
-        io::RawFd,
-        prelude::AsRawFd,
-    },
-    pin::Pin,
-    task::{Context as TaskContext, Poll},
+use std::os::unix::{
+    fs::{FileTypeExt, OpenOptionsExt},
+    io::RawFd,
+    prelude::AsRawFd,
 };
 
 use anyhow::{Context, Result};
 use tokio::{
-    fs::{File, OpenOptions},
+    fs::File,
     io::{AsyncRead, AsyncWrite},
+    net::unix::pipe::{Receiver, Sender},
 };
 use url::Url;
 
@@ -37,7 +33,23 @@ fn set_flag_with_blocking(fd: RawFd) {
     }
 }
 
-fn open_fifo_write(path: &str) -> Result<File> {
+async fn open_fifo_read(path: &str) -> Result<Box<dyn AsyncRead + Send + Unpin>> {
+    let file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+        .await
+        .with_context(|| format!("open fifo for read: {path}"))?;
+    if file.metadata().await?.file_type().is_fifo() {
+        return Ok(Box::new(Receiver::from_owned_fd(
+            file.into_std().await.into(),
+        )?));
+    }
+    set_flag_with_blocking(file.as_raw_fd());
+    Ok(Box::new(file))
+}
+
+fn open_fifo_write(path: &str) -> Result<Box<dyn AsyncWrite + Send + Unpin>> {
     let std_file = std::fs::OpenOptions::new()
         .write(true)
         // It's not for non-block openning FIFO but for non-block stream which
@@ -46,15 +58,13 @@ fn open_fifo_write(path: &str) -> Result<File> {
         .open(path)
         .with_context(|| format!("open fifo for write: {path}"))?;
 
-    // Debug
-    let meta = std_file.metadata()?;
-    if !meta.file_type().is_fifo() {
-        debug!(sl!(), "[DEBUG]{} is not a fifo (type mismatch)", path);
+    if std_file.metadata()?.file_type().is_fifo() {
+        return Ok(Box::new(Sender::from_owned_fd(std_file.into())?));
     }
 
     set_flag_with_blocking(std_file.as_raw_fd());
 
-    Ok(File::from_std(std_file))
+    Ok(Box::new(File::from_std(std_file)))
 }
 
 pub struct ShimIo {
@@ -82,17 +92,8 @@ impl ShimIo {
 
             // Since we had opened the stdin as write mode in the Process::new function,
             // thus it wouldn't be blocked to open it as read mode.
-            match OpenOptions::new()
-                .read(true)
-                .custom_flags(libc::O_NONBLOCK)
-                .open(&stdin)
-                .await
-            {
-                Ok(file) => {
-                    // Set it to blocking to avoid infinitely handling EAGAIN when the reader is empty
-                    set_flag_with_blocking(file.as_raw_fd());
-                    Some(Box::new(file))
-                }
+            match open_fifo_read(stdin).await {
+                Ok(file) => Some(file),
                 Err(err) => {
                     error!(sl!(), "failed to open {} error {:?}", &stdin, err);
                     None
@@ -138,7 +139,7 @@ impl ShimIo {
                 if url.scheme() == "fifo" {
                     let path = url.path();
                     match open_fifo_write(path) {
-                        Ok(f) => return Some(Box::new(ShimIoWrite::File(f))),
+                        Ok(f) => return Some(f),
                         Err(err) => error!(sl!(), "failed to open fifo {} error {:?}", path, err),
                     }
                 } else {
@@ -160,32 +161,65 @@ impl ShimIo {
     }
 }
 
-#[derive(Debug)]
-enum ShimIoWrite {
-    File(File),
-    // TODO: support other type
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-impl AsyncWrite for ShimIoWrite {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut TaskContext<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        match &mut *self {
-            ShimIoWrite::File(f) => Pin::new(f).poll_write(cx, buf),
-        }
+    #[test]
+    fn stdin_open_uses_blocking_pool() {
+        let path = std::env::temp_dir().join(format!("kata-file-{}", uuid::Uuid::new_v4()));
+        std::fs::write(&path, b"stdin payload").unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            });
+            entered_rx.recv().unwrap();
+            let open = open_fifo_read(path.to_str().unwrap());
+            tokio::pin!(open);
+            let synchronous = tokio::select! {
+                biased;
+                _ = &mut open => true,
+                _ = tokio::task::yield_now() => false,
+            };
+            // Release before asserting so even a regression cannot hang runtime drop.
+            release_tx.send(()).unwrap();
+            blocker.await.unwrap();
+            assert!(!synchronous, "stdin open bypassed the blocking pool");
+            let mut reader = open.await.unwrap();
+            let mut data = Vec::new();
+            reader.read_to_end(&mut data).await.unwrap();
+            assert_eq!(data, b"stdin payload");
+        });
+        std::fs::remove_file(path).unwrap();
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            ShimIoWrite::File(f) => Pin::new(f).poll_flush(cx),
-        }
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            ShimIoWrite::File(f) => Pin::new(f).poll_shutdown(cx),
-        }
+    #[tokio::test]
+    async fn regular_file_fallback_preserves_flags_and_flush() {
+        let dir = std::env::temp_dir().join(format!("kata-file-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&dir).unwrap();
+        let input = dir.join("input");
+        let output = dir.join("output");
+        std::fs::write(&input, b"abcdef").unwrap();
+        std::fs::write(&output, b"XXXXXXXX-tail").unwrap();
+        let mut reader = open_fifo_read(input.to_str().unwrap()).await.unwrap();
+        let mut writer = open_fifo_write(output.to_str().unwrap()).unwrap();
+        assert_eq!(tokio::io::copy(&mut reader, &mut writer).await.unwrap(), 6);
+        writer.flush().await.unwrap();
+        drop(writer);
+        assert_eq!(std::fs::read(&output).unwrap(), b"abcdefXX-tail");
+        assert!(open_fifo_write(dir.join("missing").to_str().unwrap()).is_err());
+        let mut null = open_fifo_write("/dev/null").unwrap();
+        null.write_all(b"discard").await.unwrap();
+        null.flush().await.unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -25,13 +25,14 @@ use oci_spec::runtime as oci;
 use resource::ResourceManager;
 use runtime_spec as spec;
 use tokio::sync::{OnceCell, RwLock};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::instrument;
 
 use kata_sys_util::{hooks::HookStates, netns::NetnsGuard};
 
 use crate::container_manager::is_termination_signal;
 
-use super::{logger_with_process, Container};
+use super::{container::IoLifecycle, logger_with_process, Container};
 
 pub struct VirtContainerManager {
     sid: String,
@@ -41,6 +42,8 @@ pub struct VirtContainerManager {
     agent: Arc<dyn Agent>,
     hypervisor: Arc<dyn Hypervisor>,
     vmm_master_tid: OnceCell<u32>,
+    io_cancel: CancellationToken,
+    io_tasks: TaskTracker,
 }
 
 impl std::fmt::Debug for VirtContainerManager {
@@ -66,6 +69,8 @@ impl VirtContainerManager {
         agent: Arc<dyn Agent>,
         hypervisor: Arc<dyn Hypervisor>,
         resource_manager: Arc<ResourceManager>,
+        io_cancel: CancellationToken,
+        io_tasks: TaskTracker,
     ) -> Self {
         Self {
             sid: sid.to_string(),
@@ -75,6 +80,8 @@ impl VirtContainerManager {
             agent,
             hypervisor,
             vmm_master_tid: OnceCell::new(),
+            io_cancel,
+            io_tasks,
         }
     }
 
@@ -99,6 +106,10 @@ impl ContainerManager for VirtContainerManager {
             self.agent.clone(),
             self.resource_manager.clone(),
             self.hypervisor.get_passfd_listener_addr().await.ok(),
+            IoLifecycle {
+                cancel: self.io_cancel.child_token(),
+                tasks: self.io_tasks.clone(),
+            },
         )
         .await
         .context("new container")?;
@@ -164,6 +175,8 @@ impl ContainerManager for VirtContainerManager {
                 let c = containers
                     .remove(container_id)
                     .ok_or_else(|| Error::ContainerNotFound(container_id.to_string()))?;
+                // Signal only; never join I/O tasks while holding this registry lock.
+                c.cancel_io();
 
                 // Poststop Hooks:
                 // * should be run in runtime namespace
@@ -193,6 +206,7 @@ impl ContainerManager for VirtContainerManager {
                 let c = containers
                     .get(container_id)
                     .ok_or_else(|| Error::ContainerNotFound(container_id.to_string()))?;
+                c.cancel_exec_io(&process.exec_id).await;
                 let state = c.state_process(process).await.context("state process");
                 c.delete_exec_process(process)
                     .await
@@ -270,7 +284,9 @@ impl ContainerManager for VirtContainerManager {
         // agent returns ProcessAlreadyTerminated error.
         // For SIGKILL/SIGTERM, we should treat these as success since the
         // container is effectively terminated.
-        c.kill_process(&req.process, req.signal, req.all)
+        let mut io_cancel = None;
+        let result = c
+            .kill_process(&req.process, req.signal, req.all, &mut io_cancel)
             .await
             .or_else(|err| {
                 let is_term_signal = is_termination_signal(req.signal);
@@ -293,7 +309,15 @@ impl ContainerManager for VirtContainerManager {
                 } else {
                     Err(err)
                 }
-            })
+            });
+        // SIGTERM is catchable and must retain normal output draining. Only
+        // abandon output after SIGKILL was accepted (or the target is gone).
+        if req.signal == libc::SIGKILL as u32 && result.is_ok() {
+            if let Some(io_cancel) = io_cancel {
+                io_cancel.cancel();
+            }
+        }
+        result
     }
 
     #[instrument]

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
@@ -13,6 +13,7 @@ use awaitgroup::{WaitGroup, Worker as WaitGroupWorker};
 use common::types::{ContainerProcess, ProcessExitStatus, ProcessStateInfo, ProcessStatus, PID};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{watch, RwLock};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use super::container::Container;
 use super::io::{BinaryLogger, ContainerIo, PassfdIo, ShimIo};
@@ -77,6 +78,9 @@ pub struct Process {
 
     // io streams using vsock fd passthrough feature
     pub passfd_io: Option<PassfdIo>,
+    // Only destructive host operations cancel legacy stdio. Normal exit drains it.
+    pub(crate) io_cancel: CancellationToken,
+    pub(crate) io_tasks: TaskTracker,
 }
 
 fn open_fifo(path: &str, is_read: bool, is_write: bool) -> Result<File> {
@@ -134,6 +138,8 @@ impl Process {
             exit_watcher_rx: Some(receiver),
             exit_watcher_tx: Some(sender),
             passfd_io: None,
+            io_cancel: CancellationToken::new(),
+            io_tasks: TaskTracker::new(),
         }
     }
 
@@ -265,6 +271,8 @@ impl Process {
         container_io: ContainerIo,
     ) -> Result<()> {
         info!(self.logger, "start io and wait");
+        let _starting_io = self.io_tasks.token();
+        anyhow::ensure!(!self.io_cancel.is_cancelled(), "process I/O was cancelled");
 
         self.pre_fifos_open()?;
         // new shim io
@@ -325,33 +333,42 @@ impl Process {
 
         info!(self.logger, "run_io_copy[{}] starts", io_name);
         let logger = self.logger.new(o!("io_name" => io_name.clone()));
+        let io_cancel = self.io_cancel.clone();
+        let io_done = self.io_tasks.token();
 
         tokio::spawn(async move {
-            match tokio::io::copy(&mut reader, &mut writer).await {
-                Err(e) => {
+            let result = tokio::select! {
+                biased;
+                _ = io_cancel.cancelled() => {
+                    info!(logger, "run_io_copy[{}]: cancelled for teardown", io_name);
+                    None
+                }
+                result = tokio::io::copy(&mut reader, &mut writer) => Some(result),
+            };
+            match result {
+                None => {}
+                Some(Err(e)) => {
                     warn!(
                         logger,
                         "run_io_copy[{}]: failed to copy stream: {}", io_name, e
                     );
                 }
-                Ok(length) => {
+                Some(Ok(length)) => {
                     info!(
                         logger,
                         "run_io_copy[{}]: stop to copy stream length {}", io_name, length
                     );
                     // Send EOF to agent by calling rpc write_stdin with 0 length data
                     if io_type == StdIoType::Stdin {
-                        writer
-                            .shutdown()
-                            .await
-                            .map_err(|e| {
-                                error!(
-                                    logger,
-                                    "run_io_copy[{}]: failed to shutdown: {:?}", io_name, e
-                                );
-                                e
-                            })
-                            .ok();
+                        tokio::select! {
+                            biased;
+                            _ = io_cancel.cancelled() => {},
+                            result = writer.shutdown() => {
+                                if let Err(e) = result {
+                                    error!(logger, "run_io_copy[{}]: failed to shutdown: {:?}", io_name, e);
+                                }
+                            }
+                        }
                     }
                 }
             };
@@ -359,6 +376,8 @@ impl Process {
             // Close the destination before notifying the waiter. Binary
             // loggers must see pipe EOF before their shutdown signal.
             drop(writer);
+            drop(reader);
+            drop(io_done);
             if let Some(w) = wgw {
                 w.done()
             }
@@ -367,9 +386,8 @@ impl Process {
         Ok(())
     }
 
-    /// A container is considered exited once its IO ended.
-    /// This function waits for IO to end. And then, do some cleanup
-    /// things.
+    /// Drain stdio before WaitProcess, which reaps the guest's stream state.
+    /// Destructive operations can cancel the copies to unblock this wait.
     async fn run_io_wait(
         &mut self,
         containers: Arc<RwLock<HashMap<String, Container>>>,
@@ -383,22 +401,26 @@ impl Process {
         let exit_status = self.exit_status.clone();
         let exit_notifier = self.exit_watcher_tx.take();
         let status = self.status.clone();
+        let io_cancel = self.io_cancel.clone();
+        let io_done = self.io_tasks.token();
 
         tokio::spawn(async move {
-            // wait on all of the container's io stream terminated
             info!(logger, "begin wait group io");
             wg.wait().await;
             info!(logger, "end wait group for io");
 
             if let Some(binary_logger) = binary_logger {
-                binary_logger.shutdown().await;
+                binary_logger.shutdown(&io_cancel).await;
             }
+            // Shutdown joins only host I/O, never agent wait or container cleanup.
+            drop(io_done);
 
             let req = agent::WaitProcessRequest {
                 process_id: process.clone().into(),
             };
 
             info!(logger, "begin wait process");
+
             // If wait_process fails (e.g., VM died), we still set status to Stopped
             // This ensures that subsequent Kill() calls see the process as already stopped and return success.
             let exit_code = match agent.wait_process(req).await {
@@ -439,6 +461,7 @@ impl Process {
             drop(status);
 
             drop(exit_notifier);
+
             info!(logger, "end io wait thread");
         });
         Ok(())
@@ -493,7 +516,190 @@ impl Process {
 
 #[cfg(test)]
 mod tests {
-    use super::is_binary_stdio;
+    use super::*;
+    use std::{io::Read, os::fd::AsRawFd, path::PathBuf, time::Duration};
+
+    struct Fifo {
+        path: PathBuf,
+        reader: File,
+        capacity: usize,
+    }
+
+    impl Fifo {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!("kata-stdio-{}", uuid::Uuid::new_v4()));
+            let name = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+            assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o600) }, 0);
+            let reader = open_fifo_read(path.to_str().unwrap()).unwrap();
+            let capacity = unsafe { libc::fcntl(reader.as_raw_fd(), libc::F_SETPIPE_SZ, 4096) };
+            assert!(capacity > 0);
+            Self {
+                path,
+                reader,
+                capacity: capacity as usize,
+            }
+        }
+
+        async fn full(&self) {
+            tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    let mut bytes = 0_i32;
+                    assert_eq!(
+                        unsafe { libc::ioctl(self.reader.as_raw_fd(), libc::FIONREAD, &mut bytes) },
+                        0
+                    );
+                    if bytes as usize == self.capacity {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+    }
+
+    impl Drop for Fifo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    async fn copy_to_fifo(
+        fifo: &Fifo,
+        token: CancellationToken,
+        data: Vec<u8>,
+    ) -> (Process, WaitGroup) {
+        let id = ContainerProcess::new("stdio-test", "exec-test").unwrap();
+        let mut process = Process::new(
+            &id,
+            0,
+            "",
+            None,
+            Some(fifo.path.to_str().unwrap().into()),
+            None,
+            false,
+        );
+        process.io_cancel = token;
+        process.pre_fifos_open().unwrap();
+        let shim = ShimIo::new(&None, &process.stdout, &None, "stdio-test", "test")
+            .await
+            .unwrap();
+        let wg = WaitGroup::new();
+        process
+            .run_io_copy(
+                StdIoType::Stdout,
+                Some(wg.worker()),
+                Box::new(std::io::Cursor::new(data)),
+                shim.stdout.unwrap(),
+            )
+            .await
+            .unwrap();
+        (process, wg)
+    }
+
+    #[tokio::test]
+    async fn cancelled_full_fifo_releases_wait_group_without_reading() {
+        let fifo = Fifo::new();
+        let token = CancellationToken::new();
+        let (process, mut wg) =
+            copy_to_fifo(&fifo, token.clone(), vec![0; fifo.capacity * 2]).await;
+        fifo.full().await;
+        // Keep both read ends open and never consume any output.
+        token.cancel();
+        tokio::time::timeout(Duration::from_secs(2), wg.wait())
+            .await
+            .unwrap();
+        assert!(process.stdout_r.is_some());
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_copy_start_and_sibling_isolation() {
+        let parent = CancellationToken::new();
+        let first = parent.child_token();
+        let sibling = parent.child_token();
+        first.cancel();
+        let fifo = Fifo::new();
+        let (_process, mut wg) = copy_to_fifo(&fifo, first, vec![0; fifo.capacity * 2]).await;
+        tokio::time::timeout(Duration::from_secs(2), wg.wait())
+            .await
+            .unwrap();
+        assert!(!sibling.is_cancelled());
+        assert!(!parent.is_cancelled());
+        parent.cancel();
+        assert!(sibling.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn stdin_keeper_defers_eof_until_writer_is_closed() {
+        use std::io::Write;
+        use tokio::io::AsyncReadExt;
+        let fifo = Fifo::new();
+        let id = ContainerProcess::new("stdio-test", "exec-test").unwrap();
+        let mut process = Process::new(
+            &id,
+            0,
+            "",
+            Some(fifo.path.to_str().unwrap().into()),
+            None,
+            None,
+            false,
+        );
+        let mut shim = ShimIo::new(&process.stdin, &None, &None, "stdio-test", "test")
+            .await
+            .unwrap();
+        process.post_fifos_open().unwrap();
+        let mut external_writer = open_fifo_write(fifo.path.to_str().unwrap()).unwrap();
+        external_writer.write_all(b"stdin").unwrap();
+        drop(external_writer);
+        let reader = shim.stdin.as_mut().unwrap();
+        let mut data = [0; 5];
+        reader.read_exact(&mut data).await.unwrap();
+        assert_eq!(&data, b"stdin");
+        let mut byte = [0];
+        tokio::select! {
+            biased;
+            result = reader.read(&mut byte) => panic!("stdin keeper did not defer EOF: {:?}", result),
+            _ = tokio::task::yield_now() => {},
+        }
+        process.stdin_w.take();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(2), reader.read(&mut byte))
+                .await
+                .unwrap()
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn normal_backpressured_fifo_keeps_every_byte_and_reaches_eof() {
+        let mut fifo = Fifo::new();
+        let mut expected = vec![0; (1024 * 1024).max(fifo.capacity * 2)];
+        expected.extend_from_slice(b"STDOUT-END\n");
+        let (process, mut wg) =
+            copy_to_fifo(&fifo, CancellationToken::new(), expected.clone()).await;
+        fifo.full().await;
+        let mut actual = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut buf = [0; 1024];
+            loop {
+                match fifo.reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => actual.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(e) => panic!("read failed: {}", e),
+                }
+                tokio::task::yield_now().await;
+            }
+            wg.wait().await;
+        })
+        .await
+        .unwrap();
+        assert_eq!(actual, expected);
+        // A keeper is still present: EOF must depend on writers, not this read end.
+        assert!(process.stdout_r.is_some());
+    }
 
     #[test]
     fn identifies_binary_logger_uri() {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -183,6 +183,8 @@ impl RuntimeHandler for VirtContainer {
             agent,
             hypervisor,
             resource_manager,
+            sandbox.io_cancel_token(),
+            sandbox.io_tasks.clone(),
         );
         Ok(RuntimeInstance {
             sandbox: Arc::new(sandbox),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -88,7 +88,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use strum::Display;
 use tokio::sync::{mpsc::Sender, watch, Mutex, RwLock};
-use tokio_util::sync::CancellationToken;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::instrument;
 
 pub(crate) const VIRTCONTAINER: &str = "virt_container";
@@ -151,6 +151,7 @@ pub struct VirtSandbox {
     shm_size: u64,
     factory: Option<Factory>,
     cancel_token: CancellationToken,
+    pub(crate) io_tasks: TaskTracker,
 }
 
 impl std::fmt::Debug for VirtSandbox {
@@ -197,11 +198,16 @@ impl VirtSandbox {
             sandbox_config: Some(sandbox_config),
             factory: Some(factory),
             cancel_token,
+            io_tasks: TaskTracker::new(),
         })
     }
 
     pub fn get_agent(&self) -> Arc<dyn Agent> {
         self.agent.clone()
+    }
+
+    pub(crate) fn io_cancel_token(&self) -> CancellationToken {
+        self.cancel_token.child_token()
     }
 
     pub fn get_sid(&self) -> String {
@@ -1318,6 +1324,9 @@ impl Sandbox for VirtSandbox {
     }
 
     async fn stop(&self) -> Result<()> {
+        // Also release blocked host I/O if the VM is already stopped. This
+        // signals cancellation only; no copy task is joined under a lock.
+        self.cancel_token.cancel();
         let state = {
             let sandbox_inner = self.inner.read().await;
             sandbox_inner.state
@@ -1326,10 +1335,6 @@ impl Sandbox for VirtSandbox {
         if state == SandboxState::Stopped {
             return Ok(());
         }
-
-        // Cancel the OOM watcher before tearing down the VM so it exits
-        // cleanly instead of hitting ECONNRESET/EOF on a closed channel.
-        self.cancel_token.cancel();
 
         info!(sl!(), "begin stop sandbox");
         if state == SandboxState::Init {
@@ -1350,6 +1355,10 @@ impl Sandbox for VirtSandbox {
         info!(sl!(), "shutdown");
 
         self.stop().await.context("stop")?;
+
+        // No sandbox/container lock is held while cancelled copies and loggers finish.
+        self.io_tasks.close();
+        self.io_tasks.wait().await;
 
         self.cleanup().await.context("do the clean up")?;
 
@@ -1670,6 +1679,7 @@ impl Persist for VirtSandbox {
             shm_size: DEFAULT_SHM_SIZE,
             factory: None,
             cancel_token: CancellationToken::default(),
+            io_tasks: TaskTracker::new(),
         })
     }
 }


### PR DESCRIPTION
## Summary

Fix the destructive-teardown failure mode described in **Problem 1 of #13676**, while preserving runtime-rs's normal stdio/`WaitProcess` ordering.

A stopped stdout/stderr consumer can leave a legacy FIFO copy blocked indefinitely. Because runtime-rs waits for these copies before calling agent `WaitProcess`, this can prevent exit reporting and teardown from completing.

Use cancellable, nonblocking FIFO I/O to release those copies during destructive teardown. After an accepted `SIGKILL` (including the existing already-terminated error handling), cancel the matching I/O scope: container-wide for init or `all=true`, and only the selected exec for an individual exec kill. Preserve the stopped-process early return: an invocation that signals nothing cancels nothing. Delete cancels the deleted scope; sandbox Stop/Shutdown cancels the sandbox scope. Destructive teardown also terminates and reaps binary loggers, and Shutdown joins the tracked host I/O tasks before cleanup.

Normal exit and `SIGTERM` still drain stdout/stderr, shut down the binary logger, and then call agent `WaitProcess`. A permanently stalled reader can therefore still delay normal exit reporting; this PR deliberately preserves that behavior. Destructive teardown may discard pending output. **Stop/Shutdown initiation is the cancellation boundary**, including when `stop_vm()` subsequently fails; this does not promise continued I/O after a failed Stop.

No kata-agent/protocol changes. **Problem 2 is outside this PR.**

### Why preserve drain-before-WaitProcess?

An earlier QEMU/containerd A/B experiment with early `WaitProcess` lost the final **57,374 bytes** and trailing marker from backpressured output. Agent `WaitProcess` can remove the stream state before subsequent `ReadStdout`/`ReadStderr` calls finish. The base drained the complete payload, so this fix retains the normal ordering and provides cancellation for destructive teardown.

## Validation

Rebased onto `caf2339138429dc0dc976b72bb9d8b12ce62dd36`, preserving main's OOM notifier wiring.

Current revision:

- `cargo test --locked -p virt_container`: 26 passed, including a regression for SIGKILL cancellation scope, individual exec isolation, the stopped-exec `all=true` no-op, and SIGTERM.
- `make -C src/runtime-rs test`: 272 passed.
- `make -C src/runtime-rs check`: formatting and Clippy passed.
- `git diff --check`: passed.
- Local component harness: 20 passed. Reverting SIGKILL token capture to init-only makes the new crate regression fail; the corrected implementation passes.

The focused crate unit tests are included in the PR. The larger component harness and containerd/QEMU driver are local manual validation tools, not part of this patch.

Previous normal-QEMU validation, **before this rebase**:

- Original five-scenario suite: **50/50 passed** (blocked FIFO + SIGKILL, slow consumer, normal binary logger, blocked logger teardown, and exec isolation).
- Additional targeted cases passed: dual stdout/stderr, stderr-only, SIGTERM, TTY, CloseIO/stdin EOF, regular files, multi-container isolation, Delete without prior Kill, direct Shutdown, and blocked binary logger Shutdown.
- The container-wide SIGKILL correction in `bfef7bc97` additionally passed `kill-all 1` and `exec-isolation 1`: target init and exec waits completed before Delete/Shutdown, the peer container retained its complete output, and task/runtime/container/bundle/sandbox cleanup completed.
- Full-output cases verified 4,194,334 bytes, the trailing marker, and SHA-256 `13ebec50d7dbd7dd7a8e44d35453555b9d0f9d285360a6ab9a79aa65359d1efa`.

For direct Shutdown cases, the pending Wait outcome is recorded only after successful bounded Shutdown; the pass conditions are logger reap and task/runtime/container/bundle/sandbox cleanup. Shutdown may close the shim server before an outstanding Wait RPC completes.

A fresh normal-QEMU shim has been built from `7089c746a4f86f68e2ccc94b96b55fdf97877586`, with source hashes, Cargo feature metadata, and checksum-pinned manual commands. **Post-rebase validation on this exact build now passed**, run manually with sudo by the author; the runner verified all pinned package checksums:

- `kill-all 1`: init, blocked exec and normal exec each returned exit 137; all Wait calls completed in 15 ms, before Delete/Shutdown. The peer container retained all 4,194,334 bytes with the expected SHA-256, and the shared sandbox remained alive until cleanup. Final runtime processes, tasks, containers, bundles and sandbox paths: all zero.
- `exec-isolation 1`: the victim returned exit 137 while the sibling stayed running; victim Delete completed in 1 ms. The sibling retained the complete payload, matching SHA-256 and trailing marker. Final runtime processes and bundle were absent.
- Both scenarios reported `SCENARIO_PASS` and `TEST_EXIT_STATUS=0`.
