### PR TITLE
runtime: restore host driver on physical VFIO attach failure

### DIFF
--- a/docs/physical-endpoint-vfio-restore.md
+++ b/docs/physical-endpoint-vfio-restore.md
@@ -1,0 +1,177 @@
+# Physical VF leftover on vfio-pci after a failed Kata start
+
+Branch: `restore-vf-host-driver-on-attach-failure`
+
+This note records the leak we found, the restore path Kata already had, and
+the gaps this change closes.
+
+## Symptom
+
+A Kata pod using an SR-IOV VF (cold-plug / physical endpoint) fails to start.
+On the next attempt the same VF is still bound to `vfio-pci`. There is no
+host netdev (`mlx5_core` is gone), so CNI / Kata cannot rediscover the
+device. The VF stays unusable until a manual rebind or a reboot.
+
+This showed up on DPU-host Kata workloads where the device plugin hands out
+a PCI VF that is still a host netdev. Kata is the component that rebinds it
+to `vfio-pci` for QEMU passthrough.
+
+OVN-Kubernetes does not bind the VF to `vfio-pci` on this path. It should
+not try to unbind it either: that would collide with real VFIO users
+(KubeVirt).
+
+## Who binds the VF
+
+Sandbox create walks the pod netns, classifies a PCI netdev as a physical
+endpoint, then attaches it:
+
+```
+CreateSandbox
+  → createNetwork / addAllEndpoints
+    → scanEndpointsInNs
+      → addSingleEndpoint
+           isPhysicalIface() == true
+           createPhysicalEndpoint()   // saves BDF + current host driver (mlx5_core)
+           endpoint.Attach()
+             → bindNICToVFIO()
+               → drivers.BindDevicetoVFIO(bdf, "mlx5_core")
+```
+
+`BindDevicetoVFIO` is the actual PCI rebind:
+
+1. Write `vfio-pci` to `/sys/bus/pci/devices/<bdf>/driver_override`
+2. Unbind from `mlx5_core` (host netdev disappears)
+3. Write BDF to `/sys/bus/pci/drivers_probe` so `vfio-pci` claims it
+4. Return `/dev/vfio/<iommu-group>` for QEMU
+
+The same sequence exists in the Rust runtime (`bind_device_to_vfio`).
+
+## Restore Kata already had
+
+Kata already knows how to put the VF back. That primitive is `Detach`:
+
+```go
+func (endpoint *PhysicalEndpoint) Detach(...) error {
+    return bindNICToHost(endpoint) // BindDevicetoHost(bdf, saved Driver)
+}
+```
+
+`Detach` does **not** require the endpoint to be fully plugged into QEMU.
+It only needs `BDF` and `Driver`, which `createPhysicalEndpoint` fills
+**before** `Attach`. It also does not need a network namespace.
+
+That primitive is already used from:
+
+1. **Sandbox create failure** (`createSandboxFromConfig`): a `defer` calls
+   `removeNetwork` if anything after network setup fails (VM start,
+   containers, …).
+2. **Sandbox stop**: `removeNetwork` → `RemoveEndpoints` → `Detach` for
+   each recorded endpoint.
+
+So a successful Attach followed by a later sandbox failure already
+restores the VF.
+
+`removeNetwork` / `RemoveEndpoints` are the **list** wrappers. They only
+call `Detach` on endpoints stored in `n.eps`. That is the limitation.
+
+`HotDetach` is a different API: it also removes the device from the
+sandbox device manager. It is not valid if `AddDevice` never succeeded.
+
+## The leak
+
+The PCI bind happens **before** the endpoint is recorded:
+
+```
+bindNICToVFIO()          // VF is now vfio-pci
+AddDevice() / cgroup     // can fail here
+n.eps = append(...)      // only on success
+```
+
+If `AddDevice` (or cgroup setup) fails, `Attach` returns an error and the
+endpoint is never appended to `n.eps`. The existing `removeNetwork` defer
+still runs, but it walks an empty list and restores nothing.
+
+A second hole **undoes** the existing restore: `scanEndpointsInNs` on a
+later interface failure did `n.eps = n.eps[:epsBefore]` **without**
+`Detach`. Endpoints that had already been attached were forgotten, so
+the createSandbox defer could not see them either.
+
+The same “not on `n.eps` yet” hole existed if rate-limiter setup failed
+after a successful `Attach`.
+
+CRI timeout / SIGKILL still bypasses every in-process path, including
+the original defer. This change does not fix that.
+
+## What we changed
+
+### Go runtime — `physical_endpoint.go`
+
+- `Attach` and `HotAttach` use a named return and a `defer`. After a
+  successful `bindNICToVFIO`, any later error calls `endpoint.Detach`.
+  That reuses the existing PCI restore instead of a parallel helper.
+- `HotAttach` calls `Detach`, not `HotDetach`, because `HotDetach` talks
+  to the device manager.
+- Tests stub PCI rebind via unexported `bindToVFIO` / `bindToHost` fields
+  on the endpoint under test, not package-level function variables.
+
+### Go runtime — `network_linux.go`
+
+- `addSingleEndpoint`: if rate-limiter setup fails after Attach, call
+  `Detach` before returning. The endpoint is not on `n.eps` yet.
+- `scanEndpointsInNs`: on any scan error, `Detach` endpoints added
+  during this scan **before** truncating `n.eps`.
+- Shared helper `detachEndpointBestEffort` so those two paths use the
+  same `Detach` / `HotDetach` choice as teardown.
+
+### Go runtime — `pkg/device/drivers/vfio.go`
+
+There is no `Endpoint` object at this layer, only a BDF. If
+`drivers_probe` or VFIO path lookup fails after the unbind, call
+`BindDevicetoHost` (the same function `Detach` uses). Otherwise the VF
+can sit unbound or on `vfio-pci` with no endpoint to roll back.
+
+### Rust runtime — `physical_endpoint.rs` and `vfio.rs`
+
+Same idea: after `bind_device_to_vfio`, if `get_vfio_device` or
+`do_handle_device` fails, restore via `bind_device_to_host`. If the
+sysfs probe write fails, restore there too.
+
+The Rust `setup()` loop still does not detach already-attached siblings
+if a later endpoint’s `attach()` fails. That is a smaller gap (typical
+DPU Kata pods have one physical VF) and was left for a follow-up.
+
+### Tests
+
+- `physical_endpoint_test.go`
+  - Attach restores via `Detach` when `AddDevice` fails
+  - HotAttach does the same
+  - Attach does **not** call restore when the VFIO bind itself fails
+- `network_linux_test.go`
+  - scan rollback Detaches a physical endpoint
+  - scan rollback keeps endpoints that existed before this scan
+
+Linux compile of `virtcontainers` and `pkg/device/drivers` was checked
+from macOS with `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c`.
+
+## Files
+
+| File | Why |
+|---|---|
+| `src/runtime/virtcontainers/physical_endpoint.go` | Restore on Attach/HotAttach failure using `Detach` |
+| `src/runtime/virtcontainers/physical_endpoint_test.go` | Cover that restore |
+| `src/runtime/virtcontainers/network_linux.go` | Detach before dropping `n.eps`; Detach after rate-limiter failure |
+| `src/runtime/virtcontainers/network_linux_test.go` | Cover scan rollback |
+| `src/runtime/pkg/device/drivers/vfio.go` | Restore if bind-to-vfio fails mid-sysfs |
+| `src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs` | Same Attach-failure restore |
+| `src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs` | Same mid-bind restore |
+
+## Still open
+
+- **SIGKILL / CRI timeout:** `kata-runtime` is killed after the bind.
+  Nothing in-process can run `Detach`. The VF stays on `vfio-pci` until
+  a manual rebind, reboot, or a later safety net (for example DPU-host
+  CNI ADD refusing a leftover VFIO device).
+- **Rust multi-endpoint `setup()`:** first VF attached, second `attach()`
+  fails; first VF is not detached in this patch.
+- **Device plugin** still allocates VFs without checking the live driver.
+  That is outside Kata.

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -711,8 +711,19 @@ pub fn bind_device_to_vfio(bdf: &str, host_driver: &str, _vendor_device_id: &str
     info!(sl!(), "{} is unbound from {}", bdf, host_driver);
 
     // echo bdf > /sys/bus/pci/drivers_probe
-    fs::write(SYS_BUS_PCI_DRIVER_PROBE, bdf)
-        .with_context(|| format!("Failed to echo {bdf} > {SYS_BUS_PCI_DRIVER_PROBE}"))?;
+    if let Err(err) = fs::write(SYS_BUS_PCI_DRIVER_PROBE, bdf) {
+        if let Err(restore_err) = bind_device_to_host(bdf, host_driver, _vendor_device_id) {
+            warn!(
+                sl!(),
+                "failed to restore {} to {} after vfio probe failure: {}",
+                bdf,
+                host_driver,
+                restore_err
+            );
+        }
+        return Err(err)
+            .with_context(|| format!("Failed to echo {bdf} > {SYS_BUS_PCI_DRIVER_PROBE}"));
+    }
 
     info!(sl!(), "echo {} > /sys/bus/pci/drivers_probe", bdf);
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -761,16 +761,28 @@ pub fn bind_device_to_host(bdf: &str, host_driver: &str, _vendor_device_id: &str
 
     override_driver(bdf, host_driver).context("override driver")?;
 
-    // echo bdf > /sys/bus/pci/drivers/vfio-pci/unbind"
-    std::fs::write(VFIO_PCI_DRIVER_UNBIND, bdf)
-        .with_context(|| format!("echo {bdf}> {VFIO_PCI_DRIVER_UNBIND}"))?;
-    info!(sl!(), "echo {} > {}", bdf, VFIO_PCI_DRIVER_UNBIND);
+    unbind_pci_device_if_bound(
+        is_equal_driver(bdf, VFIO_PCI_DRIVER),
+        Path::new(VFIO_PCI_DRIVER_UNBIND),
+        bdf,
+    )?;
 
     // echo bdf > /sys/bus/pci/drivers_probe
     std::fs::write(SYS_BUS_PCI_DRIVER_PROBE, bdf)
         .with_context(|| format!("echo {bdf} > {SYS_BUS_PCI_DRIVER_PROBE}"))?;
     info!(sl!(), "echo {} > {}", bdf, SYS_BUS_PCI_DRIVER_PROBE);
 
+    Ok(())
+}
+
+fn unbind_pci_device_if_bound(bound_to_vfio: bool, unbind_path: &Path, bdf: &str) -> Result<()> {
+    if !bound_to_vfio {
+        return Ok(());
+    }
+
+    fs::write(unbind_path, bdf)
+        .with_context(|| format!("echo {bdf} > {}", unbind_path.display()))?;
+    info!(sl!(), "echo {} > {}", bdf, unbind_path.display());
     Ok(())
 }
 
@@ -901,4 +913,36 @@ pub fn get_vfio_device(device: String) -> Result<String> {
     }
 
     Ok(vfio_device)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unbind_pci_device_if_bound;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn unbind_bound_pci_device() {
+        let temp_dir = TempDir::new().expect("create temp directory");
+        let unbind_path = temp_dir.path().join("unbind");
+
+        unbind_pci_device_if_bound(true, &unbind_path, "0000:03:00.1")
+            .expect("unbind bound PCI device");
+
+        assert_eq!(
+            fs::read_to_string(unbind_path).expect("read unbind file"),
+            "0000:03:00.1"
+        );
+    }
+
+    #[test]
+    fn accept_unbound_pci_device() {
+        let temp_dir = TempDir::new().expect("create temp directory");
+        let unbind_path = temp_dir.path().join("unbind");
+
+        unbind_pci_device_if_bound(false, &unbind_path, "0000:03:00.1")
+            .expect("accept unbound PCI device");
+
+        assert!(!unbind_path.exists());
+    }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
@@ -105,6 +105,19 @@ impl PhysicalEndpoint {
             hostdev_id: std::sync::Mutex::new(None),
         })
     }
+
+    fn restore_host_driver(&self, cause: &str) {
+        if let Err(err) = driver::bind_device_to_host(
+            &self.bdf,
+            &self.driver,
+            &self.vendor_device_id.vendor_device_id(),
+        ) {
+            warn!(
+                sl!(),
+                "failed to restore {} to {} after {}: {}", self.bdf, self.driver, cause, err
+            );
+        }
+    }
 }
 
 #[async_trait]
@@ -153,7 +166,13 @@ impl Endpoint for PhysicalEndpoint {
         )
         .with_context(|| format!("bind physical endpoint from {} to vfio", &self.driver))?;
 
-        let vfio_device = get_vfio_device(self.bdf.clone()).context("get vfio device failed.")?;
+        let vfio_device = match get_vfio_device(self.bdf.clone()) {
+            Ok(dev) => dev,
+            Err(err) => {
+                self.restore_host_driver("get vfio device");
+                return Err(err).context("get vfio device failed.");
+            }
+        };
         let vfio_dev_config = &mut VfioConfig {
             host_path: vfio_device.clone(),
             dev_type: "pci".to_string(),
@@ -164,10 +183,18 @@ impl Endpoint for PhysicalEndpoint {
         // create and insert VFIO device into Kata VM; do_handle_device returns
         // the DeviceType with guest_pci_path already computed by
         // do_add_pcie_endpoint() inside VfioDevice::register().
-        let device_type =
-            do_handle_device(&self.d, &DeviceConfig::VfioCfg(vfio_dev_config.clone()))
-                .await
-                .context("do handle device failed.")?;
+        let device_type = match do_handle_device(
+            &self.d,
+            &DeviceConfig::VfioCfg(vfio_dev_config.clone()),
+        )
+        .await
+        {
+            Ok(dt) => dt,
+            Err(err) => {
+                self.restore_host_driver("do handle device");
+                return Err(err).context("do handle device failed.");
+            }
+        };
 
         // Store the QEMU hostdev_id for later QMP-based PCI path resolution.
         // The topology-computed guest_pci_path from do_add_pcie_endpoint() is

--- a/src/runtime/pkg/device/drivers/vfio.go
+++ b/src/runtime/pkg/device/drivers/vfio.go
@@ -332,10 +332,27 @@ func BindDevicetoVFIO(bdf, hostDriver string) (string, error) {
 	// Invoke drivers_probe so that the driver matching driver_override, in our case
 	// the vfio-pci driver will probe the device.
 	if err := utils.WriteToFile(driversProbePath, []byte(bdf)); err != nil {
+		restoreHostDriverAfterVFIO(bdf, hostDriver, "vfio probe")
 		return "", err
 	}
 
-	return GetVFIODevPath(bdf)
+	vfioPath, err := GetVFIODevPath(bdf)
+	if err != nil {
+		restoreHostDriverAfterVFIO(bdf, hostDriver, "vfio path lookup")
+		return "", err
+	}
+
+	return vfioPath, nil
+}
+
+func restoreHostDriverAfterVFIO(bdf, hostDriver, cause string) {
+	if err := BindDevicetoHost(bdf, hostDriver); err != nil {
+		deviceLogger().WithFields(logrus.Fields{
+			"device-bdf":  bdf,
+			"host-driver": hostDriver,
+			"cause":       cause,
+		}).WithError(err).Error("failed to restore host driver after VFIO bind failure")
+	}
 }
 
 // BindDevicetoHost unbinds the device from vfio-pci driver and binds it to the

--- a/src/runtime/pkg/device/drivers/vfio.go
+++ b/src/runtime/pkg/device/drivers/vfio.go
@@ -378,7 +378,7 @@ func BindDevicetoHost(bdf, hostDriver string) error {
 		"driver-path": unbindDriverPath,
 	}).Info("Unbinding device from driver")
 
-	if err := utils.WriteToFile(unbindDriverPath, []byte(bdf)); err != nil {
+	if err := unbindPCIDeviceIfBound(unbindDriverPath, bdf); err != nil {
 		return err
 	}
 
@@ -390,4 +390,12 @@ func BindDevicetoHost(bdf, hostDriver string) error {
 	// Invoke drivers_probe so that the driver matching driver_override, in this case
 	// the previous host driver will probe the device.
 	return utils.WriteToFile(driversProbePath, []byte(bdf))
+}
+
+func unbindPCIDeviceIfBound(unbindPath, bdf string) error {
+	if err := utils.WriteToFile(unbindPath, []byte(bdf)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
 }

--- a/src/runtime/pkg/device/drivers/vfio_test.go
+++ b/src/runtime/pkg/device/drivers/vfio_test.go
@@ -7,6 +7,8 @@
 package drivers
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
@@ -47,4 +49,59 @@ func TestGetVFIODetails(t *testing.T) {
 		}
 	}
 
+}
+
+func TestUnbindPCIDeviceIfBound(t *testing.T) {
+	bdf := "0000:03:00.1"
+
+	tests := []struct {
+		name       string
+		state      string
+		wantUnbind bool
+		wantErr    bool
+	}{
+		{
+			name:       "bound device is unbound",
+			state:      "bound",
+			wantUnbind: true,
+		},
+		{
+			name: "unbound device is accepted",
+		},
+		{
+			name:    "other unbind errors are returned",
+			state:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			driverDir := filepath.Join(tempDir, "driver")
+			unbindPath := filepath.Join(driverDir, "unbind")
+			switch test.state {
+			case "bound":
+				assert.NoError(t, os.Mkdir(driverDir, 0o755))
+				assert.NoError(t, os.WriteFile(unbindPath, nil, 0o600))
+			case "invalid":
+				assert.NoError(t, os.WriteFile(driverDir, nil, 0o600))
+			}
+
+			err := unbindPCIDeviceIfBound(unbindPath, bdf)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			contents, err := os.ReadFile(unbindPath)
+			if test.wantUnbind {
+				assert.NoError(t, err)
+				assert.Equal(t, bdf, string(contents))
+			} else {
+				assert.True(t, os.IsNotExist(err))
+			}
+		})
+	}
 }

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -243,6 +243,7 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 		if rxRateLimiterMaxRate > 0 {
 			networkLogger().Info("Add Rx Rate Limiter")
 			if err := addRxRateLimiter(endpoint, rxRateLimiterMaxRate); err != nil {
+				n.detachEndpointBestEffort(ctx, s, endpoint, hotplug)
 				return nil, err
 			}
 		}
@@ -250,6 +251,7 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 		if txRateLimiterMaxRate > 0 {
 			networkLogger().Info("Add Tx Rate Limiter")
 			if err := addTxRateLimiter(endpoint, txRateLimiterMaxRate); err != nil {
+				n.detachEndpointBestEffort(ctx, s, endpoint, hotplug)
 				return nil, err
 			}
 		}
@@ -258,6 +260,18 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 	n.eps = append(n.eps, endpoint)
 
 	return endpoint, nil
+}
+
+func (n *LinuxNetwork) detachEndpointBestEffort(ctx context.Context, s *Sandbox, endpoint Endpoint, hotplug bool) {
+	var err error
+	if hotplug && s != nil {
+		err = endpoint.HotDetach(ctx, s, n.netNSCreated, n.netNSPath)
+	} else {
+		err = endpoint.Detach(ctx, n.netNSCreated, n.netNSPath)
+	}
+	if err != nil {
+		networkLogger().WithField("endpoint", endpoint.Name()).WithError(err).Warn("failed to detach endpoint after a later attach failure")
+	}
 }
 
 func (n *LinuxNetwork) removeSingleEndpoint(ctx context.Context, s *Sandbox, endpoint Endpoint, hotplug bool) error {
@@ -429,7 +443,7 @@ func (n *LinuxNetwork) scanEndpointsInNs(ctx context.Context, s *Sandbox, nsPath
 	for _, link := range linkList {
 		netInfo, err := networkInfoFromLink(netlinkHandle, link)
 		if err != nil {
-			// No rollback needed — no endpoints were added in this iteration yet.
+			n.rollbackScanEndpoints(ctx, s, hotplug, epsBefore)
 			return nil, err
 		}
 
@@ -459,14 +473,26 @@ func (n *LinuxNetwork) scanEndpointsInNs(ctx context.Context, s *Sandbox, nsPath
 			}
 			return addErr
 		}); err != nil {
-			// Rollback: remove any endpoints added during this scan
-			// so that a failed scan does not leave partial side effects.
-			n.eps = n.eps[:epsBefore]
+			// Detach endpoints added during this scan before forgetting
+			// them. Physical endpoints have already rebound the VF to
+			// vfio-pci; dropping them from n.eps without Detach leaks
+			// that binding.
+			n.rollbackScanEndpoints(ctx, s, hotplug, epsBefore)
 			return nil, err
 		}
 	}
 
 	return added, nil
+}
+
+func (n *LinuxNetwork) rollbackScanEndpoints(ctx context.Context, s *Sandbox, hotplug bool, epsBefore int) {
+	if epsBefore > len(n.eps) {
+		return
+	}
+	for _, ep := range n.eps[epsBefore:] {
+		n.detachEndpointBestEffort(ctx, s, ep, hotplug)
+	}
+	n.eps = n.eps[:epsBefore]
 }
 
 // detectHypervisorNetns checks whether the hypervisor process is running in a

--- a/src/runtime/virtcontainers/network_linux_test.go
+++ b/src/runtime/virtcontainers/network_linux_test.go
@@ -614,3 +614,53 @@ func TestGatewaySetFromRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestRollbackScanEndpointsDetachesPhysicalEndpoint(t *testing.T) {
+	assert := assert.New(t)
+
+	var restoredBDF string
+	ep := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		BDF:       "0000:03:00.1",
+		Driver:    "mlx5_core",
+		bindToHost: func(endpoint *PhysicalEndpoint) error {
+			restoredBDF = endpoint.BDF
+			return nil
+		},
+	}
+	n := &LinuxNetwork{
+		eps: []Endpoint{ep},
+	}
+
+	n.rollbackScanEndpoints(context.Background(), nil, false, 0)
+	assert.Equal("0000:03:00.1", restoredBDF)
+	assert.Empty(n.eps)
+}
+
+func TestRollbackScanEndpointsPreservesEarlierEndpoints(t *testing.T) {
+	assert := assert.New(t)
+
+	nopHost := func(_ *PhysicalEndpoint) error { return nil }
+	existing := &PhysicalEndpoint{
+		IfaceName:  "eth0",
+		HardAddr:   net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x01}.String(),
+		BDF:        "0000:03:00.0",
+		Driver:     "mlx5_core",
+		bindToHost: nopHost,
+	}
+	added := &PhysicalEndpoint{
+		IfaceName:  "eth1",
+		HardAddr:   net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x02}.String(),
+		BDF:        "0000:03:00.1",
+		Driver:     "mlx5_core",
+		bindToHost: nopHost,
+	}
+	n := &LinuxNetwork{
+		eps: []Endpoint{existing, added},
+	}
+
+	n.rollbackScanEndpoints(context.Background(), nil, false, 1)
+	assert.Equal(1, len(n.eps))
+	assert.Equal(existing, n.eps[0])
+}

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -40,6 +40,11 @@ type PhysicalEndpoint struct {
 	VendorDeviceID     string
 	PCIPath            vcTypes.PciPath
 	CCWDevice          *vcTypes.CcwDevice
+
+	// Optional replacements for the PCI bind helpers. Nil in production;
+	// tests set them to avoid writing sysfs.
+	bindToVFIO func(*PhysicalEndpoint) (string, error)
+	bindToHost func(*PhysicalEndpoint) error
 }
 
 // Properties returns the properties of the physical interface.
@@ -94,7 +99,7 @@ func (endpoint *PhysicalEndpoint) NetworkPair() *NetworkInterfacePair {
 
 // Attach for physical endpoint binds the physical network interface to
 // vfio-pci and adds device to the hypervisor with vfio-passthrough.
-func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error {
+func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) (err error) {
 	span, ctx := physicalTrace(ctx, "Attach", endpoint)
 	defer span.End()
 
@@ -113,12 +118,12 @@ func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error 
 	// MAC reconciliation, see rpc.rs::update_interface) still keeps L2/L3
 	// working.
 	if endpoint.HardAddr != "" && endpoint.BDF != "" {
-		if err := setVfAdminMAC(endpoint.BDF, endpoint.HardAddr); err != nil {
+		if macErr := setVfAdminMAC(endpoint.BDF, endpoint.HardAddr); macErr != nil {
 			networkLogger().WithFields(logrus.Fields{
 				"bdf":    endpoint.BDF,
 				"netdev": endpoint.IfaceName,
 				"hwAddr": endpoint.HardAddr,
-			}).WithError(err).Warn("setVfAdminMAC: skipped, falling back to in-guest MAC reconciliation")
+			}).WithError(macErr).Warn("setVfAdminMAC: skipped, falling back to in-guest MAC reconciliation")
 		}
 	}
 
@@ -128,6 +133,23 @@ func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error 
 	if err != nil {
 		return err
 	}
+
+	// bindNICToVFIO has already taken the VF off the host netdev driver.
+	// If anything below fails the endpoint is never recorded, so the
+	// sandbox-level removeNetwork rollback will not see it. Detach is
+	// safe here: for a physical endpoint it only rebinds PCI using BDF
+	// and the host driver saved in createPhysicalEndpoint.
+	defer func() {
+		if err != nil {
+			if derr := endpoint.Detach(ctx, false, ""); derr != nil {
+				networkLogger().WithFields(logrus.Fields{
+					"bdf":    endpoint.BDF,
+					"driver": endpoint.Driver,
+					"netdev": endpoint.IfaceName,
+				}).WithError(derr).Error("failed to Detach physical endpoint after Attach failure")
+			}
+		}
+	}()
 
 	c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
 	if err != nil {
@@ -163,7 +185,7 @@ func (endpoint *PhysicalEndpoint) Detach(ctx context.Context, netNsCreated bool,
 }
 
 // HotAttach for physical endpoint not supported yet
-func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, s *Sandbox) error {
+func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, s *Sandbox) (err error) {
 	span, ctx := physicalTrace(ctx, "HotAttach", endpoint)
 	defer span.End()
 
@@ -173,6 +195,21 @@ func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, s *Sandbox) err
 	if err != nil {
 		return err
 	}
+
+	// Same as Attach: reuse Detach (PCI rebind) rather than HotDetach.
+	// HotDetach also removes the device from the sandbox device manager,
+	// which is not valid if AddDevice never succeeded.
+	defer func() {
+		if err != nil {
+			if derr := endpoint.Detach(ctx, false, ""); derr != nil {
+				networkLogger().WithFields(logrus.Fields{
+					"bdf":    endpoint.BDF,
+					"driver": endpoint.Driver,
+					"netdev": endpoint.IfaceName,
+				}).WithError(derr).Error("failed to Detach physical endpoint after HotAttach failure")
+			}
+		}
+	}()
 
 	c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
 	if err != nil {
@@ -310,10 +347,16 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 }
 
 func bindNICToVFIO(endpoint *PhysicalEndpoint) (string, error) {
+	if endpoint.bindToVFIO != nil {
+		return endpoint.bindToVFIO(endpoint)
+	}
 	return drivers.BindDevicetoVFIO(endpoint.BDF, endpoint.Driver)
 }
 
 func bindNICToHost(endpoint *PhysicalEndpoint) error {
+	if endpoint.bindToHost != nil {
+		return endpoint.bindToHost(endpoint)
+	}
 	return drivers.BindDevicetoHost(endpoint.BDF, endpoint.Driver)
 }
 

--- a/src/runtime/virtcontainers/physical_endpoint_test.go
+++ b/src/runtime/virtcontainers/physical_endpoint_test.go
@@ -9,6 +9,7 @@ package virtcontainers
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -48,6 +49,86 @@ func TestPhysicalEndpoint_HotDetach(t *testing.T) {
 
 	err := v.HotDetach(context.Background(), s, true, "")
 	assert.Error(err)
+}
+
+func TestPhysicalEndpoint_AttachRestoresHostDriverOnAddDeviceFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	var restored *PhysicalEndpoint
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		BDF:       "0000:03:00.1",
+		Driver:    "mlx5_core",
+		bindToVFIO: func(_ *PhysicalEndpoint) (string, error) {
+			return "/dev/null", nil
+		},
+		bindToHost: func(endpoint *PhysicalEndpoint) error {
+			restored = endpoint
+			return nil
+		},
+	}
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+		config:     &SandboxConfig{},
+	}
+
+	err := v.Attach(context.Background(), s)
+	assert.Error(err)
+	assert.Equal(v, restored)
+}
+
+func TestPhysicalEndpoint_HotAttachRestoresHostDriverOnAddDeviceFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	var restored *PhysicalEndpoint
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		BDF:       "0000:03:00.1",
+		Driver:    "mlx5_core",
+		bindToVFIO: func(_ *PhysicalEndpoint) (string, error) {
+			return "/dev/null", nil
+		},
+		bindToHost: func(endpoint *PhysicalEndpoint) error {
+			restored = endpoint
+			return nil
+		},
+	}
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+		config:     &SandboxConfig{},
+	}
+
+	err := v.HotAttach(context.Background(), s)
+	assert.Error(err)
+	assert.Equal(v, restored)
+}
+
+func TestPhysicalEndpoint_AttachDoesNotRestoreWhenBindFails(t *testing.T) {
+	assert := assert.New(t)
+
+	hostCalled := false
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		BDF:       "0000:03:00.1",
+		Driver:    "mlx5_core",
+		bindToVFIO: func(_ *PhysicalEndpoint) (string, error) {
+			return "", fmt.Errorf("bind to vfio-pci failed")
+		},
+		bindToHost: func(_ *PhysicalEndpoint) error {
+			hostCalled = true
+			return nil
+		},
+	}
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+		config:     &SandboxConfig{},
+	}
+
+	err := v.Attach(context.Background(), s)
+	assert.Error(err)
+	assert.False(hostCalled)
 }
 
 func TestIsPhysicalIface(t *testing.T) {


### PR DESCRIPTION
## Summary

When Kata prepares an SR-IOV VF for cold-plug passthrough, it moves the device from its host driver to `vfio-pci`. If pod creation then fails, some error paths leave the VF on `vfio-pci` instead of returning it to the host.

This also affects later pods: the SR-IOV device plugin can allocate the same PCI device again, but the VF no longer has a host network interface, so CNI and Kata cannot discover it. Recovery currently requires manually rebinding the VF or rebooting the node.

This PR makes the attach operation transactional: if Kata cannot finish attaching the VF, it restores the driver that was recorded before the operation began. The fix covers both the Go runtime and runtime-rs.

## Why the existing cleanup missed it

Kata binds the VF to `vfio-pci` before adding the endpoint to its network endpoint list. Normal teardown only cleans up endpoints in that list, which means it cannot see a device when an error occurs in that gap.

The same problem existed in a few related paths:

- device or cgroup setup failed after the VF was rebound;
- rate-limiter setup failed before the endpoint was recorded;
- scanning a later interface failed and discarded endpoints added earlier in the scan;
- the low-level VFIO probe or device-path lookup failed after the host driver was detached.

## What changed

- Restore the saved host driver when `Attach` or `HotAttach` fails after the VFIO bind.
- Detach endpoints added by a failed network scan before removing them from the endpoint list.
- Roll back a successful attach if rate-limiter setup fails.
- Restore the host driver when low-level VFIO setup fails, including when the failed probe leaves the device completely unbound.
- Apply equivalent rollback behavior to runtime-rs.
- Add focused tests for the endpoint, scan, and unbound-device recovery paths.

The implementation reuses the existing `Detach` / `BindDevicetoHost` behavior rather than adding a second restoration mechanism.

## Scope and limitations

This handles failures that return through Kata's normal error paths. It cannot run cleanup if the runtime is killed with `SIGKILL` or terminated by a CRI timeout after the VF was rebound.

The following related cases remain outside this PR:

- runtime-rs does not yet detach previously attached sibling endpoints if a later endpoint fails;
- the SR-IOV device plugin does not verify the VF's live driver before allocating it.

For background and manual recovery steps, see [Stale VF cleanup](https://github.com/jensfr/rhcos-layer-kata-dpu/tree/dpu-coldplug-nvidia-ref#stale-vf-cleanup).

## Testing

- [x] `go vet` for `virtcontainers` and `pkg/device/drivers` with `GOOS=linux`
- [x] Linux/amd64 compile of the `virtcontainers` and `pkg/device/drivers` tests
- [x] Focused `pkg/device/drivers` tests for bound, unbound, and error cases
- [ ] Focused `virtcontainers` tests on a Linux host
- [ ] CI lint and runtime-rs checks
