### PR TITLE
agent: fix wrong binaries in iptables-restore path constants

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -3556,19 +3556,15 @@ OtherField:other
     async fn test_ip_tables() {
         skip_if_not_root!();
 
-        let iptables_cmd_list = [
-            USR_IPTABLES_SAVE,
-            USR_IP6TABLES_SAVE,
-            USR_IPTABLES_RESTORE,
-            USR_IP6TABLES_RESTORE,
-            IPTABLES_SAVE,
-            IP6TABLES_SAVE,
-            IPTABLES_RESTORE,
-            IP6TABLES_RESTORE,
+        let iptables_cmd_pairs = [
+            (USR_IPTABLES_SAVE, IPTABLES_SAVE),
+            (USR_IP6TABLES_SAVE, IP6TABLES_SAVE),
+            (USR_IPTABLES_RESTORE, IPTABLES_RESTORE),
+            (USR_IP6TABLES_RESTORE, IP6TABLES_RESTORE),
         ];
 
-        for cmd in iptables_cmd_list {
-            if !check_command(cmd) {
+        for (usr_sbin_cmd, sbin_cmd) in iptables_cmd_pairs {
+            if !check_command(usr_sbin_cmd) && !check_command(sbin_cmd) {
                 warn!(
                     sl(),
                     "one or more commands for ip tables test are missing, skip it"

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -127,11 +127,11 @@ const TRUSTED_IMAGE_STORAGE_DEVICE: &str = "/dev/trusted_store";
 /// or /usr/sbin, we need to check both of them
 const USR_IPTABLES_SAVE: &str = "/usr/sbin/iptables-save";
 const IPTABLES_SAVE: &str = "/sbin/iptables-save";
-const USR_IPTABLES_RESTORE: &str = "/usr/sbin/iptables-store";
+const USR_IPTABLES_RESTORE: &str = "/usr/sbin/iptables-restore";
 const IPTABLES_RESTORE: &str = "/sbin/iptables-restore";
 const USR_IP6TABLES_SAVE: &str = "/usr/sbin/ip6tables-save";
 const IP6TABLES_SAVE: &str = "/sbin/ip6tables-save";
-const USR_IP6TABLES_RESTORE: &str = "/usr/sbin/ip6tables-save";
+const USR_IP6TABLES_RESTORE: &str = "/usr/sbin/ip6tables-restore";
 const IP6TABLES_RESTORE: &str = "/sbin/ip6tables-restore";
 const KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
 


### PR DESCRIPTION
USR_IPTABLES_RESTORE pointed at /usr/sbin/iptables-store, which does not exist, and USR_IP6TABLES_RESTORE pointed at /usr/sbin/ip6tables-save.

set_ip_tables selects its binary by testing whether the /usr/sbin variant exists. For IPv6 that test passed on any guest shipping ip6tables-save, so restore ran ip6tables-save instead.

For IPv4 the misspelled path never exists, so selection fell back to /sbin/iptables-restore and the fault stayed latent unless a guest ships iptables only in /usr/sbin.

Also, test_ip_tables() was demanding both halves of that fallback, so the test only ran where /sbin was a symlink to /usr/sbin, and silently skipped on any system that shipped iptables in a single location.