### PR TITLE
runtime-rs: allow virtio-fs for confidential guests in qemu

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -807,10 +807,10 @@ impl QemuInner {
     pub(crate) async fn capabilities(&self) -> Result<Capabilities> {
         let mut caps = Capabilities::default();
 
-        // Confidential Guest doesn't permit virtio-fs.
-        let flags = if self.hypervisor_config().security_info.confidential_guest
-            || self.hypervisor_config().shared_fs.shared_fs.is_none()
-        {
+        // Allow virtio-fs for confidential guests when shared_fs is explicitly
+        // configured, to match the go runtime and permit experimentation with
+        // confidential file storage.
+        let flags = if self.hypervisor_config().shared_fs.shared_fs.is_none() {
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::BlockDeviceDiscardSupport


### PR DESCRIPTION
This might be slightly controversial and I'm not sure whether there is any overlaps with what we (s390x downstream team) are trying to do and the coco confidential storage discussions that have recently started and whether this restriction will impact them. If there are concerns about opening up this option then maybe we could consider do this for just s390x?

We would like to experiment with confidential file storage, so have confidential_guest=true and shared_fs=virtiofs enabled. This is possible in the go runtime, but not in runtime-rs, so relax this restriction.