### PR TITLE
runtime-rs: enable accept_local for l3forwarding taps

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/network_model/l3_forwarding_model.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/l3_forwarding_model.rs
@@ -56,6 +56,22 @@ impl NetworkModel for L3ForwardingModel {
         }
         let pod_ipv4 = pod_addrs.first().copied();
 
+        // The workload IP remains configured on the CNI-provided interface in the host-side
+        // netns while the guest uses the same address. Packets from the guest therefore arrive
+        // on the tap with a source address that is local to this netns. Allow those packets so
+        // the route lookup used by proxy ARP can succeed.
+        fs::write(
+            format!(
+                "/proc/sys/net/ipv4/conf/{}/accept_local",
+                pair.tap.tap_iface.name
+            ),
+            "1",
+        )
+        .context(format!(
+            "enable accept_local on {}",
+            pair.tap.tap_iface.name
+        ))?;
+
         // Enable proxy arp so we can respond to ARP requests using the tap and virt interfaces.
         fs::write(
             format!(


### PR DESCRIPTION
## Summary

Enable `accept_local` on the Kata TAP interface when using the runtime-rs
`l3forwarding` network model.

The host-side CNI interface keeps the workload IPv4 address while the
guest uses the same address. Traffic from the guest therefore arrives on
`tap*_kata` with a source address that Linux also considers local to the
host-side pod network namespace.

Without `accept_local=1` on the TAP, the input route lookup used by proxy
ARP can reject that local source. As a result, guest ARP requests for the
gateway receive no proxy ARP reply and connectivity is broken.

Set `net.ipv4.conf.<tap>.accept_local=1` only on the Kata TAP, alongside
the existing proxy ARP and IPv4 forwarding configuration.

## Environment

* Debian 12
* 6.1.0-51-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.177-1 (2026-07-16) x86_64 GNU/Linux
* runtime-rs & dragonball
* `internetworking_model = "l3forwarding"`
* Multus with macvlan as the default interface
* No Istio or service mesh

This was found while using `l3forwarding` with Multus network policy
enforcement through:

https://github.com/jclab-oss/multi-networkpolicy-nftables/pull/1

That setup requires traffic to traverse the host-side pod network stack,
so `l3forwarding` is used instead of the L2 `tcfilter` forwarding path.

## Reproduction

The host-side pod network namespace was configured as expected:

```text
eth0       172.30.0.101/24
tap0_kata  169.254.0.1/32

default via 172.30.0.1 dev eth0
172.30.0.0/24 dev eth0
172.30.0.101 dev tap0_kata scope link
```

`ip_forward` and `proxy_arp` were enabled.

When the guest tried to reach the gateway, `tap0_kata` repeatedly
received:

```text
ARP Request who-has 172.30.0.1 tell 172.30.0.101
```

No proxy ARP reply was generated, and no packet was observed on the
CNI-provided `eth0` interface.

The corresponding input route lookup also failed:

```text
ip route get 172.30.0.1 from 172.30.0.101 iif tap0_kata
RTNETLINK answers: Invalid argument
```

After enabling:

```text
net.ipv4.conf.tap0_kata.accept_local=1
```

connectivity was restored.
