### PR TITLE
kata-deploy: onboard SELinux enforced tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -16,6 +16,7 @@ self-hosted-runner:
     - garm-ubuntu-2304
     - garm-ubuntu-2304-smaller
     - garm-ubuntu-2204-smaller
+    - kata-deploy-selinux
     - ppc64le
     - ppc64le-k8s
     - ppc64le-small

--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -104,3 +104,42 @@ jobs:
       - name: Report tests
         if: always()
         run: bash tests/functional/kata-deploy/gha-run.sh report-tests
+
+  # This runner is a cluster on an enforcing node.
+  run-kata-deploy-selinux-tests:
+    name: run-kata-deploy-selinux-tests
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    runs-on: kata-deploy-selinux
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HYPERVISOR: qemu-runtime-rs
+      KUBERNETES: rke2
+      # The rest of the suite is not SELinux-specific and stays on the hosted runners.
+      KATA_DEPLOY_TEST_UNION: >-
+        kata-deploy-selinux-job.bats
+        kata-deploy-selinux-daemonset.bats
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Run tests
+        timeout-minutes: 60
+        run: bash tests/functional/kata-deploy/gha-run.sh run-tests
+
+      - name: Report tests
+        if: always()
+        run: bash tests/functional/kata-deploy/gha-run.sh report-tests

--- a/tests/functional/kata-deploy/kata-deploy-selinux-daemonset.bats
+++ b/tests/functional/kata-deploy/kata-deploy-selinux-daemonset.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The installer's SELinux confinement in daemonset mode, on a real enforcing node.
+#
+# This mode runs every stage in one container, which therefore needs the union of
+# their domains, kata_deploy_t. Job mode passing says nothing about that union: a
+# permission one stage's domain grants can still be missing from it. Unconfined,
+# the install runs as container_t and dies in AVC denials (#13751).
+#
+# Required environment variables:
+#   DOCKER_REGISTRY - Container registry for kata-deploy image
+#   DOCKER_REPO     - Repository name for kata-deploy image
+#   DOCKER_TAG      - Image tag to test
+#   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
+#   KUBERNETES      - K8s distribution
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+source "${BATS_TEST_DIRNAME}/lib/selinux.bash"
+
+# Matched on the binary behind /proc/PID/exe, not the command line, which would
+# also match the shell doing the matching.
+kata_deploy_process_contexts() {
+	run_on_host 'for p in /host/proc/[0-9]*; do case $(readlink $p/exe 2>/dev/null) in */kata-deploy) cat $p/attr/current 2>/dev/null; echo;; esac; done'
+}
+
+setup_file() {
+	skip_unless_enforcing_node
+	ensure_helm
+	assert_chart_supports_selinux
+
+	# There is no dispatcher here to report a failure: a denied install just
+	# crashloops until helm gives up, so do not give it the default ten minutes.
+	export HELM_TIMEOUT="${HELM_TIMEOUT:-5m}"
+
+	mark_audit_log
+	echo "# Deploying kata-deploy in daemonset mode with SELinux confinement..." >&3
+	deploy_kata "" --set deploymentMode=daemonset --set selinux.enabled=true
+}
+
+@test "The loader finds every domain the stages ask for in the node's policy" {
+	assert_domains_resolve
+}
+
+@test "The policy module is loaded into the node's policy store" {
+	assert_module_still_loaded
+}
+
+@test "The install runs in the union domain" {
+	# kube-kata stays alive behind its health probes, so unlike the job-mode
+	# stages its domain can be read straight off the node.
+	run kata_deploy_process_contexts
+	echo "# kata-deploy process contexts: ${output}" >&3
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"kata_deploy_t"* ]]
+	[[ "${output}" != *":container_t:"* ]]
+	[[ "${output}" != *":spc_t:"* ]]
+}
+
+@test "The confined install does its host work" {
+	assert_artifacts_installed
+}
+
+@test "The confined install logged no AVC denials" {
+	assert_no_kata_deploy_denials "the daemonset-mode install"
+}
+
+@test "The confined uninstall reverts the node, and leaves the module loaded" {
+	mark_audit_log
+	uninstall_kata
+	kubectl wait nodes --timeout=300s --all --for condition=Ready=True
+
+	assert_artifacts_removed
+	assert_no_kata_deploy_denials "the daemonset-mode uninstall"
+	assert_module_still_loaded
+}
+
+# Last, and in the suite the union runs last, so the node is left as it was found
+# and neither the tests above nor the other suite see a store without the module.
+@test "The removal semodule -r documents takes the module off the node" {
+	run remove_policy_module
+	echo "# semodule -r kata-deploy: ${output}" >&3
+	[ "${status}" -eq 0 ]
+
+	assert_module_removed
+}
+
+teardown_file() {
+	uninstall_kata 2>/dev/null || true
+}

--- a/tests/functional/kata-deploy/kata-deploy-selinux-job.bats
+++ b/tests/functional/kata-deploy/kata-deploy-selinux-job.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The installer's SELinux confinement in job mode, on a real enforcing node.
+#
+# This mode runs each stage in a container of its own, so each gets a domain of
+# its own. Unconfined, they run as container_t and the install dies in AVC
+# denials (#13751).
+#
+# Required environment variables:
+#   DOCKER_REGISTRY - Container registry for kata-deploy image
+#   DOCKER_REPO     - Repository name for kata-deploy image
+#   DOCKER_TAG      - Image tag to test
+#   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
+#   KUBERNETES      - K8s distribution
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+source "${BATS_TEST_DIRNAME}/lib/selinux.bash"
+
+NODE_BINARY="/host/usr/local/bin/mkfs.erofs"
+
+# Configured directly rather than through the EROFS snapshotter, so the domain
+# is covered wherever this runs.
+NODE_BINARIES_VALUES=(
+	--set 'nodeBinaries.erofs-utils.image=quay.io/kata-containers/erofs-utils:1.9.3'
+	--set 'nodeBinaries.erofs-utils.binaries[0]=mkfs.erofs'
+)
+
+# The default reaps the per-node Job pods while the suite is still reading them.
+JOB_TTL=3600
+
+setup_file() {
+	skip_unless_enforcing_node
+	ensure_helm
+	assert_chart_supports_selinux
+
+	mark_audit_log
+	echo "# Deploying kata-deploy in job mode with SELinux confinement..." >&3
+	# A denial is deterministic, so per-node retries only delay the report.
+	deploy_kata "" \
+		--set deploymentMode=job \
+		--set selinux.enabled=true \
+		--set job.backoffLimit=0 \
+		--set "job.ttlSecondsAfterFinished=${JOB_TTL}" \
+		"${NODE_BINARIES_VALUES[@]}"
+}
+
+@test "The loader finds every domain the stages ask for in the node's policy" {
+	assert_domains_resolve
+}
+
+@test "The policy module is loaded into the node's policy store" {
+	assert_module_still_loaded
+}
+
+@test "The confined stages do their host work" {
+	assert_artifacts_installed
+}
+
+@test "The nodeBinaries stage writes the node's /usr/local/bin" {
+	# bin_t, which kata_deploy_node_binaries_t alone may write, and reaching it
+	# means the stage also took the node mutation lock under var_lock_t.
+	run run_on_host "test -x ${NODE_BINARY} && echo INSTALLED || echo MISSING"
+	echo "# ${NODE_BINARY}: ${output}" >&3
+	[[ "${output}" == *"INSTALLED"* ]]
+}
+
+@test "The confined install logged no AVC denials" {
+	assert_no_kata_deploy_denials "the job-mode install"
+}
+
+@test "The confined cleanup stages uninstall, and leave the module loaded" {
+	mark_audit_log
+	uninstall_kata
+	kubectl wait nodes --timeout=300s --all --for condition=Ready=True
+
+	assert_artifacts_removed
+	assert_no_kata_deploy_denials "the job-mode uninstall"
+	assert_module_still_loaded
+}
+
+teardown_file() {
+	uninstall_kata 2>/dev/null || true
+}

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -24,11 +24,13 @@ HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
 # Run a command against the host node's filesystem, mounted at /host inside a
 # short-lived privileged pod.
 # Usage: run_on_host "test -d /host/opt/kata && echo YES || echo NO"
+#        run_on_host "chroot /host /usr/sbin/semodule -r kata-deploy" false
 #
 # We avoid `kubectl run --rm -i` because rke2 injects session-recording banners
 # into interactive pods, polluting stdout. Instead: create, wait, fetch logs, delete.
 run_on_host() {
 	local cmd="$1"
+	local read_only="${2:-true}"
 	local node_name
 	node_name=$(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name | head -1)
 	local pod_name="host-exec-${RANDOM}"
@@ -47,7 +49,7 @@ run_on_host() {
 					\"imagePullPolicy\": \"IfNotPresent\",
 					\"command\": [\"sh\", \"-c\", \"${cmd}\"],
 					\"securityContext\": {\"privileged\": true},
-					\"volumeMounts\": [{\"name\": \"host\", \"mountPath\": \"/host\", \"readOnly\": true}]
+					\"volumeMounts\": [{\"name\": \"host\", \"mountPath\": \"/host\", \"readOnly\": ${read_only}}]
 				}],
 				\"volumes\": [{\"name\": \"host\", \"hostPath\": {\"path\": \"/\"}}]
 			}

--- a/tests/functional/kata-deploy/lib/selinux.bash
+++ b/tests/functional/kata-deploy/lib/selinux.bash
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for the kata-deploy SELinux suites.
+
+# status, output and BATS_FILE_TMPDIR are bats'; HELM_NAMESPACE is helm-deploy.bash'.
+# shellcheck disable=SC2154
+
+AUDIT_LOG="/host/var/log/audit/audit.log"
+KATA_INSTALL_DIR="/host/opt/kata"
+
+selinux_enforce() {
+	run_on_host 'cat /host/sys/fs/selinux/enforce 2>/dev/null || echo none'
+}
+
+skip_unless_enforcing_node() {
+	run selinux_enforce
+	echo "# SELinux enforce: ${output}" >&3
+	if [[ "${output}" != *"1"* ]]; then
+		skip "the installer's SELinux confinement needs a node with SELinux enforcing"
+	fi
+
+	# Without the log the denial checks would pass without having looked.
+	if ! run_on_host 'test -r /host/var/log/audit/audit.log'; then
+		skip "no readable ${AUDIT_LOG}: auditd has to be running for denials to land there"
+	fi
+}
+
+# A chart with no confinement to render runs the stages as container_t, which
+# fails the same way a missing rule does but only after the install has retried
+# and helm has timed out. Say so up front instead.
+assert_chart_supports_selinux() {
+	run helm template kata-deploy "$(get_chart_path)" --set selinux.enabled=true
+	[[ "${status}" -eq 0 ]]
+	if [[ "${output}" != *"install-stage-selinux-policy"* ]]; then
+		echo "# the chart renders no selinux-policy stage: selinux.enabled is not supported here" >&3
+		return 1
+	fi
+}
+
+policy_module_path() {
+	run_on_host 'ls -d /host/var/lib/selinux/*/active/modules/*/kata-deploy 2>/dev/null | head -1'
+}
+
+# The loader's own selector, so this works for the DaemonSet and Job pods alike.
+policy_loader_log() {
+	kubectl -n "${HELM_NAMESPACE}" logs -l "$(kata_deploy_pod_selector)" \
+		-c selinux-policy --tail=-1 2>/dev/null || true
+}
+
+audit_mark_file() {
+	echo "${BATS_FILE_TMPDIR}/audit-offset"
+}
+
+mark_audit_log() {
+	run run_on_host 'wc -c < /host/var/log/audit/audit.log'
+	[[ "${status}" -eq 0 ]]
+	echo "${output//[^0-9]/}" > "$(audit_mark_file)"
+}
+
+# Scoped to kata_deploy and to the window since mark_audit_log, so neither
+# another workload nor an earlier run can fail a suite.
+denials_since_mark() {
+	local offset
+	offset=$(cat "$(audit_mark_file)")
+	run_on_host "tail -c +$((offset + 1)) /host/var/log/audit/audit.log | grep 'avc: *denied' | grep kata_deploy || true"
+}
+
+# Diagnostics: a stage whose label did not apply is denied as container_t, which
+# the scoped grep cannot tell apart from another container's noise.
+all_denials_since_mark() {
+	local offset
+	offset=$(cat "$(audit_mark_file)")
+	run_on_host "tail -c +$((offset + 1)) /host/var/log/audit/audit.log | grep 'avc: *denied' || true"
+}
+
+assert_no_kata_deploy_denials() {
+	local what="${1}"
+
+	run all_denials_since_mark
+	echo "# All denials during ${what}: ${output:-none}" >&3
+
+	run denials_since_mark
+	echo "# kata_deploy denials during ${what}: ${output:-none}" >&3
+	[[ "${status}" -eq 0 ]]
+	[[ -z "${output}" ]]
+}
+
+# The loader logs this only after checking. When it cannot check it warns and
+# says nothing, so requiring the line makes an unverified load a failure.
+assert_domains_resolve() {
+	run policy_loader_log
+	echo "# selinux-policy stage log: ${output}" >&3
+	[[ "${output}" == *"domains resolve"* ]]
+}
+
+assert_artifacts_installed() {
+	run run_on_host "ls ${KATA_INSTALL_DIR}"
+	echo "# ${KATA_INSTALL_DIR}: ${output}" >&3
+	[[ "${status}" -eq 0 ]]
+	[[ "${output}" == *"bin"* ]]
+}
+
+assert_artifacts_removed() {
+	run run_on_host "test -e ${KATA_INSTALL_DIR} && echo PRESENT || echo GONE"
+	echo "# ${KATA_INSTALL_DIR} after uninstall: ${output}" >&3
+	[[ "${output}" == *"GONE"* ]]
+}
+
+# Removing the module is left to the admin: another release may still need it.
+assert_module_still_loaded() {
+	run policy_module_path
+	echo "# Policy store entry: ${output}" >&3
+	[[ -n "${output}" ]]
+}
+
+# What values.yaml tells the admin to run. Under a chroot with the host writable,
+# as the installer does: the store belongs to the node, and so does its semodule.
+remove_policy_module() {
+	run_on_host 'chroot /host /usr/sbin/semodule -r kata-deploy || chroot /host /sbin/semodule -r kata-deploy' false
+}
+
+assert_module_removed() {
+	run policy_module_path
+	echo "# Policy store entry after removal: ${output:-none}" >&3
+	[[ -z "${output}" ]]
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -16,7 +16,7 @@ source "${kata_deploy_dir}/../../common.bash"
 export BATS_TEST_FAIL_FAST="${BATS_TEST_FAIL_FAST:-no}"
 
 if [[ -n "${KATA_DEPLOY_TEST_UNION:-}" ]]; then
-	KATA_DEPLOY_TEST_UNION=("${KATA_DEPLOY_TEST_UNION}")
+	read -r -a KATA_DEPLOY_TEST_UNION <<< "${KATA_DEPLOY_TEST_UNION}"
 else
 	KATA_DEPLOY_TEST_UNION=()
 


### PR DESCRIPTION
I've added a new runner, using Alma 10.2 + RKE2, which runs with SELInux enforced, and we can use it to test out that kata-deploy can be deployed on such systems.

This PR only adds the jobs and onboards the runner.

ci-devel: https://github.com/kata-containers/kata-containers/actions/runs/34223320901