### PR TITLE
runtime-rs: use MMIO block transport for Dragonball on aarch64

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -31,8 +31,28 @@ ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 ##TARGET default: build code
 default: runtime show-header
 ##TARGET test: run cargo tests for runtime-rs and all its sub-crates.
-test: static-checks-build
+test: test-dragonball-config static-checks-build
 	@cargo test $(PACKAGE_FLAGS) --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture  --skip bindgen
+
+##TARGET test-dragonball-config: verify architecture-specific generated configuration defaults.
+test-dragonball-config:
+	@tmp_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
+	for arch_driver in "aarch64 virtio-blk-mmio" "x86_64 virtio-blk-pci"; do \
+		set -- $$arch_driver; \
+		arch="$$1"; \
+		expected="$$2"; \
+		config="$$tmp_dir/configuration-dragonball-$$arch.toml"; \
+		cp config/configuration-dragonball.toml.in "$$config.in"; \
+		$(MAKE) --no-print-directory ARCH="$$arch" CONFIG_DB="$$config" "$$config"; \
+		for field in vm_rootfs_driver block_device_driver; do \
+			actual=$$(awk -F'"' -v field="$$field" '$$1 == field " = " { print $$2 }' "$$config"); \
+			if [ "$$actual" != "$$expected" ]; then \
+				printf '%s: expected %s=%s, got %s\n' "$$arch" "$$field" "$$expected" "$$actual" >&2; \
+				exit 1; \
+			fi; \
+		done; \
+	done
 install: install-runtime install-configs
 
 ifeq (,$(realpath $(ARCH_FILE)))
@@ -302,9 +322,14 @@ ifneq (,$(DBCMD))
     SYSCONFIG_PATHS += $(SYSCONFIG_DB)
     CONFIGS += $(CONFIG_DB)
     # dragonball-specific options (all should be suffixed by "_DB")
+ifeq ($(ARCH),aarch64)
+    VMROOTFSDRIVER_DB := virtio-blk-mmio
+    DEFBLOCKSTORAGEDRIVER_DB := virtio-blk-mmio
+else
     VMROOTFSDRIVER_DB := virtio-blk-pci
-    DEFMAXVCPUS_DB := 0
     DEFBLOCKSTORAGEDRIVER_DB := virtio-blk-pci
+endif
+    DEFMAXVCPUS_DB := 0
     DEFNETWORKMODEL_DB := tcfilter
     KERNELPARAMS_DB = console=ttyS1 agent.log_vport=1025
     KERNELTYPE_DB = uncompressed
@@ -1194,4 +1219,5 @@ endif
 	help \
 	optimize \
 	show-header \
-	show-summary
+	show-summary \
+	test-dragonball-config

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -139,7 +139,7 @@ default_maxmemory = @DEFMAXMEMSZ@
 # is backed by a block device or a file. This driver facilitates attaching the
 # storage directly to the guest VM.
 #
-# DB supports virtio-blk-mmio and virtio-blk-pci, virtio-blk-pci is prefered
+# Dragonball uses the architecture-appropriate virtio block transport.
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER_DB@"
 
 # This option changes the default hypervisor and kernel parameters


### PR DESCRIPTION
## Motivation

Dragonball builds for aarch64 (`ARCH_SUPPORT_DB := x86_64 aarch64`), but a default aarch64 sandbox cannot mount its root image. The Dragonball section of `src/runtime-rs/Makefile` sets `vm_rootfs_driver` and `block_device_driver` to `virtio-blk-pci` for every architecture. On aarch64 the guest boot FDT enumerates virtio MMIO devices only, so the PCI root disk never appears and the guest panics:

```
VFS: Cannot open root device "/dev/vda1" or unknown-block(0,0)
```

The guest command line lists `virtio_mmio` devices only. Block-backed volumes hit the same mismatch, so correcting the rootfs driver alone still leaves normal volumes broken.

#11716 added PCI support to Dragonball and made PCI the default. That default works on x86_64, but it leaves aarch64 with no usable block transport, so aarch64 users need a downstream configuration override to start any sandbox.

## Resolution

Select the Dragonball block transport by architecture: `virtio-blk-mmio` for both `vm_rootfs_driver` and `block_device_driver` on aarch64, and `virtio-blk-pci` elsewhere. Both fields move together so the root image and block-backed volumes agree on one transport. The template comment that recommended PCI unconditionally is updated to match.

Add a `test-dragonball-config` target that generates the Dragonball configuration for aarch64 and x86_64 and checks both driver fields. `make test` depends on it, so reintroducing a single-architecture default fails the build instead of the guest.

Fixes: #13768