### PR TITLE
deps: Bump netlink versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,9 +3587,9 @@ dependencies = [
  "log",
  "logging",
  "mem-agent",
- "netlink-packet-core 0.7.0",
- "netlink-packet-route 0.19.0",
- "netlink-sys 0.7.0",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
  "nix 0.31.3",
  "oci-spec 0.10.0",
  "opentelemetry 0.17.0",
@@ -3601,7 +3601,7 @@ dependencies = [
  "protocols",
  "regex",
  "rstest",
- "rtnetlink 0.14.1",
+ "rtnetlink",
  "runtime-spec",
  "rustjail",
  "s390_pv_core",
@@ -4308,107 +4308,43 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
-dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
-dependencies = [
- "paste",
-]
+checksum = "2d6e2daf9a8c2e21302714706860a0e6be02e03d17294ecc66b354ea7d4059dd"
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
-dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "log",
- "netlink-packet-core 0.7.0",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "59d48ffc8b73a506e1ff0878528c72668f2bfbc3d875b6be890a96be5d0d5576"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "log",
- "netlink-packet-core 0.8.1",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
+ "netlink-packet-core",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "97e03ae6247c6cdb499e8f14e98c72b83954d85822b687056e3a21150b438f2b"
 dependencies = [
  "bytes 1.11.1",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
- "netlink-packet-core 0.7.0",
- "netlink-sys 0.8.8",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "netlink-proto"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
-dependencies = [
- "bytes 1.11.1",
- "futures",
- "log",
- "netlink-packet-core 0.8.1",
- "netlink-sys 0.8.8",
+ "netlink-packet-core",
+ "netlink-sys",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "netlink-sys"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
-dependencies = [
- "futures",
- "libc",
- "log",
- "tokio",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+checksum = "c99d38e00b420df49e940fe0826e667c3dad82ac68eb4c2bbf754c1c14a83a10"
 dependencies = [
  "bytes 1.11.1",
  "futures-util",
@@ -4484,17 +4420,6 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if 1.0.4",
- "libc",
 ]
 
 [[package]]
@@ -5219,12 +5144,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-absolutize"
@@ -6456,15 +6375,15 @@ dependencies = [
  "lazy_static",
  "libc",
  "logging",
- "netlink-packet-core 0.8.1",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-core",
+ "netlink-packet-route",
  "netns-rs",
  "nix 0.31.3",
  "oci-spec 0.10.0",
  "persist",
  "rand 0.10.1",
  "rstest",
- "rtnetlink 0.21.0",
+ "rtnetlink",
  "scopeguard",
  "serde",
  "serde_json",
@@ -6589,37 +6508,19 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.14.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core 0.7.0",
- "netlink-packet-route 0.19.0",
- "netlink-packet-utils",
- "netlink-proto 0.11.5",
- "netlink-sys 0.8.8",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+checksum = "90f60a3ee149005c5819e03e3d73ba4a470bc18b52b0c8422cfe1bea2cae63c6"
 dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "netlink-packet-core 0.8.1",
- "netlink-packet-route 0.30.0",
- "netlink-proto 0.12.0",
- "netlink-sys 0.8.8",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
  "nix 0.30.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,9 +175,9 @@ ipnetwork = "0.17.0"
 lazy_static = "1.4"
 libc = "0.2.94"
 log = "0.4.14"
-netlink-packet-core = "0.7.0"
-netlink-packet-route = "0.19.0"
-netlink-sys = { version = "0.7.0", features = ["tokio_socket"] }
+netlink-packet-core = "0.9.0"
+netlink-packet-route = "0.33.0"
+netlink-sys = { version = "0.9.0", features = ["tokio_socket"] }
 netns-rs = "0.1.0"
 # Note: nix needs to stay sync'd with libs versions
 nix = { version = "0.31.3", features = ["fs", "mount", "sched", "process", "ioctl", "signal", "socket", "feature", "user", "hostname", "term", "event", "mman", "reboot"] }
@@ -190,7 +190,7 @@ protobuf = "3.7.2"
 rand = "0.10.1"
 regex = "1.10.5"
 rstest = "0.26.1"
-rtnetlink = "0.14.0"
+rtnetlink = "0.23.0"
 scan_fmt = "0.2.6"
 scopeguard = "1.0.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -10,9 +10,9 @@ use crate::{device::pcipath_to_sysfs, pci};
 use anyhow::{anyhow, Context, Result};
 use futures::{future, TryStreamExt};
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
-use netlink_packet_route::link::{LinkAttribute, LinkMessage};
-use netlink_packet_route::neighbour::NeighbourFlag;
-use netlink_packet_route::route::{RouteFlag, RouteHeader, RouteProtocol, RouteScope, RouteType};
+use netlink_packet_route::link::{LinkAttribute, LinkFlags, LinkMessage};
+use netlink_packet_route::neighbour::NeighbourFlags;
+use netlink_packet_route::route::{RouteHeader, RouteProtocol, RouteScope, RouteType};
 use netlink_packet_route::{
     address::{AddressAttribute, AddressMessage},
     route::RouteMetric,
@@ -23,7 +23,7 @@ use netlink_packet_route::{
 };
 use nix::errno::Errno;
 use protocols::types::{ARPNeighbor, IPAddress, IPFamily, Interface, Route};
-use rtnetlink::{new_connection, IpVersion};
+use rtnetlink::{new_connection, IpVersion, LinkUnspec, RouteMessageBuilder};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::fs;
@@ -52,35 +52,7 @@ impl fmt::Display for LinkFilter<'_> {
     }
 }
 
-const ALL_RULE_FLAGS: [NeighbourFlag; 8] = [
-    NeighbourFlag::Use,
-    NeighbourFlag::Own,
-    NeighbourFlag::Controller,
-    NeighbourFlag::Proxy,
-    NeighbourFlag::ExtLearned,
-    NeighbourFlag::Offloaded,
-    NeighbourFlag::Sticky,
-    NeighbourFlag::Router,
-];
-
-const ALL_ROUTE_FLAGS: [RouteFlag; 16] = [
-    RouteFlag::Dead,
-    RouteFlag::Pervasive,
-    RouteFlag::Onlink,
-    RouteFlag::Offload,
-    RouteFlag::Linkdown,
-    RouteFlag::Unresolved,
-    RouteFlag::Trap,
-    RouteFlag::Notify,
-    RouteFlag::Cloned,
-    RouteFlag::Equalize,
-    RouteFlag::Prefix,
-    RouteFlag::LookupTable,
-    RouteFlag::FibMatch,
-    RouteFlag::RtOffload,
-    RouteFlag::RtTrap,
-    RouteFlag::OffloadFailed,
-];
+const ALL_RULE_FLAGS: NeighbourFlags = NeighbourFlags::all();
 
 /// A filter to query addresses.
 pub enum AddressFilter {
@@ -182,13 +154,15 @@ impl Handle {
 
                 // update the existing interface name with a temporary name, otherwise
                 // it would failed to udpate this interface with an existing name.
-                let mut request = self.handle.link().set(link.index());
-                request.message_mut().header = link.header.clone();
                 let link_name = link.name();
                 let temp_name = link_name.clone() + "_temp";
-
-                request
+                let msg = LinkUnspec::new_with_index(link.index())
+                    .set_header(link.header.clone())
                     .name(temp_name.clone())
+                    .build();
+                self.handle
+                    .link()
+                    .change(msg)
                     .execute()
                     .await
                     .map_err(|err| {
@@ -206,14 +180,16 @@ impl Handle {
 
         // Update link
         let link = self.find_link(LinkFilter::Address(&iface.hwAddr)).await?;
-        let mut request = self.handle.link().set(link.index());
-        request.message_mut().header = link.header.clone();
-
-        request
+        let msg = LinkUnspec::new_with_index(link.index())
+            .set_header(link.header.clone())
             .mtu(iface.mtu as _)
             .name(iface.name.clone())
             .arp(iface.raw_flags & libc::IFF_NOARP as u32 == 0)
             .up()
+            .build();
+        self.handle
+            .link()
+            .change(msg)
             .execute()
             .await
             .map_err(|err| {
@@ -226,12 +202,14 @@ impl Handle {
 
         // swap the updated iface's name.
         if let Some(nlink) = new_link {
-            let mut request = self.handle.link().set(nlink.index());
-            request.message_mut().header = nlink.header.clone();
-
-            request
+            let msg = LinkUnspec::new_with_index(nlink.index())
+                .set_header(nlink.header.clone())
                 .name(link.name())
                 .up()
+                .build();
+            self.handle
+                .link()
+                .change(msg)
                 .execute()
                 .await
                 .map_err(|err| {
@@ -291,10 +269,13 @@ impl Handle {
             self.enable_link(link.index(), false).await?;
         }
 
-        let mut request = self.handle.link().set(link.index());
-        request.message_mut().header = link.header.clone();
-        request
+        let msg = LinkUnspec::new_with_index(link.index())
+            .set_header(link.header.clone())
             .address(parsed_mac.to_vec())
+            .build();
+        self.handle
+            .link()
+            .change(msg)
             .execute()
             .await
             .with_context(|| format!("failed to set MAC for interface {} to {}", ifname, mac))?;
@@ -394,27 +375,26 @@ impl Handle {
     }
 
     pub async fn enable_link(&self, link_index: u32, up: bool) -> Result<()> {
-        let link_req = self.handle.link().set(link_index);
-        let set_req = if up { link_req.up() } else { link_req.down() };
-        set_req.execute().await?;
+        let builder = LinkUnspec::new_with_index(link_index);
+        let msg = if up { builder.up() } else { builder.down() };
+        self.handle.link().change(msg.build()).execute().await?;
         Ok(())
     }
 
     async fn query_routes(&self, ip_version: Option<IpVersion>) -> Result<Vec<RouteMessage>> {
         let list = if let Some(ip_version) = ip_version {
-            self.handle
-                .route()
-                .get(ip_version)
-                .execute()
-                .try_collect()
-                .await?
+            let msg = match ip_version {
+                IpVersion::V4 => RouteMessageBuilder::<std::net::Ipv4Addr>::new().build(),
+                IpVersion::V6 => RouteMessageBuilder::<std::net::Ipv6Addr>::new().build(),
+            };
+            self.handle.route().get(msg).execute().try_collect().await?
         } else {
             // These queries must be executed sequentially, otherwise
             // it'll throw "Device or resource busy (os error 16)"
             let routes4 = self
                 .handle
                 .route()
-                .get(IpVersion::V4)
+                .get(RouteMessageBuilder::<std::net::Ipv4Addr>::new().build())
                 .execute()
                 .try_collect::<Vec<_>>()
                 .await
@@ -423,7 +403,7 @@ impl Handle {
             let routes6 = self
                 .handle
                 .route()
-                .get(IpVersion::V6)
+                .get(RouteMessageBuilder::<std::net::Ipv6Addr>::new().build())
                 .execute()
                 .try_collect::<Vec<_>>()
                 .await
@@ -527,40 +507,6 @@ impl Handle {
 
             use RouteAttribute as Nla;
 
-            // Build a common indeterminate ip request
-            let mut request = self
-                .handle
-                .route()
-                .add()
-                .table_id(MAIN_TABLE)
-                .kind(uni_cast)
-                .protocol(boot_prot)
-                .scope(scope);
-
-            let message = request.message_mut();
-
-            // calculate the Flag vec from the u32 flags
-            let mut got: u32 = 0;
-            let mut flags = Vec::new();
-            for flag in ALL_ROUTE_FLAGS {
-                if (route.flags & (u32::from(flag))) > 0 {
-                    flags.push(flag);
-                    got += u32::from(flag);
-                }
-            }
-            if got != route.flags {
-                flags.push(RouteFlag::Other(route.flags - got));
-            }
-
-            message.header.flags = flags;
-
-            if route.mtu != 0 {
-                let route_metrics = vec![RouteMetric::Mtu(route.mtu)];
-                message
-                    .attributes
-                    .push(RouteAttribute::Metrics(route_metrics));
-            }
-
             // `rtnetlink` offers a separate request builders for different IP versions (IP v4 and v6).
             // This if branch is a bit clumsy because it does almost the same.
             if route.family() == IPFamily::v6 {
@@ -571,19 +517,32 @@ impl Handle {
                 };
 
                 // Build IP v6 request
-                let mut request = request
-                    .v6()
+                let mut v6_builder = RouteMessageBuilder::<Ipv6Addr>::new()
+                    .table_id(MAIN_TABLE)
+                    .kind(uni_cast)
+                    .protocol(boot_prot)
+                    .scope(scope)
                     .destination_prefix(dest_addr.ip(), dest_addr.prefix())
-                    .output_interface(link.index())
-                    .replace();
+                    .output_interface(link.index());
+                {
+                    let message = v6_builder.get_mut();
+                    message.header.flags =
+                        netlink_packet_route::route::RouteFlags::from_bits_retain(route.flags);
+                    if route.mtu != 0 {
+                        let route_metrics = vec![RouteMetric::Mtu(route.mtu)];
+                        message
+                            .attributes
+                            .push(RouteAttribute::Metrics(route_metrics));
+                    }
+                }
 
                 if !route.source.is_empty() {
                     let network = Ipv6Network::from_str(&route.source)?;
                     if network.prefix() > 0 {
-                        request = request.source_prefix(network.ip(), network.prefix());
+                        v6_builder = v6_builder.source_prefix(network.ip(), network.prefix());
                     } else {
-                        request
-                            .message_mut()
+                        v6_builder
+                            .get_mut()
                             .attributes
                             .push(Nla::PrefSource(RouteAddress::from(network.ip())));
                     }
@@ -591,9 +550,10 @@ impl Handle {
 
                 if !route.gateway.is_empty() {
                     let ip = Ipv6Addr::from_str(&route.gateway)?;
-                    request = request.gateway(ip);
+                    v6_builder = v6_builder.gateway(ip);
                 }
 
+                let request = self.handle.route().add(v6_builder.build()).replace();
                 if let Err(rtnetlink::Error::NetlinkError(message)) = request.execute().await {
                     if let Some(code) = message.code {
                         if Errno::from_raw(code.get()) != Errno::EEXIST {
@@ -615,19 +575,32 @@ impl Handle {
                 };
 
                 // Build IP v4 request
-                let mut request = request
-                    .v4()
+                let mut v4_builder = RouteMessageBuilder::<Ipv4Addr>::new()
+                    .table_id(MAIN_TABLE)
+                    .kind(uni_cast)
+                    .protocol(boot_prot)
+                    .scope(scope)
                     .destination_prefix(dest_addr.ip(), dest_addr.prefix())
-                    .output_interface(link.index())
-                    .replace();
+                    .output_interface(link.index());
+                {
+                    let message = v4_builder.get_mut();
+                    message.header.flags =
+                        netlink_packet_route::route::RouteFlags::from_bits_retain(route.flags);
+                    if route.mtu != 0 {
+                        let route_metrics = vec![RouteMetric::Mtu(route.mtu)];
+                        message
+                            .attributes
+                            .push(RouteAttribute::Metrics(route_metrics));
+                    }
+                }
 
                 if !route.source.is_empty() {
                     let network = Ipv4Network::from_str(&route.source)?;
                     if network.prefix() > 0 {
-                        request = request.source_prefix(network.ip(), network.prefix());
+                        v4_builder = v4_builder.source_prefix(network.ip(), network.prefix());
                     } else {
-                        request
-                            .message_mut()
+                        v4_builder
+                            .get_mut()
                             .attributes
                             .push(RouteAttribute::PrefSource(RouteAddress::from(network.ip())));
                     }
@@ -635,9 +608,10 @@ impl Handle {
 
                 if !route.gateway.is_empty() {
                     let ip = Ipv4Addr::from_str(&route.gateway)?;
-                    request = request.gateway(ip);
+                    v4_builder = v4_builder.gateway(ip);
                 }
 
+                let request = self.handle.route().add(v4_builder.build()).replace();
                 if let Err(rtnetlink::Error::NetlinkError(message)) = request.execute().await {
                     if let Some(code) = message.code {
                         if Errno::from_raw(code.get()) != Errno::EEXIST {
@@ -729,12 +703,7 @@ impl Handle {
 
         let link = self.find_link(LinkFilter::Name(&neigh.device)).await?;
 
-        let mut flags = Vec::new();
-        for flag in ALL_RULE_FLAGS {
-            if (neigh.flags as u8 & (u8::from(flag))) > 0 {
-                flags.push(flag);
-            }
-        }
+        let flags = ALL_RULE_FLAGS & NeighbourFlags::from_bits_retain(neigh.flags as u8);
         let state = if neigh.state == 0 {
             NeighbourState::Permanent
         } else {
@@ -749,7 +718,7 @@ impl Handle {
             .replace();
         if !neigh.lladdr.is_empty() {
             let lladdr = parse_mac_address(&neigh.lladdr).context("parsing lladdr")?;
-            req = req.link_local_address(&lladdr);
+            req = req.link_layer_address(&lladdr);
         }
         req.execute().await.context("executing NeighbourAddRequest")
     }
@@ -845,12 +814,7 @@ impl Link {
 
     /// Returns whether the link is UP
     fn is_up(&self) -> bool {
-        let mut flags: u32 = 0;
-        for flag in &self.header.flags {
-            flags += u32::from(*flag);
-        }
-
-        flags as i32 & libc::IFF_UP > 0
+        self.header.flags.contains(LinkFlags::Up)
     }
 
     fn index(&self) -> u32 {
@@ -1296,5 +1260,160 @@ mod tests {
         );
 
         clean_env_for_test_add_one_arp_neighbor(TEST_DUMMY_INTERFACE, TEST_ARP_IP);
+    }
+
+    #[tokio::test]
+    #[serial(route_tests)]
+    async fn update_routes_ipv4() {
+        skip_if_not_root!();
+
+        const IFACE: &str = "dummy_route4";
+        const DEST: &str = "198.51.100.0/24";
+        const GW: &str = "192.0.2.1";
+        const IFACE_ADDR: &str = "192.0.2.2/24";
+
+        // Setup: create dummy interface and assign an address so the gateway
+        // is reachable (required for adding a route with a gateway).
+        let _ = Command::new("ip").args(["link", "delete", IFACE]).output();
+        Command::new("modprobe")
+            .arg("dummy")
+            .output()
+            .expect("modprobe dummy");
+        let out = Command::new("ip")
+            .args(["link", "add", IFACE, "type", "dummy"])
+            .output()
+            .expect("ip link add");
+        if !out.status.success() {
+            println!(
+                "INFO: skipping test - cannot create dummy link: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            return;
+        }
+        struct Cleanup(&'static str);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = Command::new("ip").args(["link", "delete", self.0]).output();
+            }
+        }
+        let _cleanup = Cleanup(IFACE);
+
+        let out = Command::new("ip")
+            .args(["addr", "add", IFACE_ADDR, "dev", IFACE])
+            .output()
+            .expect("ip addr add");
+        if !out.status.success() {
+            println!(
+                "INFO: skipping test - cannot assign address: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            return;
+        }
+        Command::new("ip")
+            .args(["link", "set", IFACE, "up"])
+            .output()
+            .expect("ip link set up");
+
+        let mut handle = Handle::new().unwrap();
+        let route = Route {
+            dest: DEST.to_string(),
+            gateway: GW.to_string(),
+            device: IFACE.to_string(),
+            ..Default::default()
+        };
+
+        let result = handle.update_routes(iter::once(route)).await;
+        if is_netlink_permission_error(&result) {
+            return;
+        }
+        result.expect("update_routes IPv4 failed");
+
+        // Verify the route exists via `ip route show`.
+        let out = Command::new("ip")
+            .args(["route", "show", DEST])
+            .output()
+            .expect("ip route show");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("198.51.100"),
+            "expected route not found in `ip route show` output: {}",
+            stdout
+        );
+    }
+
+    #[tokio::test]
+    #[serial(route_tests)]
+    async fn update_routes_ipv6() {
+        skip_if_not_root!();
+
+        const IFACE: &str = "dummy_route6";
+        const DEST: &str = "2001:db8:1::/48";
+        const GW: &str = "2001:db8::1";
+        const IFACE_ADDR: &str = "2001:db8::2/32";
+
+        let _ = Command::new("ip").args(["link", "delete", IFACE]).output();
+        Command::new("modprobe")
+            .arg("dummy")
+            .output()
+            .expect("modprobe dummy");
+        let out = Command::new("ip")
+            .args(["link", "add", IFACE, "type", "dummy"])
+            .output()
+            .expect("ip link add");
+        if !out.status.success() {
+            println!(
+                "INFO: skipping test - cannot create dummy link: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            return;
+        }
+        struct Cleanup(&'static str);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = Command::new("ip").args(["link", "delete", self.0]).output();
+            }
+        }
+        let _cleanup = Cleanup(IFACE);
+
+        let out = Command::new("ip")
+            .args(["addr", "add", IFACE_ADDR, "dev", IFACE])
+            .output()
+            .expect("ip addr add");
+        if !out.status.success() {
+            println!(
+                "INFO: skipping test - cannot assign address: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            return;
+        }
+        Command::new("ip")
+            .args(["link", "set", IFACE, "up"])
+            .output()
+            .expect("ip link set up");
+
+        let mut handle = Handle::new().unwrap();
+        let mut route = Route::default();
+        route.set_dest(DEST.to_string());
+        route.set_gateway(GW.to_string());
+        route.set_device(IFACE.to_string());
+        route.set_family(IPFamily::v6);
+
+        let result = handle.update_routes(iter::once(route)).await;
+        if is_netlink_permission_error(&result) {
+            return;
+        }
+        result.expect("update_routes IPv6 failed");
+
+        // Verify the route exists via `ip -6 route show`.
+        let out = Command::new("ip")
+            .args(["-6", "route", "show", DEST])
+            .output()
+            .expect("ip -6 route show");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("2001:db8:1::"),
+            "expected route not found in `ip -6 route show` output: {}",
+            stdout
+        );
     }
 }

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -10,7 +10,7 @@ use crate::AGENT_CONFIG;
 use slog::Logger;
 
 use anyhow::{anyhow, Result};
-use netlink_sys::{protocols, SocketAddr, TokioSocket};
+use netlink_sys::{protocols, AsyncSocket, AsyncSocketExt, SocketAddr, TokioSocket};
 use std::fmt::Debug;
 use std::os::unix::io::FromRawFd;
 use std::sync::Arc;
@@ -184,7 +184,7 @@ pub async fn watch_uevents(
         socket = TokioSocket::from_raw_fd(fd);
     }
 
-    socket.bind(&SocketAddr::new(0, 1))?;
+    socket.socket_mut().bind(&SocketAddr::new(0, 1))?;
 
     loop {
         select! {

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -18,13 +18,13 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 byte-unit = "5.1.6"
 cgroups.workspace = true
-futures = "0.3.11"
+futures = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 netns-rs = { workspace = true }
 nix = { workspace = true }
 rand = { workspace = true }
-scopeguard = "1.0.0"
+scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
@@ -36,7 +36,7 @@ oci-spec = { workspace = true }
 inotify = "0.11.0"
 walkdir = "2.5.0"
 flate2 = "1.1"
-tempfile = "3.19.1"
+tempfile = { workspace = true }
 hex = "0.4"
 base64 = { workspace = true }
 bytes = { workspace = true }
@@ -48,9 +48,9 @@ hyperlocal = { workspace = true }
 ## Dependencies from `rust-netlink`
 ## 0.30+ parses IFLA_INET6_CONF on kernels 6.17+ (240-byte blob; DEVCONF_FORCE_FORWARDING).
 futures-lite = "2"
-netlink-packet-core = "0.8"
-netlink-packet-route = "0.30"
-rtnetlink = "0.21"
+netlink-packet-core = { workspace = true }
+netlink-packet-route = { workspace = true }
+rtnetlink = { workspace = true }
 
 # Local dependencies
 agent = { workspace = true }


### PR DESCRIPTION
The rtnetlink and netlink-packet-route crates are bumped to remove the paste dependency and resolve vuln RUSTSEC-2024-0436

Adapt the agent's netlink code to the new APIs:
- NeighbourFlag (enum) → NeighbourFlags (bitflags struct)
- RouteFlag (enum) with Vec<RouteFlag> → RouteFlags::from_bits_retain()
- LinkHandle::set(u32) → LinkUnspec::new_with_index().build() + LinkHandle::change(LinkMessage) for ip-link-set operations
- RouteHandle::add() / get(IpVersion) → RouteMessageBuilder + add/get accepting a RouteMessage directly
- LinkFlags is now a bitflags struct; replace the manual flag-sum loop in is_up() with LinkFlags::contains(LinkFlags::Up)
- NeighbourAddRequest::link_local_address() → link_layer_address()
- TokioSocket::bind() → socket_mut().bind(); import AsyncSocketExt to keep recv_from_full() working via the trait

Generated-by: IBM Bob