### PR TITLE
kata-deploy: enable NFD in the NVIDIA presets

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -89,3 +89,6 @@ runtimeClasses:
   enabled: true
   createDefault: false
   defaultName: "kata"
+
+node-feature-discovery:
+  enabled: true

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -102,8 +102,6 @@ shims:
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the snp label by other
-      # means to your SNP nodes.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         amd.feature.node.kubernetes.io/snp: "true"
@@ -124,8 +122,6 @@ shims:
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the snp label by other
-      # means to your SNP nodes.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         amd.feature.node.kubernetes.io/snp: "true"
@@ -146,8 +142,6 @@ shims:
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the tdx label by other
-      # means to your TDX nodes.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         intel.feature.node.kubernetes.io/tdx: "true"
@@ -168,8 +162,6 @@ shims:
     runtimeClass:
       # These labels are automatically added by gpu-operator and NFD
       # respectively. Override if you want to use a different label.
-      # If you don't have NFD, you need to add the tdx label by other
-      # means to your TDX nodes.
       nodeSelector:
         nvidia.com/cc.ready.state: "true"
         intel.feature.node.kubernetes.io/tdx: "true"
@@ -182,3 +174,6 @@ runtimeClasses:
   enabled: true
   createDefault: false
   defaultName: "kata"
+
+node-feature-discovery:
+  enabled: true


### PR DESCRIPTION
Both presets depend on node-feature-discovery: the GPU one selects on the SNP/TDX labels NFD advertises, and both rely on it to keep Kata off nodes without virtualization support.