### PR TITLE
gha: move agent and runtime build checks to non-cloud runners for ppc64le

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: >-
       ${{
         ( contains(inputs.instance, 's390x') && matrix.component.name == 'runtime' ) && 's390x' ||
+        ( contains(inputs.instance, 'ppc64le') && ( matrix.component.name == 'agent' || matrix.component.name == 'runtime' ) ) && 'ppc64le' ||
         inputs.instance
       }}
     strategy:
@@ -148,7 +149,7 @@ jobs:
           XDG_RUNTIME_DIR=$(mktemp -d "/tmp/kata-tests-$USER.XXX" | tee >(xargs chmod 0700))
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> "$GITHUB_ENV"
       - name: Skip tests that depend on virtualization capable runners when needed
-        if: ${{ endsWith(inputs.instance, '-arm') || inputs.instance == 'ubuntu-24.04-ppc64le' }}
+        if: ${{ endsWith(inputs.instance, '-arm') }}
         run: |
           echo "GITHUB_RUNNER_CI_NON_VIRT=true" >> "$GITHUB_ENV"
       - name: Running `${{ matrix.command }}` for ${{ matrix.component.name }}


### PR DESCRIPTION
With recent introduction of nightly build checks for ppc64le, the checks are running on the cloud runners.

Move the agent and runtime checks to the self hosted ppc64le runners to support the tests which rely on kvm and vsock.