### PR TITLE
gha: move build checks to nightly workflow for ppc64le

### DIFF
--- a/.github/workflows/build-checks-ppc64le.yaml
+++ b/.github/workflows/build-checks-ppc64le.yaml
@@ -1,0 +1,18 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'
+
+name: Build checks for ppc64le
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build-checks-ppc64le
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-checks:
+    uses: ./.github/workflows/build-checks.yaml
+    with:
+      instance: "ubuntu-24.04-ppc64le"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -148,7 +148,7 @@ jobs:
           XDG_RUNTIME_DIR=$(mktemp -d "/tmp/kata-tests-$USER.XXX" | tee >(xargs chmod 0700))
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> "$GITHUB_ENV"
       - name: Skip tests that depend on virtualization capable runners when needed
-        if: ${{ endsWith(inputs.instance, '-arm') }}
+        if: ${{ endsWith(inputs.instance, '-arm') || inputs.instance == 'ubuntu-24.04-ppc64le' }}
         run: |
           echo "GITHUB_RUNNER_CI_NON_VIRT=true" >> "$GITHUB_ENV"
       - name: Running `${{ matrix.command }}` for ${{ matrix.component.name }}

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -31,7 +31,6 @@ jobs:
         instance:
           - "ubuntu-24.04-arm"
           - "ubuntu-24.04-s390x"
-          - "ppc64le"
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}

--- a/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,6 +41,10 @@ func setupCheckHostIsVMContainerCapable(assert *assert.Assertions, cpuInfoFile s
 }
 
 func TestCCCheckCLIFunction(t *testing.T) {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
+		t.Skip("Skipping the test as the GitHub self hosted runners for ppc64le do not support Virtualization")
+	}
+
 	cpuData := []testCPUData{
 		fakeCPUData,
 	}

--- a/src/runtime/cmd/kata-runtime/kata-env_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_ppc64le_test.go
@@ -5,7 +5,10 @@
 
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := ""
@@ -15,5 +18,8 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 }
 
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
+		t.Skip("Skipping the test as the GitHub self hosted runners for ppc64le do not support Virtualization")
+	}
 	testEnvGetEnvInfoSetsCPUTypeGeneric(t)
 }


### PR DESCRIPTION
- Move build checks to a new nightly workflow for Power instead of running on PRs
- Support `GITHUB_RUNNER_CI_NON_VIRT` in ppc64le tests for runners which do not support virtualisation.