### PR TITLE
runtime-rs: set a fixed serial for QEMU initdata

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -866,7 +866,7 @@ impl VirtSandbox {
             "initdata push data into compressed block: {:?}", &image_path
         );
         let block_driver = &hypervisor_config.blockdev_info.block_device_driver;
-        let block_config = BlockConfigModern {
+        let mut block_config = BlockConfigModern {
             path_on_host: image_path.display().to_string(),
             is_readonly: true,
             driver_option: block_driver.clone(),
@@ -875,6 +875,16 @@ impl VirtSandbox {
             queue_size: hypervisor_config.blockdev_info.queue_size,
             ..Default::default()
         };
+        if self.resource_manager.config().await.runtime.hypervisor_name == HYPERVISOR_QEMU {
+            // Match the Go runtime: expose initdata by its virtio-blk serial.
+            block_config.driver_option = if uses_native_ccw_bus() {
+                VIRTIO_BLK_CCW
+            } else {
+                VIRTIO_BLK_PCI
+            }
+            .to_owned();
+            block_config.serial_override = "initdata".to_owned();
+        }
         let initdata_config = InitDataConfig(block_config, initdata_digest);
         info!(sl!(), "initdata config: {:?}", initdata_config.clone());
 


### PR DESCRIPTION
## Summary

Set the QEMU initdata disk serial to `initdata`, matching the Go runtime.
This gives guest initdata consumers a stable device identifier instead of
requiring them to discover the disk by scanning device contents.

Use virtio-blk for this disk independently of the configured block device
driver, selecting CCW on architectures that require it and PCI otherwise.
The QEMU SCSI device path does not currently apply `serial_override`, so
setting the serial alone would not cover configurations using `virtio-scsi`.
Ordinary disks continue to use the configured driver, and other hypervisor
backends retain their existing initdata configuration.

Fixes: #12764

## Testing

- `cargo check --locked -p virt_container -j 4` passed.
- Existing `qemu::cmdline_generator::tests::test_qemu_block_discard_unmap_params` test passed.
- `git diff --check` passed.
- Ran the modified Rust runtime through containerd with QEMU 6.2/KVM on x86_64,
  using a Kata Linux 6.18.35 guest kernel and the existing Kata agent initrd.
- With `block_device_driver = "virtio-scsi"`, supplied initdata through the
  `io.katacontainers.config.hypervisor.cc_init_data` annotation. The runtime
  emitted `virtio-blk-pci` with `serial=initdata`, and the guest reported
  `/sys/block/vda/serial` as `initdata`. The agent logged `Initdata version: 0.1.0`.
- In the same sandbox, passed a separate temporary block device through
  `ctr run --device`. The runtime hotplugged it as `scsi-hd`; the guest exposed
  it as `sda`. Writing a marker, syncing, and reading it back succeeded.

No persistent regression test is included. The full CI matrix, s390x/CCW,
other hypervisors, udev by-id links, and confidential-guest attestation were
not tested locally.

## AI Disclosure

The implementation was assisted with OpenAI Codex.