### PR TITLE
release: helm: Upload the try-*.values files as part of the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -364,7 +364,7 @@ jobs:
 
   publish-release:
     name: publish-release
-    needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, publish-kata-monitor-image, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
+    needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, publish-kata-monitor-image, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball, upload-helm-chart-tarball ]
     runs-on: ubuntu-22.04
     permissions:
       contents: write # needed for the `gh release` commands

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -341,6 +341,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Upload the helm chart values presets
+        run: |
+          ./tools/packaging/release/release.sh upload-helm-chart-values-files
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Login to the OCI registries
         env:
           QUAY_DEPLOYER_USERNAME: ${{ vars.QUAY_DEPLOYER_USERNAME }}

--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -811,6 +811,15 @@ See the default [`values.yaml`](#parameters) for the remaining `job.*` options
 
 We provide a few examples that you can pass to helm via the `-f`/`--values` flag.
 
+Each is published as a release asset and `-f` takes a URL, so helm fetches the
+file itself. Replace `VERSION` in both the flag and the URL, or use
+`/releases/latest/download/<file>` for the newest release.
+
+!!! warning "Releases up to and including 4.1.0"
+    Those releases do not carry the presets as assets. Fetch the desired file from
+    its tag instead, replacing `<file>` with the preset filename:
+    `https://raw.githubusercontent.com/kata-containers/kata-containers/refs/tags/VERSION/tools/packaging/kata-deploy/helm-chart/kata-deploy/<file>`
+
 ### [`try-kata-tee.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-tee.values.yaml)
 
 This file enables only the TEE (Trusted Execution Environment) shims for confidential computing:
@@ -818,7 +827,7 @@ This file enables only the TEE (Trusted Execution Environment) shims for confide
 ```sh
 helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
   --version VERSION \
-  -f try-kata-tee.values.yaml
+  -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-tee.values.yaml
 ```
 
 Includes:
@@ -839,7 +848,7 @@ DaemonSet on the node):
 ```sh
 helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
   --version VERSION \
-  -f try-kata-nvidia-cpu.values.yaml
+  -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-nvidia-cpu.values.yaml
 ```
 
 Includes:
@@ -857,7 +866,7 @@ DaemonSet on the node):
 ```sh
 helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
   --version VERSION \
-  -f try-kata-nvidia-gpu.values.yaml
+  -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-nvidia-gpu.values.yaml
 ```
 
 Includes:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -5,7 +5,7 @@
 # Usage:
 #   helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
 #     --version VERSION \
-#     -f try-kata-nvidia-cpu.values.yaml
+#     -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-nvidia-cpu.values.yaml
 
 debug: false
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -4,7 +4,7 @@
 # Usage:
 #   helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
 #     --version VERSION \
-#     -f try-kata-nvidia-gpu.values.yaml
+#     -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-nvidia-gpu.values.yaml
 
 debug: false
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-tee.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-tee.values.yaml
@@ -4,7 +4,7 @@
 # Usage:
 #   helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
 #     --version VERSION \
-#     -f try-kata-tee.values.yaml
+#     -f https://github.com/kata-containers/kata-containers/releases/download/VERSION/try-kata-tee.values.yaml
 
 debug: false
 

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -14,6 +14,7 @@ set -o errtrace
 
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root_dir="$(cd "${this_script_dir}/../../../" && pwd)"
+helm_chart_dir="${repo_root_dir}/tools/packaging/kata-deploy/helm-chart/kata-deploy"
 
 KATA_DEPLOY_IMAGE_TAGS="${KATA_DEPLOY_IMAGE_TAGS:-}"
 IFS=' ' read -r -a IMAGE_TAGS <<< "${KATA_DEPLOY_IMAGE_TAGS}"
@@ -253,8 +254,27 @@ function _upload_helm_chart_tarball()
 
 	RELEASE_VERSION="$(_release_version)"
 
-	helm package "${repo_root_dir}"/tools/packaging/kata-deploy/helm-chart/kata-deploy
+	helm package "${helm_chart_dir}"
 	gh release upload "${RELEASE_VERSION}" "kata-deploy-${RELEASE_VERSION}.tgz"
+}
+
+function _upload_helm_chart_values_files()
+{
+	_check_required_env_var "GH_TOKEN"
+
+	RELEASE_VERSION="$(_release_version)"
+
+	local values_files=()
+	shopt -s nullglob
+	values_files=( "${helm_chart_dir}"/try-kata-*.values.yaml )
+	shopt -u nullglob
+
+	[[ "${#values_files[@]}" -eq 0 ]] && \
+		_die "no try-kata-*.values.yaml presets found in ${helm_chart_dir}"
+
+	# Plain names, unlike the other assets, so /releases/latest/download/ works.
+	echo "uploading assets '${values_files[*]##*/}' for tag: ${RELEASE_VERSION}"
+	gh release upload --clobber "${RELEASE_VERSION}" "${values_files[@]}"
 }
 
 function main()
@@ -272,6 +292,7 @@ function main()
 		upload-vendored-code-tarball) _upload_vendored_code_tarball ;;
 		upload-libseccomp-tarball) _upload_libseccomp_tarball ;;
 		upload-helm-chart-tarball) _upload_helm_chart_tarball ;;
+		upload-helm-chart-values-files) _upload_helm_chart_values_files ;;
 		publish-release) _publish_release ;;
 		*) >&2 _die "Invalid argument" ;;
 	esac


### PR DESCRIPTION
So the users can easily access them without having to manually download the files, the charts, or the code.