### PR TITLE
kata-deploy: remove containerd handlers a redeploy drops

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy-variant-toggle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-variant-toggle.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Toggling the debug variant off has to withdraw its containerd runtime handler
+# along with its RuntimeClass. A handler left registered names a configuration
+# the same redeploy deleted, and pods that land on it never leave
+# ContainerCreating.
+#
+# Required environment variables:
+#   DOCKER_REGISTRY - Container registry for kata-deploy image
+#   DOCKER_REPO     - Repository name for kata-deploy image
+#   DOCKER_TAG      - Image tag to test
+#   KATA_HYPERVISOR - Hypervisor to test (qemu, clh, etc.)
+#   KUBERNETES      - K8s distribution (microk8s, k3s, rke2, etc.)
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
+load "${repo_root_dir}/tests/gha-run-k8s-common.sh"
+
+source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
+
+BASE_HANDLER="kata-${KATA_HYPERVISOR}"
+DEBUG_HANDLER="kata-${KATA_HYPERVISOR}-debug"
+TOGGLE_POD_NAME="kata-variant-toggle"
+
+# The handlers the CRI reports it can serve, one per line. This is the list the
+# scheduler and the kubelet work from, so it is where a stale handler does harm.
+node_runtime_handlers() {
+	kubectl get nodes -o jsonpath='{range .items[*].status.runtimeHandlers[*]}{.name}{"\n"}{end}' 2>/dev/null
+}
+
+# Kubernetes below 1.30 does not publish the field at all.
+runtime_handlers_published() {
+	[[ -n "$(node_runtime_handlers)" ]]
+}
+
+# Wait for ${1} to be advertised (${2} = yes) or withdrawn (${2} = no). The
+# kubelet republishes on its own sync interval, well after helm returns.
+wait_for_handler() {
+	local handler="${1}"
+	local want="${2}"
+	local retries=0
+
+	while [[ ${retries} -lt 60 ]]; do
+		local found="no"
+		node_runtime_handlers | grep -qx "${handler}" && found="yes"
+		[[ "${found}" == "${want}" ]] && return 0
+		retries=$((retries + 1))
+		sleep 2
+	done
+
+	echo "# handler ${handler}: wanted advertised=${want}, node reports:" >&3
+	node_runtime_handlers >&3
+	return 1
+}
+
+# Every containerd configuration kata-deploy may have written a handler into,
+# drop-in or whole-file. Each distribution uses one, so the rest are absent.
+CONTAINERD_CONFIG_DIRS="/host/etc/containerd \
+/host/var/lib/rancher/k3s/agent/etc/containerd \
+/host/var/lib/rancher/rke2/agent/etc/containerd \
+/host/opt/kata/containerd"
+
+# The containerd configuration files naming ${1}, or NONE.
+containerd_configs_naming() {
+	run_on_host "grep -rl ${1} ${CONTAINERD_CONFIG_DIRS} 2>/dev/null; echo NONE"
+}
+
+setup_file() {
+	ensure_helm
+
+	echo "# Image: ${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" >&3
+	echo "# Hypervisor: ${KATA_HYPERVISOR}" >&3
+	echo "# K8s distribution: ${KUBERNETES}" >&3
+
+	# The base values carry debug: true, so this brings the variant up.
+	echo "# Deploying kata-deploy with debug on..." >&3
+	deploy_kata
+	echo "# kata-deploy deployed successfully" >&3
+}
+
+@test "Debug variant is registered while debug is on" {
+	kubectl get runtimeclass "${DEBUG_HANDLER}" -o name
+
+	run run_on_host "test -d /host/opt/kata/share/defaults/kata-containers/custom-runtimes/${DEBUG_HANDLER} && echo PRESENT || echo MISSING"
+	echo "# ${DEBUG_HANDLER} config directory: ${output}" >&3
+	[[ "${output}" == *"PRESENT"* ]]
+
+	# Also the baseline for the next test: without a hit here, finding no hit
+	# once debug is off would say nothing about the handler having been removed.
+	run containerd_configs_naming "${DEBUG_HANDLER}"
+	echo "# containerd configs naming ${DEBUG_HANDLER}: ${output}" >&3
+	[[ "${output}" == *"/host/"* ]]
+
+	if ! runtime_handlers_published; then
+		skip "this Kubernetes does not publish node.status.runtimeHandlers"
+	fi
+
+	wait_for_handler "${DEBUG_HANDLER}" yes
+	wait_for_handler "${BASE_HANDLER}" yes
+}
+
+@test "Turning debug off withdraws the variant handler" {
+	echo "# Redeploying with debug off..." >&3
+	deploy_kata "" --set debug=false
+
+	kubectl wait nodes --timeout=300s --all --for condition=Ready=True
+
+	run kubectl get runtimeclass "${DEBUG_HANDLER}" -o name
+	echo "# RuntimeClass ${DEBUG_HANDLER}: ${output}" >&3
+	[[ "${status}" -ne 0 ]]
+
+	run run_on_host "test -d /host/opt/kata/share/defaults/kata-containers/custom-runtimes/${DEBUG_HANDLER} && echo PRESENT || echo GONE"
+	echo "# ${DEBUG_HANDLER} config directory: ${output}" >&3
+	[[ "${output}" == *"GONE"* ]]
+
+	# The configuration the handler would have been served from is gone, so the
+	# handler has no business still being registered anywhere.
+	run containerd_configs_naming "${DEBUG_HANDLER}"
+	echo "# containerd configs naming ${DEBUG_HANDLER}: ${output}" >&3
+	[[ "${output}" == "NONE" ]]
+
+	# The base shim was never turned off, so a prune that took it too would be
+	# just as broken.
+	run containerd_configs_naming "${BASE_HANDLER}"
+	echo "# containerd configs naming ${BASE_HANDLER}: ${output}" >&3
+	[[ "${output}" == *"/host/"* ]]
+
+	if ! runtime_handlers_published; then
+		skip "this Kubernetes does not publish node.status.runtimeHandlers"
+	fi
+
+	wait_for_handler "${DEBUG_HANDLER}" no
+	wait_for_handler "${BASE_HANDLER}" yes
+}
+
+@test "Base runtime still runs pods after the variant is withdrawn" {
+	cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${TOGGLE_POD_NAME}
+spec:
+  runtimeClassName: ${BASE_HANDLER}
+  restartPolicy: Never
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: test
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: IfNotPresent
+      command: ["sleep", "60"]
+EOF
+
+	kubectl wait --for=condition=Ready "pod/${TOGGLE_POD_NAME}" --timeout=180s
+}
+
+teardown() {
+	if [[ "${BATS_TEST_COMPLETED:-}" != "1" && -z "${BATS_TEST_SKIPPED:-}" ]]; then
+		kubectl describe pod "${TOGGLE_POD_NAME}" 2>/dev/null || true
+		kubectl -n "${HELM_NAMESPACE}" logs -l "$(kata_deploy_pod_selector)" 2>/dev/null || true
+	fi
+}
+
+teardown_file() {
+	kubectl delete pod "${TOGGLE_POD_NAME}" --ignore-not-found=true --wait=false 2>/dev/null || true
+	uninstall_kata 2>/dev/null || true
+}

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -29,6 +29,7 @@ else
 	KATA_DEPLOY_TEST_UNION+=( \
 		"kata-deploy.bats" \
 		"kata-deploy-custom-runtimes.bats" \
+		"kata-deploy-variant-toggle.bats" \
 		"kata-deploy-lifecycle.bats" \
 		"kata-deploy-scheduling.bats" \
 		"kata-deploy-tee-keys.bats" \

--- a/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
+++ b/tools/packaging/kata-deploy/binary/src/runtime/containerd.rs
@@ -9,6 +9,7 @@ use crate::utils;
 use crate::utils::toml as toml_utils;
 use anyhow::{Context, Result};
 use log::info;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -230,14 +231,26 @@ fn configure_user_containerd_drop_in(config: &Config, paths: &ContainerdPaths) -
     Ok(())
 }
 
+fn containerd_runtimes_table(pluginid: &str) -> String {
+    format!(".plugins.{pluginid}.containerd.runtimes")
+}
+
+fn containerd_runtime_platform_table(handler: &str) -> String {
+    format!(
+        ".plugins.{}.runtime_platforms.\"{}\"",
+        CONTAINERD_CRI_IMAGES_PLUGIN_ID, handler
+    )
+}
+
 fn write_containerd_runtime_config(
     config_file: &Path,
     pluginid: &str,
     params: &ContainerdRuntimeParams,
 ) -> Result<()> {
     let runtime_table = format!(
-        ".plugins.{}.containerd.runtimes.{}",
-        pluginid, params.runtime_name
+        "{}.{}",
+        containerd_runtimes_table(pluginid),
+        params.runtime_name
     );
     let runtime_options_table = format!("{runtime_table}.options");
     let runtime_type = format!("\"io.containerd.{}.v2\"", params.runtime_name);
@@ -292,8 +305,8 @@ fn write_containerd_runtime_config(
             toml_utils::set_toml_value(
                 config_file,
                 &format!(
-                    ".plugins.{}.runtime_platforms.\"{}\".snapshotter",
-                    CONTAINERD_CRI_IMAGES_PLUGIN_ID, params.runtime_name
+                    "{}.snapshotter",
+                    containerd_runtime_platform_table(&params.runtime_name)
                 ),
                 snapshotter,
             )?;
@@ -447,6 +460,76 @@ pub async fn configure_custom_containerd_runtime(
     Ok(())
 }
 
+fn configured_containerd_handlers(config: &Config) -> HashSet<String> {
+    let mut handlers: HashSet<String> = config.shim_handlers().into_iter().collect();
+    if config.custom_runtimes_enabled {
+        handlers.extend(config.custom_runtimes.iter().map(|r| r.handler.clone()));
+    }
+    handlers
+}
+
+/// The file is not always exclusively ours: without conf.d the handlers sit in
+/// the node's own containerd config, and k0s and K3s share one drop-in path
+/// between installations. The trailing separator keeps /opt/kata off the
+/// handlers of /opt/kata-dev.
+fn containerd_handler_is_ours(
+    config_file: &Path,
+    pluginid: &str,
+    handler: &str,
+    dest_dir: &str,
+) -> bool {
+    let runtime_table = format!("{}.\"{}\"", containerd_runtimes_table(pluginid), handler);
+    let owned_prefix = format!("{}/", dest_dir.trim_end_matches('/'));
+
+    [
+        format!("{runtime_table}.runtime_path"),
+        format!("{runtime_table}.options.ConfigPath"),
+    ]
+    .iter()
+    .any(|path| {
+        toml_utils::get_toml_value(config_file, path)
+            .is_ok_and(|value| value.starts_with(&owned_prefix))
+    })
+}
+
+/// Installs only ever add handlers, so one dropped between two installs stays
+/// registered and advertised with the config its ConfigPath names deleted, and
+/// pods aimed at it hang in ContainerCreating.
+fn reconcile_containerd_runtimes(
+    config_file: &Path,
+    pluginid: &str,
+    dest_dir: &str,
+    configured: &HashSet<String>,
+) -> Result<()> {
+    let runtimes_table = containerd_runtimes_table(pluginid);
+
+    for handler in toml_utils::get_toml_table_keys(config_file, &runtimes_table)? {
+        if configured.contains(&handler)
+            || !containerd_handler_is_ours(config_file, pluginid, &handler, dest_dir)
+        {
+            continue;
+        }
+
+        info!(
+            "Removing stale containerd runtime handler '{}' from {}",
+            handler,
+            config_file.display()
+        );
+        toml_utils::delete_toml_value(config_file, &format!("{runtimes_table}.\"{handler}\""))?;
+
+        // The images plugin registers the handler a second time, for snapshotter
+        // selection.
+        if is_containerd_v3_config(pluginid) {
+            toml_utils::delete_toml_value(
+                config_file,
+                &containerd_runtime_platform_table(&handler),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn configure_containerd(config: &Config, runtime: &str) -> Result<()> {
     info!("Add Kata Containers as a supported runtime for containerd");
 
@@ -537,6 +620,18 @@ pub async fn configure_containerd(config: &Config, runtime: &str) -> Result<()> 
             );
         }
     }
+
+    let configuration_file = get_containerd_output_path(&paths);
+    let pluginid = match paths.plugin_id.as_deref() {
+        Some(plugin_id) => plugin_id,
+        None => get_containerd_pluginid(&paths.config_file, runtime)?,
+    };
+    reconcile_containerd_runtimes(
+        &configuration_file,
+        pluginid,
+        &config.dest_dir,
+        &configured_containerd_handlers(config),
+    )?;
 
     configure_user_containerd_drop_in(config, &paths)?;
 
@@ -1196,6 +1291,99 @@ mod tests {
             version,
             expected_error
         );
+    }
+
+    const DEST_DIR: &str = "/opt/kata";
+
+    fn write_handler(path: &Path, pluginid: &str, handler: &str, dest_dir: &str) {
+        let mut params = make_params(handler, Some("\"nydus\""));
+        params.runtime_path = format!("\"{dest_dir}/bin/containerd-shim-kata-v2\"");
+        params.config_path = format!(
+            "\"{dest_dir}/share/defaults/kata-containers/custom-runtimes/{handler}/configuration-qemu.toml\""
+        );
+        write_containerd_runtime_config(path, pluginid, &params).unwrap();
+    }
+
+    fn handler_exists(path: &Path, pluginid: &str, handler: &str) -> bool {
+        toml_utils::get_toml_value(
+            path,
+            &format!(
+                "{}.\"{}\".runtime_type",
+                containerd_runtimes_table(pluginid),
+                handler
+            ),
+        )
+        .is_ok()
+    }
+
+    #[rstest]
+    #[case(CONTAINERD_V3_RUNTIME_PLUGIN_ID)]
+    #[case(CONTAINERD_V2_CRI_PLUGIN_ID)]
+    fn stale_kata_handlers_are_removed(#[case] pluginid: &str) {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path();
+        std::fs::write(path, "").unwrap();
+
+        write_handler(path, pluginid, "kata-qemu", DEST_DIR);
+        write_handler(path, pluginid, "kata-qemu-debug", DEST_DIR);
+        write_handler(path, pluginid, "kata-qemu-devkit", DEST_DIR);
+
+        let configured = HashSet::from(["kata-qemu".to_string()]);
+        reconcile_containerd_runtimes(path, pluginid, DEST_DIR, &configured).unwrap();
+
+        assert!(handler_exists(path, pluginid, "kata-qemu"));
+        assert!(!handler_exists(path, pluginid, "kata-qemu-debug"));
+        assert!(!handler_exists(path, pluginid, "kata-qemu-devkit"));
+
+        if !is_containerd_v3_config(pluginid) {
+            return;
+        }
+
+        let snapshotter_of = |handler: &str| {
+            toml_utils::get_toml_value(
+                path,
+                &format!("{}.snapshotter", containerd_runtime_platform_table(handler)),
+            )
+        };
+        assert_eq!(snapshotter_of("kata-qemu").unwrap(), "nydus");
+        assert!(snapshotter_of("kata-qemu-debug").is_err());
+        assert!(snapshotter_of("kata-qemu-devkit").is_err());
+    }
+
+    #[test]
+    fn handlers_of_others_are_left_alone() {
+        let pluginid = CONTAINERD_V3_RUNTIME_PLUGIN_ID;
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path();
+        std::fs::write(path, "").unwrap();
+
+        write_handler(path, pluginid, "kata-qemu-debug", "/opt/kata-dev");
+        let mut runc = make_params("runc", None);
+        runc.runtime_path = "\"/usr/bin/runc\"".to_string();
+        runc.config_path = "\"/etc/runc/config.toml\"".to_string();
+        write_containerd_runtime_config(path, pluginid, &runc).unwrap();
+
+        reconcile_containerd_runtimes(path, pluginid, DEST_DIR, &HashSet::new()).unwrap();
+
+        assert!(handler_exists(path, pluginid, "kata-qemu-debug"));
+        assert!(handler_exists(path, pluginid, "runc"));
+    }
+
+    #[test]
+    fn reconcile_containerd_runtimes_without_handlers_is_noop() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path();
+        std::fs::write(path, "version = 3\n").unwrap();
+
+        reconcile_containerd_runtimes(
+            path,
+            CONTAINERD_V3_RUNTIME_PLUGIN_ID,
+            DEST_DIR,
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "version = 3\n");
     }
 
     const LEGACY_IMPORT: &str = "/opt/kata/containerd/config.d/kata-deploy.toml";

--- a/tools/packaging/kata-deploy/binary/src/utils/toml.rs
+++ b/tools/packaging/kata-deploy/binary/src/utils/toml.rs
@@ -162,6 +162,43 @@ pub fn delete_toml_value(file_path: &Path, path: &str) -> Result<()> {
     Ok(())
 }
 
+/// The keys of the table at `path`, or an empty Vec if it does not exist.
+pub fn get_toml_table_keys(file_path: &Path, path: &str) -> Result<Vec<String>> {
+    let content = std::fs::read_to_string(file_path)
+        .with_context(|| format!("Failed to read TOML file: {file_path:?}"))?;
+
+    let (_header, toml_content) = split_non_toml_header(&content);
+    let doc = toml_content
+        .parse::<DocumentMut>()
+        .context("Failed to parse TOML")?;
+
+    let parts = parse_toml_path(path)?;
+
+    let mut current_table = doc.as_table();
+    for (i, part) in parts.iter().enumerate() {
+        let Some(item) = current_table.get(part.as_str()) else {
+            return Ok(Vec::new());
+        };
+
+        if i == parts.len() - 1 {
+            return match item {
+                Item::Table(table) => Ok(table.iter().map(|(key, _)| key.to_string()).collect()),
+                Item::Value(Value::InlineTable(table)) => {
+                    Ok(table.iter().map(|(key, _)| key.to_string()).collect())
+                }
+                _ => Err(anyhow::anyhow!("Path '{path}' is not a table")),
+            };
+        }
+
+        match item {
+            Item::Table(table) => current_table = table,
+            _ => return Ok(Vec::new()),
+        }
+    }
+
+    Ok(Vec::new())
+}
+
 /// Get a TOML value at a given path
 pub fn get_toml_value(file_path: &Path, path: &str) -> Result<String> {
     let content = std::fs::read_to_string(file_path)
@@ -1754,6 +1791,50 @@ imports = ["/etc/containerd/conf.d/*.toml", "/opt/kata/containerd/config.d/kata-
         )
         .unwrap();
         assert_eq!(runtime_type, "io.containerd.kata-qemu.v2");
+    }
+
+    #[test]
+    fn test_get_toml_table_keys() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let temp_path = temp_file.path();
+        std::fs::write(
+            temp_path,
+            concat!(
+                "[plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.kata-qemu]\n",
+                "runtime_type = \"io.containerd.kata-qemu.v2\"\n",
+                "[plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.kata-qemu.options]\n",
+                "ConfigPath = \"/opt/kata/configuration.toml\"\n",
+                "[plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.runc]\n",
+                "runtime_type = \"io.containerd.runc.v2\"\n",
+            ),
+        )
+        .unwrap();
+
+        let keys = get_toml_table_keys(
+            temp_path,
+            ".plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes",
+        )
+        .unwrap();
+        assert_eq!(keys, vec!["kata-qemu", "runc"]);
+
+        assert!(get_toml_table_keys(temp_path, ".plugins.\"nope\".runtimes")
+            .unwrap()
+            .is_empty());
+        assert!(get_toml_table_keys(
+            temp_path,
+            ".plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.runc.runtime_type"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_get_toml_table_keys_inline_table() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let temp_path = temp_file.path();
+        std::fs::write(temp_path, "runtimes = { kata-qemu = {}, runc = {} }\n").unwrap();
+
+        let keys = get_toml_table_keys(temp_path, ".runtimes").unwrap();
+        assert_eq!(keys, vec!["kata-qemu", "runc"]);
     }
 
     #[test]


### PR DESCRIPTION
configure_containerd only ever added handlers, so turning a variant off left its stanza behind naming the configuration the same redeploy had deleted. The node kept advertising the handler and pods on it hung in ContainerCreating.

Reconcile instead: drop every stanza under this installation's dest_dir that the current configuration did not just write, and its
runtime_platforms entry in the CRI images plugin.