### PR TITLE
kata-deploy: postpone the switch to the job deploymentMode as default to 4.3.0

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -280,10 +280,10 @@ fails the render rather than deploying something that cannot work.
 The chart can install Kata on nodes in one of two ways, selected with the
 top-level `deploymentMode` value:
 
-- **`daemonset`**: the long-running `kata-deploy` DaemonSet installs
+- **`daemonset`** (default): the long-running `kata-deploy` DaemonSet installs
   Kata on every matching node and reverts it when the pod is terminated (i.e. on
   uninstall). This is the historical behavior and is unchanged.
-- **`job`** (default): there is **no always-on component**. A tiny
+- **`job`**: there is **no always-on component**. A tiny
   [`k8s-job-dispatcher`](https://github.com/kata-containers/k8s-job-dispatcher)
   Job runs as a `post-install`/`post-upgrade` hook, enumerates the selected nodes
   **live** via the Kubernetes API, and creates one
@@ -308,24 +308,23 @@ top-level `deploymentMode` value:
   escalation, read-only root filesystem, `RuntimeDefault` seccomp), never touches
   the host, and can be confined to nodes you trust.
 
-`job` is the default; ask for `daemonset` explicitly to keep the historical
-behavior:
+`daemonset` is the default; ask for `job` explicitly to get the per-node Jobs:
 
-=== "Job (default)"
-    ```yaml title="values.yaml"
-    deploymentMode: job
-    ```
-
-=== "DaemonSet"
+=== "DaemonSet (default)"
     ```yaml title="values.yaml"
     deploymentMode: daemonset
     ```
 
-!!! warning "Upgrading a release installed before `job` became the default"
+=== "Job"
+    ```yaml title="values.yaml"
+    deploymentMode: job
+    ```
+
+!!! warning "Choose the mode at install time"
     `deploymentMode` is [immutable for the life of a release](#how-installations-keep-out-of-each-others-way-on-a-node),
-    so an existing `daemonset` release does not silently move to per-node Jobs:
-    the upgrade is refused instead. Keep `deploymentMode: daemonset` in your
-    values to stay where you are, or `helm uninstall` first to adopt `job`.
+    so an existing release cannot be moved between the two: the upgrade is
+    refused instead. To adopt `job` mode on a release already running the
+    DaemonSet, `helm uninstall` it first.
 
 #### Where the credentials live
 

--- a/docs/how-to/how-to-use-erofs-snapshotter-with-kata.md
+++ b/docs/how-to/how-to-use-erofs-snapshotter-with-kata.md
@@ -9,30 +9,33 @@ When used with Kata Containers `runtime-rs`, the EROFS snapshotter enables
 entirely. This delivers lower overhead, better performance, and smaller memory
 footprints compared to traditional shared-filesystem approaches.
 
-> **Deploying with kata-deploy? It does all of this for you**: a
-> [kata-deploy](../helm-configuration.md) deployment in `job` mode sets all of this
-> up on every node it selects: containerd's EROFS snapshotter and differ
-> configuration, the shims you enable pointed at the snapshotter, and the `erofs`
-> and dm-verity modules loaded and recorded so they come back after a reboot.
->
-> Those settings need erofs-utils 1.8.2 or newer. Where a node packages something
-> older, or nothing at all, [`nodeBinaries`](../helm-configuration.md#nodebinaries)
-> takes it from a container image instead:
->
-> ```yaml
-> deploymentMode: job
-> snapshotter:
->   setup: ["erofs"]
-> nodeBinaries:
->   erofs-utils:
->     image: quay.io/kata-containers/erofs-utils:1.9.3
->     binaries: [mkfs.erofs, dump.erofs, fsck.erofs]
-> ```
->
-> [`try-kata-nvidia-cpu.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml)
-> sets the EROFS side of this up and carries that block commented out, to uncomment
-> on nodes needing it. Read on for what any of it means, or to set a host up without
-> kata-deploy.
+!!! tip "Deploying with kata-deploy? It does all of this for you"
+    A [kata-deploy](../helm-configuration.md) deployment sets all of this up on
+    every node it selects: containerd's EROFS snapshotter and differ
+    configuration, and the shims you enable pointed at the snapshotter. In `job`
+    mode it also loads the `erofs` and dm-verity modules and records them so they
+    come back after a reboot; the DaemonSet does not, so there the node has to
+    bring them itself.
+
+    Those settings need erofs-utils 1.8.2 or newer. Where a node packages something
+    older, or nothing at all, [`nodeBinaries`](../helm-configuration.md#nodebinaries)
+    takes it from a container image instead — which is itself `job`-mode only,
+    since staging binaries onto the node relies on the per-node pipeline:
+
+    ```yaml title="values.yaml"
+    deploymentMode: job
+    snapshotter:
+      setup: ["erofs"]
+    nodeBinaries:
+      erofs-utils:
+        image: quay.io/kata-containers/erofs-utils:1.9.3
+        binaries: [mkfs.erofs, dump.erofs, fsck.erofs]
+    ```
+
+    [`try-kata-nvidia-cpu.values.yaml`](https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml)
+    sets the EROFS side of this up and carries that block commented out, to uncomment
+    on nodes needing it. Read on for what any of it means, or to set a host up without
+    kata-deploy.
 
 ## Quick Start Guide
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,10 +154,11 @@ For the full set of configuration options (shim selection, custom runtimes,
 node selectors, TEE shims, drop-in configuration files and more), see the
 [Helm configuration document](helm-configuration.md).
 
-!!! note "Deployment modes: Job vs DaemonSet"
-    Short-lived, staged per-node Jobs (no always-on component on the node) are
-    the default install model (`deploymentMode: job`). You can instead use the
-    long-running `kata-deploy` DaemonSet by setting `deploymentMode: daemonset`.
+!!! note "Deployment modes: DaemonSet vs Job"
+    The long-running `kata-deploy` DaemonSet is the default install model
+    (`deploymentMode: daemonset`). You can instead use short-lived, staged
+    per-node Jobs, which leave no always-on component on the node, by setting
+    `deploymentMode: job`.
     See [Deployment Modes (DaemonSet vs Job)](helm-configuration.md#deployment-modes-daemonset-vs-job)
     for details and node-selection options.
 

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -948,6 +948,29 @@ function load_dm_verity_modules() {
 		die "the dm_verity kernel module is not available after modprobe"
 }
 
+# Gives the node what only kata-deploy's per-node Jobs would have brought it.
+#
+# The job pipeline stages erofs-utils onto the node (nodeBinaries) and has a
+# privileged stage that loads the modules EROFS needs. The DaemonSet does
+# neither - it is one container with no such ordering - so a node it installs
+# has to arrive with both, and the install's host check fails it if it does not.
+#
+# Which mode this applies to is the caller's to decide. Nothing is prepared for
+# job mode, deliberately: doing so would hide its own stages failing to.
+function prepare_host_for_erofs() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] || return 0
+
+	# Also loads the erofs module.
+	install_erofs_utils
+
+	# EROFS mounts its layer blobs through loop devices.
+	sudo modprobe loop
+
+	if [[ "${EROFS_DMVERITY:-}" == "dmverity" ]]; then
+		load_dm_verity_modules
+	fi
+}
+
 # Points containerd at the erofs differ and snapshotter, as a conf.d drop-in.
 #
 # This is the non-Kubernetes counterpart of what kata-deploy writes on the k8s

--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -33,13 +33,6 @@ source "${BATS_TEST_DIRNAME}/lib/helm-deploy.bash"
 LIFECYCLE_POD_NAME="kata-lifecycle-test"
 
 setup_file() {
-	# erofs-utils now reaches the node through the job pipeline's staging, which
-	# the DaemonSet has no equivalent of, and these runners package none of their
-	# own. The other flavours cover this suite in daemonset mode.
-	if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
-		skip "the DaemonSet cannot install the erofs-utils the node lacks"
-	fi
-
 	ensure_helm
 
 	echo "# Image: ${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" >&3

--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -153,10 +153,6 @@ EOF
 	uninstall_kata
 	echo "# Uninstall complete, verifying cleanup..." >&3
 
-	# Wait for node to recover — containerd restart during cleanup may
-	# cause brief unavailability (especially on k3s/rke2/microk8s).
-	kubectl wait nodes --timeout=300s --all --for condition=Ready=True
-
 	# RuntimeClasses must be gone (filter out AKS-managed ones)
 	local rc_count
 	rc_count=$(kubectl get runtimeclasses --no-headers 2>/dev/null | grep -v "kata-mshv-vm-isolation" | grep -c "kata" || true)

--- a/tests/functional/kata-deploy/kata-deploy-multi-install.bats
+++ b/tests/functional/kata-deploy/kata-deploy-multi-install.bats
@@ -64,7 +64,7 @@ refute_match() {
 
 	echo "${rendered}" | grep -q 'name: my-release-kata-deploy-state'
 	echo "${rendered}" | grep -q 'multiInstallSuffix: "dev"'
-	echo "${rendered}" | grep -q 'deploymentMode: "job"'
+	echo "${rendered}" | grep -q 'deploymentMode: "daemonset"'
 }
 
 @test "Helm template: an unverifiable pre-state upgrade is refused" {

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -5,8 +5,7 @@
 #
 # Shared helm deployment helpers for kata-deploy tests
 #
-# Expects tests/common.bash to have been loaded: the EROFS host preparation
-# below calls install_erofs_utils and load_dm_verity_modules from it.
+# Expects tests/common.bash and tests/gha-run-k8s-common.sh to have been loaded.
 #
 # Required environment variables:
 #   DOCKER_REGISTRY - Container registry for kata-deploy image
@@ -122,6 +121,36 @@ kata_deploy_pod_selector() {
 	else
 		echo "app.kubernetes.io/name=kata-deploy"
 	fi
+}
+
+# Whether the DaemonSet and its pods are gone. An unreachable API answers
+# nothing, so that counts as "still there".
+kata_deploy_ds_gone() {
+	local leftovers
+
+	leftovers="$(kubectl -n "${HELM_NAMESPACE}" get daemonset,pod \
+		-l name=kata-deploy -o name --request-timeout=10s 2>/dev/null)" || return 1
+
+	[[ -z "${leftovers}" ]]
+}
+
+# helm's uninstall can return while the deletion is still in flight, and the
+# next install then creates a DaemonSet the old cascade deletes again.
+# The default outlasts terminationGracePeriodSeconds (600).
+# Arguments:
+#   $1 - (Optional) seconds to wait, default 660
+wait_for_kata_deploy_ds_gone() {
+	local timeout="${1:-660}"
+
+	if waitForProcess "${timeout}" 5 kata_deploy_ds_gone; then
+		return 0
+	fi
+
+	echo "the kata-deploy DaemonSet was still there ${timeout}s after the uninstall" >&2
+	kubectl -n "${HELM_NAMESPACE}" get daemonset,pod -l name=kata-deploy || true
+	kubectl -n "${HELM_NAMESPACE}" logs -l name=kata-deploy --tail=100 \
+		--prefix --timestamps || true
+	return 1
 }
 
 # Get the path to the helm chart
@@ -323,4 +352,12 @@ uninstall_kata() {
 		--ignore-not-found --wait --cascade foreground --timeout 10m || true
 
 	wait_for_api_and_retry_uninstall "${HELM_RELEASE_NAME}" "${HELM_NAMESPACE}"
+
+	local ret=0
+
+	wait_for_kata_deploy_ds_gone || ret=1
+	# errexit would skip this after the wait above fails.
+	wait_for_nodes_ready || ret=1
+
+	return "${ret}"
 }

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -5,6 +5,9 @@
 #
 # Shared helm deployment helpers for kata-deploy tests
 #
+# Expects tests/common.bash to have been loaded: the EROFS host preparation
+# below calls install_erofs_utils and load_dm_verity_modules from it.
+#
 # Required environment variables:
 #   DOCKER_REGISTRY - Container registry for kata-deploy image
 #   DOCKER_REPO     - Repository name for kata-deploy image
@@ -16,7 +19,8 @@
 #   EROFS_SNAPSHOTTER_MODE      - "disk" or "memory"
 #   EROFS_DMVERITY              - Set to "dmverity" to enable dm-verity
 #   EROFS_MERGE_MODE            - "merged" or "unmerged"
-#   EROFS_UTILS_IMAGE           - Image kata-deploy takes erofs-utils from
+#   EROFS_UTILS_IMAGE           - Image kata-deploy takes erofs-utils from, in
+#                                 job mode
 
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-kata-deploy}"
 HELM_NAMESPACE="${HELM_NAMESPACE:-kube-system}"
@@ -127,14 +131,47 @@ get_chart_path() {
 	echo "${script_dir}/../../../../tools/packaging/kata-deploy/helm-chart/kata-deploy"
 }
 
+# The mode the deploy about to happen will install: what the caller asked for,
+# or the chart's own default. The host preparation and the values differ by mode,
+# so a guess would prepare the node for a release that is not coming.
+#
+# Arguments:
+#   $1 - (Optional) the caller's extra values file
+#   $@ - (Optional) the caller's extra helm arguments
+requested_deployment_mode() {
+	local extra_values_file="${1:-}"
+	shift || true
+	local arg mode
+
+	# --set wins over any values file, in whichever order helm was given them.
+	for arg in "$@"; do
+		case "${arg}" in
+			*deploymentMode=*)
+				echo "${arg##*deploymentMode=}" | cut -d, -f1
+				return
+				;;
+		esac
+	done
+
+	if [[ -n "${extra_values_file}" && -f "${extra_values_file}" ]]; then
+		mode="$(yq -r '.deploymentMode // ""' "${extra_values_file}")"
+		if [[ -n "${mode}" ]]; then
+			echo "${mode}"
+			return
+		fi
+	fi
+
+	yq -r '.deploymentMode' "$(get_chart_path)/values.yaml"
+}
+
 # Generate base values YAML that disables all shims except the specified one
 # Arguments:
 #   $1 - Output file path
-#   $2 - (Optional) Additional values file to merge
+#   $2 - Deployment mode the values are for ("daemonset" or "job")
 # shellcheck disable=SC2154
 generate_base_values() {
 	local output_file="$1"
-	local extra_values_file="${2:-}"
+	local deployment_mode="${2:-daemonset}"
 
 	local k8s_distribution="${KUBERNETES}"
 	if [[ "${k8s_distribution}" == "kubeadm" ]]; then
@@ -149,6 +186,20 @@ generate_base_values() {
 			erofs_dmverity="true"
 		fi
 
+		# Job mode takes erofs-utils from an image, covering the path a node
+		# packaging none of its own actually takes. The DaemonSet cannot stage
+		# binaries at all, so there prepare_host_for_erofs puts them on the node
+		# instead and asking for them here would only fail the render.
+		local node_binaries_values=""
+		if [[ "${deployment_mode}" == "job" ]]; then
+			node_binaries_values="
+nodeBinaries:
+  erofs-utils:
+    image: \"${EROFS_UTILS_IMAGE:-quay.io/kata-containers/erofs-utils:1.9.3}\"
+    binaries: [mkfs.erofs]
+"
+		fi
+
 		shim_snapshotter_values="    containerd:
       snapshotter: erofs"
 		snapshotter_values="snapshotter:
@@ -156,13 +207,7 @@ generate_base_values() {
   erofsSnapshotterMode: \"${EROFS_SNAPSHOTTER_MODE:-}\"
   erofsDmverity: ${erofs_dmverity}
   erofsMergeMode: \"${EROFS_MERGE_MODE:-}\"
-
-# The node has no erofs-utils of its own; see deploy_k8s.
-nodeBinaries:
-  erofs-utils:
-    image: \"${EROFS_UTILS_IMAGE:-quay.io/kata-containers/erofs-utils:1.9.3}\"
-    binaries: [mkfs.erofs]
-
+${node_binaries_values}
 # fs-verity would also need the backing filesystem prepared for it, and these
 # tests only care about dm-verity.
 containerd:
@@ -209,12 +254,22 @@ deploy_kata() {
 
 	local chart_path
 	local values_yaml
+	local deployment_mode
 
 	chart_path="$(get_chart_path)"
 	values_yaml=$(mktemp)
 
+	deployment_mode="$(requested_deployment_mode "${extra_values_file}" \
+		"${extra_helm_args[@]}")"
+
+	# The DaemonSet stages no binaries and loads no modules, so the node has to
+	# arrive with what EROFS needs. Job mode brings its own, and is left alone.
+	if [[ "${deployment_mode}" == "daemonset" ]]; then
+		prepare_host_for_erofs
+	fi
+
 	# Generate base values
-	generate_base_values "${values_yaml}"
+	generate_base_values "${values_yaml}" "${deployment_mode}"
 
 	# NFD is vendored under charts/*.tgz; no helm dependency fetch needed.
 

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -577,19 +577,17 @@ function deploy_k8s() {
 		microk8s) deploy_microk8s ;;
 		kubeadm|vanilla)
 			if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
-				# No erofs-utils is installed on the node on purpose: these
-				# runners package nothing new enough, which is the very case
-				# nodeBinaries exists for, so the install has to bring its
-				# own.
-
 				# fsverity is only needed here because, unlike
 				# the docker and nerdctl jobs, these do enable
 				# fs-verity on the layer blobs.
 				sudo apt-get -y install --no-install-recommends fsverity
 
-				# erofs, loop and the dm-verity targets are left unloaded on
-				# purpose: kata-deploy's own privileged stage loads and persists
-				# them, and pre-loading them here would hide it failing to.
+				# erofs-utils and the modules EROFS needs are deliberately not
+				# prepared here. What the node needs depends on the mode being
+				# deployed, and this single cluster serves both: the erofs leg
+				# runs the job-mode host-module suite alongside the daemonset
+				# ones. prepare_host_for_erofs does it per deploy instead, so
+				# job mode still faces a bare node and has to load its own.
 
 				# Ensure fsverity is enabled on the disk, otherwise
 				# fsverity won't work on the erofs-snapshotter side.
@@ -904,10 +902,18 @@ function helm_helper() {
 			done
 		fi
 
-		# The node has no erofs-utils of its own; see deploy_k8s.
+		# The node has none of its own; see deploy_k8s. Job mode stages them
+		# from an image, which is the case nodeBinaries exists for. The
+		# DaemonSet cannot stage anything, so there the node is given
+		# erofs-utils directly and asking for nodeBinaries would fail the
+		# render.
 		if [[ "${SNAPSHOTTER}" == "erofs" ]]; then
-			yq -i ".nodeBinaries[\"erofs-utils\"].image = \"${EROFS_UTILS_IMAGE}\"" "${values_yaml}"
-			yq -i ".nodeBinaries[\"erofs-utils\"].binaries = [\"mkfs.erofs\", \"dump.erofs\", \"fsck.erofs\"]" "${values_yaml}"
+			if [[ "${deployment_mode}" == "job" ]]; then
+				yq -i ".nodeBinaries[\"erofs-utils\"].image = \"${EROFS_UTILS_IMAGE}\"" "${values_yaml}"
+				yq -i ".nodeBinaries[\"erofs-utils\"].binaries = [\"mkfs.erofs\", \"dump.erofs\", \"fsck.erofs\"]" "${values_yaml}"
+			else
+				prepare_host_for_erofs
+			fi
 		fi
 
 		if [[ -n "${EROFS_SNAPSHOTTER_MODE}" ]]; then

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -76,6 +76,42 @@ wait_for_api_and_retry_uninstall() {
 		--ignore-not-found --wait --timeout 5m || true
 }
 
+# True when every node reports Ready. An unreachable API answers nothing, so
+# that counts as false here and leaves the caller to ask again.
+all_nodes_ready() {
+	local ready
+
+	ready="$(kubectl get nodes -o json --request-timeout=10s 2>/dev/null |
+		jq -r '.items[].status.conditions[] | select(.type == "Ready") | .status')" ||
+		return 1
+
+	[[ -n "${ready}" ]] || return 1
+
+	! grep -qv '^True$' <<< "${ready}"
+}
+
+# Wait for every node to report Ready, which after an uninstall means waiting
+# for the API to come back too.
+#
+# `kubectl wait` is a single watch and gives up when its connection breaks,
+# which is exactly what a control plane restarting under it does - and on
+# microk8s the control plane runs on the very containerd the SIGTERM cleanup
+# restarts. Polling makes an API that is still on its way back a retry rather
+# than a verdict.
+# Arguments:
+#   $1 - (Optional) seconds to wait, default 300
+wait_for_nodes_ready() {
+	local timeout="${1:-300}"
+
+	if waitForProcess "${timeout}" 5 all_nodes_ready; then
+		return 0
+	fi
+
+	echo "not every node became Ready within ${timeout}s" >&2
+	kubectl get nodes || true
+	return 1
+}
+
 function _print_instance_type() {
 	case "${K8S_TEST_HOST_TYPE}" in
 		small)

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-cpu.values.yaml
@@ -9,10 +9,17 @@
 
 debug: false
 
-# Install Kata via short-lived per-node Jobs instead of an always-on DaemonSet.
-# A tiny dispatcher Job fans out one install Job per selected node and exits, so
-# nothing keeps running on the node once the install completes.
-deploymentMode: job
+# Install Kata via the long-running kata-deploy DaemonSet, which installs it on
+# every selected node and reverts it when its pod is terminated. The alternative
+# is short-lived per-node Jobs (deploymentMode: job), where a tiny dispatcher Job
+# fans out one install Job per selected node and exits, so nothing keeps running
+# on the node once the install completes.
+#
+# NOTE: only the per-node Jobs load host kernel modules; the DaemonSet does not.
+# The EROFS settings below therefore need erofs, loop, dm_mod and dm_verity
+# already available on every node, and persistent across reboots. The install's
+# host check fails the node rather than configuring a snapshotter it cannot run.
+deploymentMode: daemonset
 
 snapshotter:
   setup: ["erofs"]
@@ -29,6 +36,10 @@ snapshotter:
 # are removed again on uninstall. The install refuses to replace an
 # /usr/local/bin/mkfs.erofs it did not put there, and that image is published for
 # amd64 and arm64 only.
+#
+# Staging binaries onto the node relies on the per-node Jobs' ordered pipeline, so
+# uncommenting this also means setting deploymentMode: job above. Leaving it on
+# daemonset fails the render rather than deploying something that cannot work.
 #
 # nodeBinaries:
 #   erofs-utils:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -8,10 +8,17 @@
 
 debug: false
 
-# Install Kata via short-lived per-node Jobs instead of an always-on DaemonSet.
-# A tiny dispatcher Job fans out one install Job per selected node and exits, so
-# nothing keeps running on the node once the install completes.
-deploymentMode: job
+# Install Kata via the long-running kata-deploy DaemonSet, which installs it on
+# every selected node and reverts it when its pod is terminated. The alternative
+# is short-lived per-node Jobs (deploymentMode: job), where a tiny dispatcher Job
+# fans out one install Job per selected node and exits, so nothing keeps running
+# on the node once the install completes.
+#
+# NOTE: only the per-node Jobs load host kernel modules; the DaemonSet does not.
+# The EROFS settings below therefore need erofs, loop, dm_mod and dm_verity
+# already available on every node, and persistent across reboots. The install's
+# host check fails the node rather than configuring a snapshotter it cannot run.
+deploymentMode: daemonset
 
 snapshotter:
   setup: ["nydus", "erofs"]
@@ -30,6 +37,10 @@ snapshotter:
 # are removed again on uninstall. The install refuses to replace an
 # /usr/local/bin/mkfs.erofs it did not put there, and that image is published for
 # amd64 and arm64 only.
+#
+# Staging binaries onto the node relies on the per-node Jobs' ordered pipeline, so
+# uncommenting this also means setting deploymentMode: job above. Leaving it on
+# daemonset fails the render rather than deploying something that cannot work.
 #
 # nodeBinaries:
 #   erofs-utils:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -1,8 +1,8 @@
 # Deployment model for installing/cleaning up Kata on nodes.
-#   daemonset: the long-running kata-deploy DaemonSet installs Kata on
+#   daemonset: (default) the long-running kata-deploy DaemonSet installs Kata on
 #              every matching node and reverts it on pod termination (uninstall).
-#   job:       (default) no always-on component. A tiny k8s-job-dispatcher Job runs
-#              as a post-install/upgrade hook, enumerates
+#   job:       no always-on component. A tiny k8s-job-dispatcher Job runs as a
+#              post-install/upgrade hook, enumerates
 #              the selected nodes LIVE, and creates one node-pinned install Job
 #              per node - paced to job.parallelism and guaranteeing one install
 #              per node. Each per-node Job runs the staged pipeline as ordered
@@ -48,7 +48,7 @@
 #   Each stage writes why it is giving up to /dev/termination-log, so the reason
 #   is in the pod's status rather than only in a log that
 #   job.ttlSecondsAfterFinished deletes along with the pod.
-deploymentMode: job  # daemonset | job
+deploymentMode: daemonset  # daemonset | job
 
 # Settings specific to deploymentMode: job
 job:


### PR DESCRIPTION
Our QA has been doing tests with the job deploymentMode and some issues were found. As I'm not really working till next week, and we are targeting a release on Monday, we'll just postpone the full switch to the Kata Containers 4.3.0, and address the bugs without rushing.