### PR TITLE
Bump pcilibs-rs to 28308229

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5269,25 +5269,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "pci-ids"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098762dc8ca11c831fee9544ae9f7eae8fc4666ec37e7b753f56d624c03d725e"
+name = "pcilibs-rs"
+version = "0.1.0"
+source = "git+https://github.com/kata-containers/pcilibs-rs?rev=28308229#28308229a8601b5dd616a9f9907002dec781e3ac"
 dependencies = [
+ "nix 0.31.3",
  "nom",
  "phf",
  "phf_codegen",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "pcilibs-rs"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/pcilibs-rs?rev=d248714e#d248714ed4b34b5738dbafab510611f543802e27"
-dependencies = [
- "nix 0.31.3",
- "pci-ids",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ wasm_container = { path = "src/runtime-rs/crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/lib`
 kata-sys-util = { path = "src/libs/kata-sys-util" }
-pcilibs-rs = { git = "https://github.com/kata-containers/pcilibs-rs", rev = "d248714e" }
+pcilibs-rs = { git = "https://github.com/kata-containers/pcilibs-rs", rev = "28308229" }
 pod-resources-rs = { path = "src/libs/pod-resources-rs" }
 kata-types = { path = "src/libs/kata-types", features = ["safe-path"] }
 logging = { path = "src/libs/logging" }

--- a/tools/packaging/release/generate_vendor.sh
+++ b/tools/packaging/release/generate_vendor.sh
@@ -55,7 +55,7 @@ create_vendor_tarball() {
 		done
 
 	# shellcheck disable=SC2086
-	tar -cvzf "${tarball_path}" ${vendor_dir_list}
+	tar -cvzf "${tarball_path}" ${vendor_dir_list} && rm -rf ${vendor_dir_list}
 	popd
 }
 


### PR DESCRIPTION
This brings reproducible PCI ids (see [1]). The gain is that
the vendored code of pcilibs-rs now stops refreshing the PCI
ids database from [2] at build time and provides a well
identified one instead. This allows reproducible hermetic
builds. Hard requirement for some downstreams.

[1] https://github.com/kata-containers/pcilibs-rs/pull/12
[2] https://github.com/pciutils/pciids

The `generate_vendor.sh` patch isn't strictly related but it was handy to test the fix in my local kata repo.