### PR TITLE
runtime-rs: write vmdk descriptor file on host for CLH

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/block_source.rs
@@ -1,0 +1,214 @@
+// Copyright © 2026, Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::VmdkConfig;
+
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::io::Write as _;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+fn extent_reference(extent_path: &str, descriptor_dir: &Path) -> String {
+    let path = Path::new(extent_path);
+    if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
+        if parent == descriptor_dir {
+            return name.to_string_lossy().into_owned();
+        }
+    }
+    extent_path.to_string()
+}
+
+/// Render a VMDK descriptor for a structured layout.
+///
+/// This mirrors the QEMU backend's `render_vmdk_descriptor`, but references the
+/// backing extents by their real host paths
+fn render_vmdk_descriptor(config: &VmdkConfig, descriptor_dir: &Path) -> Result<String> {
+    let total_sectors = config
+        .total_sectors()
+        .ok_or_else(|| anyhow!("VMDK total sector count overflow"))?;
+    if total_sectors == 0 {
+        return Err(anyhow!("VMDK contains no non-empty extents"));
+    }
+
+    let mut descriptor = String::new();
+    writeln!(descriptor, "# Disk DescriptorFile")?;
+    writeln!(descriptor, "version=1")?;
+    writeln!(descriptor, "CID=fffffffe")?;
+    writeln!(descriptor, "parentCID=ffffffff")?;
+    writeln!(descriptor, "createType=\"twoGbMaxExtentFlat\"")?;
+    writeln!(descriptor)?;
+    writeln!(descriptor, "# Extent description")?;
+    for extent in &config.extents {
+        let extent_path = extent_reference(&extent.path_on_host, descriptor_dir);
+        writeln!(
+            descriptor,
+            "RW {} FLAT \"{}\" {}",
+            extent.sectors, extent_path, extent.file_offset
+        )?;
+    }
+
+    let cylinders = total_sectors.div_ceil(63 * 16);
+    writeln!(descriptor)?;
+    writeln!(descriptor, "# The Disk Data Base")?;
+    writeln!(descriptor, "#DDB")?;
+    writeln!(descriptor)?;
+    writeln!(descriptor, "ddb.virtualHWVersion = \"4\"")?;
+    writeln!(descriptor, "ddb.geometry.cylinders = \"{cylinders}\"")?;
+    writeln!(descriptor, "ddb.geometry.heads = \"16\"")?;
+    writeln!(descriptor, "ddb.geometry.sectors = \"63\"")?;
+    writeln!(descriptor, "ddb.adapterType = \"ide\"")?;
+
+    Ok(descriptor)
+}
+
+/// Validate that every backing extent exists and is large enough for the layout.
+fn validate_extents(vmdk: &VmdkConfig) -> Result<()> {
+    let mut required_sectors_by_path: HashMap<&str, u64> = HashMap::new();
+    for extent in &vmdk.extents {
+        let required_sectors = extent
+            .file_offset
+            .checked_add(extent.sectors)
+            .ok_or_else(|| anyhow!("VMDK extent sector count overflow"))?;
+        required_sectors_by_path
+            .entry(extent.path_on_host.as_str())
+            .and_modify(|maximum| *maximum = (*maximum).max(required_sectors))
+            .or_insert(required_sectors);
+    }
+
+    for (path, required_sectors) in &required_sectors_by_path {
+        let metadata = fs::metadata(path).with_context(|| format!("stat VMDK extent {path}"))?;
+        if !metadata.is_file() {
+            return Err(anyhow!("VMDK extent {path} is not a regular file"));
+        }
+        if metadata.len().div_ceil(512) < *required_sectors {
+            return Err(anyhow!(
+                "VMDK extent {path} is shorter than its declared layout"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Materialize a VMDK descriptor on the host.
+pub(super) fn prepare_vmdk_descriptor(descriptor_path: &str, vmdk: &VmdkConfig) -> Result<()> {
+    if vmdk.extents.is_empty() {
+        return Err(anyhow!("VMDK contains no extents"));
+    }
+
+    validate_extents(vmdk)?;
+
+    let path = Path::new(descriptor_path);
+    let descriptor_dir = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| anyhow!("VMDK descriptor path has no parent directory"))?;
+
+    let descriptor = render_vmdk_descriptor(vmdk, descriptor_dir)?;
+
+    fs::create_dir_all(descriptor_dir).with_context(|| {
+        format!(
+            "create VMDK descriptor directory {}",
+            descriptor_dir.display()
+        )
+    })?;
+
+    // Write to a temporary file and rename so a failure never leaves a partial
+    // descriptor at the path cloud-hypervisor is about to open.
+    let tmp_path = path.with_extension("vmdk.tmp");
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&tmp_path)
+        .with_context(|| format!("create VMDK descriptor {}", tmp_path.display()))?;
+    file.write_all(descriptor.as_bytes())
+        .with_context(|| format!("write VMDK descriptor {}", tmp_path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("flush VMDK descriptor {}", tmp_path.display()))?;
+    drop(file);
+
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "rename VMDK descriptor {} -> {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn renders_structured_vmdk_layout() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/images/first.raw", 8, 0);
+        config.push_extent("/images/first.raw", 4, 8);
+        config.push_extent("/images/second.raw", 16, 0);
+
+        let descriptor = render_vmdk_descriptor(&config, Path::new("/descriptors")).unwrap();
+        assert!(descriptor.contains("createType=\"twoGbMaxExtentFlat\""));
+        assert!(descriptor.contains("RW 8 FLAT \"/images/first.raw\" 0"));
+        assert!(descriptor.contains("RW 4 FLAT \"/images/first.raw\" 8"));
+        assert!(descriptor.contains("RW 16 FLAT \"/images/second.raw\" 0"));
+    }
+
+    #[test]
+    fn references_same_directory_extents_by_file_name() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/run/vmdk/gpt-head.img", 2048, 0);
+        config.push_extent("/run/vmdk/pad-0.img", 8, 0);
+        config.push_extent("/var/lib/containerd/layer.erofs", 16, 0);
+
+        let descriptor = render_vmdk_descriptor(&config, Path::new("/run/vmdk")).unwrap();
+        assert!(descriptor.contains("RW 2048 FLAT \"gpt-head.img\" 0"));
+        assert!(descriptor.contains("RW 8 FLAT \"pad-0.img\" 0"));
+        assert!(descriptor.contains("RW 16 FLAT \"/var/lib/containerd/layer.erofs\" 0"));
+    }
+
+    #[test]
+    fn writes_descriptor_referencing_host_extents() {
+        let dir = tempdir().unwrap();
+        let extent = dir.path().join("extent-flat.img");
+        fs::write(&extent, vec![0u8; 8 * 512]).unwrap();
+
+        let mut vmdk = VmdkConfig::default();
+        vmdk.push_extent(extent.to_str().unwrap(), 8, 0);
+
+        let descriptor_path = dir.path().join("merged.vmdk");
+        prepare_vmdk_descriptor(descriptor_path.to_str().unwrap(), &vmdk).unwrap();
+
+        let contents = fs::read_to_string(&descriptor_path).unwrap();
+        // The extent lives in the descriptor's directory, so it is referenced by name.
+        assert!(contents.contains("RW 8 FLAT \"extent-flat.img\" 0"));
+        assert!(!descriptor_path.with_extension("vmdk.tmp").exists());
+    }
+
+    #[test]
+    fn rejects_short_vmdk_extent() {
+        let dir = tempdir().unwrap();
+        let extent = dir.path().join("extent-flat.img");
+        fs::write(&extent, vec![0u8; 512]).unwrap();
+
+        let mut vmdk = VmdkConfig::default();
+        vmdk.push_extent(extent.to_str().unwrap(), 1, 0);
+        vmdk.push_extent(extent.to_str().unwrap(), 1, 1);
+
+        let descriptor_path = dir.path().join("merged.vmdk");
+        let error = prepare_vmdk_descriptor(descriptor_path.to_str().unwrap(), &vmdk).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("shorter than its declared layout"));
+        assert!(!descriptor_path.exists());
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/ch/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/block_source.rs
@@ -22,6 +22,19 @@ fn extent_reference(extent_path: &str, descriptor_dir: &Path) -> String {
     extent_path.to_string()
 }
 
+// The VMDK descriptor wraps the extent path in double quotes and has
+// no escape mechanism, so a `"`, newline, or carriage return in a path would
+// terminate the field early and could inject additional descriptor lines.
+// Reject such paths rather than emit a malformed descriptor.
+fn validate_extent_reference(reference: &str, extent_path: &str) -> Result<()> {
+    if reference.contains(['"', '\n', '\r']) {
+        return Err(anyhow!(
+            "VMDK extent path {extent_path} contains characters unsupported by the descriptor grammar"
+        ));
+    }
+    Ok(())
+}
+
 /// Render a VMDK descriptor for a structured layout.
 ///
 /// This mirrors the QEMU backend's `render_vmdk_descriptor`, but references the
@@ -44,6 +57,7 @@ fn render_vmdk_descriptor(config: &VmdkConfig, descriptor_dir: &Path) -> Result<
     writeln!(descriptor, "# Extent description")?;
     for extent in &config.extents {
         let extent_path = extent_reference(&extent.path_on_host, descriptor_dir);
+        validate_extent_reference(&extent_path, &extent.path_on_host)?;
         writeln!(
             descriptor,
             "RW {} FLAT \"{}\" {}",
@@ -192,6 +206,23 @@ mod tests {
         // The extent lives in the descriptor's directory, so it is referenced by name.
         assert!(contents.contains("RW 8 FLAT \"extent-flat.img\" 0"));
         assert!(!descriptor_path.with_extension("vmdk.tmp").exists());
+    }
+
+    #[test]
+    fn rejects_extent_paths_with_descriptor_grammar_characters() {
+        for bad in [
+            "/images/ev\"il.raw",
+            "/images/ev\nil.raw",
+            "/images/ev\ril.raw",
+        ] {
+            let mut config = VmdkConfig::default();
+            config.push_extent(bad, 8, 0);
+
+            let error = render_vmdk_descriptor(&config, Path::new("/descriptors")).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("unsupported by the descriptor grammar"));
+        }
     }
 
     #[test]

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use super::block_source::prepare_vmdk_descriptor;
 use super::inner::CloudHypervisorInner;
 use crate::ch::utils::get_rootless_symlink_sandbox_jailer_root;
 use crate::device::pci_path::PciPath;
@@ -286,6 +287,13 @@ impl CloudHypervisorInner {
         disk_config.direct = config
             .is_direct
             .unwrap_or(self.config.blockdev_info.block_device_cache_direct);
+
+        // Render the structured VMDK layout into a descriptor file on host.
+        if let Some(vmdk) = &config.vmdk {
+            prepare_vmdk_descriptor(&config.path_on_host, vmdk)?;
+            disk_config.path = Some(config.path_on_host.as_str().into());
+            disk_config.image_type = ImageType::Raw;
+        }
 
         disk_config.rate_limiter_config = RateLimiterConfig::new(
             self.config.blockdev_info.disk_rate_limiter_bw_max_rate,

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -23,6 +23,7 @@ macro_rules! sl {
       };
   }
 
+mod block_source;
 mod inner;
 mod inner_device;
 mod inner_hypervisor;

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -375,8 +375,9 @@ pub(crate) struct ErofsMultiLayerRootfs {
     rwlayer_storage: Option<Storage>,
     // Read-only EROFS layer storages (lower layers), one per partition in GPT mode
     erofs_storages: Vec<Storage>,
-    // Paths to generated GPT metadata files (head, padding) for cleanup
-    gpt_metadata_paths: Vec<PathBuf>,
+    // Host artifacts generated for a VMDK-backed rootfs (GPT head, padding
+    // images, and the VMDK descriptor), removed on cleanup after device unplug.
+    generated_artifact_paths: Vec<PathBuf>,
     // Container-scoped runtime directory that may only contain generated helper artifacts.
     generated_artifacts_dir: PathBuf,
 }
@@ -398,7 +399,7 @@ impl ErofsMultiLayerRootfs {
         let mut device_ids = Vec::new();
         let mut rwlayer_storage: Option<Storage> = None;
         let mut erofs_storages: Vec<Storage> = Vec::new();
-        let mut gpt_metadata_paths: Vec<PathBuf> = Vec::new();
+        let mut generated_artifact_paths: Vec<PathBuf> = Vec::new();
         // Track whether GPT+VMDK erofs layers have already been processed in bulk.
         let mut gpt_erofs_processed = false;
 
@@ -577,9 +578,11 @@ impl ErofsMultiLayerRootfs {
                             generate_gpt_vmdk_with_layout(sid, cid, erofs_layers)
                                 .context("gptdisk: failed to generate GPT VMDK")?;
 
-                        // Track GPT metadata files (head + padding) for cleanup
-                        gpt_metadata_paths.push(gpt_files.head_path.clone());
-                        gpt_metadata_paths.extend(gpt_files.pad_paths.iter().cloned());
+                        // Track every host artifact backing this VMDK for cleanup:
+                        // GPT metadata files (head + padding) and the descriptor
+                        // text file
+                        generated_artifact_paths.push(gpt_files.head_path.clone());
+                        generated_artifact_paths.extend(gpt_files.pad_paths.iter().cloned());
                         for idx in 0..layout.partitions.len() {
                             if idx > 0 {
                                 // Check for padding files (only created when there are gaps)
@@ -589,10 +592,11 @@ impl ErofsMultiLayerRootfs {
                                     .unwrap()
                                     .join(format!("pad-{}.img", idx));
                                 if pad_path.exists() {
-                                    gpt_metadata_paths.push(pad_path);
+                                    generated_artifact_paths.push(pad_path);
                                 }
                             }
                         }
+                        generated_artifact_paths.push(PathBuf::from(&erofs_path));
 
                         info!(
                             sl!(),
@@ -753,6 +757,14 @@ impl ErofsMultiLayerRootfs {
                             vmdk.is_some()
                         );
 
+                        // A structured layout means a VMM backend materializes a
+                        // VMDK descriptor at `erofs_path`; track it for cleanup.
+                        // A single device carries no descriptor (`erofs_path` is
+                        // the EROFS image itself), so only track when merging.
+                        if vmdk.is_some() {
+                            generated_artifact_paths.push(PathBuf::from(&erofs_path));
+                        }
+
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
                             vmdk,
@@ -852,7 +864,7 @@ impl ErofsMultiLayerRootfs {
             device_ids,
             rwlayer_storage,
             erofs_storages,
-            gpt_metadata_paths,
+            generated_artifact_paths,
             generated_artifacts_dir: PathBuf::from(kata_types::prefix_with_rootless_dir(
                 DEFAULT_KATA_GUEST_ROOT_SHARED_FS,
             ))
@@ -913,9 +925,9 @@ impl Rootfs for ErofsMultiLayerRootfs {
             dm.try_remove_device(device_id).await?;
         }
 
-        // Clean up GPT metadata files (head, padding).
-        for metadata_path in &self.gpt_metadata_paths {
-            safely_remove_file(metadata_path, &self.generated_artifacts_dir)?;
+        // Remove the generated VMDK artifacts (GPT head, padding, descriptor).
+        for artifact_path in &self.generated_artifact_paths {
+            safely_remove_file(artifact_path, &self.generated_artifacts_dir)?;
         }
 
         Ok(())


### PR DESCRIPTION
Write the VMDK descriptor text to host path when using erofs backed rootfs with Cloud Hypervisor. Cloud Hypervisor currently uses this host path as disk-path to open the block device.

This brings back the behaviour before the refactor in commit 34a9fdd for VMMs using host paths instead of opened fd's. The refactor moved the VMDK source into an in-memory object. This requires handling the vmdk source info on a per-vmm basis.

Fixes: #13778