### PR TITLE
runtime-rs: share VMDK helpers across VMMs and track temporary EROFS VMDK files

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -36,6 +36,7 @@ pub mod remote;
 pub mod selinux;
 pub use kernel_param::Param;
 pub mod utils;
+pub(crate) mod vmdk;
 use std::collections::HashMap;
 
 #[cfg(all(

--- a/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/block_source.rs
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::vmdk::validate_vmdk_layout;
 use crate::VmdkConfig;
 
 use anyhow::{anyhow, Context, Result};
 use nix::sys::memfd::{memfd_create, MFdFlags};
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::fmt::Write as _;
 use std::fs::{File, OpenOptions};
 use std::io::Write as _;
 use std::os::fd::AsRawFd;
@@ -68,50 +68,6 @@ fn open_block_source(
     }
 
     Ok((file, metadata))
-}
-
-fn render_vmdk_descriptor(
-    config: &VmdkConfig,
-    backing_paths: &HashMap<String, String>,
-) -> Result<String> {
-    let total_sectors = config
-        .total_sectors()
-        .ok_or_else(|| anyhow!("VMDK total sector count overflow"))?;
-    if total_sectors == 0 {
-        return Err(anyhow!("VMDK contains no non-empty extents"));
-    }
-
-    let mut descriptor = String::new();
-    writeln!(descriptor, "# Disk DescriptorFile")?;
-    writeln!(descriptor, "version=1")?;
-    writeln!(descriptor, "CID=fffffffe")?;
-    writeln!(descriptor, "parentCID=ffffffff")?;
-    writeln!(descriptor, "createType=\"twoGbMaxExtentFlat\"")?;
-    writeln!(descriptor)?;
-    writeln!(descriptor, "# Extent description")?;
-    for extent in &config.extents {
-        let path = backing_paths
-            .get(&extent.path_on_host)
-            .ok_or_else(|| anyhow!("missing prepared VMDK extent {}", extent.path_on_host))?;
-        writeln!(
-            descriptor,
-            "RW {} FLAT \"{}\" {}",
-            extent.sectors, path, extent.file_offset
-        )?;
-    }
-
-    let cylinders = total_sectors.div_ceil(63 * 16);
-    writeln!(descriptor)?;
-    writeln!(descriptor, "# The Disk Data Base")?;
-    writeln!(descriptor, "#DDB")?;
-    writeln!(descriptor)?;
-    writeln!(descriptor, "ddb.virtualHWVersion = \"4\"")?;
-    writeln!(descriptor, "ddb.geometry.cylinders = \"{cylinders}\"")?;
-    writeln!(descriptor, "ddb.geometry.heads = \"16\"")?;
-    writeln!(descriptor, "ddb.geometry.sectors = \"63\"")?;
-    writeln!(descriptor, "ddb.adapterType = \"ide\"")?;
-
-    Ok(descriptor)
 }
 
 fn create_vmdk_descriptor_file(
@@ -177,21 +133,7 @@ where
         });
     };
 
-    if vmdk.extents.is_empty() {
-        return Err(anyhow!("VMDK contains no extents"));
-    }
-
-    let mut required_sectors_by_path: HashMap<&str, u64> = HashMap::new();
-    for extent in &vmdk.extents {
-        let required_sectors = extent
-            .file_offset
-            .checked_add(extent.sectors)
-            .ok_or_else(|| anyhow!("VMDK extent sector count overflow"))?;
-        required_sectors_by_path
-            .entry(extent.path_on_host.as_str())
-            .and_modify(|maximum| *maximum = (*maximum).max(required_sectors))
-            .or_insert(required_sectors);
-    }
+    let layout = validate_vmdk_layout(vmdk)?;
 
     let mut backing_paths = HashMap::new();
     for extent in &vmdk.extents {
@@ -203,9 +145,8 @@ where
         // O_DIRECT. QEMU fdsets require an exact O_DIRECT match, so preserve
         // that existing reopen behavior for delegated extent descriptors.
         let (file, metadata) = open_block_source(&extent.path_on_host, is_readonly, false, true)?;
-        let required_sectors = required_sectors_by_path
-            .get(extent.path_on_host.as_str())
-            .copied()
+        let required_sectors = layout
+            .required_sectors_for(&extent.path_on_host)
             .ok_or_else(|| anyhow!("missing VMDK extent size for {}", extent.path_on_host))?;
         if metadata.len().div_ceil(512) < required_sectors {
             return Err(anyhow!(
@@ -218,7 +159,12 @@ where
         backing_paths.insert(extent.path_on_host.clone(), fd_path);
     }
 
-    let descriptor = render_vmdk_descriptor(vmdk, &backing_paths)?;
+    let descriptor = layout.render_descriptor_with(|extent| {
+        backing_paths
+            .get(&extent.path_on_host)
+            .cloned()
+            .ok_or_else(|| anyhow!("missing prepared VMDK extent {}", extent.path_on_host))
+    })?;
     let descriptor =
         create_vmdk_descriptor_file(Path::new(path), &descriptor, is_readonly, is_direct)?;
     let filename = register(descriptor, "vmdk-descriptor")?;
@@ -237,24 +183,6 @@ mod tests {
     use std::io::{Read, Seek, SeekFrom};
     use std::os::unix::fs::symlink;
     use tempfile::tempdir;
-
-    #[test]
-    fn renders_structured_vmdk_layout() {
-        let mut config = VmdkConfig::default();
-        config.push_extent("/images/first.raw", 8, 0);
-        config.push_extent("/images/first.raw", 4, 8);
-        config.push_extent("/images/second.raw", 16, 0);
-        let backing_paths = HashMap::from([
-            ("/images/first.raw".to_string(), "/dev/fdset/1".to_string()),
-            ("/images/second.raw".to_string(), "/dev/fdset/2".to_string()),
-        ]);
-
-        let descriptor = render_vmdk_descriptor(&config, &backing_paths).unwrap();
-        assert!(descriptor.contains("RW 8 FLAT \"/dev/fdset/1\" 0"));
-        assert!(descriptor.contains("RW 4 FLAT \"/dev/fdset/1\" 8"));
-        assert!(descriptor.contains("RW 16 FLAT \"/dev/fdset/2\" 0"));
-        assert!(descriptor.contains("ddb.geometry.cylinders = \"1\""));
-    }
 
     #[test]
     fn prepares_raw_source_with_requested_access() {

--- a/src/runtime-rs/crates/hypervisor/src/vmdk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/vmdk.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! VMM-neutral helpers for structured flat VMDK layouts.
+//!
+//! VMM backends retain responsibility for opening or otherwise validating their
+//! backing sources, and for materializing or passing the resulting descriptor.
+
+use crate::{VmdkConfig, VmdkExtent};
+
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+/// A structurally validated VMDK layout.
+///
+/// The required sector count is the greatest `file_offset + sectors` for each
+/// unique backing path. Backends use it to verify the backing source they open
+/// or stat is large enough for the layout.
+#[derive(Debug)]
+pub(crate) struct VmdkLayout<'a> {
+    extents: &'a [VmdkExtent],
+    total_sectors: u64,
+    required_sectors_by_path: HashMap<&'a str, u64>,
+}
+
+/// Validate a structured VMDK layout without accessing backing sources.
+pub(crate) fn validate_vmdk_layout(vmdk: &VmdkConfig) -> Result<VmdkLayout<'_>> {
+    if vmdk.extents.is_empty() {
+        return Err(anyhow!("VMDK contains no extents"));
+    }
+
+    let total_sectors = vmdk
+        .total_sectors()
+        .ok_or_else(|| anyhow!("VMDK total sector count overflow"))?;
+    if total_sectors == 0 {
+        return Err(anyhow!("VMDK contains no non-empty extents"));
+    }
+
+    let mut required_sectors_by_path: HashMap<&str, u64> = HashMap::new();
+    for extent in &vmdk.extents {
+        let required_sectors = extent
+            .file_offset
+            .checked_add(extent.sectors)
+            .ok_or_else(|| anyhow!("VMDK extent sector count overflow"))?;
+        required_sectors_by_path
+            .entry(extent.path_on_host.as_str())
+            .and_modify(|maximum| *maximum = (*maximum).max(required_sectors))
+            .or_insert(required_sectors);
+    }
+
+    Ok(VmdkLayout {
+        extents: &vmdk.extents,
+        total_sectors,
+        required_sectors_by_path,
+    })
+}
+
+impl VmdkLayout<'_> {
+    /// Return the number of sectors required for the backing source at `path`.
+    ///
+    /// A source may supply more than one extent, so this is the greatest
+    /// `file_offset + sectors` among its extents. VMM backends use it when
+    /// checking that a backing source is large enough.
+    pub(crate) fn required_sectors_for(&self, path: &str) -> Option<u64> {
+        self.required_sectors_by_path.get(path).copied()
+    }
+
+    /// Render a VMDK descriptor using VMM-specific extent references.
+    ///
+    /// `resolve_extent_reference` translates each host backing extent into the
+    /// reference written to the descriptor. For example, QEMU resolves an
+    /// extent to its `/dev/fdset/N` path, while a VMM that opens host paths
+    /// directly can return a host-relative or absolute path.
+    pub(crate) fn render_descriptor_with<F>(
+        &self,
+        mut resolve_extent_reference: F,
+    ) -> Result<String>
+    where
+        F: FnMut(&VmdkExtent) -> Result<String>,
+    {
+        let mut descriptor = String::new();
+        writeln!(descriptor, "# Disk DescriptorFile")?;
+        writeln!(descriptor, "version=1")?;
+        writeln!(descriptor, "CID=fffffffe")?;
+        writeln!(descriptor, "parentCID=ffffffff")?;
+        writeln!(descriptor, "createType=\"twoGbMaxExtentFlat\"")?;
+        writeln!(descriptor)?;
+        writeln!(descriptor, "# Extent description")?;
+        for extent in self.extents {
+            let reference = resolve_extent_reference(extent)?;
+            // VMDK quoted path fields have no escape mechanism. Reject values
+            // that would terminate the field or inject descriptor lines.
+            if reference.contains(['"', '\n', '\r']) {
+                return Err(anyhow!(
+                    "VMDK extent reference contains characters unsupported by the descriptor grammar"
+                ));
+            }
+            writeln!(
+                descriptor,
+                "RW {} FLAT \"{}\" {}",
+                extent.sectors, reference, extent.file_offset
+            )?;
+        }
+
+        let cylinders = self.total_sectors.div_ceil(63 * 16);
+        writeln!(descriptor)?;
+        writeln!(descriptor, "# The Disk Data Base")?;
+        writeln!(descriptor, "#DDB")?;
+        writeln!(descriptor)?;
+        writeln!(descriptor, "ddb.virtualHWVersion = \"4\"")?;
+        writeln!(descriptor, "ddb.geometry.cylinders = \"{cylinders}\"")?;
+        writeln!(descriptor, "ddb.geometry.heads = \"16\"")?;
+        writeln!(descriptor, "ddb.geometry.sectors = \"63\"")?;
+        writeln!(descriptor, "ddb.adapterType = \"ide\"")?;
+
+        Ok(descriptor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_structured_vmdk_layout() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/images/first.raw", 8, 0);
+        config.push_extent("/images/first.raw", 4, 8);
+        config.push_extent("/images/second.raw", 16, 0);
+        let references = HashMap::from([
+            ("/images/first.raw", "/dev/fdset/1"),
+            ("/images/second.raw", "/dev/fdset/2"),
+        ]);
+
+        let descriptor = validate_vmdk_layout(&config)
+            .unwrap()
+            .render_descriptor_with(|extent| {
+                references
+                    .get(extent.path_on_host.as_str())
+                    .map(|reference| (*reference).to_string())
+                    .ok_or_else(|| anyhow!("missing prepared VMDK extent {}", extent.path_on_host))
+            })
+            .unwrap();
+
+        assert!(descriptor.contains("RW 8 FLAT \"/dev/fdset/1\" 0"));
+        assert!(descriptor.contains("RW 4 FLAT \"/dev/fdset/1\" 8"));
+        assert!(descriptor.contains("RW 16 FLAT \"/dev/fdset/2\" 0"));
+        assert!(descriptor.contains("ddb.geometry.cylinders = \"1\""));
+    }
+
+    #[test]
+    fn records_largest_requirement_for_each_extent_path() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/images/extent.raw", 1, 0);
+        config.push_extent("/images/extent.raw", 2, 8);
+
+        let layout = validate_vmdk_layout(&config).unwrap();
+        assert_eq!(layout.required_sectors_for("/images/extent.raw"), Some(10));
+    }
+
+    #[test]
+    fn rejects_invalid_resolved_extent_references() {
+        let mut config = VmdkConfig::default();
+        config.push_extent("/images/extent.raw", 1, 0);
+
+        for reference in ["bad\"reference", "bad\nreference", "bad\rreference"] {
+            let error = validate_vmdk_layout(&config)
+                .unwrap()
+                .render_descriptor_with(|_| Ok(reference.to_string()))
+                .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("unsupported by the descriptor grammar"));
+        }
+    }
+
+    #[test]
+    fn rejects_empty_and_overflowing_layouts() {
+        let empty = VmdkConfig::default();
+        assert!(validate_vmdk_layout(&empty)
+            .unwrap_err()
+            .to_string()
+            .contains("contains no extents"));
+
+        let mut overflowing = VmdkConfig::default();
+        overflowing.push_extent("/images/extent.raw", 1, u64::MAX);
+        assert!(validate_vmdk_layout(&overflowing)
+            .unwrap_err()
+            .to_string()
+            .contains("sector count overflow"));
+    }
+}

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -375,8 +375,10 @@ pub(crate) struct ErofsMultiLayerRootfs {
     rwlayer_storage: Option<Storage>,
     // Read-only EROFS layer storages (lower layers), one per partition in GPT mode
     erofs_storages: Vec<Storage>,
-    // Paths to generated GPT metadata files (head, padding) for cleanup
-    gpt_metadata_paths: Vec<PathBuf>,
+    // Temporary host files used by VMDK-backed rootfs layouts (GPT
+    // leading-metadata image, padding images, and descriptor), removed after
+    // device teardown.
+    generated_file_paths: Vec<PathBuf>,
     // Container-scoped runtime directory that may only contain generated helper artifacts.
     generated_artifacts_dir: PathBuf,
 }
@@ -398,7 +400,7 @@ impl ErofsMultiLayerRootfs {
         let mut device_ids = Vec::new();
         let mut rwlayer_storage: Option<Storage> = None;
         let mut erofs_storages: Vec<Storage> = Vec::new();
-        let mut gpt_metadata_paths: Vec<PathBuf> = Vec::new();
+        let mut generated_file_paths: Vec<PathBuf> = Vec::new();
         // Track whether GPT+VMDK erofs layers have already been processed in bulk.
         let mut gpt_erofs_processed = false;
 
@@ -577,9 +579,9 @@ impl ErofsMultiLayerRootfs {
                             generate_gpt_vmdk_with_layout(sid, cid, erofs_layers)
                                 .context("gptdisk: failed to generate GPT VMDK")?;
 
-                        // Track GPT metadata files (head + padding) for cleanup
-                        gpt_metadata_paths.push(gpt_files.head_path.clone());
-                        gpt_metadata_paths.extend(gpt_files.pad_paths.iter().cloned());
+                        // Track every generated file backing this VMDK for cleanup.
+                        generated_file_paths.push(gpt_files.head_path.clone());
+                        generated_file_paths.extend(gpt_files.pad_paths.iter().cloned());
                         for idx in 0..layout.partitions.len() {
                             if idx > 0 {
                                 // Check for padding files (only created when there are gaps)
@@ -589,10 +591,15 @@ impl ErofsMultiLayerRootfs {
                                     .unwrap()
                                     .join(format!("pad-{}.img", idx));
                                 if pad_path.exists() {
-                                    gpt_metadata_paths.push(pad_path);
+                                    generated_file_paths.push(pad_path);
                                 }
                             }
                         }
+                        // GPT assembly always produces a structured VMDK layout.
+                        // `erofs_path` is its reserved descriptor path. QEMU leaves
+                        // no file there, so cleanup is a no-op until a VMM
+                        // materializes the descriptor.
+                        generated_file_paths.push(PathBuf::from(&erofs_path));
 
                         info!(
                             sl!(),
@@ -753,6 +760,14 @@ impl ErofsMultiLayerRootfs {
                             vmdk.is_some()
                         );
 
+                        // Only a multi-device result has a structured VMDK layout
+                        // and reserves `erofs_path` for its descriptor. A
+                        // single-device result is raw EROFS, whose source path must
+                        // not be tracked as a generated temporary file.
+                        if vmdk.is_some() {
+                            generated_file_paths.push(PathBuf::from(&erofs_path));
+                        }
+
                         let device_config = &mut BlockConfigModern {
                             driver_option: block_driver.clone(),
                             vmdk,
@@ -852,7 +867,7 @@ impl ErofsMultiLayerRootfs {
             device_ids,
             rwlayer_storage,
             erofs_storages,
-            gpt_metadata_paths,
+            generated_file_paths,
             generated_artifacts_dir: PathBuf::from(kata_types::prefix_with_rootless_dir(
                 DEFAULT_KATA_GUEST_ROOT_SHARED_FS,
             ))
@@ -913,9 +928,9 @@ impl Rootfs for ErofsMultiLayerRootfs {
             dm.try_remove_device(device_id).await?;
         }
 
-        // Clean up GPT metadata files (head, padding).
-        for metadata_path in &self.gpt_metadata_paths {
-            safely_remove_file(metadata_path, &self.generated_artifacts_dir)?;
+        // Remove temporary VMDK files (GPT leading metadata, padding, descriptor).
+        for file_path in &self.generated_file_paths {
+            safely_remove_file(file_path, &self.generated_artifacts_dir)?;
         }
 
         Ok(())


### PR DESCRIPTION
## Motivation/Rationale

This change goes back to #13779 - these changes should be non-destructive to our current code base, may or may not be taken at this point.

As discussed in #13779 when we upgrade CLH to a release which includes https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8599, our CLH VMM code (incl. api-client) can be updated to select FlatVmdK rather than Raw, and to support multi-layer EROFS using host paths (see #13779). At this point we can get relevant CI coverage for samples beyond the current single VM template sample and we can remove all CI TODOs for CLH+EROFS.

This PR here is in support of this upcoming work, I can keep it in draft until it is required, or its commits can be absorbed in a future PR. Either works. In any case, some review on this would be good to make sure the refactor is sane.

While creating a new vmdk.rs file, I intentionally left VmdkConfig within src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs. Please let me know if you see the potential for more re-organization, I'm happy to do some more if deemed useful.


## Two commits


1. Propose src/runtime-rs/crates/hypervisor/src/vmdk.rs for VMM-neutral helpers that validate and render structured VMDK layouts produced for EROFS-snapshotter rootfses:
The change extracts structured-VMDK layout validation and descriptor rendering from QEMU's block-source preparation into the new file. The common code accepts a VMM-specific extent-reference resolver. QEMU resolves extents to fdset paths and keeps the descriptor anonymous. A VMM that uses host paths, such as Cloud Hypervisor, can resolve references accordingly and
materialize the descriptor on the host. Source opening, backing-file checks, and descriptor transport remain VMM-specific.

2. Improve naming and tracking for VMDK-backed EROFS root layouts:
The change improves names and documentation for temporary host files used by VMDK-backed EROFS rootfs layouts.
Further, the change tracks the descriptor path reserved by structured VMDK layouts alongside the GPT leading-metadata and padding images. This common bookkeeping supports VMMs that materialize a descriptor on the host, while VMMs that pass an anonymous descriptor leave no file at the reserved path and therefore need no cleanup. This way, e.g., QEMU using anon. descriptors and CLH using host paths can both work at the same time.

