### PR TITLE
WIP: dragonball: Reset stale vsock connections on snapshot restore

### DIFF
--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 use std::any::Any;
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
@@ -23,6 +24,7 @@ use super::backend::VsockBackend;
 use super::defs::uapi;
 use super::epoll_handler::VsockEpollHandler;
 use super::muxer::{Error as MuxerError, VsockGenericMuxer, VsockMuxer};
+use super::persist::VsockState;
 use super::{Result, VsockError};
 use crate::device::{VirtioDeviceConfig, VirtioDeviceInfo};
 use crate::{ActivateResult, ConfigResult, DbsGuestAddressSpace, VirtioDevice};
@@ -54,9 +56,9 @@ pub struct Vsock<AS: GuestAddressSpace, M: VsockGenericMuxer = VsockMuxer> {
     device_info: VirtioDeviceInfo,
     subscriber_id: Option<SubscriberId>,
     /// Shared with the activated epoll handler rather than moved into it, so
-    /// that the device can still reach the muxer once the handler owns it.
-    /// The handler locks it per packet; the only other user is the device
-    /// thread, so the lock is effectively uncontended.
+    /// that `save_state()` can still read the live connection state. The
+    /// handler locks it per packet; contention is between the device thread
+    /// and the rare snapshot, so the lock is effectively uncontended.
     muxer: Option<Arc<Mutex<M>>>,
     phantom: PhantomData<AS>,
 }
@@ -131,9 +133,12 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     /// Borrow the muxer, which the device shares with its epoll handler.
     ///
     /// A poisoned lock is reported, not panicked on. It means some thread
-    /// panicked while mutating the muxer, so its state may be incomplete;
-    /// refusing the operation is the safe answer, and taking the VMM down
-    /// with a second panic is not.
+    /// panicked while mutating the muxer, so its connection state may be
+    /// incomplete -- and this method's callers are the snapshot paths. A
+    /// snapshot that under-reports live connections restores a guest holding
+    /// sockets whose peers are gone, which is the exact failure
+    /// reset-on-restore exists to prevent, so refusing to save is the safe
+    /// answer. Taking the VMM down with a second panic is not.
     fn muxer(&self) -> Result<std::sync::MutexGuard<'_, M>> {
         self.muxer
             .as_ref()
@@ -143,28 +148,73 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     }
 }
 
-impl<'a, AS: GuestAddressSpace, M: VsockGenericMuxer> crate::persist::VirtioDevicePersist<'a>
-    for Vsock<AS, M>
-{
-    type State = crate::persist::VirtioDeviceInfoState;
+// Snapshot support is implemented for the concrete muxer rather than for any
+// `VsockGenericMuxer`: capturing connection identity is a property of the real
+// muxer, not of the channel abstraction, and a fake muxer could only mirror it
+// -- which is the kind of parallel state this device state exists to avoid.
+impl<'a, AS: GuestAddressSpace> crate::persist::VirtioDevicePersist<'a> for Vsock<AS, VsockMuxer> {
+    type State = VsockState;
     type SaveArgs = ();
     type RestoreArgs = ();
     type Error = crate::Error;
 
-    /// Capture the guest-negotiated state of this device.
+    /// Capture the guest-negotiated state of this device, together with the
+    /// identity of every connection that is live right now.
     ///
-    /// Live vsock connection state is not captured: a snapshot must be taken
-    /// at a clean quiesce point with no active connections.
+    /// The host half of a live connection cannot be captured -- it is a file
+    /// descriptor, an epoll registration and a peer process -- so the
+    /// snapshot records only each connection's port tuple, which is enough
+    /// for [`restore_state`](Self::restore_state) to tell the restored guest
+    /// that the connection is gone.
+    ///
+    /// The tuples are read from the live muxer, which the device shares with
+    /// its epoll handler, so they cannot disagree with it.
     fn save_state(&mut self, _args: ()) -> crate::Result<Self::State> {
-        Ok(self.device_info.save_state())
+        let reset_connections = self.muxer()?.connections_to_reset();
+        Ok(VsockState {
+            device_info: self.device_info.save_state(),
+            reset_connections,
+        })
     }
 
-    /// Restore the guest-negotiated state of this device.
+    /// Restore the guest-negotiated state of this device and queue one
+    /// `VSOCK_OP_RST` per connection the snapshot recorded.
     ///
     /// The device must have been re-created with the same configuration and
-    /// must not have been activated yet.
+    /// must not have been activated yet: the resets are queued on the muxer
+    /// the device still owns, and delivered by the RX pass that
+    /// [`activate`](VirtioDevice::activate) runs before the vCPUs resume.
+    /// No connection object is created -- there is nothing to connect to.
     fn restore_state(&mut self, state: &Self::State, _args: ()) -> crate::Result<()> {
-        self.device_info.restore_state(state)
+        // Check the reset list for self-consistency first, so a malformed
+        // snapshot is refused before anything is touched.
+        let mut seen = HashSet::with_capacity(state.reset_connections.len());
+        for id in &state.reset_connections {
+            if !seen.insert(*id) {
+                warn!(
+                    "virtio-vsock: duplicate reset tuple in snapshot (lp={}, pp={})",
+                    id.local_port, id.peer_port
+                );
+                return Err(crate::Error::InvalidInput);
+            }
+        }
+
+        // Then the guest-negotiated state, which is the check most likely to
+        // reject a mismatched snapshot: it refuses a feature set the guest
+        // never negotiated against, and does so before mutating anything, so
+        // a device rebuilt from the wrong configuration keeps its muxer
+        // untouched.
+        self.device_info.restore_state(&state.device_info)?;
+
+        // Queue the resets last. This validates the list against the muxer's
+        // own bound before extending the queue, so it too cannot apply half
+        // of a rejected list.
+        self.muxer()?
+            .queue_restore_resets(&state.reset_connections)
+            .map_err(|err| {
+                warn!("virtio-vsock: failed to queue restore resets: {err:?}");
+                crate::Error::InvalidInput
+            })
     }
 }
 
@@ -210,15 +260,28 @@ where
         trace!(target: "virtio-vsock", "{}: VirtioDevice::activate()", self.id());
 
         self.device_info.check_queue_sizes(&config.queues[..])?;
-        // The device keeps its own handle rather than handing the muxer over.
+        // The device keeps its own handle: sharing the muxer, rather than
+        // handing it over, is what lets `save_state()` read live connection
+        // state after activation.
         let muxer = self
             .muxer
             .as_ref()
             .ok_or(VsockError::MuxerUnavailable)
             .map_err(crate::Error::from)?
             .clone();
-        let handler: VsockEpollHandler<AS, Q, R, M> =
+        let mut handler: VsockEpollHandler<AS, Q, R, M> =
             VsockEpollHandler::new(config, self.id().to_owned(), self.cid, muxer);
+
+        // On the restore path the muxer already holds a reset for every
+        // connection that was live when the snapshot was taken, and nothing
+        // else would deliver them: `init()` only registers epoll listeners,
+        // and `process_rx()` otherwise runs only on a queue or backend event.
+        // The transport has replayed the queue addresses and MSI
+        // configuration by now, so this pass sees the descriptors the guest
+        // posted before the snapshot and can raise the interrupt before the
+        // vCPUs resume. On cold boot a fresh muxer has nothing pending and
+        // this is a no-op.
+        handler.flush_pending_rx();
 
         self.subscriber_id = Some(self.device_info.register_event_handler(Box::new(handler)));
 
@@ -273,10 +336,12 @@ mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap, GuestRegionMmap};
 
     use super::super::defs::uapi;
-    use super::super::tests::{test_bytes, TestContext, TestMuxer};
+    use super::super::persist::VsockConnectionId;
+    use super::super::tests::{test_bytes, TestContext};
     use super::super::VsockChannel;
     use super::*;
     use crate::device::VirtioDeviceConfig;
+    use crate::persist::VirtioDevicePersist;
     use crate::tests::create_address_space;
     use crate::VirtioQueueConfig;
 
@@ -295,7 +360,8 @@ mod tests {
                     config,
                     self.id().to_owned(),
                     self.cid,
-                    self.muxer.as_ref().unwrap().clone(),
+                    // safe to unwrap, because we create muxer using New()
+                    self.muxer.take().unwrap(),
                 );
 
             Ok(handler)
@@ -432,8 +498,46 @@ mod tests {
         ctx.device.activate(config).unwrap();
     }
 
+    fn conn_id(local_port: u32, peer_port: u32) -> VsockConnectionId {
+        VsockConnectionId {
+            local_port,
+            peer_port,
+        }
+    }
+
+    /// Build a device config from the shared harness. `ctx.queues` is
+    /// muxer-agnostic, so a real-muxer device can be activated with it.
+    fn config_from(
+        test_ctx: &TestContext,
+        ctx: &mut super::super::tests::EventHandlerContext<'_>,
+    ) -> VirtioDeviceConfig<Arc<GuestMemoryMmap<()>>, QueueSync> {
+        let kvm = Kvm::new().unwrap();
+        let vm_fd = Arc::new(kvm.create_vm().unwrap());
+        VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
+            Arc::new(test_ctx.mem.clone()),
+            create_address_space(),
+            vm_fd,
+            DeviceResources::new(),
+            ctx.queues.drain(..).collect(),
+            None,
+            Arc::new(NoopNotifier::new()),
+        )
+    }
+
+    /// A device with a real `VsockMuxer`, for the checks that exercise the
+    /// muxer's own limits rather than the mock's bookkeeping.
+    fn real_muxer_device() -> Vsock<Arc<GuestMemoryMmap<()>>> {
+        Vsock::new(
+            52,
+            Arc::new(super::super::defs::QUEUE_SIZES.to_vec()),
+            EpollManager::default(),
+            false,
+        )
+        .unwrap()
+    }
+
     /// Make a thread panic while holding `lock`, poisoning it.
-    fn poison(lock: Arc<Mutex<TestMuxer>>) {
+    fn poison(lock: Arc<Mutex<VsockMuxer>>) {
         let previous = std::panic::take_hook();
         // The panic below is the point of the test; don't print its backtrace.
         std::panic::set_hook(Box::new(|_| {}));
@@ -447,43 +551,22 @@ mod tests {
     }
 
     #[test]
-    fn test_device_reaches_the_muxer_the_handler_uses() {
-        skip_if_kvm_unaccessable!();
-
-        // The point of sharing: after activation has handed the muxer to the
-        // epoll handler, the device still sees the handler's view of it.
-        let test_ctx = TestContext::new();
-        let mut ctx = test_ctx.create_event_handler_context();
-
-        let kvm = Kvm::new().unwrap();
-        let vm_fd = Arc::new(kvm.create_vm().unwrap());
-        let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
-            Arc::new(test_ctx.mem.clone()),
-            create_address_space(),
-            vm_fd,
-            DeviceResources::new(),
-            ctx.queues.drain(..).collect(),
-            None,
-            Arc::new(NoopNotifier::new()),
-        );
-        let shared = ctx.device.muxer.as_ref().unwrap().clone();
-        ctx.device.activate(config).unwrap();
-
-        shared.lock().unwrap().set_pending_rx(true);
-        assert!(ctx.device.muxer().unwrap().has_pending_rx());
-    }
-
-    #[test]
     fn test_poisoned_muxer_lock_is_reported_not_panicked() {
-        let mut ctx = TestContext::new();
-        poison(ctx.device.muxer.as_ref().unwrap().clone());
+        let mut device = real_muxer_device();
+        poison(device.muxer.as_ref().unwrap().clone());
 
         // A thread panicked mid-mutation, so the muxer's state may be
         // incomplete. Report that rather than panicking a second thread.
         let backend = Box::new(super::super::backend::VsockInnerBackend::new().unwrap());
         assert!(matches!(
-            ctx.device.add_backend(backend, false),
+            device.add_backend(backend, false),
             Err(VsockError::MuxerLockPoisoned)
+        ));
+        assert!(matches!(
+            device.save_state(()),
+            Err(crate::Error::VirtioVsockError(
+                VsockError::MuxerLockPoisoned
+            ))
         ));
     }
 
@@ -498,18 +581,183 @@ mod tests {
             &mut ctx.device,
         );
 
-        let kvm = Kvm::new().unwrap();
-        let vm_fd = Arc::new(kvm.create_vm().unwrap());
-        let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
-            Arc::new(test_ctx.mem.clone()),
-            create_address_space(),
-            vm_fd,
-            DeviceResources::new(),
-            ctx.queues.drain(..).collect(),
-            None,
-            Arc::new(NoopNotifier::new()),
+        let config = config_from(&test_ctx, &mut ctx);
+        assert!(ctx.device.activate(config).is_err());
+    }
+
+    #[test]
+    fn test_save_state_captures_what_the_muxer_reports() {
+        let mut device = real_muxer_device();
+
+        // A cold-booted device with no connections has nothing to reset --
+        // and neither does one that was merely paused and resumed, since
+        // neither touches the muxer's connection state.
+        let state = device.save_state(()).unwrap();
+        assert!(state.reset_connections.is_empty());
+        assert_eq!(
+            state.device_info,
+            device.device_info.save_state(),
+            "the guest-negotiated state must be captured unchanged"
         );
 
-        assert!(ctx.device.activate(config).is_err());
+        // Whatever the live muxer owes the guest is what gets captured. The
+        // union itself is the muxer's business and is tested there; here the
+        // point is only that `save_state()` reads the real thing.
+        let stale = vec![conn_id(1024, 7), conn_id(1025, 9)];
+        device
+            .muxer()
+            .unwrap()
+            .queue_restore_resets(&stale)
+            .unwrap();
+        assert_eq!(device.save_state(()).unwrap().reset_connections, stale);
+    }
+
+    #[test]
+    fn test_restore_state_queues_one_reset_per_connection() {
+        let mut device = real_muxer_device();
+        let stale = vec![conn_id(1024, 7), conn_id(1025, 9)];
+        let state = VsockState {
+            device_info: device.device_info.save_state(),
+            reset_connections: stale.clone(),
+        };
+
+        device.restore_state(&state, ()).unwrap();
+
+        let muxer = device.muxer().unwrap();
+        assert!(muxer.has_pending_rx());
+        // No connection object is created; the resets are still owed, so a
+        // snapshot taken now carries them forward rather than losing them.
+        assert_eq!(muxer.connections_to_reset(), stale);
+    }
+
+    #[test]
+    fn test_restore_state_without_connections_queues_nothing() {
+        let mut device = real_muxer_device();
+        let state = VsockState {
+            device_info: device.device_info.save_state(),
+            reset_connections: Vec::new(),
+        };
+
+        device.restore_state(&state, ()).unwrap();
+        assert!(!device.muxer().unwrap().has_pending_rx());
+    }
+
+    #[test]
+    fn test_restore_state_refuses_malformed_reset_state() {
+        // A repeated tuple would reset the same guest socket twice, and says
+        // the state was not produced by `save_state()`.
+        let mut device = real_muxer_device();
+        let state = VsockState {
+            device_info: device.device_info.save_state(),
+            reset_connections: vec![conn_id(1024, 7), conn_id(1024, 7)],
+        };
+        assert!(matches!(
+            device.restore_state(&state, ()),
+            Err(crate::Error::InvalidInput)
+        ));
+        assert!(!device.muxer().unwrap().has_pending_rx());
+
+        // More tuples than any snapshot could legitimately carry.
+        let mut device = real_muxer_device();
+        let excess = super::super::muxer::defs::MAX_RESTORE_RESETS + 1;
+        let state = VsockState {
+            device_info: device.device_info.save_state(),
+            reset_connections: (0..excess as u32).map(|i| conn_id(1024 + i, 7)).collect(),
+        };
+        assert!(matches!(
+            device.restore_state(&state, ()),
+            Err(crate::Error::InvalidInput)
+        ));
+        assert!(!device.muxer().unwrap().has_pending_rx());
+
+        // A feature set the guest never negotiated against. This is checked
+        // before the resets are queued, so a device rebuilt from the wrong
+        // configuration keeps its muxer untouched.
+        let mut device = real_muxer_device();
+        let mut device_info = device.device_info.save_state();
+        device_info.avail_features ^= 1;
+        let state = VsockState {
+            device_info,
+            reset_connections: vec![conn_id(1024, 7)],
+        };
+        assert!(matches!(
+            device.restore_state(&state, ()),
+            Err(crate::Error::InvalidInput)
+        ));
+        assert!(!device.muxer().unwrap().has_pending_rx());
+    }
+
+    #[test]
+    fn test_activate_delivers_restored_resets() {
+        skip_if_kvm_unaccessable!();
+
+        // Queueing a reset is not delivering it: `init()` only registers
+        // epoll listeners, and `process_rx()` otherwise runs only on a queue
+        // or backend event. Activation must make the pass itself, so the
+        // guest sees the resets before its vCPUs resume.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        let mut device = real_muxer_device();
+        let stale = conn_id(1024, 7);
+        device
+            .restore_state(
+                &VsockState {
+                    device_info: device.device_info.save_state(),
+                    reset_connections: vec![stale],
+                },
+                (),
+            )
+            .unwrap();
+
+        let config = config_from(&test_ctx, &mut ctx);
+        device.activate(config).unwrap();
+
+        // The descriptor the guest posted before the snapshot was used, and
+        // the muxer now owes it nothing -- the reset is what consumed it.
+        // That the reset is well formed is the muxer's contract, asserted
+        // against the real builder in `muxer_impl`'s tests.
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+        assert!(device.muxer().unwrap().connections_to_reset().is_empty());
+    }
+
+    #[test]
+    fn test_activate_on_cold_boot_touches_no_descriptor() {
+        skip_if_kvm_unaccessable!();
+
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        let mut device = real_muxer_device();
+
+        let config = config_from(&test_ctx, &mut ctx);
+        device.activate(config).unwrap();
+
+        // A fresh muxer has nothing pending, so activation is a no-op.
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+    }
+
+    #[test]
+    fn test_device_reaches_the_muxer_the_handler_uses() {
+        skip_if_kvm_unaccessable!();
+
+        // The point of sharing the muxer: after activation has handed it to
+        // the epoll handler, the device still sees the handler's view of it,
+        // so a snapshot cannot disagree with the running device.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        let mut device = real_muxer_device();
+        let shared = device.muxer.as_ref().unwrap().clone();
+        let config = config_from(&test_ctx, &mut ctx);
+        device.activate(config).unwrap();
+
+        let stale = conn_id(1024, 7);
+        shared
+            .lock()
+            .unwrap()
+            .queue_restore_resets(&[stale])
+            .unwrap();
+        assert_eq!(
+            device.save_state(()).unwrap().reset_connections,
+            vec![stale]
+        );
     }
 }

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
@@ -8,7 +8,7 @@
 // found in the THIRD-PARTY file.
 use std::any::Any;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use dbs_device::resources::ResourceConstraint;
 use dbs_utils::epoll_manager::{EpollManager, SubscriberId};
@@ -53,7 +53,11 @@ pub struct Vsock<AS: GuestAddressSpace, M: VsockGenericMuxer = VsockMuxer> {
     queue_sizes: Arc<Vec<u16>>,
     device_info: VirtioDeviceInfo,
     subscriber_id: Option<SubscriberId>,
-    muxer: Option<M>,
+    /// Shared with the activated epoll handler rather than moved into it, so
+    /// that the device can still reach the muxer once the handler owns it.
+    /// The handler locks it per packet; the only other user is the device
+    /// thread, so the lock is effectively uncontended.
+    muxer: Option<Arc<Mutex<M>>>,
     phantom: PhantomData<AS>,
 }
 
@@ -102,7 +106,7 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
                 epoll_mgr,
             ),
             subscriber_id: None,
-            muxer: Some(muxer),
+            muxer: Some(Arc::new(Mutex::new(muxer))),
             phantom: PhantomData,
         })
     }
@@ -114,13 +118,28 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
     /// add backend for vsock muxer
     // NOTE: Backend is not allowed to add when vsock device is activated.
     pub fn add_backend(&mut self, backend: Box<dyn VsockBackend>, is_default: bool) -> Result<()> {
-        if let Some(muxer) = self.muxer.as_mut() {
-            muxer
-                .add_backend(backend, is_default)
-                .map_err(VsockError::Muxer)
-        } else {
-            Err(VsockError::Muxer(MuxerError::BackendAddAfterActivated))
+        // The muxer outlives activation now, so a missing one no longer says
+        // the device was activated; the subscriber id does.
+        if self.subscriber_id.is_some() {
+            return Err(VsockError::Muxer(MuxerError::BackendAddAfterActivated));
         }
+        self.muxer()?
+            .add_backend(backend, is_default)
+            .map_err(VsockError::Muxer)
+    }
+
+    /// Borrow the muxer, which the device shares with its epoll handler.
+    ///
+    /// A poisoned lock is reported, not panicked on. It means some thread
+    /// panicked while mutating the muxer, so its state may be incomplete;
+    /// refusing the operation is the safe answer, and taking the VMM down
+    /// with a second panic is not.
+    fn muxer(&self) -> Result<std::sync::MutexGuard<'_, M>> {
+        self.muxer
+            .as_ref()
+            .ok_or(VsockError::MuxerUnavailable)?
+            .lock()
+            .map_err(|_| VsockError::MuxerLockPoisoned)
     }
 }
 
@@ -191,13 +210,15 @@ where
         trace!(target: "virtio-vsock", "{}: VirtioDevice::activate()", self.id());
 
         self.device_info.check_queue_sizes(&config.queues[..])?;
-        let handler: VsockEpollHandler<AS, Q, R, M> = VsockEpollHandler::new(
-            config,
-            self.id().to_owned(),
-            self.cid,
-            // safe to unwrap, because we create muxer using New()
-            self.muxer.take().unwrap(),
-        );
+        // The device keeps its own handle rather than handing the muxer over.
+        let muxer = self
+            .muxer
+            .as_ref()
+            .ok_or(VsockError::MuxerUnavailable)
+            .map_err(crate::Error::from)?
+            .clone();
+        let handler: VsockEpollHandler<AS, Q, R, M> =
+            VsockEpollHandler::new(config, self.id().to_owned(), self.cid, muxer);
 
         self.subscriber_id = Some(self.device_info.register_event_handler(Box::new(handler)));
 
@@ -234,9 +255,11 @@ where
                 Ok(_) => debug!("virtio-vsock: removed subscriber_id {subscriber_id:?}"),
                 Err(err) => warn!("virtio-vsock: failed to remove event handler: {err:?}"),
             };
-        } else {
-            self.muxer.take();
         }
+        // Drop the device's handle either way. Before activation this is the
+        // only one, so the muxer's epoll FD and backend sockets are released
+        // here; afterwards the removed handler drops the last one.
+        self.muxer.take();
     }
 }
 
@@ -250,7 +273,8 @@ mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap, GuestRegionMmap};
 
     use super::super::defs::uapi;
-    use super::super::tests::{test_bytes, TestContext};
+    use super::super::tests::{test_bytes, TestContext, TestMuxer};
+    use super::super::VsockChannel;
     use super::*;
     use crate::device::VirtioDeviceConfig;
     use crate::tests::create_address_space;
@@ -271,8 +295,7 @@ mod tests {
                     config,
                     self.id().to_owned(),
                     self.cid,
-                    // safe to unwrap, because we create muxer using New()
-                    self.muxer.take().unwrap(),
+                    self.muxer.as_ref().unwrap().clone(),
                 );
 
             Ok(handler)
@@ -407,5 +430,86 @@ mod tests {
 
         // Test activation.
         ctx.device.activate(config).unwrap();
+    }
+
+    /// Make a thread panic while holding `lock`, poisoning it.
+    fn poison(lock: Arc<Mutex<TestMuxer>>) {
+        let previous = std::panic::take_hook();
+        // The panic below is the point of the test; don't print its backtrace.
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::thread::spawn(move || {
+            let _guard = lock.lock().unwrap();
+            panic!("poison the muxer lock");
+        })
+        .join();
+        std::panic::set_hook(previous);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_device_reaches_the_muxer_the_handler_uses() {
+        skip_if_kvm_unaccessable!();
+
+        // The point of sharing: after activation has handed the muxer to the
+        // epoll handler, the device still sees the handler's view of it.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+
+        let kvm = Kvm::new().unwrap();
+        let vm_fd = Arc::new(kvm.create_vm().unwrap());
+        let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
+            Arc::new(test_ctx.mem.clone()),
+            create_address_space(),
+            vm_fd,
+            DeviceResources::new(),
+            ctx.queues.drain(..).collect(),
+            None,
+            Arc::new(NoopNotifier::new()),
+        );
+        let shared = ctx.device.muxer.as_ref().unwrap().clone();
+        ctx.device.activate(config).unwrap();
+
+        shared.lock().unwrap().set_pending_rx(true);
+        assert!(ctx.device.muxer().unwrap().has_pending_rx());
+    }
+
+    #[test]
+    fn test_poisoned_muxer_lock_is_reported_not_panicked() {
+        let mut ctx = TestContext::new();
+        poison(ctx.device.muxer.as_ref().unwrap().clone());
+
+        // A thread panicked mid-mutation, so the muxer's state may be
+        // incomplete. Report that rather than panicking a second thread.
+        let backend = Box::new(super::super::backend::VsockInnerBackend::new().unwrap());
+        assert!(matches!(
+            ctx.device.add_backend(backend, false),
+            Err(VsockError::MuxerLockPoisoned)
+        ));
+    }
+
+    #[test]
+    fn test_activate_without_a_muxer_is_reported_not_panicked() {
+        skip_if_kvm_unaccessable!();
+
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        // `remove()` drops the device's muxer handle.
+        VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::remove(
+            &mut ctx.device,
+        );
+
+        let kvm = Kvm::new().unwrap();
+        let vm_fd = Arc::new(kvm.create_vm().unwrap());
+        let config = VirtioDeviceConfig::<Arc<GuestMemoryMmap<()>>, QueueSync>::new(
+            Arc::new(test_ctx.mem.clone()),
+            create_address_space(),
+            vm_fd,
+            DeviceResources::new(),
+            ctx.queues.drain(..).collect(),
+            None,
+            Arc::new(NoopNotifier::new()),
+        );
+
+        assert!(ctx.device.activate(config).is_err());
     }
 }

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/epoll_handler.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/epoll_handler.rs
@@ -8,6 +8,7 @@
 // found in the THIRD-PARTY file.
 
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use dbs_utils::epoll_manager::{EventOps, EventSet, Events, MutEventSubscriber};
 use log::{error, trace, warn};
@@ -61,7 +62,11 @@ pub struct VsockEpollHandler<
 > {
     pub(crate) config: VirtioDeviceConfig<AS, Q, R>,
     id: String,
-    pub(crate) muxer: M,
+    /// Shared with the owning device, which needs to reach the muxer after
+    /// activation. Locked per packet; the only other user is the device
+    /// thread, so it is effectively uncontended (this is what Cloud
+    /// Hypervisor does too).
+    pub(crate) muxer: Arc<Mutex<M>>,
     _cid: u64,
 }
 
@@ -72,12 +77,40 @@ where
     R: GuestMemoryRegion,
     M: VsockGenericMuxer,
 {
-    pub fn new(config: VirtioDeviceConfig<AS, Q, R>, id: String, cid: u64, muxer: M) -> Self {
+    pub fn new(
+        config: VirtioDeviceConfig<AS, Q, R>,
+        id: String,
+        cid: u64,
+        muxer: Arc<Mutex<M>>,
+    ) -> Self {
         VsockEpollHandler {
             config,
             id,
             _cid: cid,
             muxer,
+        }
+    }
+
+    /// Borrow the muxer, or `None` if a thread panicked while holding its
+    /// lock.
+    ///
+    /// Nothing here can return an error -- `MutEventSubscriber::process()`
+    /// yields `()` -- so a poisoned lock is logged and the operation is
+    /// skipped, the way this file already handles a queue it cannot walk.
+    /// The vsock device stops moving packets; the VMM keeps running, which a
+    /// second panic would not allow.
+    ///
+    /// The lock is never held across a call that takes it again -- `Mutex` is
+    /// not reentrant -- so every caller binds the guard to a local rather
+    /// than using it inline in a condition, which under edition 2018 would
+    /// keep it alive for the whole `if` statement.
+    pub(crate) fn muxer(&self) -> Option<std::sync::MutexGuard<'_, M>> {
+        match self.muxer.lock() {
+            Ok(muxer) => Some(muxer),
+            Err(_) => {
+                error!("{}: vsock muxer lock poisoned, skipping", self.id);
+                None
+            }
         }
     }
 
@@ -108,9 +141,16 @@ where
                 };
 
                 if let Some(mut desc_chain) = iter.next() {
+                    let mut muxer = match self.muxer.lock() {
+                        Ok(muxer) => muxer,
+                        Err(_) => {
+                            error!("{}: vsock muxer lock poisoned, stopping RX", self.id);
+                            break;
+                        }
+                    };
                     let used_len = match VsockPacket::from_rx_virtq_head(&mut desc_chain) {
                         Ok(mut pkt) => {
-                            if self.muxer.recv_pkt(&mut pkt).is_ok() {
+                            if muxer.recv_pkt(&mut pkt).is_ok() {
                                 pkt.hdr().len() as u32 + pkt.len()
                             } else {
                                 // We are using a consuming iterator over the virtio buffers, so, if we
@@ -168,7 +208,17 @@ where
                         }
                     };
 
-                    if self.muxer.send_pkt(&pkt).is_err() {
+                    // Field access, not `self.muxer()`: the helper borrows
+                    // all of `self`, which the queue guard above already
+                    // borrows mutably.
+                    let send_err = match self.muxer.lock() {
+                        Ok(mut muxer) => muxer.send_pkt(&pkt).is_err(),
+                        Err(_) => {
+                            error!("{}: vsock muxer lock poisoned, stopping TX", self.id);
+                            break;
+                        }
+                    };
+                    if send_err {
                         iter.go_to_previous_position();
                         break;
                     }
@@ -191,7 +241,10 @@ where
         trace!("{}: handle RX queue event", self.id);
         if let Err(e) = self.config.queues[QUEUE_RX].consume_event() {
             error!("{}: failed to consume rx queue event, {:?}", self.id, e);
-        } else if self.muxer.has_pending_rx() {
+            return;
+        }
+        let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
+        if pending {
             self.process_rx(mem);
         }
     }
@@ -206,7 +259,8 @@ where
             // we sent during TX queue processing. If that happened, we
             // need to fetch those responses and place them into RX
             // buffers.
-            if self.muxer.has_pending_rx() {
+            let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
+            if pending {
                 self.process_rx(mem);
             }
         }
@@ -222,7 +276,9 @@ where
     pub(crate) fn notify_backend_event(&mut self, events: &Events, mem: &AS::M) {
         trace!("{}: backend event", self.id);
         let events = epoll::Events::from_bits(events.event_set().bits()).unwrap();
-        self.muxer.notify(events);
+        if let Some(mut muxer) = self.muxer() {
+            muxer.notify(events);
+        }
         // After the backend has been kicked, it might've freed up some
         // resources, so we can attempt to send it more data to process. In
         // particular, if `self.backend.send_pkt()` halted the TX queue
@@ -231,7 +287,8 @@ where
         self.process_tx(mem);
         // This event may have caused some packets to be queued up by the
         // backend. Make sure they are processed.
-        if self.muxer.has_pending_rx() {
+        let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
+        if pending {
             self.process_rx(mem);
         }
     }
@@ -296,8 +353,17 @@ where
             );
         }
 
-        let be_fd = self.muxer.as_raw_fd();
-        let be_evset = EventSet::from_bits(self.muxer.get_polled_evset().bits()).unwrap();
+        let be = self.muxer().map(|muxer| {
+            (
+                muxer.as_raw_fd(),
+                EventSet::from_bits(muxer.get_polled_evset().bits()).unwrap(),
+            )
+        });
+        // A poisoned lock here leaves the backend unregistered; the error is
+        // already logged, and the queue listeners above still stand.
+        let Some((be_fd, be_evset)) = be else {
+            return;
+        };
         let events = Events::with_data_raw(be_fd, defs::BACKEND_EVENT, be_evset);
         if let Err(e) = ops.add(events) {
             error!(
@@ -342,7 +408,7 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(false);
+                epoll_handler.muxer().unwrap().set_pending_rx(false);
             }
             ctx.signal_txq_event();
 
@@ -362,7 +428,7 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(true);
+                epoll_handler.muxer().unwrap().set_pending_rx(true);
             }
             ctx.signal_txq_event();
 
@@ -381,8 +447,11 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(false);
-                epoll_handler.muxer.set_tx_err(Some(VsockError::NoData));
+                epoll_handler.muxer().unwrap().set_pending_rx(false);
+                epoll_handler
+                    .muxer()
+                    .unwrap()
+                    .set_tx_err(Some(VsockError::NoData));
             }
             ctx.signal_txq_event();
 
@@ -407,7 +476,7 @@ mod tests {
             // should have reached the backend.
             assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                assert_eq!(epoll_handler.muxer.tx_ok_cnt, 0);
+                assert_eq!(epoll_handler.muxer().unwrap().tx_ok_cnt, 0);
             }
         }
     }
@@ -425,8 +494,11 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(true);
-                epoll_handler.muxer.set_rx_err(Some(VsockError::NoData));
+                epoll_handler.muxer().unwrap().set_pending_rx(true);
+                epoll_handler
+                    .muxer()
+                    .unwrap()
+                    .set_rx_err(Some(VsockError::NoData));
             }
             ctx.signal_rxq_event();
 
@@ -444,7 +516,7 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(true);
+                epoll_handler.muxer().unwrap().set_pending_rx(true);
             }
             ctx.signal_rxq_event();
 
@@ -465,7 +537,7 @@ mod tests {
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
                 epoll_handler.process_rx(&test_ctx.mem);
                 assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
-                assert_eq!(epoll_handler.muxer.rx_ok_cnt, 0);
+                assert_eq!(epoll_handler.muxer().unwrap().rx_ok_cnt, 0);
             }
         }
     }
@@ -482,12 +554,15 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(true);
+                epoll_handler.muxer().unwrap().set_pending_rx(true);
                 epoll_handler
                     .notify_backend_event(&Events::new_raw(0, EventSet::IN), &test_ctx.mem);
 
                 // The backend should've received this event
-                assert_eq!(epoll_handler.muxer.evset, Some(epoll::Events::EPOLLIN));
+                assert_eq!(
+                    epoll_handler.muxer().unwrap().evset,
+                    Some(epoll::Events::EPOLLIN)
+                );
             }
 
             // TX queue processing should've been triggered.
@@ -505,12 +580,15 @@ mod tests {
             ctx.arti_activate(&test_ctx.mem);
 
             if let Some(epoll_handler) = &mut ctx.epoll_handler {
-                epoll_handler.muxer.set_pending_rx(false);
+                epoll_handler.muxer().unwrap().set_pending_rx(false);
                 epoll_handler
                     .notify_backend_event(&Events::new_raw(0, EventSet::IN), &test_ctx.mem);
 
                 // The backend should've received this event.
-                assert_eq!(epoll_handler.muxer.evset, Some(epoll::Events::EPOLLIN));
+                assert_eq!(
+                    epoll_handler.muxer().unwrap().evset,
+                    Some(epoll::Events::EPOLLIN)
+                );
             }
             // TX queue processing should've been triggered.
             assert_eq!(ctx.guest_txvq.used.idx().load(), 1);
@@ -631,5 +709,42 @@ mod tests {
             GAP_START_ADDR as u64 - 4,
             GAP_SIZE as u32 + 100,
         );
+    }
+
+    #[test]
+    fn test_poisoned_muxer_lock_does_not_panic_the_handler() {
+        skip_if_kvm_unaccessable!();
+
+        // `MutEventSubscriber::process()` returns `()`, so there is nobody to
+        // report a poisoned lock to. The handler logs and skips: the vsock
+        // device stops moving packets, but the VMM survives, which a second
+        // panic would not allow.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.arti_activate(&test_ctx.mem);
+
+        {
+            let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+            epoll_handler.muxer().unwrap().set_pending_rx(true);
+
+            let lock = epoll_handler.muxer.clone();
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let result = std::thread::spawn(move || {
+                let _guard = lock.lock().unwrap();
+                panic!("poison the muxer lock");
+            })
+            .join();
+            std::panic::set_hook(previous);
+            assert!(result.is_err());
+
+            assert!(epoll_handler.muxer().is_none());
+        }
+
+        // Every entry point survives, and none of them touched the guest.
+        ctx.signal_rxq_event();
+        ctx.signal_txq_event();
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+        assert_eq!(ctx.guest_txvq.used.idx().load(), 0);
     }
 }

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/epoll_handler.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/epoll_handler.rs
@@ -62,11 +62,20 @@ pub struct VsockEpollHandler<
 > {
     pub(crate) config: VirtioDeviceConfig<AS, Q, R>,
     id: String,
-    /// Shared with the owning device, which needs to reach the muxer after
-    /// activation. Locked per packet; the only other user is the device
-    /// thread, so it is effectively uncontended (this is what Cloud
-    /// Hypervisor does too).
+    /// Shared with the owning device, which needs to read live connection
+    /// state when a snapshot is taken. Locked per packet; the only other
+    /// user is the device thread taking a snapshot, so it is effectively
+    /// uncontended (this is what Cloud Hypervisor does too).
     pub(crate) muxer: Arc<Mutex<M>>,
+    /// A descriptor whose packet was written into guest memory but whose used
+    /// ring entry could not be published, kept as `(head_index, len)`.
+    ///
+    /// `VsockPacket` writes straight through to guest memory, so by the time
+    /// `recv_pkt()` returns the guest's buffer already holds the packet and
+    /// only the publish is outstanding. Retrying that publish needs nothing
+    /// from the muxer: re-queueing the packet would be both unnecessary and
+    /// lossy, since the muxer can only reproduce resets, not RX data.
+    pending_used: Option<(u16, u32)>,
     _cid: u64,
 }
 
@@ -88,6 +97,7 @@ where
             id,
             _cid: cid,
             muxer,
+            pending_used: None,
         }
     }
 
@@ -114,6 +124,15 @@ where
         }
     }
 
+    /// Whether an RX pass has anything to do.
+    ///
+    /// A publish left outstanding by a failed `add_used()` counts: it is the
+    /// handler's own obligation, and the muxer may well have nothing further
+    /// to offer, so gating only on the muxer would strand the descriptor.
+    fn needs_rx_pass(&self) -> bool {
+        self.pending_used.is_some() || self.muxer().is_some_and(|muxer| muxer.has_pending_rx())
+    }
+
     /// Signal the guest driver that we've used some virtio buffers that it had
     /// previously made available.
     pub(crate) fn signal_used_queue(&self, idx: usize) -> VirtioResult<()> {
@@ -131,6 +150,29 @@ where
         let mut raise_irq = false;
         {
             let rxvq = &mut self.config.queues[QUEUE_RX].queue_mut().lock();
+
+            // Finish a publish that failed on an earlier pass before taking
+            // anything new from the muxer, so the guest sees packets in the
+            // order they were produced.
+            //
+            // Nothing this depends on changes between attempts -- a failed
+            // `add_used()` leaves `next_used` unadvanced, and the head index
+            // and ring address are fixed -- so this will keep failing unless
+            // guest memory itself changed. That makes the real job of
+            // `pending_used` a latch rather than a retry: while it is set,
+            // the muxer is not consumed, so a wedged ring cannot silently
+            // drain restore resets into a ring the guest will never read.
+            // The failure was already reported where it happened; stay quiet
+            // here or a busy device logs on every event.
+            if let Some((head_index, used_len)) = self.pending_used {
+                if let Err(e) = rxvq.add_used(mem, head_index, used_len) {
+                    trace!("{}: RX used ring still unusable, {:?}", self.id, e);
+                    return;
+                }
+                self.pending_used = None;
+                raise_irq = true;
+            }
+
             loop {
                 let mut iter = match rxvq.iter(mem) {
                     Err(e) => {
@@ -165,8 +207,20 @@ where
                         }
                     };
 
+                    // `iter` is not used past this point, so the queue can be
+                    // borrowed again.
+                    let head_index = desc_chain.head_index();
+                    if let Err(e) = rxvq.add_used(mem, head_index, used_len) {
+                        error!("{}: failed to add used RX buffer, {:?}", self.id, e);
+                        // The packet is already in the guest's buffer; only
+                        // the used ring entry is missing. Hold the descriptor
+                        // -- neither published nor handed back -- and retry
+                        // the publish on the next pass, which loses nothing
+                        // and needs no cooperation from the muxer.
+                        self.pending_used = Some((head_index, used_len));
+                        break;
+                    }
                     raise_irq = true;
-                    let _ = rxvq.add_used(mem, desc_chain.head_index(), used_len);
                 } else {
                     break;
                 }
@@ -177,6 +231,24 @@ where
                 error!("{}: failed to notify guest for RX queue, {:?}", self.id, e);
             }
         }
+    }
+
+    /// Deliver whatever the muxer already has pending, without waiting for a
+    /// queue or backend event.
+    ///
+    /// Called once from device activation so that resets queued by a restore
+    /// reach the guest before its vCPUs resume; queueing a reset is not
+    /// delivering it. If the guest posted no RX descriptor, the resets stay
+    /// queued and its next RX kick delivers them -- still ahead of any new
+    /// traffic.
+    pub(crate) fn flush_pending_rx(&mut self) {
+        if !self.needs_rx_pass() {
+            return;
+        }
+        trace!("{}: epoll_handler::flush_pending_rx()", self.id);
+        let guard = self.config.lock_guest_memory();
+        let mem = guard.deref();
+        self.process_rx(mem);
     }
 
     /// Walk the dirver-provided TX queue buffers, package them up as vsock
@@ -243,8 +315,7 @@ where
             error!("{}: failed to consume rx queue event, {:?}", self.id, e);
             return;
         }
-        let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
-        if pending {
+        if self.needs_rx_pass() {
             self.process_rx(mem);
         }
     }
@@ -259,8 +330,7 @@ where
             // we sent during TX queue processing. If that happened, we
             // need to fetch those responses and place them into RX
             // buffers.
-            let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
-            if pending {
+            if self.needs_rx_pass() {
                 self.process_rx(mem);
             }
         }
@@ -287,8 +357,7 @@ where
         self.process_tx(mem);
         // This event may have caused some packets to be queued up by the
         // backend. Make sure they are processed.
-        let pending = self.muxer().is_some_and(|muxer| muxer.has_pending_rx());
-        if pending {
+        if self.needs_rx_pass() {
             self.process_rx(mem);
         }
     }
@@ -381,8 +450,9 @@ mod tests {
     use vmm_sys_util::epoll::EventSet;
 
     use super::super::packet::VSOCK_PKT_HDR_SIZE;
+    use super::super::persist::VsockConnectionId;
     use super::super::tests::TestContext;
-    use super::super::VsockError;
+    use super::super::{VsockChannel, VsockError};
     use super::*;
 
     #[test]
@@ -712,6 +782,144 @@ mod tests {
     }
 
     #[test]
+    fn test_flush_pending_rx_delivers_without_an_event() {
+        skip_if_kvm_unaccessable!();
+
+        // Nothing else would deliver a reset queued by a restore: `init()`
+        // only registers epoll listeners, and `process_rx()` otherwise runs
+        // only on a queue or backend event.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.arti_activate(&test_ctx.mem);
+
+        let stale = VsockConnectionId {
+            local_port: 1024,
+            peer_port: 7,
+        };
+        let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+        epoll_handler
+            .muxer()
+            .unwrap()
+            .queue_restore_resets(&[stale])
+            .unwrap();
+        epoll_handler.flush_pending_rx();
+
+        assert_eq!(epoll_handler.muxer().unwrap().sent_resets, vec![stale]);
+        assert!(!epoll_handler.muxer().unwrap().has_pending_rx());
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+    }
+
+    #[test]
+    fn test_flush_pending_rx_with_nothing_pending() {
+        skip_if_kvm_unaccessable!();
+
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.arti_activate(&test_ctx.mem);
+
+        let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+        epoll_handler.muxer().unwrap().set_pending_rx(false);
+        epoll_handler.flush_pending_rx();
+
+        assert_eq!(epoll_handler.muxer().unwrap().rx_ok_cnt, 0);
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+    }
+
+    #[test]
+    fn test_pending_rx_survives_a_queue_with_no_descriptor() {
+        skip_if_kvm_unaccessable!();
+
+        // With no RX descriptor available the resets stay queued, and the
+        // guest's next RX kick delivers them -- still ahead of any new
+        // traffic.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        // Retract the descriptor the guest had posted.
+        ctx.guest_rxvq.avail.idx().store(0);
+        ctx.arti_activate(&test_ctx.mem);
+
+        let stale = VsockConnectionId {
+            local_port: 1024,
+            peer_port: 7,
+        };
+        let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+        epoll_handler
+            .muxer()
+            .unwrap()
+            .queue_restore_resets(&[stale])
+            .unwrap();
+        epoll_handler.flush_pending_rx();
+
+        assert!(epoll_handler.muxer().unwrap().sent_resets.is_empty());
+        assert!(epoll_handler.muxer().unwrap().has_pending_rx());
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+
+        // The guest posts a buffer and kicks the RX queue.
+        ctx.guest_rxvq.avail.idx().store(1);
+        ctx.signal_rxq_event();
+
+        let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+        assert_eq!(epoll_handler.muxer().unwrap().sent_resets, vec![stale]);
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+    }
+
+    #[test]
+    fn test_failed_publish_is_retried_and_loses_nothing() {
+        skip_if_kvm_unaccessable!();
+
+        // `VsockPacket` writes through to guest memory, so a failed
+        // `add_used()` means the packet is already in the guest's buffer and
+        // only the used ring entry is missing. The handler holds the
+        // descriptor and republishes it later; nothing is asked of the muxer.
+        let test_ctx = TestContext::new();
+        let mut ctx = test_ctx.create_event_handler_context();
+        ctx.arti_activate(&test_ctx.mem);
+
+        let stale = VsockConnectionId {
+            local_port: 1024,
+            peer_port: 7,
+        };
+        {
+            let epoll_handler = ctx.epoll_handler.as_mut().unwrap();
+            epoll_handler
+                .muxer()
+                .unwrap()
+                .queue_restore_resets(&[stale])
+                .unwrap();
+
+            // Point the used ring outside guest memory so publishing fails.
+            let good = epoll_handler.config.queues[QUEUE_RX]
+                .queue_mut()
+                .lock()
+                .used_ring();
+            epoll_handler.config.queues[QUEUE_RX]
+                .queue_mut()
+                .lock()
+                .set_used_ring_address(Some(0xffff_0000), Some(0xffff_ffff));
+            epoll_handler.flush_pending_rx();
+
+            // The muxer handed the packet over and is not asked to take it
+            // back; the obligation now lives with the handler.
+            assert_eq!(epoll_handler.muxer().unwrap().sent_resets, vec![stale]);
+            assert!(epoll_handler.pending_used.is_some());
+            assert_eq!(ctx.guest_rxvq.used.idx().load(), 0);
+
+            // Once the ring works again the descriptor is published, without
+            // the muxer producing a second packet.
+            epoll_handler.config.queues[QUEUE_RX]
+                .queue_mut()
+                .lock()
+                .set_used_ring_address(Some(good as u32), Some((good >> 32) as u32));
+            epoll_handler.muxer().unwrap().set_pending_rx(false);
+            epoll_handler.flush_pending_rx();
+
+            assert!(epoll_handler.pending_used.is_none());
+            assert_eq!(epoll_handler.muxer().unwrap().sent_resets, vec![stale]);
+        }
+        assert_eq!(ctx.guest_rxvq.used.idx().load(), 1);
+    }
+
+    #[test]
     fn test_poisoned_muxer_lock_does_not_panic_the_handler() {
         skip_if_kvm_unaccessable!();
 
@@ -739,6 +947,7 @@ mod tests {
             assert!(result.is_err());
 
             assert!(epoll_handler.muxer().is_none());
+            epoll_handler.flush_pending_rx();
         }
 
         // Every entry point survives, and none of them touched the guest.

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
@@ -126,6 +126,13 @@ pub enum VsockError {
     /// vsock muxer error
     #[error("Vsock muxer error: {0}")]
     Muxer(#[source] MuxerError),
+    /// The muxer is no longer available, the device having been removed.
+    #[error("The vsock muxer is no longer available")]
+    MuxerUnavailable,
+    /// A thread panicked while holding the muxer lock, so the muxer's state
+    /// may be incomplete and must not be trusted.
+    #[error("The vsock muxer lock is poisoned")]
+    MuxerLockPoisoned,
     /// A data fetch was attempted when no data was available.
     #[error("A data fetch was attempted when no data was available")]
     NoData,

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
@@ -11,6 +11,7 @@ mod device;
 mod epoll_handler;
 pub mod muxer;
 mod packet;
+pub mod persist;
 
 use std::os::unix::io::AsRawFd;
 
@@ -21,6 +22,7 @@ pub use self::device::Vsock;
 use self::muxer::Error as MuxerError;
 pub use self::muxer::VsockMuxer;
 use self::packet::VsockPacket;
+pub use self::persist::{VsockConnectionId, VsockState};
 
 mod defs {
     /// RX queue event: the driver added available buffers to the RX queue.
@@ -207,6 +209,7 @@ mod tests {
     use super::epoll_handler::VsockEpollHandler;
     use super::muxer::{Result as MuxerResult, VsockGenericMuxer};
     use super::packet::{VsockPacket, VSOCK_PKT_HDR_SIZE};
+    use super::persist::VsockConnectionId;
     use super::*;
     use crate::device::VirtioDeviceConfig;
     use crate::tests::{
@@ -230,9 +233,22 @@ mod tests {
         pub rx_ok_cnt: usize,
         pub tx_ok_cnt: usize,
         pub evset: Option<epoll::Events>,
+        /// Restore resets still owed to the guest, in delivery order.
+        pub restore_resets: Vec<VsockConnectionId>,
+        /// Restore resets yielded by `recv_pkt()`, in delivery order.
+        pub sent_resets: Vec<VsockConnectionId>,
     }
 
     impl TestMuxer {
+        /// Seed resets the way a restore would. Inherent rather than part of
+        /// `VsockGenericMuxer`: only handler *delivery* tests need it, and
+        /// the real union logic belongs to `VsockMuxer`.
+        pub fn queue_restore_resets(&mut self, ids: &[VsockConnectionId]) -> MuxerResult<()> {
+            self.restore_resets.extend_from_slice(ids);
+            self.pending_rx = !self.restore_resets.is_empty();
+            Ok(())
+        }
+
         pub fn new() -> Self {
             Self {
                 evfd: EventFd::new(EFD_NONBLOCK).unwrap(),
@@ -242,6 +258,8 @@ mod tests {
                 rx_ok_cnt: 0,
                 tx_ok_cnt: 0,
                 evset: None,
+                restore_resets: Vec::new(),
+                sent_resets: Vec::new(),
             }
         }
 
@@ -266,6 +284,18 @@ mod tests {
         fn recv_pkt(&mut self, _pkt: &mut VsockPacket) -> Result<()> {
             let cool_buf = [0xDu8, 0xE, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF];
             match self.rx_err.take() {
+                None if !self.restore_resets.is_empty() => {
+                    // Restore resets come first, as in the real muxer.
+                    let id = self.restore_resets.remove(0);
+                    _pkt.set_op(defs::uapi::VSOCK_OP_RST)
+                        .set_src_port(id.local_port)
+                        .set_dst_port(id.peer_port)
+                        .set_len(0);
+                    self.sent_resets.push(id);
+                    self.pending_rx = !self.restore_resets.is_empty();
+                    self.rx_ok_cnt += 1;
+                    Ok(())
+                }
                 None => {
                     if let Some(buf) = _pkt.buf_mut() {
                         for i in 0..buf.len() {

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/mod.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/mod.rs
@@ -17,7 +17,7 @@ use super::backend::{VsockBackend, VsockBackendType};
 use super::{VsockChannel, VsockEpollListener};
 pub use muxer_impl::VsockMuxer;
 
-mod defs {
+pub(crate) mod defs {
     /// Maximum number of established connections that we can handle.
     pub const MAX_CONNECTIONS: usize = 1023;
 
@@ -26,6 +26,15 @@ mod defs {
 
     /// Size of the muxer connection kill queue.
     pub const MUXER_KILLQ_SIZE: usize = 128;
+
+    /// Upper bound on the restore resets a muxer will accept.
+    ///
+    /// This must cover everything one save pass can emit, or a snapshot this
+    /// build produced would be one it refuses to restore: every live
+    /// connection, plus every standalone RST the RX queue can hold. It is a
+    /// guard against corrupt input, not a capacity limit -- each entry is a
+    /// port pair, so even the whole bound costs a few kilobytes.
+    pub const MAX_RESTORE_RESETS: usize = MAX_CONNECTIONS + MUXER_RXQ_SIZE;
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/muxer_impl.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/muxer/muxer_impl.rs
@@ -35,7 +35,7 @@
 ///       other pollable FDs are then registered under this nested epoll FD. To
 ///       route all these events to their handlers, the muxer uses another
 ///       `HashMap` object, mapping `RawFd`s to `EpollListener`s.
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::io::Read;
 use std::os::fd::FromRawFd;
@@ -48,6 +48,7 @@ use super::super::backend::{HybridStream, VsockBackend, VsockBackendType, VsockS
 use super::super::csm::{ConnState, VsockConnection};
 use super::super::defs::uapi;
 use super::super::packet::VsockPacket;
+use super::super::persist::VsockConnectionId;
 use super::super::{Result as VsockResult, VsockChannel, VsockEpollListener, VsockError};
 use super::muxer_killq::MuxerKillQ;
 use super::muxer_rxq::MuxerRxQ;
@@ -59,6 +60,15 @@ use super::{defs, Error, Result, VsockGenericMuxer};
 pub struct ConnMapKey {
     local_port: u32,
     pub(crate) peer_port: u32,
+}
+
+impl From<ConnMapKey> for VsockConnectionId {
+    fn from(key: ConnMapKey) -> Self {
+        VsockConnectionId {
+            local_port: key.local_port,
+            peer_port: key.peer_port,
+        }
+    }
 }
 
 /// A muxer RX queue item.
@@ -126,6 +136,17 @@ pub struct VsockMuxer {
     backend_map: HashMap<VsockBackendType, Box<dyn VsockBackend>>,
     /// the backend which can accept peer-initiated connection.
     peer_backend: Option<VsockBackendType>,
+    /// Resets owed to the guest for connections that were live when the
+    /// snapshot this VM was restored from was taken.
+    ///
+    /// These live in a queue of their own, drained by `recv_pkt()` ahead of
+    /// `rxq`, rather than in `rxq` itself: `MuxerRxQ` holds fewer entries
+    /// than the connection pool and lets an RST evict a queued connection
+    /// key, and a mandatory reset must not take part in a scheduler that can
+    /// drop or reorder it. Draining it first also guarantees that nothing
+    /// belonging to a new connection reaches the guest before every stale
+    /// connection has been reset.
+    restore_rstq: VecDeque<VsockConnectionId>,
 }
 
 impl VsockChannel for VsockMuxer {
@@ -135,6 +156,20 @@ impl VsockChannel for VsockMuxer {
     /// - `Ok(())`: `pkt` has been successfully filled in; or
     /// - `Err(VsockError::NoData)`: there was no available data with which to fill in the packet.
     fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
+        // Restore resets come first: the guest must not see anything
+        // belonging to a new connection before every connection that was live
+        // when the snapshot was taken has been reset.
+        if let Some(id) = self.restore_rstq.pop_front() {
+            self.build_rst_pkt(pkt, id.local_port, id.peer_port);
+            trace!(
+                "vsock: muxer.recv[restore reset, lp={}, pp={}, left={}]",
+                id.local_port,
+                id.peer_port,
+                self.restore_rstq.len()
+            );
+            return Ok(());
+        }
+
         // We'll look for instructions on how to build the RX packet in the RX
         // queue. If the queue is empty, that doesn't necessarily mean we don't
         // have any pending RX, since the queue might be out-of-sync. If that's
@@ -152,16 +187,7 @@ impl VsockChannel for VsockMuxer {
                     local_port,
                     peer_port,
                 } => {
-                    pkt.set_op(uapi::VSOCK_OP_RST)
-                        .set_src_cid(uapi::VSOCK_HOST_CID)
-                        .set_dst_cid(self.cid)
-                        .set_src_port(local_port)
-                        .set_dst_port(peer_port)
-                        .set_len(0)
-                        .set_type(uapi::VSOCK_TYPE_STREAM)
-                        .set_flags(0)
-                        .set_buf_alloc(0)
-                        .set_fwd_cnt(0);
+                    self.build_rst_pkt(pkt, local_port, peer_port);
                     self.rxq.pop().unwrap();
                     trace!(
                         "vsock: muxer.recv[rxq.len={}, type={}, op={}, sp={}, sc={}, dp={}, dc={}]: {:?}",
@@ -329,7 +355,7 @@ impl VsockChannel for VsockMuxer {
     /// Check if the muxer has any pending RX data, with which to fill a
     /// guest-provided RX buffer.
     fn has_pending_rx(&self) -> bool {
-        !self.rxq.is_empty() || !self.rxq.is_synced()
+        !self.restore_rstq.is_empty() || !self.rxq.is_empty() || !self.rxq.is_synced()
     }
 }
 
@@ -408,7 +434,51 @@ impl VsockMuxer {
             local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
             backend_map: HashMap::new(),
             peer_backend: None,
+            restore_rstq: VecDeque::new(),
         })
+    }
+
+    pub fn connections_to_reset(&self) -> Vec<VsockConnectionId> {
+        // Every live connection, plus every reset the muxer already owes the
+        // guest but has not emitted yet:
+        //
+        // - `conn_map` covers connections that have been killed but not yet
+        //   reset too, since the muxer only drops one once its RST has
+        //   actually gone out;
+        // - a standalone RST -- one answering a packet for a tuple with no
+        //   connection -- is held only in `rxq`;
+        // - `restore_rstq` holds resets inherited from an earlier restore
+        //   that the guest has not taken yet.
+        //
+        // A `BTreeSet` sorts and deduplicates, so the serialized snapshot is
+        // deterministic and a tuple present in two of the three is reported
+        // once. One RST per tuple is all a guest with one socket per tuple
+        // needs.
+        let mut ids: BTreeSet<VsockConnectionId> =
+            self.conn_map.keys().map(|key| (*key).into()).collect();
+        ids.extend(self.rxq.q.iter().filter_map(|rx| match rx {
+            MuxerRx::RstPkt {
+                local_port,
+                peer_port,
+            } => Some(VsockConnectionId {
+                local_port: *local_port,
+                peer_port: *peer_port,
+            }),
+            MuxerRx::ConnRx(_) => None,
+        }));
+        ids.extend(self.restore_rstq.iter().copied());
+        ids.into_iter().collect()
+    }
+
+    pub fn queue_restore_resets(&mut self, ids: &[VsockConnectionId]) -> Result<()> {
+        // Bounded so a corrupt snapshot cannot make the muxer allocate
+        // without limit. The bound covers everything `connections_to_reset()`
+        // can emit, so a snapshot this build produced is always restorable.
+        if self.restore_rstq.len() + ids.len() > defs::MAX_RESTORE_RESETS {
+            return Err(Error::TooManyConnections);
+        }
+        self.restore_rstq.extend(ids.iter().copied());
+        Ok(())
     }
 
     /// Handle/dispatch an epoll event to its listener.
@@ -979,6 +1049,25 @@ impl VsockMuxer {
         if !pushed {
             warn!("vsock: muxer.rxq full; dropping RST packet for lp={local_port}, pp={peer_port}");
         }
+    }
+
+    /// Fill in `pkt` as an RST going from `local_port` on the host to
+    /// `peer_port` on the guest.
+    ///
+    /// A connection's port tuple is all it takes to build a complete reset,
+    /// which is why a snapshot need record nothing else, and why restore
+    /// queues reset instructions rather than packets.
+    fn build_rst_pkt(&self, pkt: &mut VsockPacket, local_port: u32, peer_port: u32) {
+        pkt.set_op(uapi::VSOCK_OP_RST)
+            .set_src_cid(uapi::VSOCK_HOST_CID)
+            .set_dst_cid(self.cid)
+            .set_src_port(local_port)
+            .set_dst_port(peer_port)
+            .set_len(0)
+            .set_type(uapi::VSOCK_TYPE_STREAM)
+            .set_flags(0)
+            .set_buf_alloc(0)
+            .set_fwd_cnt(0);
     }
 }
 
@@ -1639,5 +1728,262 @@ mod tests {
         fs::remove_file(Path::new(&host_sock_path_1)).unwrap_or_default();
         fs::remove_file(Path::new(&host_sock_path_2)).unwrap_or_default();
         fs::remove_file(Path::new(&host_sock_path_3)).unwrap_or_default();
+    }
+
+    fn conn_id(local_port: u32, peer_port: u32) -> VsockConnectionId {
+        VsockConnectionId {
+            local_port,
+            peer_port,
+        }
+    }
+
+    /// Assert that `pkt` is a well-formed reset for `id`.
+    fn assert_is_rst_for(pkt: &VsockPacket, id: VsockConnectionId) {
+        assert_eq!(pkt.op(), uapi::VSOCK_OP_RST);
+        assert_eq!(pkt.type_(), uapi::VSOCK_TYPE_STREAM);
+        assert_eq!(pkt.src_cid(), uapi::VSOCK_HOST_CID);
+        assert_eq!(pkt.dst_cid(), PEER_CID);
+        assert_eq!(pkt.src_port(), id.local_port);
+        assert_eq!(pkt.dst_port(), id.peer_port);
+        assert_eq!(pkt.len(), 0);
+    }
+
+    #[test]
+    fn test_connections_to_reset_follows_conn_map() {
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("/tmp/reset_set_conn_map");
+        assert!(ctx.muxer.connections_to_reset().is_empty());
+
+        let (_stream, local_port) = ctx.local_connect(PEER_PORT);
+        assert_eq!(
+            ctx.muxer.connections_to_reset(),
+            vec![conn_id(local_port, PEER_PORT)]
+        );
+
+        // The guest resets the connection, so the muxer drops it.
+        ctx.init_pkt(local_port, PEER_PORT, uapi::VSOCK_OP_RST);
+        ctx.send();
+        assert!(!ctx.muxer.conn_map.contains_key(&ConnMapKey {
+            local_port,
+            peer_port: PEER_PORT,
+        }));
+        assert!(ctx.muxer.connections_to_reset().is_empty());
+    }
+
+    #[test]
+    fn test_connections_to_reset_keeps_killed_connection() {
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("/tmp/reset_set_killed_conn");
+        let (_stream, local_port) = ctx.local_connect(PEER_PORT);
+        let key = ConnMapKey {
+            local_port,
+            peer_port: PEER_PORT,
+        };
+
+        // A killed connection still owes the guest an RST, and the muxer only
+        // drops it once that RST actually goes out. Until then a snapshot
+        // must still capture it.
+        ctx.muxer.kill_connection(key);
+        assert!(ctx.muxer.conn_map.contains_key(&key));
+        assert_eq!(
+            ctx.muxer.connections_to_reset(),
+            vec![conn_id(local_port, PEER_PORT)]
+        );
+
+        ctx.recv();
+        assert_is_rst_for(&ctx.pkt, conn_id(local_port, PEER_PORT));
+        assert!(ctx.muxer.connections_to_reset().is_empty());
+    }
+
+    #[test]
+    fn test_connections_to_reset_records_standalone_rst() {
+        const LOCAL_PORT: u32 = 1026;
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("/tmp/reset_set_orphan_rst");
+
+        // An orphan packet gets answered with a standalone RST, which lives
+        // in the RX queue and nowhere else -- so `conn_map` cannot account
+        // for it.
+        ctx.init_pkt(LOCAL_PORT, PEER_PORT, uapi::VSOCK_OP_RW);
+        ctx.send();
+        assert!(ctx.muxer.conn_map.is_empty());
+        assert_eq!(
+            ctx.muxer.connections_to_reset(),
+            vec![conn_id(LOCAL_PORT, PEER_PORT)]
+        );
+
+        ctx.recv();
+        assert_is_rst_for(&ctx.pkt, conn_id(LOCAL_PORT, PEER_PORT));
+        assert!(ctx.muxer.connections_to_reset().is_empty());
+    }
+
+    #[test]
+    fn test_connections_to_reset_carries_undelivered_restore_resets() {
+        // A reset queued by a restore but not yet taken by the guest is still
+        // owed to it. Snapshotting such a VM must carry the obligation
+        // forward rather than drop it on the floor.
+        let mut ctx = MuxerTestContext::new("/tmp/reset_set_restore_carry");
+        let stale = [conn_id(1030, 7), conn_id(1031, 8)];
+        ctx.muxer.queue_restore_resets(&stale).unwrap();
+
+        assert_eq!(ctx.muxer.connections_to_reset(), stale.to_vec());
+
+        ctx.recv();
+        assert_is_rst_for(&ctx.pkt, stale[0]);
+        assert_eq!(ctx.muxer.connections_to_reset(), vec![stale[1]]);
+
+        ctx.recv();
+        assert!(ctx.muxer.connections_to_reset().is_empty());
+    }
+
+    #[test]
+    fn test_connections_to_reset_is_sorted_and_deduplicated() {
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("/tmp/reset_set_sorted");
+        let (_stream, local_port) = ctx.local_connect(PEER_PORT);
+
+        // A tuple can be owed a reset from more than one source at once; the
+        // guest has a single socket per tuple and needs a single RST.
+        ctx.muxer
+            .queue_restore_resets(&[conn_id(local_port, PEER_PORT), conn_id(1, 1)])
+            .unwrap();
+        ctx.muxer.enq_rst(u32::MAX, 9);
+
+        let ids = ctx.muxer.connections_to_reset();
+        assert_eq!(
+            ids,
+            vec![
+                conn_id(1, 1),
+                conn_id(local_port, PEER_PORT),
+                conn_id(u32::MAX, 9),
+            ]
+        );
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(ids, sorted);
+    }
+
+    #[test]
+    fn test_restore_resets_precede_new_connection_traffic() {
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("/tmp/restore_resets_order");
+        let stale = [conn_id(1030, 7), conn_id(1031, 8)];
+        ctx.muxer.queue_restore_resets(&stale).unwrap();
+        assert!(ctx.muxer.has_pending_rx());
+
+        // Restore creates no connection object: the host half of those
+        // connections no longer exists, and neither does their local port
+        // reservation.
+        assert!(ctx.muxer.conn_map.is_empty());
+        assert!(ctx.muxer.local_port_set.is_empty());
+        // But they are still owed to the guest, so a snapshot taken before
+        // they go out must carry them forward.
+        assert_eq!(ctx.muxer.connections_to_reset(), stale.to_vec());
+
+        // A new host-initiated connection arrives after the restore, so the
+        // muxer has traffic of its own queued behind the resets.
+        let mut stream = UnixStream::connect(ctx.host_sock_path.clone()).unwrap();
+        stream.set_nonblocking(true).unwrap();
+        ctx.notify_muxer();
+        stream
+            .write_all(format!("CONNECT {PEER_PORT}\n").as_bytes())
+            .unwrap();
+        ctx.notify_muxer();
+        let local_port = ctx.muxer.local_port_last;
+        assert_eq!(ctx.muxer.conn_map.len(), 1);
+
+        // Every stale connection is reset before anything belonging to the
+        // new connection reaches the guest.
+        for id in stale {
+            assert!(ctx.muxer.has_pending_rx());
+            ctx.recv();
+            assert_is_rst_for(&ctx.pkt, id);
+        }
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_REQUEST);
+        assert_eq!(ctx.pkt.src_port(), local_port);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+    }
+
+    #[test]
+    fn test_restore_resets_bypass_the_rx_queue() {
+        let mut ctx = MuxerTestContext::new("/tmp/restore_resets_capacity");
+
+        // The RX queue holds fewer entries than the connection pool, and lets
+        // an RST evict a queued connection key. Mandatory resets take part in
+        // neither: the connection limit is what bounds them.
+        let stale: Vec<_> = (0..defs::MAX_CONNECTIONS)
+            .map(|i| conn_id(1030 + i as u32, 7))
+            .collect();
+        assert!(stale.len() > defs::MUXER_RXQ_SIZE);
+        ctx.muxer.queue_restore_resets(&stale).unwrap();
+        assert!(ctx.muxer.rxq.is_empty());
+
+        for id in &stale {
+            ctx.recv();
+            assert_is_rst_for(&ctx.pkt, *id);
+        }
+        assert!(!ctx.muxer.has_pending_rx());
+    }
+
+    #[test]
+    fn test_queue_restore_resets_refuses_excess() {
+        let mut ctx = MuxerTestContext::new("/tmp/restore_resets_excess");
+        let too_many: Vec<_> = (0..=defs::MAX_RESTORE_RESETS)
+            .map(|i| conn_id(1030 + i as u32, 7))
+            .collect();
+
+        assert!(matches!(
+            ctx.muxer.queue_restore_resets(&too_many),
+            Err(Error::TooManyConnections)
+        ));
+        assert!(!ctx.muxer.has_pending_rx());
+
+        // The limit applies to the queue as a whole, not to one call.
+        ctx.muxer
+            .queue_restore_resets(&too_many[..defs::MAX_RESTORE_RESETS])
+            .unwrap();
+        assert!(matches!(
+            ctx.muxer.queue_restore_resets(&too_many[..1]),
+            Err(Error::TooManyConnections)
+        ));
+    }
+
+    #[test]
+    fn test_restore_accepts_everything_save_can_emit() {
+        // The save path unions the connection pool with the RX queue's
+        // standalone RSTs, so it can emit more tuples than there are
+        // connections. If the restore bound were the connection limit, this
+        // build would produce snapshots it then refused to restore.
+        let mut ctx = MuxerTestContext::new("/tmp/restore_resets_roundtrip");
+
+        let mut expected = Vec::new();
+        for i in 0..defs::MUXER_RXQ_SIZE {
+            let id = conn_id(2000 + i as u32, 7);
+            ctx.muxer.enq_rst(id.local_port, id.peer_port);
+            expected.push(id);
+        }
+        // Plus a full restore queue inherited from an earlier restore.
+        let inherited: Vec<_> = (0..defs::MAX_CONNECTIONS)
+            .map(|i| conn_id(9000 + i as u32, 7))
+            .collect();
+        ctx.muxer.queue_restore_resets(&inherited).unwrap();
+        expected.extend_from_slice(&inherited);
+        expected.sort_unstable();
+
+        let saved = ctx.muxer.connections_to_reset();
+        assert_eq!(saved, expected);
+        assert!(saved.len() > defs::MAX_CONNECTIONS);
+
+        // A fresh muxer must accept that state back.
+        let mut restored = VsockMuxer::new(PEER_CID).unwrap();
+        restored.queue_restore_resets(&saved).unwrap();
+        assert_eq!(restored.connections_to_reset(), saved);
     }
 }

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/persist.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/persist.rs
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot state of the virtio-vsock device.
+//!
+//! A snapshot preserves guest RAM, so it preserves the guest kernel's
+//! AF_VSOCK sockets. It cannot preserve what those sockets were talking to:
+//! the host half of a connection is a file descriptor, an epoll registration
+//! and a peer process, none of which can be handed to a new VMM process. A
+//! restore therefore has to tell the guest that every connection which was
+//! live when the snapshot was taken is gone, by sending it a `VSOCK_OP_RST`
+//! per connection.
+//!
+//! All that requires is each connection's port tuple, which is what
+//! [`VsockState::reset_connections`] carries.
+
+use serde::{Deserialize, Serialize};
+
+use crate::persist::VirtioDeviceInfoState;
+
+/// Identity of one vsock muxer connection, as recorded in a snapshot.
+///
+/// A connection is keyed by its host (`local_port`) and guest (`peer_port`)
+/// ports. The guest CID belongs to the device, so it is not repeated per
+/// connection, and the device id in the enclosing state says which device
+/// owns a tuple when a VM has several.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct VsockConnectionId {
+    /// Host-side port.
+    pub local_port: u32,
+    /// Guest-side port.
+    pub peer_port: u32,
+}
+
+/// Serializable state of a virtio-vsock device.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VsockState {
+    /// Guest-negotiated device state.
+    #[serde(flatten)]
+    pub device_info: VirtioDeviceInfoState,
+    /// Connections that were live when the snapshot was taken. Restore sends
+    /// the guest one `VSOCK_OP_RST` per tuple, ahead of any other RX traffic.
+    /// Sorted and deduplicated, which keeps the serialized form
+    /// deterministic.
+    #[serde(default)]
+    pub reset_connections: Vec<VsockConnectionId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(local_port: u32, peer_port: u32) -> VsockConnectionId {
+        VsockConnectionId {
+            local_port,
+            peer_port,
+        }
+    }
+
+    #[test]
+    fn test_vsock_state_json_roundtrip() {
+        let state = VsockState {
+            device_info: VirtioDeviceInfoState {
+                avail_features: 0x1_0000_0001,
+                acked_features: 1,
+                config_space: vec![3, 0, 0, 0, 0, 0, 0, 0],
+            },
+            reset_connections: vec![id(1023, 9), id(1024, 7)],
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        // `device_info` is flattened, so a snapshot produced before reset
+        // support stays readable field-for-field.
+        assert!(json.contains("\"acked_features\":1"));
+        assert_eq!(serde_json::from_str::<VsockState>(&json).unwrap(), state);
+    }
+
+    #[test]
+    fn test_vsock_state_without_reset_list_deserializes() {
+        let json = serde_json::json!({
+            "avail_features": 0u64,
+            "acked_features": 0u64,
+            "config_space": Vec::<u8>::new(),
+        })
+        .to_string();
+
+        let state: VsockState = serde_json::from_str(&json).unwrap();
+        assert!(state.reset_connections.is_empty());
+    }
+}

--- a/src/dragonball/src/device_manager/vsock_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vsock_dev_mgr.rs
@@ -6,6 +6,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use dbs_virtio_devices as virtio;
@@ -13,7 +14,7 @@ use dbs_virtio_devices::mmio::DRAGONBALL_FEATURE_INTR_USED;
 use dbs_virtio_devices::vsock::backend::{
     VsockInnerBackend, VsockInnerConnector, VsockTcpBackend, VsockUnixStreamBackend,
 };
-use dbs_virtio_devices::vsock::Vsock;
+use dbs_virtio_devices::vsock::{Vsock, VsockState};
 use dbs_virtio_devices::Error as VirtioError;
 use serde_derive::{Deserialize, Serialize};
 
@@ -322,9 +323,9 @@ impl<'a> dbs_snapshot::Persist<'a> for VsockDeviceMgr {
 
     /// Capture the state of all vsock devices.
     ///
-    /// The virtual machine must be paused when this is called. Live vsock
-    /// connection state is not captured: snapshots must be taken at a clean
-    /// quiesce point with no active connections.
+    /// The virtual machine must be paused when this is called. The host half
+    /// of a live vsock connection cannot be captured, so each device records
+    /// the identity of its live connections instead; restore resets them.
     fn save_state(&mut self, _args: ()) -> std::result::Result<Self::State, Self::Error> {
         let mut devices = Vec::new();
         for info in self.info_list.iter() {
@@ -349,11 +350,48 @@ impl<'a> dbs_snapshot::Persist<'a> for VsockDeviceMgr {
     /// The devices must have been re-created from the same configuration
     /// (matched by id) and must not have been activated yet. Must be called
     /// before the guest vCPUs resume.
+    ///
+    /// The state is validated in full before any of it is applied, so that a
+    /// malformed snapshot is refused rather than half-restored.
     fn restore_state(
         &mut self,
         state: &Self::State,
         _args: (),
     ) -> std::result::Result<(), Self::Error> {
+        // A repeated device id would restore two sets of connection resets
+        // onto the same device and leave another device with none. This is a
+        // property of the state alone, so check it before looking at the VM.
+        let mut seen_ids = HashSet::with_capacity(state.devices.len());
+        for dev_state in &state.devices {
+            if !seen_ids.insert(dev_state.config.id()) {
+                return Err(VsockDeviceError::DeviceIDAlreadyExist(
+                    dev_state.config.id().to_string(),
+                ));
+            }
+        }
+
+        // Saving records every configured device, so a state naming fewer is
+        // not one this VM produced. Restoring it anyway would silently leave
+        // the missing device un-restored, and with no resets for the stale
+        // guest sockets that restored RAM still holds.
+        if state.devices.len() != self.info_list.len() {
+            return Err(VsockDeviceError::Virtio(VirtioError::InvalidInput));
+        }
+
+        // Every device in the state must match a configured device: the
+        // resets it carries belong to that device's guest sockets, and have
+        // nowhere else to go. With the count equal and no id repeated, this
+        // makes the two sets identical.
+        for dev_state in &state.devices {
+            if !self
+                .info_list
+                .iter()
+                .any(|info| info.config.id() == dev_state.config.id())
+            {
+                return Err(VsockDeviceError::Virtio(VirtioError::InvalidInput));
+            }
+        }
+
         for dev_state in &state.devices {
             let info = self
                 .info_list
@@ -376,9 +414,13 @@ impl<'a> dbs_snapshot::Persist<'a> for VsockDeviceMgr {
     }
 }
 
-/// Snapshot state of one vsock device (config + guest-negotiated device state
-/// + transport state); see [`persist::VirtioDevState`].
-pub type VsockDevState = persist::VirtioDevState<VsockDeviceConfigInfo>;
+/// Snapshot state of one vsock device (config + device state + transport
+/// state); see [`persist::VirtioDevState`].
+///
+/// The device state is [`VsockState`] rather than the default
+/// `VirtioDeviceInfoState`: besides the guest-negotiated device state it
+/// carries the connections restore has to reset.
+pub type VsockDevState = persist::VirtioDevState<VsockDeviceConfigInfo, VsockState>;
 
 /// Snapshot state of the vsock device manager.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -396,5 +438,115 @@ impl Default for VsockDeviceMgr {
             default_inner_connector: None,
             use_shared_irq: USE_SHARED_IRQ,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dbs_snapshot::Persist;
+    use dbs_virtio_devices::persist::MmioV2TransportState;
+
+    use super::*;
+    use crate::device_manager::persist::VirtioTransportState;
+
+    fn dev_state(id: &str) -> VsockDevState {
+        VsockDevState {
+            config: VsockDeviceConfigInfo {
+                id: id.to_string(),
+                guest_cid: 3,
+                ..Default::default()
+            },
+            device_info: VsockState::default(),
+            transport: VirtioTransportState::Mmio(MmioV2TransportState::default()),
+        }
+    }
+
+    #[test]
+    fn test_restore_state_rejects_duplicate_device_id() {
+        // A repeated id would restore two sets of connection resets onto the
+        // same device, leaving another with none.
+        let mut mgr = VsockDeviceMgr::default();
+        let state = VsockDeviceMgrState {
+            devices: vec![dev_state("vsock0"), dev_state("vsock0")],
+        };
+
+        assert!(matches!(
+            mgr.restore_state(&state, ()),
+            Err(VsockDeviceError::DeviceIDAlreadyExist(id)) if id == "vsock0"
+        ));
+    }
+
+    #[test]
+    fn test_restore_state_rejects_missing_device() {
+        // Saving records every configured device, so a state naming fewer is
+        // not one this VM produced. Accepting it would leave the missing
+        // device un-restored and its stale guest sockets un-reset.
+        let mut mgr = VsockDeviceMgr::default();
+        mgr.info_list
+            .insert_or_update(&VsockDeviceConfigInfo {
+                id: "vsock0".to_string(),
+                guest_cid: 3,
+                ..Default::default()
+            })
+            .unwrap();
+        mgr.info_list
+            .insert_or_update(&VsockDeviceConfigInfo {
+                id: "vsock1".to_string(),
+                guest_cid: 4,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let state = VsockDeviceMgrState {
+            devices: vec![dev_state("vsock0")],
+        };
+        assert!(matches!(
+            mgr.restore_state(&state, ()),
+            Err(VsockDeviceError::Virtio(VirtioError::InvalidInput))
+        ));
+    }
+
+    #[test]
+    fn test_restore_state_rejects_unknown_device() {
+        // The VM must have been re-created from the configuration the
+        // snapshot was taken with; a device the state names but the VM does
+        // not have has nowhere to put its resets.
+        let mut mgr = VsockDeviceMgr::default();
+        let state = VsockDeviceMgrState {
+            devices: vec![dev_state("vsock0")],
+        };
+
+        assert!(matches!(
+            mgr.restore_state(&state, ()),
+            Err(VsockDeviceError::Virtio(VirtioError::InvalidInput))
+        ));
+    }
+
+    #[test]
+    fn test_restore_state_without_devices_is_a_no_op() {
+        let mut mgr = VsockDeviceMgr::default();
+        assert!(mgr
+            .restore_state(&VsockDeviceMgrState::default(), ())
+            .is_ok());
+    }
+
+    #[test]
+    fn test_device_mgr_state_json_roundtrip() {
+        let mut state = dev_state("vsock0");
+        state.device_info.reset_connections = vec![dbs_virtio_devices::vsock::VsockConnectionId {
+            local_port: 1024,
+            peer_port: 7,
+        }];
+        let state = VsockDeviceMgrState {
+            devices: vec![state],
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let loaded: VsockDeviceMgrState = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.devices.len(), 1);
+        assert_eq!(
+            loaded.devices[0].device_info.reset_connections,
+            state.devices[0].device_info.reset_connections
+        );
     }
 }


### PR DESCRIPTION
## Problem

A snapshot preserves guest RAM, so a restored guest keeps its AF_VSOCK sockets — but not what they were talking to. The host half of a vsock
connection is a file descriptor, an epoll registration and a peer process, none of which survive into a new VMM process.

Restored guests were therefore left holding sockets whose peers no longer existed. Concretely, on **every** restore the guest's dbs-upcall
server kept a dead connection on port 0xDB while the host opened a fresh one, because `init_upcall()` runs on the restore path too.

## Fix

Record each live connection's `(local_port, peer_port)` in the device's snapshot state and send the guest one `VSOCK_OP_RST` per tuple on
restore, drained ahead of normal RX so nothing belonging to a new connection arrives first. Activation makes one RX pass itself, because
queueing a reset is not delivering it and nothing else would.

Tuples are read from the live muxer at save time rather than mirrored into shadow state, so they cannot drift from it: connections killed but
not yet reset are still in the pool, a standalone RST lives only in the RX queue, and resets inherited from an earlier restore are carried
forward instead of dropped.

The first commit is a behaviour-preserving refactor that shares the muxer between the device and its epoll handler, which is what lets a
snapshot read live connection state at all.

## Status

Tracing confirms this works: a snapshot records the live connections, restore queues their resets, and a replacement connection completes its
vsock handshake in about 2 ms.

It does **not** fix the template hang, and that failure is now well characterised as a separate problem. On a wedged restore the guest kernel
establishes new vsock connections normally, but kata-agent's ttrpc service is *globally* unresponsive — an independent client on a second
connection also gets no reply to a bare `Check`. The same byte-identical template then restores successfully on retry, so this is a
restore-time race in guest userspace, not a bad artifact and not a transport failure.

A control run confirms that hang is not introduced here: upstream/main with only the benchmark harness applied — both vsock commits
confirmed absent — reproduced the identical failure once in 34 runs, against twice in 50 on this branch. Those samples are far too small to
compare rates, but the failure occurring without these commits at all is what matters.

Two constraints found while investigating, for whoever picks that up:

- `hybrid vsock: connected` proves only that the guest kernel returned `VSOCK_OP_RESPONSE`. It does not prove kata-agent accepted the socket.
- The agent's logger accepts exactly one connection for its whole lifetime (`src/agent/src/main.rs`: `Backlog::new(1)`, then a single accept that consumes the listening fd). It never listens again, so a template VM consumes it and restored VMs have no agent logs.

## Note

`FORMAT_EPOCH` is unchanged, since snapshot support is experimental. An older template still restores and simply queues no resets, so **existing templates must be regenerated**.
