### PR TITLE
runtime-rs: cap network queues at boot vCPUs

### DIFF
--- a/src/dragonball/crates/dbs_utils/src/net/tap.rs
+++ b/src/dragonball/crates/dbs_utils/src/net/tap.rs
@@ -104,6 +104,8 @@ impl Tap {
     /// # Arguments
     ///
     /// * `if_name` - the name of the interface.
+    /// * `multi_vq` - create a multiqueue TAP if true. If false, create a
+    ///   single-queue TAP or attach one queue to an existing multiqueue TAP.
     /// # Example
     ///
     /// ```no_run
@@ -131,7 +133,12 @@ impl Tap {
                 }) as c_short;
         }
 
-        Tap::create_tap_with_ifreq(&mut ifreq)
+        match Self::create_tap_with_ifreq(&mut ifreq) {
+            Err(Error::CreateTap(err)) if !multi_vq && err.raw_os_error() == Some(libc::EINVAL) => {
+                Self::open_named(if_name, true)
+            }
+            result => result,
+        }
     }
 
     fn create_tap_with_ifreq(ifreq: &mut net_gen::ifreq) -> Result<Tap> {
@@ -386,6 +393,35 @@ mod tests {
         str::from_utf8(&tap.if_name[..null_pos])
             .unwrap()
             .to_string()
+    }
+
+    #[test]
+    #[ignore = "requires /dev/net/tun and CAP_NET_ADMIN"]
+    fn test_open_named_existing_multiqueue() {
+        let index = NEXT_IP.fetch_add(1, Ordering::SeqCst);
+        let name = format!("dbs_mq{index}");
+        let original = Tap::open_named(&name, true).unwrap();
+        let mut ifreq = original.get_ifreq();
+        // Only the flags field of the union is accessed.
+        unsafe {
+            *ifreq.ifr_ifru.ifru_flags.as_mut() &= !(net_gen::IFF_MULTI_QUEUE as c_short);
+        }
+        assert!(matches!(
+            Tap::create_tap_with_ifreq(&mut ifreq),
+            Err(Error::CreateTap(err)) if err.raw_os_error() == Some(libc::EINVAL)
+        ));
+        let tap = Tap::open_named(&name, false).unwrap();
+        assert_ne!(tap.if_flags() & net_gen::IFF_MULTI_QUEUE, 0);
+        assert_eq!(tap.into_mq_taps(1).unwrap().len(), 1);
+
+        let name = format!("dbs_sq{index}");
+        let tap = Tap::open_named(&name, false).unwrap();
+        assert_eq!(tap.if_flags() & net_gen::IFF_MULTI_QUEUE, 0);
+        assert!(matches!(
+            Tap::open_named(&name, true),
+            Err(Error::CreateTap(err)) if err.raw_os_error() == Some(libc::EINVAL)
+        ));
+        assert!(tap.into_mq_taps(2).is_err());
     }
 
     #[test]

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1811,6 +1811,11 @@ fn yes() -> bool {
 }
 
 impl Hypervisor {
+    /// Queue-pair limit shared by multiqueue network backends.
+    pub fn network_queue_limit(&self) -> u32 {
+        (self.cpu_info.default_vcpus.ceil() as u32).clamp(1, MAX_NETWORK_QUEUES)
+    }
+
     /// Validates the path of the hypervisor executable against configured patterns.
     pub fn validate_hypervisor_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         validate_path_pattern(&self.valid_hypervisor_paths, path)

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -214,7 +214,7 @@ queue_size = 128
 num_queues = 1
 
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -214,7 +214,7 @@ queue_size = 128
 num_queues = 1
 
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -236,7 +236,8 @@ queue_size = 128
 num_queues = 1
 
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
+# The userspace virtio-net backend (disable_vhost_net = true) always uses one queue pair.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-openvmm-azure-runtime-rs.toml.in
@@ -166,13 +166,9 @@ queue_size = 128
 # Block device multi-queue, default 1
 num_queues = 1
 
-# network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
-# More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
-# across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
-# Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),
-# so it should typically not exceed the number of vCPUs or the practical parallelism of the networking backend.
-# Default: 1, Range: 1..=256
+# OpenVMM supports one virtio-net queue pair (RX/TX).
+# network_queues always resolves to 1 for this hypervisor.
+# Directly attached TAP devices must be created without multiqueue.
 network_queues = @DEFNETQUEUES@
 
 # Enable pre allocation of VM RAM, default false

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -439,7 +439,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-cpu-runtime-rs.toml.in
@@ -455,7 +455,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -454,7 +454,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -484,7 +484,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -460,7 +460,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -448,7 +448,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -411,7 +411,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -459,7 +459,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -436,7 +436,7 @@ rx_rate_limiter_max_rate = 0
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
 # network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
+# Setting network_queues = N creates min(N, 256, boot vCPUs) RX/TX queue pairs.
 # More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
 # across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
 # Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -248,13 +248,9 @@ rx_rate_limiter_max_rate = 0
 # queueing discipline.
 # Default 0-sized value means unlimited rate.
 tx_rate_limiter_max_rate = 0
-# network_queues configures the number of virtio-net queue pairs (RX/TX) exposed to the guest.
-# Setting network_queues = N creates N RX queues and N TX queues (i.e., N queue pairs).
-# More queues can improve network throughput and reduce per-queue contention by allowing packet processing to scale
-# across multiple vCPUs/threads (subject to host/guest capabilities and backend configuration such as vhost-net).
-# Increasing this value consumes more resources (e.g., virtqueue state, interrupts/MSI-X vectors, backend threads),
-# so it should typically not exceed the number of vCPUs or the practical parallelism of the networking backend.
-# Default: 1, Range: 1..=256
+# Firecracker supports one virtio-net queue pair (RX/TX).
+# network_queues always resolves to 1 for this hypervisor.
+# Directly attached TAP devices must be created without multiqueue.
 network_queues = @DEFNETQUEUES@
 
 # disable applying SELinux on the VMM process (default false)

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -134,7 +134,12 @@ impl CloudHypervisorInner {
     }
 
     pub fn hypervisor_config(&self) -> HypervisorConfig {
-        self.config.clone()
+        let mut config = self.config.clone();
+        config.network_info.network_queues = config
+            .network_info
+            .network_queues
+            .clamp(1, config.network_queue_limit());
+        config
     }
 }
 
@@ -158,7 +163,7 @@ impl Persist for CloudHypervisorInner {
             jailed: false,
             jailer_root: String::default(),
             netns: self.netns.clone(),
-            config: self.hypervisor_config(),
+            config: self.config.clone(),
             run_dir: self.run_dir.clone(),
             guest_protection_to_use: self.guest_protection_to_use.clone(),
 
@@ -204,6 +209,63 @@ impl Persist for CloudHypervisorInner {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_clh_network_queues_capped_at_boot_vcpus() {
+        for (cpus, requested, expected) in [
+            (1.0, 16, 1),
+            (4.0, 16, 4),
+            (16.0, 16, 16),
+            (32.0, 16, 16),
+            (1.5, 16, 2),
+            (32.0, 0, 1),
+            (32.0, 1, 1),
+            (4.0, 256, 4),
+            (256.0, 256, 256),
+            (512.0, 512, 256),
+            (0.0, 16, 1),
+        ] {
+            let mut config = HypervisorConfig::default();
+            config.cpu_info.default_vcpus = cpus;
+            config.network_info.network_queues = requested;
+
+            let mut clh = CloudHypervisorInner::default();
+            clh.set_hypervisor_config(config);
+            assert_eq!(
+                clh.hypervisor_config().network_info.network_queues,
+                expected,
+                "cpus={cpus}, requested={requested}"
+            );
+            assert_eq!(clh.config.network_info.network_queues, requested);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_network_device_queue_limit() {
+        let mut clh = CloudHypervisorInner::default();
+        clh.config.cpu_info.default_vcpus = 4.0;
+        clh.config.network_info.network_queues = 2;
+
+        for (requested, expected) in [(0, 1), (1, 1), (2, 2), (16, 4), (usize::MAX, 4)] {
+            let device = crate::NetworkDevice {
+                config: crate::NetworkConfig {
+                    queue_num: requested,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let DeviceType::Network(device) =
+                clh.add_device(DeviceType::Network(device)).await.unwrap()
+            else {
+                panic!("expected network device");
+            };
+            assert_eq!(device.config.queue_num, expected);
+            let DeviceType::Network(pending) = &clh.pending_devices[0] else {
+                panic!("expected pending network device");
+            };
+            assert_eq!(pending.config.queue_num, expected);
+        }
+    }
+
     #[actix_rt::test]
     async fn test_save_clh() {
         let (exit_notify, _exit_waiter) = mpsc::channel(1);
@@ -215,6 +277,8 @@ mod tests {
         clh.run_dir = String::from("/var/run/kata-containers/") + &clh.id;
 
         clh.guest_protection_to_use = GuestProtection::Tdx;
+        clh.config.cpu_info.default_vcpus = 4.0;
+        clh.config.network_info.network_queues = 16;
 
         let state = clh.save().await.unwrap();
         assert_eq!(state.id, clh.id);
@@ -222,12 +286,15 @@ mod tests {
         assert_eq!(state.vm_path, clh.vm_path);
         assert_eq!(state.run_dir, clh.run_dir);
         assert_eq!(state.guest_protection_to_use, clh.guest_protection_to_use);
+        assert_eq!(state.config.network_info.network_queues, 16);
         assert!(!state.jailed);
         assert_eq!(state.hypervisor_type, HYPERVISOR_NAME_CH.to_string());
 
         let clh = CloudHypervisorInner::restore(exit_notify, state.clone())
             .await
             .unwrap();
+        assert_eq!(clh.config.network_info.network_queues, 16);
+        assert_eq!(clh.hypervisor_config().network_info.network_queues, 4);
         assert_eq!(clh.id, state.id);
         assert_eq!(clh.netns, state.netns);
         assert_eq!(clh.vm_path, state.vm_path);

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -48,7 +48,13 @@ use tokio::sync::Mutex;
 const VIRTIO_FS: &str = "virtio-fs";
 
 impl CloudHypervisorInner {
-    pub(crate) async fn add_device(&mut self, device: DeviceType) -> Result<DeviceType> {
+    pub(crate) async fn add_device(&mut self, mut device: DeviceType) -> Result<DeviceType> {
+        if let DeviceType::Network(net) = &mut device {
+            net.config.queue_num = net
+                .config
+                .queue_num
+                .clamp(1, self.config.network_queue_limit() as usize);
+        }
         if self.state != VmmState::VmRunning {
             // If the VM is not running, add the device to the pending list to
             // be handled later.
@@ -434,8 +440,7 @@ impl CloudHypervisorInner {
                     shared_fs_devices.push(fs_cfg);
                 }
                 DeviceType::Network(net_device) => {
-                    let network_queues_pairs =
-                        self.hypervisor_config().network_info.network_queues as usize;
+                    let network_queues_pairs = net_device.config.queue_num;
 
                     let mut net_config = NetConfig::try_from(net_device.config.clone())?;
                     // When using fds to pass the tap device to cloud-hypervisor, tap and id fields should be None

--- a/src/runtime-rs/crates/hypervisor/src/device/tap.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/tap.rs
@@ -107,6 +107,8 @@ impl Tap {
     /// # Arguments
     ///
     /// * `if_name` - the name of the interface.
+    /// * `multi_vq` - create a multiqueue TAP if true. If false, create a
+    ///   single-queue TAP or attach one queue to an existing multiqueue TAP.
     pub fn open_named(if_name: &str, multi_vq: bool) -> Result<Tap> {
         let terminated_if_name = build_terminated_if_name(if_name)?;
 
@@ -122,7 +124,12 @@ impl Tap {
                     as c_short,
             },
         };
-        Tap::create_tap_with_ifreq(&mut ifr)
+        match Self::create_tap_with_ifreq(&mut ifr) {
+            Err(Error::CreateTap(err)) if !multi_vq && err.raw_os_error() == Some(libc::EINVAL) => {
+                Self::open_named(if_name, true)
+            }
+            result => result,
+        }
     }
 
     fn create_tap_with_ifreq(ifr: &mut ifreq) -> Result<Tap> {
@@ -260,5 +267,34 @@ impl Write for Tap {
 impl AsRawFd for Tap {
     fn as_raw_fd(&self) -> RawFd {
         self.tap_file.as_raw_fd()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires /dev/net/tun and CAP_NET_ADMIN"]
+    fn test_open_named_existing_multiqueue() {
+        let original = Tap::open_named("kata_mq", true).unwrap();
+        let mut ifr = original.get_ifreq();
+        ifr.ifr_ifru.ifru_flags = original.if_flags & !(libc::IFF_MULTI_QUEUE as c_short);
+        assert!(matches!(
+            Tap::create_tap_with_ifreq(&mut ifr),
+            Err(Error::CreateTap(err)) if err.raw_os_error() == Some(libc::EINVAL)
+        ));
+
+        let tap = Tap::open_named("kata_mq", false).unwrap();
+        assert_ne!(tap.if_flags() & libc::IFF_MULTI_QUEUE as u32, 0);
+        assert_eq!(tap.into_mq_taps(1).unwrap().len(), 1);
+
+        let tap = Tap::open_named("kata_sq", false).unwrap();
+        assert_eq!(tap.if_flags() & libc::IFF_MULTI_QUEUE as u32, 0);
+        assert!(matches!(
+            Tap::open_named("kata_sq", true),
+            Err(Error::CreateTap(err)) if err.raw_os_error() == Some(libc::EINVAL)
+        ));
+        assert!(tap.into_mq_taps(2).is_err());
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -531,7 +531,16 @@ impl DragonballInner {
     }
 
     pub fn hypervisor_config(&self) -> HypervisorConfig {
-        self.config.clone()
+        let mut config = self.config.clone();
+        config.network_info.network_queues = if config.network_info.disable_vhost_net {
+            1
+        } else {
+            config
+                .network_info
+                .network_queues
+                .clamp(1, config.network_queue_limit())
+        };
+        config
     }
 
     pub(crate) fn set_capabilities(&mut self, flag: CapabilityBits) {
@@ -565,7 +574,7 @@ impl Persist for DragonballInner {
             jailed: self.jailed,
             jailer_root: self.jailer_root.clone(),
             netns: self.netns.clone(),
-            config: self.hypervisor_config(),
+            config: self.config.clone(),
             run_dir: self.run_dir.clone(),
             cached_block_devices: self.cached_block_devices.clone(),
             passfd_listener_port: self.passfd_listener_port,
@@ -602,6 +611,51 @@ impl Persist for DragonballInner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_network_queues_preserve_request_across_restore() {
+        for (cpus, requested, expected) in [
+            (0.0, 0, 1),
+            (1.0, 16, 1),
+            (4.0, 0, 1),
+            (4.0, 2, 2),
+            (4.0, 16, 4),
+            (3.5, 16, 4),
+            (512.0, 512, 256),
+        ] {
+            for disable_vhost_net in [false, true] {
+                let (tx, _) = mpsc::channel(1);
+                let mut inner = DragonballInner::new(tx.clone());
+                inner.config.cpu_info.default_vcpus = cpus;
+                inner.config.network_info.network_queues = requested;
+                inner.config.network_info.disable_vhost_net = disable_vhost_net;
+                let expected = if disable_vhost_net { 1 } else { expected };
+
+                assert_eq!(
+                    inner.hypervisor_config().network_info.network_queues,
+                    expected
+                );
+                assert_eq!(inner.config.network_info.network_queues, requested);
+                let state = inner.save().await.unwrap();
+                assert_eq!(state.config.network_info.network_queues, requested);
+                let restored = DragonballInner::restore(tx, state).await.unwrap();
+                assert_eq!(
+                    restored.hypervisor_config().network_info.network_queues,
+                    expected
+                );
+                assert_eq!(
+                    restored
+                        .save()
+                        .await
+                        .unwrap()
+                        .config
+                        .network_info
+                        .network_queues,
+                    requested
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_template_restore_skips_boot_source_configuration() {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -353,7 +353,10 @@ impl DragonballInner {
         let guest_mac = MacAddr::parse_str(&config.mac_address).ok();
         // `config.num_queues` is a queue *pair* count (1 RX + 1 TX per pair).
         // Convert pairs into the actual queue count.
-        let num_queues = config.num_queues.max(1) * 2;
+        let num_queues = config
+            .num_queues
+            .clamp(1, self.config.network_queue_limit() as usize)
+            * 2;
         let net_cfg = NetworkInterfaceConfig {
             num_queues: Some(num_queues),
             queue_size: Some(config.queue_size as u16),

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -297,7 +297,14 @@ pub(crate) fn build_dragonball_network_config(
 
     // `config.num_queues` is a queue *pair* count (1 RX + 1 TX per pair).
     // Convert pairs into the actual queue count.
-    let num_queues = nconfig.queue_num.max(1) * 2;
+    let queue_pairs = if hconfig.network_info.disable_vhost_net {
+        1
+    } else {
+        nconfig
+            .queue_num
+            .clamp(1, hconfig.network_queue_limit() as usize)
+    };
+    let num_queues = queue_pairs * 2;
     DragonballNetworkConfig {
         num_queues: Some(num_queues),
         queue_size: Some(nconfig.queue_size as u16),
@@ -308,5 +315,44 @@ pub(crate) fn build_dragonball_network_config(
         }),
         use_shared_irq: nconfig.use_shared_irq,
         use_generic_irq: nconfig.use_generic_irq,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_config_caps_queue_pairs() {
+        for (cpus, requested, expected) in [
+            (0.0, 0, 1),
+            (1.0, 16, 1),
+            (4.0, 0, 1),
+            (4.0, 2, 2),
+            (4.0, 16, 4),
+            (3.5, 16, 4),
+            (512.0, usize::MAX, 256),
+        ] {
+            for disable_vhost_net in [false, true] {
+                let mut hconfig = HypervisorConfig::default();
+                hconfig.cpu_info.default_vcpus = cpus;
+                hconfig.network_info.disable_vhost_net = disable_vhost_net;
+                let nconfig = NetworkConfig {
+                    queue_num: requested,
+                    queue_size: 256,
+                    ..Default::default()
+                };
+
+                let config = build_dragonball_network_config(&hconfig, &nconfig);
+                let expected = if disable_vhost_net { 1 } else { expected };
+                assert_eq!(config.num_queues, Some(expected * 2));
+                assert_eq!(config.queue_sizes(), vec![256; expected * 2]);
+                assert_eq!(nconfig.queue_num, requested);
+                assert_eq!(
+                    matches!(config.backend, DragonballBackend::Virtio(_)),
+                    disable_vhost_net
+                );
+            }
+        }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner.rs
@@ -166,7 +166,9 @@ impl FcInner {
 
     pub(crate) fn hypervisor_config(&self) -> HypervisorConfig {
         debug!(sl(), "[Firecracker]: Hypervisor config");
-        self.config.clone()
+        let mut config = self.config.clone();
+        config.network_info.network_queues = 1;
+        config
     }
 
     pub(crate) fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
@@ -235,7 +237,7 @@ impl Persist for FcInner {
             hypervisor_type: HYPERVISOR_FIRECRACKER.to_string(),
             id: self.id.clone(),
             vm_path: self.vm_path.clone(),
-            config: self.hypervisor_config(),
+            config: self.config.clone(),
             jailed: self.jailed,
             jailer_root: self.jailer_root.clone(),
             run_dir: self.run_dir.clone(),

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
@@ -110,7 +110,10 @@ impl Hypervisor for Firecracker {
         inner.save_vm().await
     }
 
-    async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
+    async fn add_device(&self, mut device: DeviceType) -> Result<DeviceType> {
+        if let DeviceType::Network(network) = &mut device {
+            network.config.queue_num = 1;
+        }
         let mut inner = self.inner.write().await;
         match inner.add_device(device.clone()).await {
             Ok(_) => Ok(device),
@@ -242,5 +245,53 @@ impl Persist for Firecracker {
             inner: Arc::new(RwLock::new(inner)),
             exit_waiter: Mutex::new((exit_waiter, 0)),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NetworkConfig, NetworkDevice};
+
+    #[tokio::test]
+    async fn network_queues_use_one_pair_and_preserve_request() {
+        for requested in [0, 1, 16, 256] {
+            let firecracker = Firecracker::new();
+            let mut config = HypervisorConfig::default();
+            config.cpu_info.default_vcpus = 16.0;
+            config.network_info.network_queues = requested;
+            firecracker.set_hypervisor_config(config).await;
+            let effective = firecracker.hypervisor_config().await;
+            assert_eq!(effective.network_info.network_queues, 1);
+
+            let device = firecracker
+                .add_device(DeviceType::Network(NetworkDevice::new(
+                    "eth0".to_string(),
+                    &NetworkConfig {
+                        queue_num: requested as usize,
+                        ..Default::default()
+                    },
+                )))
+                .await
+                .unwrap();
+            let DeviceType::Network(network) = device else {
+                panic!("expected network device")
+            };
+            assert_eq!(network.config.queue_num, 1);
+            let inner = firecracker.inner.read().await;
+            let DeviceType::Network(pending) = &inner.pending_devices[0] else {
+                panic!("expected pending network device")
+            };
+            assert_eq!(pending.config.queue_num, 1);
+            drop(inner);
+
+            let state = firecracker.save().await.unwrap();
+            assert_eq!(state.config.network_info.network_queues, requested);
+            let restored = Firecracker::restore((), state).await.unwrap();
+            let effective = restored.hypervisor_config().await;
+            assert_eq!(effective.network_info.network_queues, 1);
+            let state = restored.save().await.unwrap();
+            assert_eq!(state.config.network_info.network_queues, requested);
+        }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner.rs
@@ -105,7 +105,9 @@ impl OpenVmmInner {
     }
 
     pub(crate) fn hypervisor_config(&self) -> HypervisorConfig {
-        self.config.clone()
+        let mut config = self.config.clone();
+        config.network_info.network_queues = 1;
+        config
     }
 
     pub(crate) async fn capabilities(&self) -> Result<Capabilities> {

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner_device.rs
@@ -12,7 +12,10 @@ use crate::device::DeviceType;
 use crate::{VmmState, KATA_BLK_DEV_TYPE};
 
 impl OpenVmmInner {
-    pub(crate) async fn add_device(&mut self, device: DeviceType) -> Result<DeviceType> {
+    pub(crate) async fn add_device(&mut self, mut device: DeviceType) -> Result<DeviceType> {
+        if let DeviceType::Network(network) = &mut device {
+            network.config.queue_num = 1;
+        }
         if self.state == VmmState::NotReady {
             info!(sl!(), "openvmm: VMM not ready, queueing device {}", device);
             self.pending_devices.push(device.clone());

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/mod.rs
@@ -278,7 +278,50 @@ impl Persist for OpenVmm {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{NetworkConfig, NetworkDevice};
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn network_queues_use_one_pair_and_preserve_request() {
+        for requested in [0, 1, 16, 256] {
+            let openvmm = OpenVmm::new();
+            let mut config = HypervisorConfig::default();
+            config.cpu_info.default_vcpus = 16.0;
+            config.network_info.network_queues = requested;
+            openvmm.set_hypervisor_config(config).await;
+            let effective = openvmm.hypervisor_config().await;
+            assert_eq!(effective.network_info.network_queues, 1);
+
+            let device = openvmm
+                .add_device(DeviceType::Network(NetworkDevice::new(
+                    "eth0".to_string(),
+                    &NetworkConfig {
+                        queue_num: requested as usize,
+                        ..Default::default()
+                    },
+                )))
+                .await
+                .unwrap();
+            let DeviceType::Network(network) = device else {
+                panic!("expected network device")
+            };
+            assert_eq!(network.config.queue_num, 1);
+            let inner = openvmm.inner.read().await;
+            let DeviceType::Network(pending) = &inner.pending_devices[0] else {
+                panic!("expected pending network device")
+            };
+            assert_eq!(pending.config.queue_num, 1);
+            drop(inner);
+
+            let state = openvmm.save().await.unwrap();
+            assert_eq!(state.config.network_info.network_queues, requested);
+            let restored = OpenVmm::restore((), state).await.unwrap();
+            let effective = restored.hypervisor_config().await;
+            assert_eq!(effective.network_info.network_queues, 1);
+            let state = restored.save().await.unwrap();
+            assert_eq!(state.config.network_info.network_queues, requested);
+        }
+    }
 
     #[tokio::test]
     async fn wait_vm_notifies_concurrent_and_future_waiters() {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -832,7 +832,12 @@ impl QemuInner {
 
     pub fn hypervisor_config(&self) -> HypervisorConfig {
         info!(sl!(), "QemuInner::hypervisor_config()");
-        self.config.clone()
+        let mut config = self.config.clone();
+        config.network_info.network_queues = config
+            .network_info
+            .network_queues
+            .clamp(1, config.network_queue_limit());
+        config
     }
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
@@ -1128,6 +1133,12 @@ use crate::vfio_device::VfioDeviceType;
 impl QemuInner {
     pub(crate) async fn add_device(&mut self, mut device: DeviceType) -> Result<DeviceType> {
         info!(sl!(), "QemuInner::add_device() {}", device);
+        if let DeviceType::Network(net) = &mut device {
+            net.config.queue_num = net
+                .config
+                .queue_num
+                .clamp(1, self.config.network_queue_limit() as usize);
+        }
         let is_qemu_ready_to_hotplug = self.qmp.is_some();
         if is_qemu_ready_to_hotplug {
             // hypervisor is running already
@@ -1451,7 +1462,7 @@ impl Persist for QemuInner {
         Ok(HypervisorState {
             hypervisor_type: HYPERVISOR_QEMU.to_string(),
             id: self.id.clone(),
-            config: self.hypervisor_config(),
+            config: self.config.clone(),
             ..Default::default()
         })
     }
@@ -1477,6 +1488,61 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+
+    #[tokio::test]
+    async fn test_network_queue_limit() {
+        for (cpus, requested, expected) in [
+            (1.0, 16, 1),
+            (4.0, 16, 4),
+            (1.5, 16, 2),
+            (4.0, 0, 1),
+            (4.0, 1, 1),
+            (4.0, 2, 2),
+            (8.0, 256, 8),
+            (512.0, 512, 256),
+        ] {
+            let (exit_notify, _) = mpsc::channel(1);
+            let mut qemu = QemuInner::new(exit_notify.clone());
+            qemu.config.cpu_info.default_vcpus = cpus;
+            qemu.config.network_info.network_queues = requested;
+            assert_eq!(
+                qemu.hypervisor_config().network_info.network_queues,
+                expected
+            );
+
+            let state = qemu.save().await.unwrap();
+            assert_eq!(state.config.network_info.network_queues, requested);
+            let restored = QemuInner::restore(exit_notify, state).await.unwrap();
+            assert_eq!(
+                restored.hypervisor_config().network_info.network_queues,
+                expected
+            );
+        }
+
+        let (exit_notify, _) = mpsc::channel(1);
+        let mut qemu = QemuInner::new(exit_notify);
+        qemu.config.cpu_info.default_vcpus = 4.0;
+        qemu.config.network_info.network_queues = 2;
+        for (requested, expected) in [(0, 1), (1, 1), (2, 2), (16, 4), (usize::MAX, 4)] {
+            let device = crate::NetworkDevice {
+                config: crate::NetworkConfig {
+                    queue_num: requested,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let DeviceType::Network(device) =
+                qemu.add_device(DeviceType::Network(device)).await.unwrap()
+            else {
+                panic!("expected network device");
+            };
+            assert_eq!(device.config.queue_num, expected);
+            let DeviceType::Network(pending) = qemu.devices.last().unwrap() else {
+                panic!("expected pending network device");
+            };
+            assert_eq!(pending.config.queue_num, expected);
+        }
+    }
 
     #[tokio::test]
     async fn test_network_device_hotplug_capability() {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -1016,7 +1016,7 @@ impl Qmp {
                     fd: None,
                     // Logic in cmdline_generator::Netdev::new() seems to
                     // guarantee that there will always be at least one fd.
-                    fds: Some(fd_names.join(",")),
+                    fds: Some(fd_names.join(":")),
                     helper: None,
                     ifname: None,
                     poll_us: None,
@@ -1032,7 +1032,7 @@ impl Qmp {
                     vhostfds: if vhostfd_names.is_empty() {
                         None
                     } else {
-                        Some(vhostfd_names.join(","))
+                        Some(vhostfd_names.join(":"))
                     },
                     vhostforce: None,
                     vnet_hdr: None,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -563,15 +563,16 @@ impl VirtSandbox {
 
         // Network priority: DAN > NetNS
         if dan_path.exists() {
+            // DAN can select a different network backend for each device.
+            let hypervisor_config = config.hypervisor.get(&config.runtime.hypervisor_name)?;
             Some(ResourceConfig::Network(NetworkConfig::Dan(
                 DanNetworkConfig {
                     dan_conf_path: dan_path,
-                    network_queues: self
-                        .hypervisor
-                        .hypervisor_config()
-                        .await
+                    network_queues: hypervisor_config
                         .network_info
-                        .network_queues as usize,
+                        .network_queues
+                        .clamp(1, hypervisor_config.network_queue_limit())
+                        as usize,
                 },
             )))
         } else if let Some(netns_path) = network_env.netns.as_ref() {


### PR DESCRIPTION
Prevent small pods from failing to start when a shared `network_queues` value exceeds their boot vCPUs, while letting larger pods use more than the default one queue pair.

Apply consistent caps at startup and supported hotplug, including DAN. Preserve the saved request, accept existing multiqueue TAPs when capped to one pair, and fix QEMU multiqueue hotplug.

| VMM / backend | Default | Effective maximum | Normalization |
|---|---:|---|---|
| Cloud Hypervisor, including Azure | 1 | `min(256, boot vCPUs)` | `0 → 1`; clamp to maximum |
| QEMU, all profiles | 1 | `min(256, boot vCPUs)` | `0 → 1`; clamp to maximum |
| Dragonball: vhost-net | 1 | `min(256, boot vCPUs)` | `0 → 1`; clamp to maximum |
| Dragonball: vhost-user | 1 | `min(256, boot vCPUs)` | `0 → 1`; clamp to maximum |
| Dragonball: userspace virtio-net | 1 | 1 | Any request → 1 |
| Firecracker | 1 | 1 | Any request → 1 |
| OpenVMM: virtio-net | 1 | 1 | Any request → 1 |

Counts are RX/TX queue pairs. Boot vCPUs round the CPU request up, with a minimum of one; existing backend limits still apply. DAN `queue_num=0` inherits the configured default before applying the cap.

Validation: x86_64 KVM queue/traffic tests, unit tests, and real-TUN regressions. Dragonball vhost-user testing used a DPDK MAC/MTU compatibility patch.
