### PR TITLE
runtime-rs: size static sandboxes per resource

### DIFF
--- a/docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
+++ b/docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
@@ -9,8 +9,8 @@ to be used in runtime-rs.
 
 > [!IMPORTANT]
 > For correct and predictable Kata sandbox sizing in Kubernetes, workload CPU
-> and memory limits **must** be set. Without limits, runtime-rs falls back to
-> `default_vcpus` and `default_memory`, which is a compatibility fallback and
+> and memory limits **must** be set. A dimension left without a limit falls back
+> to `default_vcpus` or `default_memory`, which is a compatibility fallback and
 > not the intended production sizing model.
 
 ## Why these fields exist
@@ -23,21 +23,24 @@ but the VM also needs extra resources for guest/kernel/runtime overhead.
 
 ## Sizing model
 
-With runtime-rs static sandbox sizing, Kata uses:
+With runtime-rs static sandbox sizing, CPU and memory are sized independently of
+each other:
 
-- If workload limits are present:
+- If a workload CPU limit is present:
   - `vm_vcpus = requested_vcpus + overhead_vcpus`
-  - `vm_memory = requested_memory + overhead_memory`
-- If workload limits are not present:
+- If a workload CPU limit is not present:
   - `vm_vcpus = default_vcpus`
+- If a workload memory limit is present:
+  - `vm_memory = requested_memory + overhead_memory`
+- If a workload memory limit is not present:
   - `vm_memory = default_memory`
 
-In other words, `default_*` is the fallback for "no limits", while
-`overhead_*` is the additive budget for "limits are set".
+In other words, `default_*` is the fallback for "no limit on that dimension",
+while `overhead_*` is the additive budget for "a limit is set on that dimension".
 For CPU, runtime-rs sums workload and overhead values, and if the computed
 result is fractional it is rounded up to the next integer (`ceil`), since VMMs
 expose integer vCPU counts. A minimum of `1` vCPU is enforced for the
-limit-driven path, including the `0 + 0` edge case.
+limit-driven path.
 
 ## `podFixed` as a sizing function
 
@@ -162,7 +165,8 @@ must also cover the host-side runtime components that live outside the VM.
 
 **Scenario intent:** show what happens when only one limit is provided.
 
-**Consequence:** once any limit exists, overhead logic applies to both dimensions.
+**Consequence:** each dimension is sized on its own, so the dimension without a
+limit falls back to its `default_*` value.
 
 **`RuntimeClass.overhead.podFixed` relationship:** same rule as Example 1;
 `podFixed` should remain higher than `overhead_*`.
@@ -183,7 +187,7 @@ Workload sets:
 
 Result:
 
-- CPU is rounded up for boot: `vm_vcpus = ceil(0 + 0.5) = 1`
+- CPU has no limit, so it falls back to the default: `vm_vcpus = default_vcpus = 2`
 - Memory uses overhead formula: `vm_memory = 512 + 128 = 640 MiB`
 
 ### 2B. CPU limit only
@@ -196,19 +200,14 @@ Workload sets:
 Result:
 
 - CPU uses overhead formula: `vm_vcpus = 1.5 + 0.5 = 2.0`
-- Memory still uses overhead baseline: `vm_memory = 0 + 128 = 128 MiB`
+- Memory has no limit, so it falls back to the default: `vm_memory = default_memory = 1024 MiB`
 
-This is the reason workload memory limits **must** be set (see the note at the
-top of this document): with a CPU limit but no memory limit, the VM is sized
-with `overhead_memory` only, which is almost certainly too small to run a real
-workload. It is the explicit overhead baseline, not a default fallback to
-`default_memory`. As a safety net, if the computed sandbox memory would be `0`
-(for example, a CPU-only workload with `overhead_memory = 0`), runtime-rs fails
+Workload memory limits should still be set (see the note at the top of this
+document): `default_memory` is an admin-chosen baseline that is unrelated to what
+this particular workload needs, so relying on it gives a VM size that is either
+wasteful or too small. As a safety net, if the computed sandbox memory would be
+`0` (for example, no memory limit and `default_memory = 0`), runtime-rs fails
 early with an actionable error instead of booting an unusable VM.
-
-This mirrors runtime-rs behavior: once limits are present for a sandbox, overhead
-is applied on both dimensions, and any missing dimension uses `0 + overhead_*`
-(with fractional CPU results rounded up).
 
 ## Example 3: `overhead_* = 0` (zero-overhead model)
 

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -66,11 +66,9 @@ kernel_params = "@KERNELPARAMS@"
 default_vcpus = @DEFVCPUS@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_CLH@
 
@@ -98,10 +96,9 @@ disable_nested_virtualization = @DEFDISABLENESTEDVIRTUALIZATION_CLH_AZURE@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_CLH@
 

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -66,11 +66,9 @@ kernel_params = "@KERNELPARAMS@"
 default_vcpus = @DEFVCPUS@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_CLH@
 
@@ -98,10 +96,9 @@ disable_nested_virtualization = @DEFDISABLENESTEDVIRTUALIZATION_CLH@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_CLH@
 

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -69,11 +69,9 @@ firmware = "@FIRMWAREPATH@"
 default_vcpus = @DEFVCPUS@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_DB@
 
@@ -122,10 +120,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_DB@
 

--- a/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
@@ -64,11 +64,9 @@ kernel_params = "@KERNELPARAMS_OPENVMM@"
 default_vcpus = @DEFVCPUS@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_OPENVMM@
 
@@ -93,10 +91,9 @@ default_maxvcpus = @DEFMAXVCPUS@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_OPENVMM@
 

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -107,11 +107,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFVCPUS_QEMU@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_TEE@
 
@@ -159,10 +157,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_TEE@
 #

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -99,11 +99,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFVCPUS_QEMU@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_QEMU@
 
@@ -151,10 +149,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_NV_BASE@
 #

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -99,11 +99,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFAULTVCPUS_NV@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_NV@
 
@@ -151,10 +149,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFAULTMEMORY_NV@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_NV@
 #

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -140,11 +140,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFAULTVCPUS_NV@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_NV@
 
@@ -192,10 +190,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFAULTMEMORY_NV@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_NV@
 #

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -116,11 +116,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFAULTVCPUS_NV@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_NV@
 
@@ -168,10 +166,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFAULTMEMORY_NV@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_NV@
 #

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -86,11 +86,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFVCPUS_QEMU@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_QEMU@
 
@@ -138,10 +136,9 @@ reclaim_guest_freed_memory = false
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_QEMU@
 #

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -95,11 +95,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFVCPUS_QEMU@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_TEE@
 
@@ -137,10 +135,9 @@ default_bridges = @DEFBRIDGES@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_TEE_SE@
 #

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -133,11 +133,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = @DEFVCPUS_QEMU@
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_TEE@
 
@@ -175,10 +173,9 @@ default_bridges = @DEFBRIDGES@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_TEE@
 

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -111,11 +111,9 @@ cpu_features = "@CPUFEATURES@"
 default_vcpus = 1
 
 # Guest-side vCPU overhead budget (fractional) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_vcpus = requested_vcpus + overhead_vcpus
-# (rounded up at boot). If a workload limit is set on another dimension (for example
-# memory) but CPU is missing, requested_vcpus is treated as 0 and vm_vcpus equals
-# overhead_vcpus (minimum 1 at boot). When no workload limits are present,
-# default_vcpus is used instead.
+# When a workload CPU limit is present, vm_vcpus = requested_vcpus + overhead_vcpus
+# (rounded up at boot, minimum 1). When it is not, default_vcpus is used instead,
+# regardless of whether a memory limit was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_vcpus = @DEFOVERHEADVCPUS_TEE@
 
@@ -153,10 +151,9 @@ default_bridges = @DEFBRIDGES@
 default_memory = @DEFMEMSZ@
 
 # Guest-side memory overhead budget (MiB) used with static_sandbox_resource_mgmt.
-# When workload limits are present, vm_memory = requested_memory + overhead_memory.
-# If a workload limit is set on another dimension (for example CPU) but memory is
-# missing, requested_memory is treated as 0, so vm_memory equals overhead_memory.
-# When no workload limits are present, default_memory is used instead.
+# When a workload memory limit is present, vm_memory = requested_memory + overhead_memory.
+# When it is not, default_memory is used instead, regardless of whether a CPU limit
+# was set.
 # See docs/how-to/how-to-size-sandbox-overhead-runtime-rs.md
 overhead_memory = @DEFOVERHEADMEMSZ_TEE@
 #

--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -167,16 +167,14 @@ impl InitialSizeManager {
             return Ok(());
         }
 
-        if self.resource.vcpu > 0.0 || self.resource.mem_mb > 0 {
-            if self.resource.vcpu > 0.0 {
-                info!(sl!(), "resource with vcpu {}", self.resource.vcpu);
-            }
-            if self.resource.mem_mb > 0 {
-                info!(sl!(), "resource with memory {}", self.resource.mem_mb);
-            }
-
+        // Sized per resource: an unset limit keeps its configured default.
+        if self.resource.vcpu > 0.0 {
+            info!(sl!(), "resource with vcpu {}", self.resource.vcpu);
             hv.cpu_info.default_vcpus = (hv.cpu_info.overhead_vcpus + self.resource.vcpu).max(1.0);
+        }
 
+        if self.resource.mem_mb > 0 {
+            info!(sl!(), "resource with memory {}", self.resource.mem_mb);
             hv.memory_info.default_memory = hv.memory_info.overhead_memory + self.resource.mem_mb;
             hv.memory_info.default_maxmemory = hv
                 .memory_info
@@ -594,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_setup_config_static_errors_on_zero_memory() {
-        let mut config = make_config(1.0, 0.5, 8, 1024, 0, 4096, true);
+        let mut config = make_config(1.0, 0.5, 8, 0, 0, 4096, true);
         let mut mgr = InitialSizeManager {
             resource: InitialSize {
                 vcpu: 1.0,
@@ -610,10 +608,10 @@ mod tests {
 
     #[rstest]
     #[case::both_limits(3.0, 0.75, 1024, 256, 1.25, 1024, 2.0, 1280)]
-    #[case::cpu_only_limit(3.0, 0.5, 1024, 128, 1.5, 0, 2.0, 128)]
-    #[case::memory_only_limit(3.0, 0.5, 1024, 128, 0.0, 512, 1.0, 640)]
+    #[case::cpu_only_limit_keeps_default_memory(3.0, 0.5, 1024, 128, 1.5, 0, 2.0, 1024)]
+    #[case::memory_only_limit_keeps_default_vcpus(3.0, 0.5, 1024, 128, 0.0, 512, 3.0, 640)]
     #[case::both_limits_zero_overhead(3.0, 0.0, 1024, 0, 1.25, 1024, 1.25, 1024)]
-    #[case::memory_only_zero_overhead(3.0, 0.0, 1024, 0, 0.0, 512, 1.0, 512)]
+    #[case::memory_only_zero_overhead(3.0, 0.0, 1024, 0, 0.0, 512, 3.0, 512)]
     fn test_setup_config_static_requested_vs_defaults(
         #[case] default_vcpus: f32,
         #[case] overhead_vcpus: f32,


### PR DESCRIPTION
Static sandbox sizing decides whether workload limits are present once for the pod, then sizes both vCPUs and memory from that single decision. A workload that sets only one of the two limits still takes that branch for both, so the resource it left unset is sized from its overhead budget alone rather than from its configured default. A pod with only a CPU limit gets overhead_memory and nothing else.

Size the two resources independently, so that one the workload asked for is sized as overhead + requested and one it did not keeps its configured default. Pods that set both limits, or neither, are unaffected.

Assisted-by: GitHub Copilot (Claude Opus 5)