### PR TITLE
kata-deploy: report why a node failed, in job mode

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -316,7 +316,7 @@ of any pod running there.
 
 | | runs where | privileged on the host | API rights |
 |---|---|---|---|
-| dispatcher (install, uninstall, and each scheduled reconcile) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; Jobs in the release namespace; `nodes/proxy: get` only when guest pull or image conversion is configured; `pods: get` and `cronjobs: get, delete` only with [`job.reconcile`](#doing-it-on-a-schedule-instead) enabled |
+| dispatcher (install, uninstall, and each scheduled reconcile) | one pod, only where you let it schedule ([Where the dispatcher runs](#where-the-dispatcher-runs)) | no | `nodes: list, get, patch`; `jobs: create, get, list, delete` and `pods: list` in the release namespace; `events: create` in `default`, which is the only namespace an Event about a Node can live in; `nodes/proxy: get` only when guest pull or image conversion is configured; `pods: get` and `cronjobs: get, delete` only with [`job.reconcile`](#doing-it-on-a-schedule-instead) enabled |
 | per-node Jobs | every node Kata is installed on | yes | **none — no token is mounted** |
 | `post-delete` hook (uninstall only) | one pod, wherever it schedules | no | `delete` on ClusterRoles, ClusterRoleBindings, Roles, RoleBindings and ServiceAccounts |
 | verification Job (only if `verification.pod` is set) | one pod, wherever it schedules | no | pods and pod logs (`create`, `delete`, `get`, `list`, `watch`), `nodes`/`events`/`daemonsets`/`jobs`: `get`, `list` |
@@ -560,6 +560,99 @@ The `before-hook-creation` delete policy first removes the stale dispatcher Job
 re-enumerates nodes live, recreates the per-node Jobs (adopting any that still
 exist rather than duplicating them), and because every stage is idempotent the
 already-installed nodes are fast no-ops. Coverage converges on the re-run.
+
+### Finding out why a node failed
+
+A rollout that fails says which nodes failed and what stopped each of them in
+three places, as long as the dispatcher lived long enough to say so. Helm prints
+its summary directly, and the node Event and annotation remain available after
+the command exits.
+
+=== "From `helm`"
+    The chart asks Helm to print the dispatcher's log when the hook fails, and
+    the dispatcher ends that log with one line per failed node, so the command
+    that failed is also the one that explains it:
+
+    ```text title="$ helm install kata-deploy ..."
+    level=INFO msg="[2026-09-03T18:22:11Z INFO ] fanning out 2 per-node Job(s) with parallelism 1\n...
+    Error: 2 node(s) failed:\n  worker-2: its job kata-deploy-install-worker-2 failed:
+    load-kernel-modules exited 1: this node has no usable virtualization backend: neither
+    /dev/kvm nor /dev/mshv is present [BackoffLimitExceeded: Job has reached the specified
+    backoff limit]\n  worker-5: its job kata-deploy-install-worker-5 failed: cri never
+    started: ImagePullBackOff: Back-off pulling image \"kata-deploy:bad-tag\"\n"
+    Error: INSTALLATION FAILED: failed post-install: resource Job/kube-system/kata-deploy-install-dispatcher not ready. status: Failed, message: Job Failed. failed: 1/1
+    ```
+
+    !!! warning "Helm prints hook logs as a single escaped line"
+        Helm writes hook output through its structured logger, so the whole log
+        arrives as one `level=INFO msg="..."` record with newlines escaped to `\n`.
+        Helm's own closing `Error:` line says only that the hook Job failed — the
+        reason is inside that record. The dispatcher keeps its output short so the
+        record stays readable, and `sed` gives it back its newlines:
+
+        ```sh
+        helm install kata-deploy "${CHART}" 2>&1 | sed -e 's/\\n/\n/g' -e 's/\\"/"/g'
+        ```
+
+        Nothing is lost either way: the same reason is on the node, in the two
+        forms below, after the command has scrolled away.
+
+=== "From the node"
+    The same reason is recorded as an Event against the `Node`, so it turns up in
+    `kubectl describe node` and in whatever already collects events from the
+    cluster:
+
+    ```text title="$ kubectl describe node worker-2"
+    Events:
+      Type     Reason     Age   From                Message
+      ----     ------     ----  ----                -------
+      Warning  JobFailed  2m    kata-deploy-job-dispatcher  its job kata-deploy-install-worker-2
+                                failed: load-kernel-modules exited 1: this node has no
+                                usable virtualization backend
+    ```
+
+    Listing them directly needs the `default` namespace rather than the release's:
+    a `Node` has no namespace, and that is the only one the API server accepts an
+    Event about a cluster-scoped object in — the same place the kubelet's own
+    node events go.
+
+    ```sh
+    kubectl get events -n default --field-selector involvedObject.kind=Node
+    ```
+
+=== "Afterwards"
+    Events expire, so the result is also written to the node itself and stays
+    until the next rollout overwrites it:
+
+    ```sh title="$ kubectl get nodes -l kata-deploy-job-dispatcher/result=failed"
+    NAME       STATUS   ROLES    AGE   VERSION
+    worker-2   Ready    <none>   9d    v1.34.1
+    ```
+
+    ```sh title="$ kubectl get node worker-2 -o jsonpath='{.metadata.annotations}'"
+    kata-deploy-job-dispatcher/error:       its job kata-deploy-install-worker-2 failed: ...
+    kata-deploy-job-dispatcher/finished-at: 2026-09-03T18:22:41Z
+    ```
+
+What makes any of that possible is that each stage writes why it is giving up to
+`/dev/termination-log`, which lands in the pod's status rather than only in its
+log. The dispatcher reads it the moment a Job is judged, and passes it on. The
+dispatcher's own pod keeps the same summary in its status as a fallback for the
+three places above: a dispatcher killed before it could report anything is
+explained by `kubectl describe pod` alone.
+
+!!! tip "A node that is stuck, rather than failed"
+    Nothing marks a Job whose pod cannot be scheduled or cannot pull its image:
+    it stays *running* until `job.activeDeadlineSeconds` expires, which is an
+    hour on the defaults. Two minutes in, and every five after that, the
+    dispatcher says what the wait is for — as a log line and as a
+    `Warning`/`JobPending` Event on the node.
+
+!!! note "Where the log still helps"
+    The summary carries one line per node. The per-node Job's own log carries
+    everything the stage printed on the way there, and `job.ttlSecondsAfterFinished`
+    (10 minutes by default) is how long you have to read it. Raise it on a cluster
+    where nobody is watching the rollout live.
 
 ### Choosing which nodes get a Job
 

--- a/tests/functional/kata-deploy/kata-deploy-privileges.bats
+++ b/tests/functional/kata-deploy/kata-deploy-privileges.bats
@@ -236,7 +236,7 @@ rbac_doc() {
 	cleanup=$(render_job_mode kata-deploy-cleanup-job.yaml)
 
 	for rendered in "${install}" "${cleanup}"; do
-		echo "${rendered}" | grep -q 'image: ghcr.io/kata-containers/k8s-job-dispatcher:0.2.0'
+		echo "${rendered}" | grep -q 'image: ghcr.io/kata-containers/k8s-job-dispatcher:0.3.0'
 		echo "${rendered}" | grep -q -- '/usr/bin/k8s-job-dispatcher'
 		echo "${rendered}" | grep -q -- '--tracking-label-prefix=kata-deploy-job-dispatcher'
 		echo "${rendered}" | grep -q -- '--node-label-key=katacontainers.io/kata-runtime'

--- a/tests/functional/kata-deploy/kata-deploy-reconcile.bats
+++ b/tests/functional/kata-deploy/kata-deploy-reconcile.bats
@@ -220,19 +220,19 @@ EOF
 	local role
 	role=$(render_with_reconcile kata-rbac.yaml)
 
-	# Reading its own pod is what --owner-job-from-pod needs; deleting the CronJob
-	# is what the uninstall hook needs.
-	echo "${role}" | grep -q 'resources: \["pods"\]'
+	# Deleting the CronJob is what the uninstall hook needs, and get on pods is
+	# how --owner-job-from-pod reads the Job that owns the tick.
 	echo "${role}" | grep -q 'resources: \["cronjobs"\]'
-	echo "${role}" | grep -q 'verbs: \["get"\]'
 	echo "${role}" | grep -q 'verbs: \["get", "delete"\]'
+	echo "${role}" | grep -q 'verbs: \["get", "list"\]'
 
-	# Neither is asked for by a release that does not run a schedule.
+	# A rollout only lists the pod a failed Job left behind.
 	local plain
 	plain=$(helm template kata-deploy "${CHART_PATH}" \
 		--set deploymentMode=job \
 		--show-only templates/kata-rbac.yaml)
-	refute_match "${plain}" 'resources: \["pods"\]'
+	echo "${plain}" | grep -q 'resources: \["pods"\]'
+	echo "${plain}" | grep -q 'verbs: \["list"\]'
 	refute_match "${plain}" 'cronjobs'
 }
 

--- a/tests/functional/kata-deploy/kata-deploy-reporting.bats
+++ b/tests/functional/kata-deploy/kata-deploy-reporting.bats
@@ -12,6 +12,14 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 
 CHART_PATH="$(get_chart_path)"
 
+refute_match() {
+	local rendered="${1}" pattern="${2}"
+	if echo "${rendered}" | grep -q -- "${pattern}"; then
+		echo "unexpected in rendered output: ${pattern}" >&2
+		return 1
+	fi
+}
+
 render_job_mode() {
 	local template="${1}"
 	shift
@@ -47,4 +55,16 @@ render_job_mode() {
 
 	rendered=$(render_job_mode kata-deploy-reconcile.yaml --set job.reconcile.enabled=true)
 	echo "${rendered}" | grep -q 'terminationMessagePolicy: FallbackToLogsOnError'
+}
+
+@test "Helm template (job mode): a failed hook prints the dispatcher's summary" {
+	local template rendered
+	for template in kata-deploy-install-job.yaml kata-deploy-cleanup-job.yaml; do
+		rendered=$(render_job_mode "${template}")
+		echo "${rendered}" | grep -q '"helm.sh/hook-output-log-policy": hook-failed'
+	done
+
+	# Only on failure: a successful rollout's log is pages of per-node progress,
+	# and printing it every time is how people learn to ignore it.
+	refute_match "$(render_job_mode kata-deploy-install-job.yaml)" 'hook-output-log-policy": hook-succeeded'
 }

--- a/tests/functional/kata-deploy/kata-deploy-reporting.bats
+++ b/tests/functional/kata-deploy/kata-deploy-reporting.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm template tests for how a failed rollout explains itself. No cluster
+# required.
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+CHART_PATH="$(get_chart_path)"
+
+render_job_mode() {
+	local template="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only "templates/${template}" \
+		"$@"
+}
+
+@test "Helm template (job mode): every stage keeps its last words in the pod's status" {
+	local jobs stages daemonset
+	jobs=$(render_job_mode kata-deploy-job-templates.yaml)
+
+	stages=$(echo "${jobs}" | grep -c 'command: \["/usr/bin/kata-deploy"')
+	[[ "${stages}" -gt 0 ]]
+	[[ "$(echo "${jobs}" | grep -c 'terminationMessagePolicy: FallbackToLogsOnError')" -eq "${stages}" ]]
+
+	# The DaemonSet runs the same binary, and restarts scroll its log away.
+	daemonset=$(helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=daemonset \
+		--show-only templates/kata-deploy.yaml)
+	echo "${daemonset}" | grep -q 'terminationMessagePolicy: FallbackToLogsOnError'
+}
+
+@test "Helm template (job mode): the dispatcher's own summary survives its pod" {
+	local template rendered
+	# Without this, a dispatcher that was OOM-killed leaves a pod whose status
+	# says "Error" and nothing else.
+	for template in kata-deploy-install-job.yaml kata-deploy-cleanup-job.yaml; do
+		rendered=$(render_job_mode "${template}")
+		echo "${rendered}" | grep -q 'terminationMessagePolicy: FallbackToLogsOnError'
+	done
+
+	rendered=$(render_job_mode kata-deploy-reconcile.yaml --set job.reconcile.enabled=true)
+	echo "${rendered}" | grep -q 'terminationMessagePolicy: FallbackToLogsOnError'
+}

--- a/tests/functional/kata-deploy/kata-deploy-reporting.bats
+++ b/tests/functional/kata-deploy/kata-deploy-reporting.bats
@@ -12,6 +12,15 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 
 CHART_PATH="$(get_chart_path)"
 
+render_job_mode() {
+	local template="${1}"
+	shift
+	helm template kata-deploy "${CHART_PATH}" \
+		--set deploymentMode=job \
+		--show-only "templates/${template}" \
+		"$@"
+}
+
 refute_match() {
 	local rendered="${1}" pattern="${2}"
 	if echo "${rendered}" | grep -q -- "${pattern}"; then
@@ -20,13 +29,13 @@ refute_match() {
 	fi
 }
 
-render_job_mode() {
-	local template="${1}"
-	shift
-	helm template kata-deploy "${CHART_PATH}" \
-		--set deploymentMode=job \
-		--show-only "templates/${template}" \
-		"$@"
+rbac_doc() {
+	local rendered="${1}" name="${2}"
+	echo "${rendered}" | awk -v want="  name: ${name}" '
+		/^---$/ { if (found) { printf "%s", doc; exit } doc = ""; found = 0; next }
+		{ doc = doc $0 "\n"; if ($0 == want) found = 1 }
+		END { if (found) printf "%s", doc }
+	'
 }
 
 @test "Helm template (job mode): every stage keeps its last words in the pod's status" {
@@ -55,6 +64,52 @@ render_job_mode() {
 
 	rendered=$(render_job_mode kata-deploy-reconcile.yaml --set job.reconcile.enabled=true)
 	echo "${rendered}" | grep -q 'terminationMessagePolicy: FallbackToLogsOnError'
+}
+
+@test "Helm template (job mode): the dispatcher may read the pods it has to explain" {
+	local rbac role noderole
+	rbac=$(render_job_mode kata-rbac.yaml)
+	role=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-role')
+	[[ -n "${role}" ]]
+
+	# A Job's status says that it failed and nothing else; its pod holds the
+	# stage, the exit code and the termination message.
+	echo "${role}" | grep -q 'resources: \["pods"\]'
+	# Namespaced: reading pods cluster-wide is a different thing to ask for.
+	echo "${role}" | grep -q '^kind: Role$'
+
+	noderole=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-noderole')
+	refute_match "${noderole}" 'pods'
+	# The node's own copy of the result rides on the runtime label's patch.
+	echo "${noderole}" | grep -q 'verbs: \[.*"patch".*\]'
+
+	refute_match "${role}" '"update"'
+	refute_match "${role}" 'pods/exec'
+
+	# The per-node Jobs still hold no credentials at all.
+	refute_match "$(render_job_mode kata-deploy-job-templates.yaml)" 'serviceAccountName'
+}
+
+@test "Helm template (job mode): Events about the node are asked for where they live" {
+	local rbac events binding
+	rbac=$(render_job_mode kata-rbac.yaml)
+
+	# The apiserver takes an Event about a cluster-scoped object in "default"
+	# only, so asking in the release namespace grants nothing.
+	events=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-events-role')
+	[[ -n "${events}" ]]
+	echo "${events}" | grep -q 'namespace: default'
+	echo "${events}" | grep -q 'resources: \["events"\]'
+	echo "${events}" | grep -q 'verbs: \["create"\]'
+	refute_match "$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-role')" 'events'
+
+	# Reading or deleting somebody else's events is not part of reporting.
+	refute_match "${events}" '"get"'
+	refute_match "${events}" '"delete"'
+
+	binding=$(rbac_doc "${rbac}" 'kata-deploy-dispatcher-events-rb')
+	echo "${binding}" | grep -q 'namespace: default'
+	echo "${binding}" | grep -q 'name: kata-deploy-dispatcher-sa'
 }
 
 @test "Helm template (job mode): a failed hook prints the dispatcher's summary" {

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -34,6 +34,7 @@ else
 		"kata-deploy-tee-keys.bats" \
 		"kata-deploy-distribution.bats" \
 		"kata-deploy-privileges.bats" \
+		"kata-deploy-reporting.bats" \
 		"kata-deploy-multi-install.bats" \
 		"kata-deploy-reconcile.bats" \
 		"kata-deploy-node-binaries.bats" \

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -22,6 +22,15 @@ use std::io::{BufRead, Write};
 /// committed to a runtime.
 const DETECTED_RUNTIME_ENV: &str = "KATA_DEPLOY_DETECTED_RUNTIME";
 
+/// Where the kubelet collects a container's last words, putting them in the
+/// pod's status rather than in a log the Job's TTL deletes minutes later.
+///
+/// A mount of its own, so it stays writable under `readOnlyRootFilesystem`.
+const TERMINATION_LOG: &str = "/dev/termination-log";
+
+/// What the kubelet keeps of that file; the rest is dropped.
+const TERMINATION_MESSAGE_MAX: usize = 4096;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -130,6 +139,47 @@ const REQUIRED_MKFS_EROFS_OPTIONS: &[&str] = &["--mkfs-time", "--sort"];
 // probe and the pod is restarted before install can finish.
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> Result<()> {
+    let result = run().await;
+    if let Err(error) = result.as_ref() {
+        write_termination_message(error);
+    }
+    result
+}
+
+/// The error chain on one line, as `kubectl` will show it.
+fn termination_message(error: &anyhow::Error) -> String {
+    // A failing host command brings its stderr along, newlines and all.
+    let mut message = format!("{error:#}")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if message.len() > TERMINATION_MESSAGE_MAX {
+        // The outermost context says which step failed, so the tail goes.
+        const ELLIPSIS: &str = "... (truncated)";
+        let keep = TERMINATION_MESSAGE_MAX - ELLIPSIS.len();
+        let keep = (0..=keep)
+            .rev()
+            .find(|index| message.is_char_boundary(*index))
+            .unwrap_or(0);
+        message.truncate(keep);
+        message.push_str(ELLIPSIS);
+    }
+    message
+}
+
+/// Best-effort: outside a pod there is no such file, and the reason is logged
+/// either way.
+fn write_termination_message(error: &anyhow::Error) {
+    if !std::path::Path::new(TERMINATION_LOG).exists() {
+        return;
+    }
+
+    if let Err(write_error) = std::fs::write(TERMINATION_LOG, termination_message(error)) {
+        log::warn!("failed to write {TERMINATION_LOG}: {write_error}");
+    }
+}
+
+async fn run() -> Result<()> {
     let args = Args::parse();
 
     // Set log level based on DEBUG environment variable
@@ -2164,6 +2214,43 @@ mod tests {
             "staged action {:?} should be visible in --help",
             value.get_name(),
         );
+    }
+
+    /// The pod's status has to read as a sentence, not as a Debug dump.
+    #[test]
+    fn the_termination_message_is_the_whole_chain_on_one_line() {
+        let error = anyhow::anyhow!("host modprobe failed for module vhost_vsock")
+            .context("failed to load the host kernel modules");
+
+        assert_eq!(
+            termination_message(&error),
+            "failed to load the host kernel modules: host modprobe failed for module vhost_vsock"
+        );
+    }
+
+    #[test]
+    fn a_commands_output_does_not_break_the_termination_message_apart() {
+        let error =
+            anyhow::anyhow!("modprobe: FATAL: module vhost_vsock not found\nin /lib/modules")
+                .context("failed to load the host kernel modules");
+
+        assert_eq!(
+            termination_message(&error),
+            "failed to load the host kernel modules: modprobe: FATAL: module vhost_vsock \
+             not found in /lib/modules"
+        );
+    }
+
+    #[test]
+    fn an_over_long_termination_message_is_marked_as_truncated() {
+        // Twelve bytes to nine characters, so the cut falls inside the "ü" -
+        // which `truncate` panics on rather than tolerates.
+        let error = anyhow::anyhow!("{}", "übergröße".repeat(500));
+        let message = termination_message(&error);
+
+        assert!(message.len() <= TERMINATION_MESSAGE_MAX);
+        assert!(message.ends_with("... (truncated)"));
+        assert!(message.starts_with("übergröße"));
     }
 
     fn module_names(modules: &[HostModule]) -> Vec<&str> {

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -873,7 +873,9 @@ kata-deploy.katacontainers.io/default
 {{- define "kata-deploy.dispatcherNodeWorkFlags" -}}
 {{- $root := .root -}}
 {{- /* Preserve the tracking and node-management contract of the dispatcher that
-       originally lived in this repository. */ -}}
+       originally lived in this repository. The prefix also names the keys each
+       node's result is recorded under, such as
+       kata-deploy-job-dispatcher/result. */ -}}
 - "--tracking-label-prefix=kata-deploy-job-dispatcher"
 - "--node-label-key=katacontainers.io/kata-runtime"
 - "--instance-label-prefix=kata-deploy.katacontainers.io"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -1605,6 +1605,10 @@ Emitted at column 0; indent with `nindent` at the call site.
   image: {{ include "kata-deploy.image" .root }}
   imagePullPolicy: {{ .root.Values.imagePullPolicy }}
   command: ["/usr/bin/kata-deploy", "{{ .action }}"]
+{{- /* kata-deploy writes why it failed to /dev/termination-log; the fallback
+       covers the deaths it cannot report itself, such as the OOM killer. Either
+       way the reason is in the pod's status, which outlives the Job's logs. */}}
+  terminationMessagePolicy: FallbackToLogsOnError
   env:
 {{- include "kata-deploy.commonEnv" .root | nindent 4 }}
   securityContext:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -79,6 +79,8 @@ spec:
         - name: dispatcher
           image: {{ include "kata-deploy.dispatcherImage" $root }}
           imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+          {{- /* The dispatcher's last words are its per-node summary. */}}
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-cleanup-job.yaml
@@ -45,6 +45,9 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- /* A failed uninstall leaves hosts half reverted, so the dispatcher's
+       account of them belongs in the `helm uninstall` output. */}}
+    "helm.sh/hook-output-log-policy": hook-failed
 spec:
   backoffLimit: 0
   ttlSecondsAfterFinished: {{ $root.Values.job.ttlSecondsAfterFinished }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -45,6 +45,9 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation
+{{- /* Otherwise Helm reports only that a hook Job failed, leaving the reader to
+       find a pod that holds the names of the nodes that failed. */}}
+    "helm.sh/hook-output-log-policy": hook-failed
 spec:
   # The dispatcher does per-node retries (job.backoffLimit) itself; a dispatcher
   # failure means "some node failed" and should surface, not be retried blindly.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-install-job.yaml
@@ -85,6 +85,8 @@ spec:
         - name: dispatcher
           image: {{ include "kata-deploy.dispatcherImage" $root }}
           imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+          {{- /* The dispatcher's last words are its per-node summary. */}}
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-reconcile.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy-reconcile.yaml
@@ -91,6 +91,9 @@ spec:
             - name: dispatcher
               image: {{ include "kata-deploy.dispatcherImage" $root }}
               imagePullPolicy: {{ $root.Values.imagePullPolicy }}
+              {{- /* No Helm run is watching a scheduled reconcile, so its pod's
+                     status is where the summary has to end up. */}}
+              terminationMessagePolicy: FallbackToLogsOnError
               securityContext:
                 privileged: false
                 allowPrivilegeEscalation: false

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -99,6 +99,9 @@ spec:
         - {{ $logLevel | quote }}
         {{- end }}
         - install
+        {{- /* kata-deploy writes why it failed to /dev/termination-log, which
+               this pod's next restart cannot scroll past. */}}
+        terminationMessagePolicy: FallbackToLogsOnError
         env:
 {{- include "kata-deploy.commonEnv" . | nindent 8 }}
 {{- $healthDefaults := dict

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -87,7 +87,8 @@ rules:
 # Enumerating nodes is inherently cluster-scoped. `get` re-reads one node (its
 # readiness, and the label back after patching it); `patch` sets the
 # katacontainers.io/kata-runtime label and lifts start-up taints, which is the
-# work the per-node Jobs used to do with a token of their own.
+# work the per-node Jobs used to do with a token of their own, and records what
+# the run made of the node under kata-deploy-job-dispatcher/result.
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list", "get", "patch"]
@@ -123,16 +124,20 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["create", "get", "list", "delete"]
-{{- if (.Values.job.reconcile | default dict).enabled }}
-# A scheduled run cannot know the name of the Job the CronJob made for it, so it
-# reads its own pod to find it and own the per-node Jobs with it.
+# A Job's status says that it failed and nothing else; the pod it left behind
+# holds the stage, the exit code and the termination message. Read before
+# job.ttlSecondsAfterFinished takes it away.
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get"]
-# And uninstall takes the schedule away before it starts reverting nodes.
+{{- if (.Values.job.reconcile | default dict).enabled }}
+  # A tick reads its own pod to find the Job that owns it.
+  verbs: ["get", "list"]
+# Uninstall takes the schedule away before it starts reverting nodes.
 - apiGroups: ["batch"]
   resources: ["cronjobs"]
   verbs: ["get", "delete"]
+{{- else }}
+  verbs: ["list"]
 {{- end }}
 ---
 kind: RoleBinding
@@ -144,6 +149,34 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ .Chart.Name }}-dispatcher-role{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kata-deploy.dispatcherServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+# The answer is also published as an Event against the Node, which is what
+# `kubectl describe node` shows. Not in the release namespace: a Node has no
+# namespace, and the apiserver only accepts an Event about a cluster-scoped
+# object in "default" - where the kubelet's own Node events go.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-dispatcher-events-role{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-dispatcher-events-rb{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Chart.Name }}-dispatcher-events-role{{ with .Values.env.multiInstallSuffix }}-{{ . }}{{ end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kata-deploy.dispatcherServiceAccountName" . }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -38,6 +38,16 @@
 #   come back after a reboot. Uninstall drops that file but never unloads a
 #   module, because module state is host-global and may be in use by something
 #   else.
+#
+# NOTE on finding out what went wrong in "job" mode:
+#   A failed rollout names the nodes that failed and what stopped each of them,
+#   in the `helm install` output, as an Event on each node, and afterwards under
+#   `kubectl get nodes -l kata-deploy-job-dispatcher/result=failed`. None of it
+#   is configured here; it is what a rollout does.
+#
+#   Each stage writes why it is giving up to /dev/termination-log, so the reason
+#   is in the pod's status rather than only in a log that
+#   job.ttlSecondsAfterFinished deletes along with the pod.
 deploymentMode: job  # daemonset | job
 
 # Settings specific to deploymentMode: job

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -58,7 +58,7 @@ job:
   # released independently of Kata Containers, so its version is pinned here.
   dispatcherImage:
     reference: ghcr.io/kata-containers/k8s-job-dispatcher
-    tag: "0.2.0"
+    tag: "0.3.0"
   # Where the dispatcher pods themselves may run (install and uninstall). Nothing
   # to do with which nodes get Kata - that is the top-level `nodeSelector` /
   # `affinity` / `tolerations`.


### PR DESCRIPTION
In job mode a failed rollout said only that a node failed, and the reason sat in the per-node Job's pod, which `ttlSecondsAfterFinished` deletes before anyone looks.

Now every stage writes its failure to `/dev/termination-log` and the pod keeps it in its status (`FallbackToLogsOnError`), Helm prints the dispatcher's summary when the hook fails (`hook-output-log-policy`), and the dispatcher, which is now using the v0.3.0 release, reports each node's result as an Event against the Node and on the Node itself.

That reporting needs `events: ["create"]` in `default` (the only namespace the API server takes an Event about a Node in) and `pods: ["list"]` in the release namespace, both added to the chart's RBAC.