### PR TITLE
kata-deploy: install erofs-utils from a container image

### DIFF
--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -39,7 +39,7 @@ jobs:
           { vmm: qemu-runtime-rs, k8s: k3s },
           { vmm: qemu-runtime-rs, k8s: rke2 },
           { vmm: qemu-runtime-rs, k8s: microk8s },
-          { vmm: qemu-nvidia-cpu-runtime-rs, k8s: kubeadm, snapshotter: erofs, erofs_snapshotter_mode: disk, erofs_dmverity: dmverity, manages_host_modules: "yes" },
+          { vmm: qemu-nvidia-cpu-runtime-rs, k8s: kubeadm, snapshotter: erofs, erofs_snapshotter_mode: disk, erofs_dmverity: dmverity },
         ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
@@ -55,12 +55,11 @@ jobs:
       # Only used when deploying the kubeadm flavour
       CONTAINER_ENGINE: containerd
       CONTAINER_ENGINE_VERSION: latest
-      # Only the kubeadm path prepares EROFS on the runner, so that is where the
-      # host module coverage lives.
+      # Only the kubeadm flavour runs EROFS, so that is where the host module
+      # coverage lives: nothing loads them but the install itself.
       SNAPSHOTTER: ${{ matrix.environment.snapshotter }}
       EROFS_SNAPSHOTTER_MODE: ${{ matrix.environment.erofs_snapshotter_mode }}
       EROFS_DMVERITY: ${{ matrix.environment.erofs_dmverity }}
-      KATA_DEPLOY_MANAGES_HOST_MODULES: ${{ matrix.environment.manages_host_modules }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -183,6 +183,78 @@ containerd matches none of the presets.
     anything, naming the value to set. An explicit `containerd.configDir` overrides
     the derivation this check is about, so it does not apply in that case.
 
+### nodeBinaries
+
+Some of what Kata needs on a node is not part of Kata: containerd's EROFS
+snapshotter, for instance, needs a `mkfs.erofs` from `erofs-utils` 1.8.2 or newer,
+which most distributions still do not package. When updating the node's packages is
+not on offer, `nodeBinaries` takes the binaries out of container images instead:
+
+```yaml title="values.yaml"
+nodeBinaries:
+  erofs-utils:                                      # (1)!
+    image: quay.io/kata-containers/erofs-utils:1.9.3
+    binaries: [mkfs.erofs, dump.erofs, fsck.erofs]  # (2)!
+    pullPolicy: IfNotPresent                        # (3)!
+```
+
+1. Each key names an entry and becomes the name of the container staging it, so it
+   has to be a valid container name — lowercase letters, digits and dashes,
+   beginning and ending with a letter or a digit — and cannot be one of the names
+   kata-deploy's own containers use. The render fails, naming the key, when it is
+   neither.
+2. Only what is listed here is taken, so an image built on a distribution does not
+   put the rest of its userland on the node. Each one names a single binary, not a
+   path or a pattern, and the render fails on anything else.
+3. Optional; defaults to the chart's `imagePullPolicy`.
+
+Every entry gets a container of its own, which copies the listed binaries into a
+pod-local volume and reaches nothing of the node's. One further container then
+installs whatever was staged into `/usr/local/bin`, ahead of `/usr/bin` in
+containerd's `PATH`, and records the names it installed so that a later run can take
+exactly those out again. That container runs the `kubectl` image, kata-deploy's own
+being distroless and having no shell to do this with.
+
+Each image needs a POSIX shell, `cp`, and every binary the entry lists, statically
+built, in one of `/usr/local/bin`, `/usr/local/sbin`, `/usr/bin`, `/usr/sbin`,
+`/bin`, `/sbin` or its root. Private images use the chart's `imagePullSecrets`.
+
+Adding another binary is a values change and nothing else, so this is the way to
+cover anything else a node turns out to lack.
+
+!!! warning "It will not replace a binary it did not install"
+
+    A file already in `/usr/local/bin` under a name an entry claims fails the
+    install, rather than being replaced, and the same goes for two entries claiming
+    the same name. Nothing on the node records where a binary in `/usr/local/bin`
+    came from, so kata-deploy only ever removes what its own marker file names.
+    Remove the file, or drop it from `nodeBinaries` to keep using it.
+
+    An install it refuses this way changes nothing: every name is checked before any
+    of them is written or removed, so the node keeps the set it already had.
+
+An uninstall takes the binaries out again, and changing an entry replaces what it
+installed. Dropping every entry leaves them in place until the release is
+uninstalled.
+
+!!! note "Side-by-side installs own separate sets"
+
+    Each release's marker file is named after its `env.multiInstallSuffix`, so
+    installing or uninstalling one leaves the binaries another one installed alone.
+    Two releases claiming the same name is still a conflict: whichever installs
+    second finds a file it did not install and fails.
+
+!!! note "One image per architecture being deployed to"
+
+    An image with no manifest for a node's architecture stalls that node's install
+    on the pull, so cover every architecture in the cluster. The `erofs-utils` image
+    above is published for `amd64` and `arm64` only.
+
+This requires `deploymentMode: job`. The staged pipeline is what puts the binaries
+in place before the host check looks for them; the DaemonSet runs the whole install
+in one container and has no such ordering. Setting `nodeBinaries` in `daemonset` mode
+fails the render rather than deploying something that cannot work.
+
 ## Deployment Modes (DaemonSet vs Job)
 
 The chart can install Kata on nodes in one of two ways, selected with the

--- a/docs/how-to/how-to-use-erofs-snapshotter-with-kata.md
+++ b/docs/how-to/how-to-use-erofs-snapshotter-with-kata.md
@@ -9,6 +9,31 @@ When used with Kata Containers `runtime-rs`, the EROFS snapshotter enables
 entirely. This delivers lower overhead, better performance, and smaller memory
 footprints compared to traditional shared-filesystem approaches.
 
+> **Deploying with kata-deploy? It does all of this for you**: a
+> [kata-deploy](../helm-configuration.md) deployment in `job` mode sets all of this
+> up on every node it selects: containerd's EROFS snapshotter and differ
+> configuration, the shims you enable pointed at the snapshotter, and the `erofs`
+> and dm-verity modules loaded and recorded so they come back after a reboot.
+>
+> Those settings need erofs-utils 1.8.2 or newer. Where a node packages something
+> older, or nothing at all, [`nodeBinaries`](../helm-configuration.md#nodebinaries)
+> takes it from a container image instead:
+>
+> ```yaml
+> deploymentMode: job
+> snapshotter:
+>   setup: ["erofs"]
+> nodeBinaries:
+>   erofs-utils:
+>     image: quay.io/kata-containers/erofs-utils:1.9.3
+>     binaries: [mkfs.erofs, dump.erofs, fsck.erofs]
+> ```
+>
+> [`try-kata-nvidia-cpu.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml)
+> sets the EROFS side of this up and carries that block commented out, to uncomment
+> on nodes needing it. Read on for what any of it means, or to set a host up without
+> kata-deploy.
+
 ## Quick Start Guide
 
 This section provides a quick overview of the steps to get started with EROFS snapshotter and Kata Containers. For detailed instructions, see the [Installation Guide](#installation-guide) section.

--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -33,6 +33,13 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 LIFECYCLE_POD_NAME="kata-lifecycle-test"
 
 setup_file() {
+	# erofs-utils now reaches the node through the job pipeline's staging, which
+	# the DaemonSet has no equivalent of, and these runners package none of their
+	# own. The other flavours cover this suite in daemonset mode.
+	if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
+		skip "the DaemonSet cannot install the erofs-utils the node lacks"
+	fi
+
 	ensure_helm
 
 	echo "# Image: ${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" >&3

--- a/tests/functional/kata-deploy/kata-deploy-node-binaries.bats
+++ b/tests/functional/kata-deploy/kata-deploy-node-binaries.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for nodeBinaries. No cluster required.
+#
+# These containers write into /usr/local/bin on every node the install selects,
+# from images kata-deploy does not build. What the chart renders for them is the
+# difference between a node gaining a binary it lacks and a node losing one
+# something else put there, and none of it surfaces until an install runs on a
+# real node. The invariants below are the ones a values or template change could
+# undo while still rendering something that looks right.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+# Two entries, so that anything per-entry is covered by more than one of them.
+NODE_BINARIES=(
+	--set deploymentMode=job
+	--set 'snapshotter.setup[0]=erofs'
+	--set 'nodeBinaries.erofs-utils.image=quay.io/kata-containers/erofs-utils:1.9.3'
+	--set 'nodeBinaries.erofs-utils.binaries[0]=mkfs.erofs'
+	--set 'nodeBinaries.erofs-utils.binaries[1]=dump.erofs'
+	--set 'nodeBinaries.extra-tools.image=quay.io/example/tools:1'
+	--set 'nodeBinaries.extra-tools.binaries[0]=thing'
+)
+
+# Render the per-node Job templates the dispatcher reads, as one YAML stream.
+per_node_jobs() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		--set deploymentMode=job \
+		--show-only templates/kata-deploy-job-templates.yaml \
+		"$@"
+}
+
+# The pod spec of one stage's per-node Job template, out of the ConfigMap holding
+# them. Grepping the whole ConfigMap cannot tell one stage from the other, and
+# install and cleanup carry different containers here.
+per_node_pod_spec() {
+	local stage="${1}"
+	shift
+	per_node_jobs "$@" | awk -v stage="${stage}" '
+		$0 == "  " stage "-job.yaml: |" { inside = 1; next }
+		inside && /^  [^ ]/ { inside = 0 }
+		inside && $0 == "        spec:" { pod = 1; next }
+		pod && /^        [^ ]/ { pod = 0 }
+		pod { print }
+	'
+}
+
+# One named container out of a stage, ending at the next peer container.
+stage_container() {
+	local stage="${1}" name="${2}"
+	shift 2
+	per_node_pod_spec "${stage}" "$@" | awk -v want="            - name: ${name}" '
+		$0 == want { inside = 1 }
+		inside && $0 != want && $0 ~ /^            - name: / { exit }
+		inside { print }
+	'
+}
+
+# The stage's containers, in the order it runs them.
+stage_container_names() {
+	local stage="${1}"
+	shift
+	per_node_pod_spec "${stage}" "$@" |
+		sed -n 's/^            - name: \(.*\)$/\1/p'
+}
+
+# Assert that rendered output does NOT contain a pattern. Not `! grep`: set -e
+# ignores its status, so anywhere but the last line of a test it could never fail
+# one.
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
+# Where a line sits in a rendered script, for the tests about what it does
+# before what.
+line_of() {
+	echo "${1}" | grep -nF -- "${2}" | head -1 | cut -d: -f1
+}
+
+last_line_of() {
+	echo "${1}" | grep -nF -- "${2}" | tail -1 | cut -d: -f1
+}
+
+# Why the chart refused to render, for the tests asserting that it does.
+render_error() {
+	helm template kata-deploy "${CHART_PATH}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		"$@" 2>&1 >/dev/null && return 1
+}
+
+@test "each nodeBinaries entry stages its binaries in a container of its own" {
+	local staging
+	staging="$(stage_container install erofs-utils "${NODE_BINARIES[@]}")"
+
+	echo "${staging}" | grep -q 'image: "quay.io/kata-containers/erofs-utils:1.9.3"'
+	echo "${staging}" | grep -q 'staged="/node-binaries/erofs-utils"'
+	echo "${staging}" | grep -q 'for binary in mkfs.erofs dump.erofs; do'
+
+	# The other entry's, so that one is not standing in for both.
+	stage_container install extra-tools "${NODE_BINARIES[@]}" |
+		grep -q 'for binary in thing; do'
+}
+
+@test "a staging container reaches nothing of the node's" {
+	local mounts
+	mounts="$(stage_container install erofs-utils "${NODE_BINARIES[@]}" |
+		sed -n '/volumeMounts:/,$p')"
+
+	# The pod-local volume it stages into, and nothing else: these run images
+	# kata-deploy does not build.
+	echo "${mounts}" | grep -q -- '- name: node-binaries'
+	refute_match "${mounts}" 'host-'
+	refute_match "$(stage_container install erofs-utils "${NODE_BINARIES[@]}")" \
+		'privileged: true'
+}
+
+@test "the install container takes the staged binaries into the node's /usr/local/bin" {
+	local install
+	install="$(stage_container install node-binaries-install "${NODE_BINARIES[@]}")"
+
+	echo "${install}" | grep -q 'node_bin=/host-usr-local/bin-writable'
+	echo "${install}" | grep -A1 -- '- name: host-usr-local-bin' |
+		grep -q 'mountPath: /host-usr-local/bin-writable'
+	# Read-only: it installs what was staged, it does not add to it.
+	echo "${install}" | grep -A2 -- '- name: node-binaries' | grep -q 'readOnly: true'
+	refute_match "${install}" 'privileged: true'
+}
+
+@test "the install takes the same node lock as every other host mutation" {
+	local stage
+	for stage in "install node-binaries-install" "cleanup node-binaries-remove"; do
+		# shellcheck disable=SC2086
+		local rendered
+		rendered="$(stage_container ${stage} "${NODE_BINARIES[@]}")"
+
+		echo "${rendered}" | grep -q 'exec 9>/host-run-lock/kata-deploy.lock'
+		echo "${rendered}" | grep -q 'flock -x 9'
+		echo "${rendered}" | grep -A1 -- '- name: host-run-lock' |
+			grep -q 'mountPath: /host-run-lock'
+	done
+}
+
+@test "the binaries are installed before the host check looks for them" {
+	local names
+	names="$(stage_container_names install "${NODE_BINARIES[@]}")"
+
+	# A staging container per entry, then the install, then the check that
+	# validates what it installed rather than what it replaced.
+	[ "$(echo "${names}" | head -4 | tr '\n' ' ')" = \
+		"erofs-utils extra-tools node-binaries-install load-kernel-modules " ]
+	echo "${names}" | grep -q '^host-check$'
+	[ "$(echo "${names}" | grep -n '^node-binaries-install$' | cut -d: -f1)" -lt \
+		"$(echo "${names}" | grep -n '^host-check$' | cut -d: -f1)" ]
+}
+
+@test "an install configuring no entry renders none of it" {
+	local spec
+	spec="$(per_node_pod_spec install --set deploymentMode=job)"
+
+	# No staging container, no install container, and no volume for them to
+	# meet in.
+	refute_match "${spec}" 'node-binaries'
+}
+
+@test "cleanup removes them whether or not an entry is still configured" {
+	local without with
+	without="$(stage_container cleanup node-binaries-remove --set deploymentMode=job)"
+	with="$(stage_container cleanup node-binaries-remove "${NODE_BINARIES[@]}")"
+
+	# Driven by the marker alone, so an uninstall tidies up even when the
+	# entries were dropped from the values first.
+	for rendered in "${without}" "${with}"; do
+		echo "${rendered}" | grep -q 'marker="${node_bin}/.kata-deploy-node-binaries"'
+		echo "${rendered}" | grep -q -- '- name: host-usr-local-bin'
+		# Nothing staged to install: taking them out is the whole job.
+		refute_match "${rendered}" 'mountPath: /node-binaries'
+	done
+}
+
+@test "the marker naming what to remove is scoped to the installation" {
+	# Side-by-side installs each own the set they installed. A shared marker
+	# would have the second one remove the first one's binaries.
+	stage_container install node-binaries-install "${NODE_BINARIES[@]}" |
+		grep -q 'marker="${node_bin}/.kata-deploy-node-binaries"'
+	stage_container install node-binaries-install "${NODE_BINARIES[@]}" \
+		--set env.multiInstallSuffix=gpu |
+		grep -q 'marker="${node_bin}/.kata-deploy-node-binaries-gpu"'
+	stage_container cleanup node-binaries-remove --set deploymentMode=job \
+		--set env.multiInstallSuffix=gpu |
+		grep -q 'marker="${node_bin}/.kata-deploy-node-binaries-gpu"'
+}
+
+@test "the previous set is kept until this one is known to be installable" {
+	local install
+	install="$(stage_container install node-binaries-install "${NODE_BINARIES[@]}")"
+
+	# The one removal that happens before anything is validated belongs to the
+	# branch taken when nothing is staged, where removing them is the job.
+	local branch first_removal branch_exit
+	branch="$(line_of "${install}" 'if [ ! -d "${staged}" ]; then')"
+	first_removal="$(line_of "${install}" 'rm -f "${node_bin}/${binary}"')"
+	branch_exit="$(line_of "${install}" 'exit 0')"
+	[ "${branch}" -lt "${first_removal}" ]
+	[ "${first_removal}" -lt "${branch_exit}" ]
+
+	# On the path that installs, a node keeps its working set when the install
+	# is refused, so nothing is taken out before every claim is checked.
+	local collision last_removal
+	collision="$(line_of "${install}" 'was not installed by kata-deploy')"
+	last_removal="$(last_line_of "${install}" 'rm -f "${node_bin}/${binary}"')"
+	[ "${collision}" -lt "${last_removal}" ]
+}
+
+@test "an entry missing what it takes is turned away" {
+	render_error --set deploymentMode=job \
+		--set 'nodeBinaries.tool.binaries[0]=thing' |
+		grep -q 'ERROR: nodeBinaries.tool.image is empty'
+
+	render_error --set deploymentMode=job \
+		--set 'nodeBinaries.tool.image=quay.io/example/tools:1' |
+		grep -q 'ERROR: nodeBinaries.tool.binaries is empty'
+}
+
+@test "a binary name a shell would take apart is turned away" {
+	# Each name reaches the node as a word of shell and as a line of the marker.
+	local name
+	for name in 'two words' '*' 'a; touch /tmp/x' '../../etc/passwd' '-rf'; do
+		render_error --set deploymentMode=job \
+			--set 'nodeBinaries.tool.image=quay.io/example/tools:1' \
+			--set-string "nodeBinaries.tool.binaries[0]=${name}" |
+			grep -q 'is not a plain file name'
+	done
+}
+
+@test "an entry name Kubernetes would refuse as a container name is turned away" {
+	local with_image=(--set deploymentMode=job
+		--set 'nodeBinaries.NAME.image=quay.io/example/tools:1'
+		--set 'nodeBinaries.NAME.binaries[0]=thing')
+
+	# The entry names the container staging its binaries, so it has to be a
+	# DNS-1123 label, short enough, and not one of ours.
+	render_error "${with_image[@]/NAME/-leading-dash}" |
+		grep -q 'not usable as a container name'
+	render_error "${with_image[@]/NAME/$(printf 'x%.0s' $(seq 64))}" |
+		grep -q 'characters long'
+	render_error "${with_image[@]/NAME/host-check}" |
+		grep -q 'container kata-deploy runs itself'
+}
+
+@test "nodeBinaries is turned away in daemonset mode, which cannot stage them" {
+	# The staging containers belong to the job pipeline, and daemonset mode
+	# renders none of them: without this the value would be silently ignored.
+	render_error --set deploymentMode=daemonset \
+		--set 'nodeBinaries.tool.image=quay.io/example/tools:1' \
+		--set 'nodeBinaries.tool.binaries[0]=thing' |
+		grep -q 'requires deploymentMode: job'
+}

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -16,6 +16,7 @@
 #   EROFS_SNAPSHOTTER_MODE      - "disk" or "memory"
 #   EROFS_DMVERITY              - Set to "dmverity" to enable dm-verity
 #   EROFS_MERGE_MODE            - "merged" or "unmerged"
+#   EROFS_UTILS_IMAGE           - Image kata-deploy takes erofs-utils from
 
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-kata-deploy}"
 HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
@@ -153,6 +154,12 @@ generate_base_values() {
   erofsSnapshotterMode: \"${EROFS_SNAPSHOTTER_MODE:-}\"
   erofsDmverity: ${erofs_dmverity}
   erofsMergeMode: \"${EROFS_MERGE_MODE:-}\"
+
+# The node has no erofs-utils of its own; see deploy_k8s.
+nodeBinaries:
+  erofs-utils:
+    image: \"${EROFS_UTILS_IMAGE:-quay.io/kata-containers/erofs-utils:1.9.3}\"
+    binaries: [mkfs.erofs]
 
 # fs-verity would also need the backing filesystem prepared for it, and these
 # tests only care about dm-verity.

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -36,6 +36,7 @@ else
 		"kata-deploy-privileges.bats" \
 		"kata-deploy-multi-install.bats" \
 		"kata-deploy-reconcile.bats" \
+		"kata-deploy-node-binaries.bats" \
 	)
 fi
 

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -586,12 +586,9 @@ function deploy_k8s() {
 				# fs-verity on the layer blobs.
 				sudo apt-get -y install --no-install-recommends fsverity
 
-				# The kata-deploy host module job leaves these unloaded, so that
-				# its own privileged stage is what has to load them.
-				if [[ "${EROFS_DMVERITY:-}" == "dmverity" ]] &&
-					[[ "${KATA_DEPLOY_MANAGES_HOST_MODULES:-no}" != "yes" ]]; then
-					load_dm_verity_modules
-				fi
+				# erofs, loop and the dm-verity targets are left unloaded on
+				# purpose: kata-deploy's own privileged stage loads and persists
+				# them, and pre-loading them here would hide it failing to.
 
 				# Ensure fsverity is enabled on the disk, otherwise
 				# fsverity won't work on the erofs-snapshotter side.

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -45,6 +45,10 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-containerd}"
 SNAPSHOTTER="${SNAPSHOTTER:-}"
 EROFS_SNAPSHOTTER_MODE="${EROFS_SNAPSHOTTER_MODE:-}"
 EROFS_MERGE_MODE="${EROFS_MERGE_MODE:-}"
+# What kata-deploy takes erofs-utils from, the runners having none new enough of
+# their own. Only amd64 and arm64 are published, which is every runner the erofs
+# jobs use.
+EROFS_UTILS_IMAGE="${EROFS_UTILS_IMAGE:-quay.io/kata-containers/erofs-utils:1.9.3}"
 
 # Wait for the Kubernetes API to recover after kata-deploy uninstall, then
 # retry the uninstall to purge any stale helm release state. On k3s/rke2,
@@ -572,7 +576,10 @@ function deploy_k8s() {
 		microk8s) deploy_microk8s ;;
 		kubeadm|vanilla)
 			if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
-				install_erofs_utils
+				# No erofs-utils is installed on the node on purpose: these
+				# runners package nothing new enough, which is the very case
+				# nodeBinaries exists for, so the install has to bring its
+				# own.
 
 				# fsverity is only needed here because, unlike
 				# the docker and nerdctl jobs, these do enable
@@ -897,6 +904,12 @@ function helm_helper() {
 			for snapshotter in "${snapshotter_list[@]}"; do
 				yq -i ".snapshotter.setup += [\"${snapshotter}\"]" "${values_yaml}"
 			done
+		fi
+
+		# The node has no erofs-utils of its own; see deploy_k8s.
+		if [[ "${SNAPSHOTTER}" == "erofs" ]]; then
+			yq -i ".nodeBinaries[\"erofs-utils\"].image = \"${EROFS_UTILS_IMAGE}\"" "${values_yaml}"
+			yq -i ".nodeBinaries[\"erofs-utils\"].binaries = [\"mkfs.erofs\", \"dump.erofs\", \"fsck.erofs\"]" "${values_yaml}"
 		fi
 
 		if [[ -n "${EROFS_SNAPSHOTTER_MODE}" ]]; then

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -1094,7 +1094,8 @@ fn validate_mkfs_erofs_options() -> Result<()> {
         format!(
             "Required host command `{MKFS_EROFS}` is not available. Install \
              erofs-utils >= {MIN_EROFS_UTILS_VERSION} before enabling the \
-             EROFS snapshotter."
+             EROFS snapshotter, or add a nodeBinaries entry taking it from \
+             an image."
         )
     })?;
 

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -110,10 +110,9 @@ const SUGGESTED_KUBELET_RUNTIME_REQUEST_TIMEOUT_SECS: u64 = 10 * 60;
 const MKFS_EROFS: &str = "mkfs.erofs";
 const MIN_EROFS_UTILS_VERSION: &str = "1.8.2";
 /// The `mkfs.erofs` options kata-deploy configures containerd's EROFS differ to
-/// use: `--mkfs-time` and `--sort=none`, both added in erofs-utils 1.8.2. The
-/// leading dashes are left out because that is how the option names appear
-/// inside the binary, which is where `validate_mkfs_erofs_options` looks.
-const REQUIRED_MKFS_EROFS_OPTIONS: &[&str] = &["mkfs-time", "sort"];
+/// use, both added in erofs-utils 1.8.2. Spelled as the binary's own usage text
+/// does, which is where `validate_mkfs_erofs_options` looks for them.
+const REQUIRED_MKFS_EROFS_OPTIONS: &[&str] = &["--mkfs-time", "--sort"];
 
 // Cap the tokio runtime to a small fixed number of worker threads. The default
 // multi-thread runtime allocates `num_cpus()` workers (each with a ~2 MiB
@@ -1087,9 +1086,9 @@ fn host_boot_config_has_builtin_feature(config_symbol: &str) -> bool {
 ///
 /// Running the host binary to ask it is not possible: it is linked against the
 /// host's loader and libraries, which the container does not have. So this
-/// searches the binary for the option names, which `getopt_long` keeps as
-/// plain strings. Their presence says exactly what the tool accepts, which is
-/// what we care about — the erofs-utils version only ever stood in for it.
+/// searches the binary for the options its usage text lists. What it documents
+/// is what it accepts, which is what we care about — the erofs-utils version
+/// only ever stood in for it.
 fn validate_mkfs_erofs_options() -> Result<()> {
     let mkfs_erofs = utils::find_host_program(MKFS_EROFS).with_context(|| {
         format!(
@@ -1105,15 +1104,15 @@ fn validate_mkfs_erofs_options() -> Result<()> {
     let missing: Vec<&str> = REQUIRED_MKFS_EROFS_OPTIONS
         .iter()
         .copied()
-        .filter(|option| !contains_c_string(&binary, option))
+        .filter(|option| !documents_option(&binary, option))
         .collect();
 
     if !missing.is_empty() {
         anyhow::bail!(
-            "Host {} does not support the --{} option(s) that kata-deploy \
+            "Host {} does not support the {} option(s) that kata-deploy \
              configures the EROFS differ to use. Install erofs-utils >= {}.",
             mkfs_erofs.display(),
-            missing.join(", --"),
+            missing.join(", "),
             MIN_EROFS_UTILS_VERSION
         );
     }
@@ -1126,19 +1125,27 @@ fn validate_mkfs_erofs_options() -> Result<()> {
     Ok(())
 }
 
-/// Whether `haystack` holds `needle` as a whole NUL-terminated string, the way
-/// a C string literal is stored in a binary. This is the `strings | grep -x` of
-/// the probe: matching a substring would accept `sort` inside `qsort`.
-fn contains_c_string(haystack: &[u8], needle: &str) -> bool {
-    let needle = needle.as_bytes();
+/// Whether `binary` documents `option`, dashes and all, as a word of its own.
+///
+/// Looking for the bare `getopt_long` name instead does not work: it is short
+/// enough for the linker to fold into the tail of an unrelated string, which
+/// nothing can tell from `sort` inside `qsort`. aarch64 builds of erofs-utils
+/// keep no `sort` but the one in glibc's `rfc3484_sort`.
+fn documents_option(binary: &[u8], option: &str) -> bool {
+    let option = option.as_bytes();
+    let bounds_word = |byte: &u8| !byte.is_ascii_alphanumeric() && !b"-_".contains(byte);
 
-    haystack
-        .windows(needle.len() + 1)
+    binary
+        .windows(option.len())
         .enumerate()
         .any(|(start, window)| {
-            window[..needle.len()] == *needle
-                && window[needle.len()] == 0
-                && (start == 0 || !haystack[start - 1].is_ascii_graphic())
+            window == option
+                // Both ends, so that `--sort` inside a longer word is no more
+                // accepted than `sort` inside `qsort` was.
+                && start
+                    .checked_sub(1)
+                    .is_none_or(|before| bounds_word(&binary[before]))
+                && binary.get(start + option.len()).is_none_or(bounds_word)
         })
 }
 
@@ -2118,23 +2125,24 @@ mod tests {
         );
     }
 
-    /// The option probe reads a binary, so it has to match whole strings the
-    /// way `strings | grep -x` does: a `getopt_long` name is NUL terminated and
-    /// never the tail of a longer word.
+    /// The usage text spellings are the ones erofs-utils 1.9.3 ships on both
+    /// amd64 and arm64; `rfc3484_sort` is what an arm64 build folds its own
+    /// `sort` into.
     #[rstest]
-    #[case(b"\0mkfs-time\0", "mkfs-time", true)]
-    #[case(b"sort\0", "sort", true)]
-    #[case(b"--sort\0", "sort", false)]
-    #[case(b"\0qsort\0", "sort", false)]
-    #[case(b"\0sorted\0", "sort", false)]
-    #[case(b"\0sort", "sort", false)]
-    #[case(b"\0mkfs-timestamp\0", "mkfs-time", false)]
-    fn test_contains_c_string(
-        #[case] haystack: &[u8],
-        #[case] needle: &str,
-        #[case] expected: bool,
-    ) {
-        assert_eq!(contains_c_string(haystack, needle), expected);
+    #[case(b"    --mkfs-time         the t", "--mkfs-time", true)]
+    #[case(b"ta\n --sort=<path,none>  ", "--sort", true)]
+    #[case(b"\0rfc3484_sort\0", "--sort", false)]
+    #[case(b"\0qsort\0", "--sort", false)]
+    #[case(b"\0--mkfs-timestamp\0", "--mkfs-time", false)]
+    #[case(b"\0--sort", "--sort", true)]
+    #[case(b"1.7.1\0", "--sort", false)]
+    // A word ending in the option is no more a mention of it than `qsort` is.
+    #[case(b"\0x--sort\0", "--sort", false)]
+    #[case(b"\0no_--mkfs-time\0", "--mkfs-time", false)]
+    // Nothing before it to look at.
+    #[case(b"--sort=<path,none>", "--sort", true)]
+    fn test_documents_option(#[case] binary: &[u8], #[case] option: &str, #[case] expected: bool) {
+        assert_eq!(documents_option(binary, option), expected);
     }
 
     /// All non-internal staged actions remain visible in `--help` so operators

--- a/tools/packaging/kata-deploy/binary/src/utils/system.rs
+++ b/tools/packaging/kata-deploy/binary/src/utils/system.rs
@@ -28,13 +28,16 @@ pub const RUST_SHIMS: &[&str] = &[
 /// against a dynamic loader and libraries that only exist in the host's mount
 /// namespace, which the container no longer has access to. It can inspect
 /// them, which is enough to tell what a host tool supports.
+///
+/// Ordered as the host's own PATH is, so that what is found here is what the
+/// host would run. A node can hold several versions of the same tool.
 const HOST_BIN_DIRS: &[&str] = &[
-    "/host-usr/bin",
-    "/host-usr/sbin",
-    "/host-usr-local/bin",
     "/host-usr-local/sbin",
-    "/host-bin",
+    "/host-usr-local/bin",
+    "/host-usr/sbin",
+    "/host-usr/bin",
     "/host-sbin",
+    "/host-bin",
 ];
 
 pub fn is_rust_shim(shim: &str) -> bool {

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -526,6 +526,53 @@ Get EROFS merge mode from structured config ("merged" or "unmerged")
 {{- end -}}
 
 {{/*
+The nodeBinaries entries, validated.
+
+Values making an entry a no-op fail the render, as on the node they would only
+surface much later, as a missing command or a layer conversion failure.
+*/}}
+{{- define "kata-deploy.nodeBinaries" -}}
+{{- $entries := .Values.nodeBinaries | default dict -}}
+{{- if $entries -}}
+{{- if ne (.Values.deploymentMode | default "daemonset") "job" -}}
+{{- fail (printf "\n\nERROR: nodeBinaries is set (%s), which requires deploymentMode: job.\n\nInstalling binaries onto the node relies on the staged install pipeline, where they are in place before the host check looks for them. The DaemonSet runs the whole install in one container and has no such ordering.\n" (keys $entries | sortAlpha | join ", ")) -}}
+{{- end -}}
+{{- /* Names of containers the install and cleanup pods carry of their own, which
+       an entry cannot take without the API server rejecting the pod for two
+       containers sharing a name. */}}
+{{- $taken := list "artifacts" "cri" "dispatcher" "host-check" "kube-kata" "load-kernel-modules" "node-binaries-install" "node-binaries-remove" "rb-cleanup" "remove-artifacts" "revert-cri" -}}
+{{- range $name, $spec := $entries -}}
+{{- /* A DNS-1123 label, which is all a container name may be. */}}
+{{- if not (regexMatch "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" $name) -}}
+{{- fail (printf "\n\nERROR: nodeBinaries key %q is not usable as a container name.\n\nIt names the container that stages those binaries, so it may hold only lowercase letters, digits and dashes, and has to begin and end with a letter or a digit.\n" $name) -}}
+{{- end -}}
+{{- if gt (len $name) 63 -}}
+{{- fail (printf "\n\nERROR: nodeBinaries key %q is %d characters long.\n\nIt names the container that stages those binaries, and Kubernetes stops at 63.\n" $name (len $name)) -}}
+{{- end -}}
+{{- if has $name $taken -}}
+{{- fail (printf "\n\nERROR: nodeBinaries key %q is the name of a container kata-deploy runs itself.\n\nTwo containers in a pod cannot share a name, so pick another: %s are taken.\n" $name (join ", " $taken)) -}}
+{{- end -}}
+{{- if not ($spec.image | default "" | trim) -}}
+{{- fail (printf "\n\nERROR: nodeBinaries.%s.image is empty.\n\nSet it to the image carrying %s, or drop the entry.\n" $name $name) -}}
+{{- end -}}
+{{- if not ($spec.binaries | default list) -}}
+{{- fail (printf "\n\nERROR: nodeBinaries.%s.binaries is empty.\n\nList the binaries to take out of %s. Nothing is installed by default, so that an image built on a distribution does not put the rest of its userland on the node.\n" $name ($spec.image | default "the image")) -}}
+{{- end -}}
+{{- /* Each name reaches the node as a word of shell, so anything a shell would
+       take apart -- whitespace, a glob, a separator -- has to be turned away
+       here rather than split, expanded or run there. A path would also escape
+       the directory the binaries are staged in. */}}
+{{- range $binary := ($spec.binaries | default list) -}}
+{{- if not (regexMatch "^[A-Za-z0-9][A-Za-z0-9._+-]*$" (toString $binary)) -}}
+{{- fail (printf "\n\nERROR: nodeBinaries.%s.binaries lists %q, which is not a plain file name.\n\nEach entry names one binary to take out of the image, so it may hold only letters, digits, dots, underscores, plus signs and dashes, and has to begin with a letter or a digit.\n" $name (toString $binary)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $entries -}}
+{{- end -}}
+
+{{/*
 Get debug value from structured config
 */}}
 {{- define "kata-deploy.getDebug" -}}
@@ -1238,6 +1285,16 @@ spec:
 {{- end }}
 {{- if eq $stage "install" }}
       initContainers:
+{{- /* All before the host check, so it validates the binaries being installed
+       rather than the versions they are there to replace. One staging container
+       per nodeBinaries entry, so a new entry is a values change only. */}}
+{{- $nodeBinaries := include "kata-deploy.nodeBinaries" $root | fromYaml }}
+{{- range $name, $spec := $nodeBinaries }}
+{{- include "kata-deploy.nodeBinariesStageContainer" (dict "root" $root "name" $name "spec" $spec) | nindent 8 }}
+{{- end }}
+{{- if $nodeBinaries }}
+{{- include "kata-deploy.nodeBinariesInstallContainer" (dict "root" $root "name" "node-binaries-install" "staged" true) | nindent 8 }}
+{{- end }}
 {{- /* Privileged, and holding the host root, because it runs the host's own modprobe. */}}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "load-kernel-modules" "action" "install-stage-load-kernel-modules" "privileged" true "mountHost" true "mountHostRoot" true "mountModulesLoad" true) | nindent 8 }}
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "host-check" "action" "install-stage-host-check" "privileged" false "mountHost" true) | nindent 8 }}
@@ -1247,6 +1304,10 @@ spec:
 {{- else }}
       initContainers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "revert-cri" "action" "cleanup-stage-revert-cri" "privileged" false "mountHost" true) | nindent 8 }}
+{{- /* After the revert, so containerd is no longer converting layers with them.
+       Unconditional, and driven by the marker alone, so that an uninstall tidies
+       up even when the entries were dropped from the values first. */}}
+{{- include "kata-deploy.nodeBinariesInstallContainer" (dict "root" $root "name" "node-binaries-remove") | nindent 8 }}
       containers:
 {{- include "kata-deploy.stageContainer" (dict "root" $root "name" "remove-artifacts" "action" "cleanup-stage-remove-artifacts" "privileged" false "mountHost" true "mountModulesLoad" true) | nindent 8 }}
 {{- end }}
@@ -1261,6 +1322,11 @@ spec:
           hostPath:
             path: /
             type: Directory
+{{- if and (eq $stage "install") (include "kata-deploy.nodeBinaries" $root | fromYaml) }}
+        {{- /* Pod-local, so those images reach nothing of the node's. */}}
+        - name: node-binaries
+          emptyDir: {}
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -1302,6 +1368,221 @@ Compute the host install directory (must match Config::from_env in the binary):
 {{- $dir = printf "%s-%s" $dir .Values.env.multiInstallSuffix -}}
 {{- end -}}
 {{- $dir -}}
+{{- end -}}
+
+{{/*
+Copy one nodeBinaries entry's binaries out of the image carrying them.
+
+The only containers running images kata-deploy did not build, hence the only ones
+reaching nothing but the volume they write to.
+
+Arguments (dict):
+  root - the top-level context (.)
+  name - the entry's name, which is also the container's
+  spec - the entry: image, binaries, and optionally pullPolicy
+
+Emitted at column 0; indent with `nindent` at the call site.
+*/}}
+{{- define "kata-deploy.nodeBinariesStageContainer" -}}
+- name: {{ .name }}
+  image: {{ .spec.image | trim | quote }}
+  imagePullPolicy: {{ .spec.pullPolicy | default .root.Values.imagePullPolicy | quote }}
+  command: ["/bin/sh", "-c"]
+  args:
+    {{- /* Every plausible layout is searched so the image is the only value to
+           set. Its own directory, so two entries offering the same name are the
+           install container's to reject rather than a silent overwrite. */}}
+    - |
+      set -eu
+
+      staged="/node-binaries/{{ .name }}"
+      mkdir -p "${staged}"
+
+      for binary in {{ .spec.binaries | join " " }}; do
+        for dir in /usr/local/bin /usr/local/sbin /usr/bin /usr/sbin /bin /sbin /; do
+          if [ -f "${dir}/${binary}" ]; then
+            cp "${dir}/${binary}" "${staged}/${binary}"
+            echo "staged ${dir}/${binary}"
+            break
+          fi
+        done
+
+        if [ ! -f "${staged}/${binary}" ]; then
+          echo "ERROR: no ${binary} in this image, in any directory searched above." >&2
+          exit 1
+        fi
+      done
+  securityContext:
+    privileged: false
+    readOnlyRootFilesystem: true
+    {{- /* The image's own user may not be able to write the volume. */}}
+    runAsUser: 0
+  volumeMounts:
+    - name: node-binaries
+      mountPath: /node-binaries
+{{- with .root.Values.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Put the staged binaries in /usr/local/bin, ahead of /usr/bin in containerd's
+PATH, and take out what a previous run put there. With nothing staged, taking
+them out is the whole job.
+
+Installs whatever the staging containers left rather than a list of its own, so
+a new nodeBinaries entry needs no change here.
+
+Runs the kubectl image because kata-deploy's own is distroless: without a shell
+it cannot do this, and giving the images carrying the binaries the node's
+/usr/local/bin would put images we do not build on the node's PATH.
+
+Arguments (dict):
+  root   - the top-level context (.)
+  name   - container name
+  staged - bool, whether the staged binaries are mounted (install, not just remove)
+
+Emitted at column 0; indent with `nindent` at the call site.
+*/}}
+{{- define "kata-deploy.nodeBinariesInstallContainer" -}}
+- name: {{ .name }}
+  image: {{ include "kata-deploy.kubectlImage" .root }}
+  imagePullPolicy: {{ .root.Values.imagePullPolicy }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+
+      node_bin=/host-usr-local/bin-writable
+      staged=/node-binaries
+
+      {{- /* The lock every other kata-deploy mutation of this node takes, so
+             that two releases installing at once take turns rather than
+             interleaving their writes. Held until this container exits. */}}
+      exec 9>/host-run-lock/kata-deploy.lock
+      flock -x 9
+
+      {{- /* /usr/local/bin holds files from many sources and none of them say
+             where they came from. Kept beside them rather than under the install
+             directory, which cleanup empties before this can read it, and named
+             after this installation so that side-by-side ones own separate sets
+             rather than removing each other's. */}}
+      marker="${node_bin}/.kata-deploy-node-binaries{{ with .root.Values.env.multiInstallSuffix }}-{{ . }}{{ end }}"
+
+      {{- /* What a previous run of this installation put there. Read, not acted
+             on yet: nothing is removed before this run knows it can carry out
+             what it is replacing them with. */}}
+      owned=""
+      if [ -f "${marker}" ]; then
+        while read -r binary; do
+          [ -n "${binary}" ] || continue
+          owned="${owned}${binary} "
+        done < "${marker}"
+      fi
+
+      {{- /* No staged directory means nothing is configured any more, or this is
+             the cleanup: taking them out is the whole job. */}}
+      if [ ! -d "${staged}" ]; then
+        for binary in ${owned}; do
+          rm -f "${node_bin}/${binary}"
+          echo "removed /usr/local/bin/${binary}"
+        done
+        rm -f "${marker}"
+        exit 0
+      fi
+
+      {{- /* Whatever the staging containers left, each in its own directory, so
+             two entries offering the same name are caught here rather than one
+             silently overwriting the other. */}}
+      claim=""
+      for path in "${staged}"/*/*; do
+        [ -f "${path}" ] || continue
+        binary="${path##*/}"
+        case " ${claim}" in
+        *" ${binary} "*)
+          echo "ERROR: ${binary} was staged by more than one nodeBinaries entry." >&2
+          exit 1
+          ;;
+        esac
+        claim="${claim}${binary} "
+      done
+
+      if [ -z "${claim}" ]; then
+        echo "ERROR: nothing was staged; see the staging containers' logs." >&2
+        exit 1
+      fi
+
+      {{- /* All of them checked before anything is written or removed, so an
+             install this node refuses leaves it the set it already had. */}}
+      for binary in ${claim}; do
+        case " ${owned}" in
+        *" ${binary} "*)
+          continue
+          ;;
+        esac
+        if [ -e "${node_bin}/${binary}" ] || [ -L "${node_bin}/${binary}" ]; then
+          echo "ERROR: /usr/local/bin/${binary} was not installed by kata-deploy." >&2
+          echo "Remove it, or drop it from nodeBinaries to keep using it." >&2
+          exit 1
+        fi
+      done
+
+      {{- /* Everything this run may touch, claimed before any of it is written:
+             a run that dies midway leaves the next one something to remove,
+             rather than a binary nothing owns. */}}
+      union="${claim}"
+      for binary in ${owned}; do
+        case " ${claim}" in
+        *" ${binary} "*)
+          continue
+          ;;
+        esac
+        union="${union}${binary} "
+      done
+      printf '%s\n' ${union} > "${marker}"
+
+      for binary in ${claim}; do
+        set -- "${staged}"/*/"${binary}"
+        {{- /* Renamed into place so nothing ever finds a partial binary. */}}
+        cp "${1}" "${node_bin}/.${binary}.new"
+        chmod 0755 "${node_bin}/.${binary}.new"
+        mv "${node_bin}/.${binary}.new" "${node_bin}/${binary}"
+        echo "installed /usr/local/bin/${binary}"
+      done
+
+      {{- /* What the previous run installed and this one no longer offers. */}}
+      for binary in ${owned}; do
+        case " ${claim}" in
+        *" ${binary} "*)
+          continue
+          ;;
+        esac
+        rm -f "${node_bin}/${binary}"
+        echo "removed /usr/local/bin/${binary}"
+      done
+
+      printf '%s\n' ${claim} > "${marker}"
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    {{- /* Writes into the node's /usr/local/bin. */}}
+    runAsUser: 0
+  volumeMounts:
+    - name: host-usr-local-bin
+      mountPath: /host-usr-local/bin-writable
+    - name: host-run-lock
+      mountPath: /host-run-lock
+{{- if .staged }}
+    - name: node-binaries
+      mountPath: /node-binaries
+      readOnly: true
+{{- end }}
+{{- with .root.Values.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -1,4 +1,7 @@
 {{- if eq (.Values.deploymentMode | default "daemonset") "daemonset" -}}
+{{- /* Only the staged install can place these, and it says so. Validated here
+       because the templates that stage them render in job mode alone. */}}
+{{- $_ := include "kata-deploy.nodeBinaries" . -}}
 {{- if index .Values "node-feature-discovery" "enabled" -}}
 {{- $existingNFDNamespace := include "kata-deploy.detectExistingNFD" . | trim -}}
 {{- if $existingNFDNamespace -}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -22,6 +22,19 @@ snapshotter:
   erofsSnapshotterMode: "memory"
   erofsDmverity: true
 
+# The EROFS settings above need erofs-utils >= 1.8.2, newer than most
+# distributions package (Ubuntu 24.04 is on 1.7.1). Nodes packaging an older one,
+# or none, can be given it from an image by uncommenting the block below: the
+# binaries go into /usr/local/bin, ahead of /usr/bin in containerd's PATH, and
+# are removed again on uninstall. The install refuses to replace an
+# /usr/local/bin/mkfs.erofs it did not put there, and that image is published for
+# amd64 and arm64 only.
+#
+# nodeBinaries:
+#   erofs-utils:
+#     image: quay.io/kata-containers/erofs-utils:1.9.3
+#     binaries: [mkfs.erofs]
+
 # EROFS fs-verity requires the backing filesystem to support fs-verity, and we
 # cannot guarantee that on an arbitrary node. Rather than gate this profile on a
 # host feature we do not control, we disable fs-verity so it works on the widest

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -23,6 +23,19 @@ snapshotter:
   erofsSnapshotterMode: "memory"
   erofsDmverity: true
 
+# The EROFS settings above need erofs-utils >= 1.8.2, newer than most
+# distributions package (Ubuntu 24.04 is on 1.7.1). Nodes packaging an older one,
+# or none, can be given it from an image by uncommenting the block below: the
+# binaries go into /usr/local/bin, ahead of /usr/bin in containerd's PATH, and
+# are removed again on uninstall. The install refuses to replace an
+# /usr/local/bin/mkfs.erofs it did not put there, and that image is published for
+# amd64 and arm64 only.
+#
+# nodeBinaries:
+#   erofs-utils:
+#     image: quay.io/kata-containers/erofs-utils:1.9.3
+#     binaries: [mkfs.erofs]
+
 # EROFS fs-verity requires the backing filesystem to support fs-verity, and we
 # cannot guarantee that on an arbitrary node. Rather than gate this profile on a
 # host feature we do not control, we disable fs-verity so it works on the widest

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -550,6 +550,43 @@ snapshotter:
   # Enable dm-verity integrity verification for EROFS lower layers.
   # Independent of erofsSnapshotterMode — works with both disk and memory.
   erofsDmverity: false
+  # Nodes packaging an erofs-utils older than the 1.8.2 these settings need, or
+  # none at all, can be given one through nodeBinaries below.
+
+# Binaries to put on each node's PATH, taken from container images, for what a
+# node's own distribution packages too old a version of or not at all. Empty
+# (the default) installs nothing.
+#
+# Each key names an entry and becomes the name of the container staging it, so
+# it has to be a valid container name. Each entry needs an image and the list of
+# binaries to take out of it:
+#
+#   nodeBinaries:
+#     erofs-utils:
+#       image: quay.io/kata-containers/erofs-utils:1.9.3
+#       binaries: [mkfs.erofs, dump.erofs, fsck.erofs]
+#       pullPolicy: IfNotPresent  # optional, defaults to imagePullPolicy
+#
+# The image needs a POSIX shell, cp, and each listed binary statically built in
+# one of /usr/local/bin, /usr/local/sbin, /usr/bin, /usr/sbin, /bin, /sbin or
+# its root. Only the listed binaries are taken, so an image built on a
+# distribution does not put the rest of its userland on the node, and each one
+# names a single binary rather than a path or a pattern.
+#
+# They are copied into /usr/local/bin, ahead of /usr/bin in containerd's PATH,
+# and removed again on uninstall. Changing an entry replaces what it installed.
+# A file already there that kata-deploy did not install fails the install rather
+# than being replaced, and two entries offering the same name fail it too;
+# either way nothing on the node is touched, so it keeps the set it had. Marker
+# files are named after env.multiInstallSuffix, so side-by-side installs own
+# separate sets.
+#
+# Requires deploymentMode: job, the install being staged so the binaries are in
+# place before the host check looks for them. Private images use the chart's
+# imagePullSecrets. An image with no manifest for a node's architecture stalls
+# that node's install on the pull, so cover every architecture being deployed
+# to; the erofs-utils image above is amd64 and arm64 only.
+nodeBinaries: {}
 
 # Shim configuration
 # By default (disableAll: false), all shims with enabled: ~ (null) are enabled.


### PR DESCRIPTION
Nodes packaging erofs-utils older than the 1.8.2 the EROFS snapshotter needs can now point kata-deploy at an image carrying a static one:
```
    snapshotter.erofsUtils.image.reference: quay.io/kata-containers/erofs-utils:1.9.3
```
An init container stages the binaries, a second one installs them into `/usr/local/bin` and removes what a previous run left. Both are idempotent, and an ownership marker keeps the cleanup from touching binaries kata-deploy did not install. Job mode only.

Two host-check bugs found on the way:
* host binaries were searched in an order that let `/usr/bin` shadow `/usr/local/bin`, so the check validated a different mkfs.erofs than containerd would run;
* the `mkfs.erofs` option probe looked for the string `sort` in the binary. On arm64 that string is not there even though the option is, so the probe rejected a perfectly good erofs-utils on every arm64 node. It looks for `--sort` and `--mkfs-time` now.

The k8s CI jobs **now stop** installing erofs-utils and loading kernel modules by hand, leaving both to the install being tested.


**Notes:**
* Please, **DO NOT ADD the `ok-to-test` label**, as this one can only be tested via a ci-devel run
* ci-devel run:
  * ~https://github.com/kata-containers/kata-containers/actions/runs/33326176357~
  * https://github.com/kata-containers/kata-containers/actions/runs/33472665779