### PR TITLE
docs: add a method for finding baremetal or nested

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,6 +63,19 @@ underlying hypervisor must expose the CPU virtualization extensions to the
 guest (for example a `host-passthrough` or `host-model` CPU, with nesting
 enabled on the bare-metal host).
 
+!!! tip "Detecting bare metal vs. nested virtualization"
+    Use `systemd-detect-virt` to determine whether you are running on bare
+    metal or inside a virtual machine:
+
+    ```sh
+    systemd-detect-virt
+    ```
+
+    - Output **`none`**: you are running directly on bare metal.
+    - Output like **`kvm`** or **`qemu`**: you are running inside a virtual
+      machine and will need nested virtualization enabled on the underlying
+      host.
+
 **Host kernel modules** for `vhost` must be loaded. Kata uses VSOCK for the
 communication channel between the runtime and the guest agent (`vhost_vsock`
 provides `/dev/vhost-vsock`); `vhost_net` is needed for networking:


### PR DESCRIPTION
A small change to the docs but very helpful when following the installation. Many a time, I don't know how my company has provisioned the remote system I'm using. I can't make an assumption that they gave me a VM. This is the best command I found to confirm it. There's another one too `lscpu | grep -i hypervisor` but `systemd-detect-virt` seemed more deterministic.