### PR TITLE
runtime-rs: Support VFIO devices in DAN (mimic'ing what the go runtime does)

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -125,6 +125,24 @@ impl DeviceManager {
         self.pcie_topology.clone()
     }
 
+    /// QEMU only creates root ports from its command line, so ports for
+    /// devices hot-plugged later must be reserved before the VM is launched.
+    pub fn reserve_pcie_root_ports(&mut self, count: u32) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+
+        // Failing here beats silently dropping the reservation and letting the
+        // hot-plug land on a bus the guest does not have.
+        let topology = self
+            .pcie_topology
+            .as_mut()
+            .ok_or_else(|| anyhow!("no PCIe topology to reserve {} root port(s) in", count))?;
+        topology.pcie_root_ports += count;
+
+        Ok(())
+    }
+
     async fn get_block_device_info(&self) -> BlockDeviceInfo {
         self.hypervisor.hypervisor_config().await.blockdev_info
     }

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -356,6 +356,11 @@ impl ResourceManagerInner {
         }
 
         if let Some(network) = self.network.as_ref() {
+            network
+                .setup_after_start_vm()
+                .await
+                .context("setup network after start vm")?;
+
             // For cold-plugged physical-endpoint VFs, the PCIe topology
             // pre-computes a wrong path because the root port has no explicit
             // addr and QEMU auto-assigns its slot.  Resolve the actual path

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -15,7 +15,7 @@
 //! the future.
 
 use std::net::IpAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ use tokio::sync::RwLock;
 use super::network_entity::NetworkEntity;
 use super::utils::address::{ip_family_from_ip_addr, parse_ip_cidr};
 use super::{EndpointState, Network};
-use crate::network::endpoint::{TapEndpoint, VhostUserEndpoint};
+use crate::network::endpoint::{PhysicalEndpoint, TapEndpoint, VhostUserEndpoint};
 use crate::network::network_info::network_info_from_dan::NetworkInfoFromDan;
 use crate::network::utils::generate_private_mac_addr;
 use crate::network::Endpoint;
@@ -44,9 +44,15 @@ pub struct Dan {
     inner: Arc<RwLock<DanInner>>,
 }
 
+struct DanEntity {
+    entity: NetworkEntity,
+    /// VFIO NICs are attached once the VM is up, the rest before boot.
+    hotplug: bool,
+}
+
 pub struct DanInner {
     netns: Option<String>,
-    entity_list: Vec<NetworkEntity>,
+    entity_list: Vec<DanEntity>,
 }
 
 impl Dan {
@@ -85,24 +91,51 @@ impl DanInner {
             // Keep `queue_num` as a pair count and the hypervisor backend converts pairs into the actual virtqueue count.
             // A JSON-provided non-zero `queue_num` (also a pair count) with a higher priority always wins.
             let (qnum, qsize) = device.device.get_effective_queues(config.network_queues);
-            let endpoint: Arc<dyn Endpoint> = match &device.device {
-                Device::VhostUser { path, .. } => Arc::new(
-                    VhostUserEndpoint::new(dev_mgr, &name, &device.guest_mac, path, qnum, qsize)
+            let (endpoint, hotplug): (Arc<dyn Endpoint>, bool) = match &device.device {
+                Device::VhostUser { path, .. } => (
+                    Arc::new(
+                        VhostUserEndpoint::new(
+                            dev_mgr,
+                            &name,
+                            &device.guest_mac,
+                            path,
+                            qnum,
+                            qsize,
+                        )
                         .await
                         .with_context(|| format!("create a vhost user endpoint, path: {path}"))?,
+                    ),
+                    false,
                 ),
-                Device::HostTap { tap_name, .. } => Arc::new(
-                    TapEndpoint::new(
-                        &handle,
-                        &name,
-                        tap_name,
-                        &device.guest_mac,
-                        qnum,
-                        qsize,
-                        dev_mgr,
-                    )
-                    .await
-                    .with_context(|| format!("create a {tap_name} tap endpoint"))?,
+                Device::HostTap { tap_name, .. } => (
+                    Arc::new(
+                        TapEndpoint::new(
+                            &handle,
+                            &name,
+                            tap_name,
+                            &device.guest_mac,
+                            qnum,
+                            qsize,
+                            dev_mgr,
+                        )
+                        .await
+                        .with_context(|| format!("create a {tap_name} tap endpoint"))?,
+                    ),
+                    false,
+                ),
+                Device::Vfio { pci_device_id } => (
+                    Arc::new(
+                        PhysicalEndpoint::new_dan(
+                            &name,
+                            &device.guest_mac,
+                            pci_device_id,
+                            dev_mgr.clone(),
+                        )
+                        .with_context(|| {
+                            format!("create a vfio endpoint for device {pci_device_id}")
+                        })?,
+                    ),
+                    true,
                 ),
             };
 
@@ -112,9 +145,12 @@ impl DanInner {
                     .context("Network info from DAN")?,
             );
 
-            entity_list.push(NetworkEntity {
-                endpoint,
-                network_info,
+            entity_list.push(DanEntity {
+                entity: NetworkEntity {
+                    endpoint,
+                    network_info,
+                },
+                hotplug,
             })
         }
 
@@ -122,6 +158,21 @@ impl DanInner {
             netns: dan_config.netns,
             entity_list,
         })
+    }
+}
+
+impl DanInner {
+    async fn attach_entities(&self, hotplug: bool) -> Result<()> {
+        for e in self.entity_list.iter().filter(|e| e.hotplug == hotplug) {
+            if let Some(device_path) = e.entity.endpoint.attach().await.context("Attach")? {
+                e.entity
+                    .network_info
+                    .set_device_path(device_path)
+                    .await
+                    .context("set device path")?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -133,22 +184,35 @@ impl Network for Dan {
         if let Some(netns) = inner.netns.as_ref() {
             _netns_guard = NetnsGuard::new(netns).context("New netns guard")?;
         }
-        for e in inner.entity_list.iter() {
-            if let Some(device_path) = e.endpoint.attach().await.context("Attach")? {
-                e.network_info
-                    .set_device_path(device_path)
-                    .await
-                    .context("set device path")?;
-            }
-        }
-        Ok(())
+        inner.attach_entities(false).await
+    }
+
+    async fn setup_after_start_vm(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        // No netns guard: vfio-pci binding and QMP are netns independent, and
+        // unlike setup() this runs on the shared multi-threaded runtime, where
+        // a guard held across an await would leak into another task.
+        inner.attach_entities(true).await
     }
 
     async fn interfaces(&self) -> Result<Vec<agent::Interface>> {
         let inner = self.inner.read().await;
         let mut interfaces = vec![];
         for e in inner.entity_list.iter() {
-            interfaces.push(e.network_info.interface().await.context("Interface")?);
+            let mut iface = e
+                .entity
+                .network_info
+                .interface()
+                .await
+                .context("Interface")?;
+            // A physical endpoint learns its path from the QMP pass rather than
+            // from attach().
+            if iface.device_path.is_empty() {
+                if let Some(pci_path) = e.entity.endpoint.guest_pci_path().await {
+                    iface.device_path = pci_path;
+                }
+            }
+            interfaces.push(iface);
         }
         Ok(interfaces)
     }
@@ -157,7 +221,7 @@ impl Network for Dan {
         let inner = self.inner.read().await;
         let mut routes = vec![];
         for e in inner.entity_list.iter() {
-            let mut list = e.network_info.routes().await.context("Routes")?;
+            let mut list = e.entity.network_info.routes().await.context("Routes")?;
             routes.append(&mut list);
         }
         Ok(routes)
@@ -167,7 +231,7 @@ impl Network for Dan {
         let inner = self.inner.read().await;
         let mut neighs = vec![];
         for e in &inner.entity_list {
-            let mut list = e.network_info.neighs().await.context("Neighs")?;
+            let mut list = e.entity.network_info.neighs().await.context("Neighs")?;
             neighs.append(&mut list);
         }
         Ok(neighs)
@@ -177,7 +241,7 @@ impl Network for Dan {
         let inner = self.inner.read().await;
         let mut ep_states = vec![];
         for e in &inner.entity_list {
-            if let Some(state) = e.endpoint.save().await {
+            if let Some(state) = e.entity.endpoint.save().await {
                 ep_states.push(state);
             }
         }
@@ -191,9 +255,18 @@ impl Network for Dan {
             _netns_guard = NetnsGuard::new(netns).context("New netns guard")?;
         }
         for e in inner.entity_list.iter() {
-            e.endpoint.detach(h).await.context("Detach")?;
+            e.entity.endpoint.detach(h).await.context("Detach")?;
         }
         Ok(())
+    }
+
+    async fn endpoints(&self) -> Vec<Arc<dyn Endpoint>> {
+        let inner = self.inner.read().await;
+        inner
+            .entity_list
+            .iter()
+            .map(|e| e.entity.endpoint.clone())
+            .collect()
     }
 }
 
@@ -250,6 +323,10 @@ pub(crate) enum Device {
         #[serde(default)]
         queue_size: usize,
     },
+    /// `pci_device_id` is the host BDF. It is named as the Go runtime names it,
+    /// so that one config file works for both runtimes.
+    #[serde(rename = "vfio")]
+    Vfio { pci_device_id: String },
 }
 
 impl Device {
@@ -268,14 +345,16 @@ impl Device {
                 queue_num,
                 queue_size,
                 ..
-            } => (queue_num, queue_size),
+            } => (*queue_num, *queue_size),
+            // A passed-through NIC has no virtio queues to size.
+            Device::Vfio { .. } => (0, 0),
         };
-        let qnum = if *queue_num == 0 {
+        let qnum = if queue_num == 0 {
             network_queues
         } else {
-            *queue_num
+            queue_num
         };
-        let qsize = if *queue_size == 0 { 256 } else { *queue_size };
+        let qsize = if queue_size == 0 { 256 } else { queue_size };
         (qnum, qsize)
     }
 }
@@ -370,9 +449,26 @@ pub fn dan_config_path(config: &TomlConfig, sandbox_id: &str) -> PathBuf {
     PathBuf::from(config.runtime.dan_conf.as_str()).join(format!("{sandbox_id}.json"))
 }
 
+pub async fn dan_vfio_device_count(dan_conf_path: &Path) -> Result<usize> {
+    let json_str = fs::read_to_string(dan_conf_path)
+        .await
+        .context("Read DAN config from file")?;
+    let dan_config: DanConfig = serde_json::from_str(&json_str).context("Invalid DAN config")?;
+
+    Ok(dan_config
+        .devices
+        .iter()
+        .filter(|d| matches!(d.device, Device::Vfio { .. }))
+        .count())
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::network::dan::{ARPNeighbor, DanDevice, Device, Interface, NetworkInfo, Route};
+    use agent::IPFamily;
+
+    use crate::network::dan::{
+        ARPNeighbor, DanConfig, DanDevice, Device, Interface, NetworkInfo, Route,
+    };
 
     #[test]
     fn test_dan_json() {
@@ -443,5 +539,105 @@ mod tests {
         };
 
         assert_eq!(dev_from_json, dev);
+    }
+
+    #[test]
+    fn test_dan_vfio_json() {
+        let json_str = r#"{
+            "netns": "/var/run/netns/cni-xxx",
+            "devices": [{
+                "name": "eth0",
+                "guest_mac": "0a:58:0a:0a:00:05",
+                "device": {
+                    "type": "vfio",
+                    "pci_device_id": "0000:85:02.5"
+                },
+                "network_info": {
+                    "interface": {
+                        "ip_addresses": ["10.10.0.5/24"],
+                        "mtu": 1500
+                    }
+                }
+            }]
+        }"#;
+
+        let config: DanConfig = serde_json::from_str(json_str).unwrap();
+        assert_eq!(config.netns.as_deref(), Some("/var/run/netns/cni-xxx"));
+        assert_eq!(
+            config.devices[0].device,
+            Device::Vfio {
+                pci_device_id: "0000:85:02.5".to_owned()
+            }
+        );
+    }
+
+    /// A config as written by a CNI plugin in the field, with every optional
+    /// member omitted.
+    #[test]
+    fn test_dan_vfio_json_from_cni_plugin() {
+        let json_str = r#"{
+          "netns": "/var/run/netns/cni-60318bd9-a55d-43c9-ad77-60c8ba270e76",
+          "devices": [
+            {
+              "name": "eth0",
+              "guest_mac": "0a:58:0a:c0:03:35",
+              "device": {
+                "type": "vfio",
+                "pci_device_id": "0000:41:08.0"
+              },
+              "network_info": {
+                "interface": {
+                  "ip_addresses": [
+                    "10.192.3.53/24"
+                  ],
+                  "mtu": 1500
+                },
+                "routes": [
+                  {
+                    "gateway": "10.192.3.1"
+                  },
+                  {
+                    "dest": "10.192.0.0/15",
+                    "gateway": "10.192.3.1"
+                  }
+                ]
+              }
+            }
+          ]
+        }"#;
+
+        let config: DanConfig = serde_json::from_str(json_str).unwrap();
+        assert_eq!(config.devices.len(), 1);
+
+        let device = &config.devices[0];
+        assert_eq!(
+            device.device,
+            Device::Vfio {
+                pci_device_id: "0000:41:08.0".to_owned()
+            }
+        );
+        assert_eq!(device.guest_mac, "0a:58:0a:c0:03:35");
+        assert_eq!(device.network_info.interface.mtu, 1500);
+        assert!(device.network_info.interface.ntype.is_empty());
+        assert_eq!(device.network_info.interface.flags, 0);
+        assert!(device.network_info.neighbors.is_empty());
+
+        // A default route has no dest, so its family comes from the gateway.
+        let default_route = &device.network_info.routes[0];
+        assert!(default_route.dest.is_empty());
+        assert_eq!(default_route.ip_family().unwrap(), IPFamily::V4);
+        assert_eq!(
+            device.network_info.routes[1].ip_family().unwrap(),
+            IPFamily::V4
+        );
+    }
+
+    #[test]
+    fn test_vfio_device_has_no_virtio_queues() {
+        let device = Device::Vfio {
+            pci_device_id: "0000:85:02.5".to_owned(),
+        };
+        // Falls back to the defaults rather than rejecting the device.
+        assert_eq!(device.get_effective_queues(4), (4, 256));
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
@@ -70,39 +70,74 @@ pub struct PhysicalEndpoint {
     /// QEMU device ID for the cold-plugged VF (e.g. "physical_nic__346_0").
     /// Stored during attach() for use in QMP-based path resolution.
     hostdev_id: std::sync::Mutex<Option<String>>,
+    /// False for DAN, where the CNI plugin owns the host driver binding.
+    rebind_on_detach: bool,
+}
+
+fn pci_device_properties(bdf: &str) -> Result<(String, VendorDevice)> {
+    let sys_pci_devices_path = Path::new(SYS_PCI_DEVICES_PATH);
+    // get driver by following symlink /sys/bus/pci/devices/$bdf/driver
+    let driver_path = sys_pci_devices_path.join(bdf).join("driver");
+    let link = driver_path.read_link().context("read link")?;
+    let driver = link
+        .file_name()
+        .map_or(String::new(), |v| v.to_str().unwrap().to_owned());
+
+    // get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
+    let iface_device_path = sys_pci_devices_path.join(bdf).join("device");
+    let device_id = std::fs::read_to_string(&iface_device_path)
+        .with_context(|| format!("read device path {:?}", &iface_device_path))?;
+
+    let iface_vendor_path = sys_pci_devices_path.join(bdf).join("vendor");
+    let vendor_id = std::fs::read_to_string(&iface_vendor_path)
+        .with_context(|| format!("read vendor path {:?}", &iface_vendor_path))?;
+
+    let vendor_device_id =
+        VendorDevice::new(&vendor_id, &device_id).context("new vendor device")?;
+
+    Ok((driver, vendor_device_id))
 }
 
 impl PhysicalEndpoint {
     pub fn new(name: &str, hardware_addr: &[u8], d: Arc<RwLock<DeviceManager>>) -> Result<Self> {
         let driver_info = link::get_driver_info(name).context("get driver info")?;
         let bdf = driver_info.bus_info;
-        let sys_pci_devices_path = Path::new(SYS_PCI_DEVICES_PATH);
-        // get driver by following symlink /sys/bus/pci/devices/$bdf/driver
-        let driver_path = sys_pci_devices_path.join(&bdf).join("driver");
-        let link = driver_path.read_link().context("read link")?;
-        let driver = link
-            .file_name()
-            .map_or(String::new(), |v| v.to_str().unwrap().to_owned());
-
-        // get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
-        let iface_device_path = sys_pci_devices_path.join(&bdf).join("device");
-        let device_id = std::fs::read_to_string(&iface_device_path)
-            .with_context(|| format!("read device path {:?}", &iface_device_path))?;
-
-        let iface_vendor_path = sys_pci_devices_path.join(&bdf).join("vendor");
-        let vendor_id = std::fs::read_to_string(&iface_vendor_path)
-            .with_context(|| format!("read vendor path {:?}", &iface_vendor_path))?;
+        let (driver, vendor_device_id) = pci_device_properties(&bdf)?;
 
         Ok(Self {
             iface_name: name.to_string(),
             hard_addr: utils::get_mac_addr(hardware_addr).context("get mac addr")?,
-            vendor_device_id: VendorDevice::new(&vendor_id, &device_id)
-                .context("new vendor device")?,
+            vendor_device_id,
             driver,
             bdf,
             d,
             guest_pci_path: std::sync::Mutex::new(None),
             hostdev_id: std::sync::Mutex::new(None),
+            rebind_on_detach: true,
+        })
+    }
+
+    /// Unlike [`PhysicalEndpoint::new`], there is no host netdev to inspect:
+    /// the BDF comes from the DAN config, and the name and MAC are the ones the
+    /// NIC will have inside the guest.
+    pub fn new_dan(
+        name: &str,
+        guest_mac: &str,
+        bdf: &str,
+        d: Arc<RwLock<DeviceManager>>,
+    ) -> Result<Self> {
+        let (driver, vendor_device_id) = pci_device_properties(bdf)?;
+
+        Ok(Self {
+            iface_name: name.to_string(),
+            hard_addr: guest_mac.to_string(),
+            vendor_device_id,
+            driver,
+            bdf: bdf.to_string(),
+            d,
+            guest_pci_path: std::sync::Mutex::new(None),
+            hostdev_id: std::sync::Mutex::new(None),
+            rebind_on_detach: false,
         })
     }
 }
@@ -173,6 +208,8 @@ impl Endpoint for PhysicalEndpoint {
         // The topology-computed guest_pci_path from do_add_pcie_endpoint() is
         // WRONG for physical endpoints (root port has no explicit addr so QEMU
         // auto-assigns its slot; the correct path requires QMP after VM boot).
+        // Hot-plugged devices are no different: QEMU does report the real path
+        // from device_add, but VfioDevice::attach() drops it.
         if let hypervisor::device::DeviceType::Vfio(vfio_dev) = device_type {
             if let Some(hostdev) = vfio_dev.devices.first() {
                 if let Ok(mut guard) = self.hostdev_id.lock() {
@@ -187,6 +224,11 @@ impl Endpoint for PhysicalEndpoint {
     // detach for physical endpoint unbinds the physical network interface from vfio-pci
     // and binds it back to the saved host driver.
     async fn detach(&self, _hypervisor: &dyn Hypervisor) -> Result<()> {
+        // For DAN, the CNI plugin undoes its own vfio-pci binding.
+        if !self.rebind_on_detach {
+            return Ok(());
+        }
+
         // bind back the physical network interface to host.
         // we need to do this even if a new network namespace has not
         // been created by virt-containers.

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 mod dan;
 mod endpoint;
-pub use dan::{dan_config_path, Dan, DanNetworkConfig};
+pub use dan::{dan_config_path, dan_vfio_device_count, Dan, DanNetworkConfig};
 pub use endpoint::endpoint_persist::EndpointState;
 pub use endpoint::Endpoint;
 mod network_entity;

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -39,6 +39,11 @@ pub enum NetworkConfig {
 #[async_trait]
 pub trait Network: Send + Sync {
     async fn setup(&self) -> Result<()>;
+    /// Attaches endpoints that can only be plugged in once the VM is running.
+    /// Runs before the interfaces are handed to the agent.
+    async fn setup_after_start_vm(&self) -> Result<()> {
+        Ok(())
+    }
     async fn interfaces(&self) -> Result<Vec<agent::Interface>>;
     async fn routes(&self) -> Result<Vec<agent::Route>>;
     async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>>;

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
@@ -8,10 +8,14 @@ use agent::{ARPNeighbor, IPAddress, Interface, Route};
 use anyhow::Result;
 use async_trait::async_trait;
 use netlink_packet_route::link::LinkFlags;
+use tokio::sync::RwLock;
 
 use super::NetworkInfo;
-use crate::network::dan::DanDevice;
+use crate::network::dan::{DanDevice, Device};
 use crate::network::utils::address::{ip_family_from_ip_addr, parse_ip_cidr};
+
+/// Matches the Go runtime's VfioEndpointType.
+const VFIO_INTERFACE_TYPE: &str = "vfio";
 
 /// NetworkInfoFromDan is responsible for converting network info in JSON
 /// to agent's network info.
@@ -20,6 +24,8 @@ pub(crate) struct NetworkInfoFromDan {
     interface: Interface,
     routes: Vec<Route>,
     neighs: Vec<ARPNeighbor>,
+    /// Only known once the device is hot-plugged, so it is filled in later.
+    device_path: RwLock<String>,
 }
 
 impl NetworkInfoFromDan {
@@ -47,6 +53,11 @@ impl NetworkInfoFromDan {
             })
             .collect();
 
+        let field_type = match dan_device.device {
+            Device::Vfio { .. } => VFIO_INTERFACE_TYPE.to_owned(),
+            _ => dan_device.network_info.interface.ntype.clone(),
+        };
+
         let interface = Interface {
             device: dan_device.name.clone(),
             name: dan_device.name.clone(),
@@ -54,7 +65,7 @@ impl NetworkInfoFromDan {
             mtu: dan_device.network_info.interface.mtu,
             hw_addr: dan_device.guest_mac.clone(),
             device_path: String::default(),
-            field_type: dan_device.network_info.interface.ntype.clone(),
+            field_type,
             raw_flags: dan_device.network_info.interface.flags & LinkFlags::Noarp.bits(),
         };
 
@@ -109,6 +120,7 @@ impl NetworkInfoFromDan {
             interface,
             routes,
             neighs,
+            device_path: RwLock::new(String::default()),
         })
     }
 }
@@ -116,7 +128,9 @@ impl NetworkInfoFromDan {
 #[async_trait]
 impl NetworkInfo for NetworkInfoFromDan {
     async fn interface(&self) -> Result<Interface> {
-        Ok(self.interface.clone())
+        let mut interface = self.interface.clone();
+        interface.device_path = self.device_path.read().await.clone();
+        Ok(interface)
     }
 
     async fn routes(&self) -> Result<Vec<Route>> {
@@ -125,6 +139,11 @@ impl NetworkInfo for NetworkInfoFromDan {
 
     async fn neighs(&self) -> Result<Vec<ARPNeighbor>> {
         Ok(self.neighs.clone())
+    }
+
+    async fn set_device_path(&self, path: String) -> Result<()> {
+        *self.device_path.write().await = path;
+        Ok(())
     }
 }
 
@@ -215,5 +234,38 @@ mod tests {
             flags: 0,
         }];
         assert_eq!(neighbors, network_info.neighs().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_network_info_from_dan_vfio() {
+        let dan_device = DanDevice {
+            name: "eth0".to_owned(),
+            guest_mac: "0a:58:0a:0a:00:05".to_owned(),
+            device: Device::Vfio {
+                pci_device_id: "0000:85:02.5".to_owned(),
+            },
+            network_info: DanNetworkInfo {
+                interface: DanInterface {
+                    ip_addresses: vec!["10.10.0.5/24".to_owned()],
+                    mtu: 1500,
+                    ntype: String::new(),
+                    flags: 0,
+                },
+                routes: vec![],
+                neighbors: vec![],
+            },
+        };
+
+        let network_info = NetworkInfoFromDan::new(&dan_device).await.unwrap();
+
+        let interface = network_info.interface().await.unwrap();
+        assert_eq!(interface.field_type, "vfio");
+        assert!(interface.device_path.is_empty());
+
+        network_info
+            .set_device_path("02/03".to_owned())
+            .await
+            .unwrap();
+        assert_eq!(network_info.interface().await.unwrap().device_path, "02/03");
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -79,7 +79,9 @@ use resource::coco_data::initdata::{
 };
 use resource::coco_data::initdata_block;
 use resource::manager::ManagerArgs;
-use resource::network::{dan_config_path, DanNetworkConfig, NetworkConfig, NetworkWithNetNsConfig};
+use resource::network::{
+    dan_config_path, dan_vfio_device_count, DanNetworkConfig, NetworkConfig, NetworkWithNetNsConfig,
+};
 use resource::{ResourceConfig, ResourceManager};
 use runtime_spec as spec;
 use std::collections::HashSet;
@@ -325,12 +327,42 @@ impl VirtSandbox {
             resource_configs.push(ResourceConfig::Protection(protection_dev_config));
         }
 
+        // Has to run before the port pool below is turned into command line
+        // arguments.
+        self.reserve_dan_pcie_root_ports()
+            .await
+            .context("failed to reserve PCIe root ports for DAN")?;
+
         // prepare pcie port device config
         if let Some(port_dev_config) = self.prepare_pcie_port_devices().await {
             resource_configs.push(ResourceConfig::PortDevice(port_dev_config));
         }
 
         Ok(resource_configs)
+    }
+
+    async fn reserve_dan_pcie_root_ports(&self) -> Result<()> {
+        let config = self.resource_manager.config().await;
+        let dan_path = dan_config_path(&config, &self.sid);
+        if !dan_path.exists() {
+            return Ok(());
+        }
+
+        let count = dan_vfio_device_count(&dan_path)
+            .await
+            .context("count DAN VFIO devices")?;
+        if count == 0 {
+            return Ok(());
+        }
+
+        info!(sl!(), "reserving {} PCIe root port(s) for DAN VFIO", count);
+        let device_manager = self.resource_manager.get_device_manager().await;
+        device_manager
+            .write()
+            .await
+            .reserve_pcie_root_ports(count as u32)?;
+
+        Ok(())
     }
 
     async fn prepare_pcie_port_devices(&self) -> Option<PortDeviceConfig> {


### PR DESCRIPTION
The Go runtime's DAN describes only `vfio` devices, while runtime-rs describes `host-tap` and `vhost-user` and rejects anything else, so a CNI plugin cannot write a single DAN file that both runtimes accept.

This adds `vfio` to the runtime-rs DAN schema, spelled as the Go runtime spells it, backed by a `PhysicalEndpoint`. The NIC is hot-plugged once the VM is up via a new `Network::setup_after_start_vm()` hook, and its guest PCI path is reported to the agent as `device_path` so the agent can find the interface by PCI address rather than by MAC — a passed-through VF still carrying its firmware MAC will not answer to a by-MAC lookup.

Because QEMU only creates `pcie-root-port` devices from its command line, the vfio devices in the DAN config are counted during sandbox preparation and one root port is reserved for each, so `pcie_root_port` no longer has to be hand-tuned for DAN to work.

QEMU only; tested with a real CNI-written DAN config on x86_64.

cc @zvonkok @PiotrProkop 