### PR TITLE
runtime-rs: stop VM on leftover unknown-init Kill/Wait

### DIFF
--- a/src/runtime-rs/crates/runtimes/common/src/container_manager.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/container_manager.rs
@@ -37,4 +37,56 @@ pub trait ContainerManager: Send + Sync {
     async fn pid(&self) -> Result<PID>;
     async fn need_shutdown_sandbox(&self, req: &ShutdownRequest) -> bool;
     async fn is_sandbox_container(&self, process_id: &ContainerProcess) -> bool;
+    async fn has_guest_container(&self, process_id: &ContainerProcess) -> bool;
+    async fn guest_map_is_empty(&self) -> bool;
+}
+
+/// Whether a Kill/Wait of a task the shim has no guest container for may
+/// stop the VM.
+///
+/// After a sandbox is left over (e.g. by a node reboot), kubelet first
+/// `StopContainer`s a CRI id that never entered the shim guest map — a
+/// container whose `CreateContainer` never reached the guest (an init
+/// stuck in `Unknown`). `KillProcess` then returns success without
+/// signalling anything ("Signal ignored due to container not existing")
+/// and `WaitProcess` returns `ContainerNotFound`, so the CRI stop times
+/// out and `StopPodSandbox` never reaches the sandbox id.
+///
+/// When the guest map holds no workload container, only the pause task
+/// and the VM remain, so stopping the VM is safe: return a synthetic
+/// Wait exit 137 so the CRI wait completes. Do not stop when another
+/// guest container is still in the map (an init crash-loop retry would
+/// otherwise fail its next `CreateContainer` with "sandbox already
+/// stopped"), and never stop for non-container (exec) processes.
+pub fn should_stop_vm_on_missing_task(
+    is_container_process: bool,
+    container_in_map: bool,
+    guest_map_empty: bool,
+) -> bool {
+    is_container_process && !container_in_map && guest_map_empty
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_stop_vm_on_missing_task;
+
+    #[test]
+    fn leftover_unknown_init_with_empty_map_stops() {
+        assert!(should_stop_vm_on_missing_task(true, false, true));
+    }
+
+    #[test]
+    fn leftover_unknown_init_with_sibling_guest_does_not_stop() {
+        assert!(!should_stop_vm_on_missing_task(true, false, false));
+    }
+
+    #[test]
+    fn existing_guest_container_does_not_stop() {
+        assert!(!should_stop_vm_on_missing_task(true, true, false));
+    }
+
+    #[test]
+    fn exec_process_does_not_stop() {
+        assert!(!should_stop_vm_on_missing_task(false, false, true));
+    }
 }

--- a/src/runtime-rs/crates/runtimes/common/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/lib.rs
@@ -5,7 +5,7 @@
 //
 
 mod container_manager;
-pub use container_manager::ContainerManager;
+pub use container_manager::{should_stop_vm_on_missing_task, ContainerManager};
 pub mod error;
 pub mod message;
 mod runtime_handler;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -8,11 +8,11 @@ use anyhow::{anyhow, Context, Result};
 use common::{
     message::{Action, Message},
     types::{
-        ContainerProcess, PlatformInfo, ProcessType, SandboxConfig, SandboxRequest,
-        SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest, TaskResponse,
-        DEFAULT_SHM_SIZE,
+        ContainerProcess, PlatformInfo, ProcessExitStatus, ProcessType, SandboxConfig,
+        SandboxRequest, SandboxResponse, SandboxStatusInfo, StartSandboxInfo, TaskRequest,
+        TaskResponse, DEFAULT_SHM_SIZE,
     },
-    RuntimeHandler, RuntimeInstance, Sandbox, SandboxNetworkEnv,
+    RuntimeHandler, RuntimeInstance, Sandbox, SandboxNetworkEnv, should_stop_vm_on_missing_task,
 };
 
 use containerd_shim_protos::events::task::{TaskCreate, TaskDelete, TaskStart};
@@ -687,6 +687,13 @@ impl RuntimeHandlerManager {
             }
             TaskRequest::KillProcess(req) => {
                 cm.kill_process(&req).await.context("kill process")?;
+                if should_stop_vm_on_missing_task(
+                    req.process.process_type == ProcessType::Container,
+                    cm.has_guest_container(&req.process).await,
+                    cm.guest_map_is_empty().await,
+                ) {
+                    sandbox.stop().await.context("stop sandbox on missing-task kill")?;
+                }
                 Ok(TaskResponse::KillProcess)
             }
             TaskRequest::ShutdownContainer(req) => {
@@ -701,8 +708,29 @@ impl RuntimeHandlerManager {
                 Ok(TaskResponse::ShutdownContainer)
             }
             TaskRequest::WaitProcess(process_id) => {
-                let exit_status = cm.wait_process(&process_id).await.context("wait process")?;
-                if cm.is_sandbox_container(&process_id).await {
+                // A leftover CRI task that never entered the guest map will
+                // never report an exit; the only remaining work for it is to
+                // stop the VM.
+                let missing_task = should_stop_vm_on_missing_task(
+                    process_id.process_type == ProcessType::Container,
+                    cm.has_guest_container(&process_id).await,
+                    cm.guest_map_is_empty().await,
+                );
+                let exit_status = match cm.wait_process(&process_id).await {
+                    Ok(status) => status,
+                    Err(err) if missing_task => {
+                        warn!(
+                            sl!(),
+                            "wait container missing ({:#}); stopping VM and reporting exit 137",
+                            err
+                        );
+                        let mut status = ProcessExitStatus::new();
+                        status.update_exit_code(137);
+                        status
+                    }
+                    Err(err) => return Err(err).context("wait process"),
+                };
+                if missing_task || cm.is_sandbox_container(&process_id).await {
                     sandbox.stop().await.context("stop sandbox")?;
 
                     // Release sandbox resources (cgroup, network, mounts, ...)

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -468,4 +468,21 @@ impl ContainerManager for VirtContainerManager {
         process.process_type == ProcessType::Container
             && process.container_id.container_id == self.sid
     }
+
+    #[instrument]
+    async fn has_guest_container(&self, process: &ContainerProcess) -> bool {
+        self.containers
+            .read()
+            .await
+            .contains_key(&process.container_id.container_id)
+    }
+
+    #[instrument]
+    async fn guest_map_is_empty(&self) -> bool {
+        // The pause container is created through the task service with
+        // container_id == sandbox id, so it sits in the container map. It is
+        // not a guest workload: only non-sandbox entries count when deciding
+        // whether a missing-task Kill/Wait may stop the VM.
+        self.containers.read().await.keys().all(|id| id == &self.sid)
+    }
 }


### PR DESCRIPTION
### Description

Fixes #13746

A leftover sandbox (e.g. after a node reboot) can hold a CRI task whose `CreateContainer` never reached the guest — an init container stuck in `Unknown`. kubelet `StopContainer` then targets that id first:

1. `KillProcess` returns success without signalling anything (`Signal ignored due to container not existing`)
2. `WaitProcess` returns `ContainerNotFound`
3. the CRI stop times out (`DeadlineExceeded`) and `StopPodSandbox` never reaches the sandbox id

so the VM stays running with the sandbox `Ready`, holding its memory and devices for as long as the node is up. We observed this on Kata 4.1 runtime-rs (Intel TDX): a leftover CPU-only sandbox kept a QEMU guest alive for **three days** while the shim logged the ignored-signal warning on every kubelet retry.

This PR adds one rule: when the guest map holds **no workload container**, a Kill/Wait of a task that is not in the map may stop the VM.

Key detail (production-validated): **the pause container must not count toward the map** — it is created through the task service with `container_id == sandbox id`, so it sits in the map. A naive `containers.is_empty()` never fires for this scenario; the empty-map predicate must compare every key against the sandbox id. That subtlety is why the rule is written as an explicit predicate with unit tests.

Guards:
- Do not stop when another guest container is still in the map — an init crash-loop retry would otherwise fail its next `CreateContainer` with `sandbox already stopped`.
- Never stop for non-container (exec) processes.
- The sandbox-id Kill/Wait path from #13666 is intentionally **not** duplicated here; this change composes with it (`WaitProcess` already stops on the sandbox id).

### Test plan

- [x] Unit tests for the predicate (`cargo test -p common`)
- [x] Production validation (shim overlay on Kata 4.1, Intel TDX, RKE2/kubelet CRI): with the empty-map rule including the pause-entry fix, the leftover sandbox's `stop_vm` fired on the first kubelet retry after reboot; a fresh CC sandbox on the same node boots and runs normally (HGX H200 8-GPU + NVSwitch TDX guest, ~8 min agent connect, no regression)
- [ ] CI (fork PRs need `ok-to-test` to run the workflow)

Made with [Cursor](https://cursor.com)